### PR TITLE
Say ‘Untitled’ instead of ’New’ letter template

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -289,7 +289,7 @@ def _add_template_by_type(template_type, template_folder_id):
 
     if template_type == "letter":
         blank_letter = service_api_client.create_service_template(
-            name="New letter template",
+            name="Untitled letter template",
             type_="letter",
             content="Body",
             service_id=current_service.id,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -289,12 +289,12 @@ def _add_template_by_type(template_type, template_folder_id):
 
     if template_type == "letter":
         blank_letter = service_api_client.create_service_template(
-            "New letter template",
-            "letter",
-            "Body",
-            current_service.id,
-            "Main heading",
-            template_folder_id,
+            name="New letter template",
+            type_="letter",
+            content="Body",
+            service_id=current_service.id,
+            subject="Main heading",
+            parent_folder_id=template_folder_id,
         )
         return redirect(
             url_for(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -289,7 +289,12 @@ def _add_template_by_type(template_type, template_folder_id):
 
     if template_type == "letter":
         blank_letter = service_api_client.create_service_template(
-            "New letter template", "letter", "Body", current_service.id, "Main heading", template_folder_id
+            "New letter template",
+            "letter",
+            "Body",
+            current_service.id,
+            "Main heading",
+            template_folder_id,
         )
         return redirect(
             url_for(

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -134,6 +134,7 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
     mock_get_services_with_no_services,
     api_user_active,
     mock_get_all_email_branding,
+    fake_uuid,
     inherited,
     email_address,
     posted,
@@ -156,7 +157,7 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
         _expected_redirect=url_for(
             "main.begin_tour",
             service_id=101,
-            template_id="Example%20text%20message%20template",
+            template_id=fake_uuid,
         ),
     )
     assert mock_get_services_with_no_services.called

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -536,7 +536,7 @@ def test_template_id_is_searchable_for_services_with_api_keys(
     mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)
 
 
-def test_can_create_email_template_with_parent_folder(client_request, mock_create_service_template):
+def test_can_create_email_template_with_parent_folder(client_request, mock_create_service_template, fake_uuid):
     data = {
         "name": "new name",
         "subject": "Food incoming!",
@@ -554,7 +554,7 @@ def test_can_create_email_template_with_parent_folder(client_request, mock_creat
         _expected_redirect=url_for(
             "main.view_template",
             service_id=SERVICE_ONE_ID,
-            template_id="new%20name",
+            template_id=fake_uuid,
         ),
     )
     mock_create_service_template.assert_called_once_with(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1137,6 +1137,36 @@ def test_choosing_to_copy_redirects(
     )
 
 
+def test_choosing_letter_creates(
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    mock_create_service_template,
+    fake_uuid,
+):
+    service_one["permissions"].append("letter")
+    client_request.post(
+        "main.choose_template",
+        service_id=SERVICE_ONE_ID,
+        _data={"operation": "add-new-template", "add_template_by_template_type": "letter"},
+        _expected_status=302,
+        _expected_redirect=url_for(
+            "main.view_template",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+        ),
+    )
+    mock_create_service_template.assert_called_once_with(
+        "New letter template",
+        "letter",
+        "Body",
+        SERVICE_ONE_ID,
+        "Main heading",
+        None,
+    )
+
+
 def test_choose_a_template_to_copy(
     client_request,
     mock_get_service_templates,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1158,12 +1158,12 @@ def test_choosing_letter_creates(
         ),
     )
     mock_create_service_template.assert_called_once_with(
-        "New letter template",
-        "letter",
-        "Body",
-        SERVICE_ONE_ID,
-        "Main heading",
-        None,
+        name="New letter template",
+        type_="letter",
+        content="Body",
+        service_id=SERVICE_ONE_ID,
+        subject="Main heading",
+        parent_folder_id=None,
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1158,7 +1158,7 @@ def test_choosing_letter_creates(
         ),
     )
     mock_create_service_template.assert_called_once_with(
-        name="New letter template",
+        name="Untitled letter template",
         type_="letter",
         content="Body",
         service_id=SERVICE_ONE_ID,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -874,8 +874,10 @@ def mock_get_service_letter_template_with_placeholders(mocker):
 
 @pytest.fixture(scope="function")
 def mock_create_service_template(mocker, fake_uuid):
-    def _create(name, type_, content, service, subject=None, parent_folder_id=None):
-        template = template_json(fake_uuid, name, type_, content, service, parent_folder_id)
+    def _create(name, type_, content, service_id, subject=None, parent_folder_id=None):
+        template = template_json(
+            service_id, fake_uuid, name=name, type_=type_, content=content, folder=parent_folder_id
+        )
         return {"data": template}
 
     return mocker.patch("app.service_api_client.create_service_template", side_effect=_create)


### PR DESCRIPTION
When you add a letter template we give it a default name of ‘New letter template’.

Then when you go to your templates pages you see:
- a link saying ‘New letter template’
- a button saying ‘New template’

In research we’ve seen people confused about how to add another template, and how to get back to the one they’ve previously been working on. We think this is because we’re using the same word (new) to refer to different things.

‘Untitled’ is the word used by Microsoft Windows, Google Docs, Mac OS and probably others to mean ‘thing that exists but hasn’t been named yet’.

This won’t rename any existing templates.

Before | After 
---|---
<img width="622" alt="image" src="https://user-images.githubusercontent.com/355079/223736041-c9cf6972-3cde-4ef0-8ad6-59e17e7c348a.png"> | <img width="625" alt="image" src="https://user-images.githubusercontent.com/355079/223735939-682834f9-4c20-417b-be59-045aabb54c62.png">
