### PR TITLE
Letter template attach pages button and view

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -21,6 +21,7 @@ from app.main.forms import (
     EmailTemplateForm,
     LetterTemplateForm,
     LetterTemplatePostageForm,
+    PDFUploadForm,
     SearchTemplatesForm,
     SetTemplateSenderForm,
     SMSTemplateForm,
@@ -876,4 +877,8 @@ def get_template_sender_form_dict(service_id, template):
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/attach-pages", methods=["GET", "POST"])
 @user_has_permissions("manage_templates")
 def letter_template_attach_pages(service_id, template_id):
-    return "TODO"
+    form = PDFUploadForm()
+
+    return render_template(
+        "views/templates/attach-pages.html", form=form, service_id=service_id, template_id=template_id
+    )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -871,3 +871,9 @@ def get_template_sender_form_dict(service_id, template):
 
     context["current_choice"] = template["service_letter_contact"] if template["service_letter_contact"] else ""
     return context
+
+
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/attach-pages", methods=["GET", "POST"])
+@user_has_permissions("manage_templates")
+def letter_template_attach_pages(service_id, template_id):
+    return "TODO"

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -32,7 +32,11 @@ from app.main.views.send import get_sender_details
 from app.models.service import Service
 from app.models.template_list import TemplateList, UserTemplateList, UserTemplateLists
 from app.template_previews import TemplatePreview, get_page_count_for_letter
-from app.utils import NOTIFICATION_TYPES, should_skip_template_page
+from app.utils import (
+    NOTIFICATION_TYPES,
+    service_has_permission,
+    should_skip_template_page,
+)
 from app.utils.templates import get_template
 from app.utils.user import user_has_permissions
 
@@ -75,6 +79,7 @@ def view_template(service_id, template_id):
         letter_too_long=is_letter_too_long(page_count),
         letter_max_pages=LETTER_MAX_PAGE_COUNT,
         page_count=page_count,
+        show_attach_pages_button=(True if current_service.has_permission("extra_letter_formatting") else False),
     )
 
 
@@ -876,6 +881,7 @@ def get_template_sender_form_dict(service_id, template):
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/attach-pages", methods=["GET", "POST"])
 @user_has_permissions("manage_templates")
+@service_has_permission("extra_letter_formatting")
 def letter_template_attach_pages(service_id, template_id):
     form = PDFUploadForm()
 

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -226,6 +226,7 @@ class MainNavigation(Navigation):
             "delete_service_template",
             "edit_service_template",
             "edit_template_postage",
+            "letter_template_attach_pages",
             "manage_template_folder",
             "send_messages",
             "send_one_off",

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -6,7 +6,7 @@
 {% set page_title = "Attach pages" %}
 
 {% block service_page_title %}
-	{{ page_title }}
+    {{ page_title }}
 {% endblock %}
 
 {% block backLink %}
@@ -17,35 +17,35 @@
 
 {% block maincolumn_content %}
 <div class="govuk-grid-row">
-	<div class="govuk-grid-column-five-sixths">
-		{{ page_header(page_title) }}
+    <div class="govuk-grid-column-five-sixths">
+        {{ page_header(page_title) }}
 
-		<p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
-		<p class="govuk-body">
-			In total, your letter must be 10 pages or less (5 double-sided sheets of paper).
-			You can attach up to 9 pages.
-		</p>
-		<p class="govuk-body">
-			Attached pages will start on the next available page.
-			If you want to start your attachment on a new sheet of paper, add 2 line breaks
-		</p>
-		<p class="govuk-body">
-			Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">letter
-				specification</a>.
-		</p>
-		<p class="govuk-body">Page size and layout: A4 portrait (210 × 297 mm)</p>
-		<p class="govuk-body">Maximum file size: 2 MB</p>
-		<p class="govuk-body">Your letter must be 10 pages or less (5 double-sided sheets of paper).</p>
+        <p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
+        <p class="govuk-body">
+            In total, your letter must be 10 pages or less (5 double-sided sheets of paper).
+            You can attach up to 9 pages.
+        </p>
+        <p class="govuk-body">
+            Attached pages will start on the next available page.
+            If you want to start your attachment on a new sheet of paper, add 2 line breaks
+        </p>
+        <p class="govuk-body">
+            Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">letter
+                specification</a>.
+        </p>
+        <p class="govuk-body">Page size and layout: A4 portrait (210 × 297 mm)</p>
+        <p class="govuk-body">Maximum file size: 2 MB</p>
+        <p class="govuk-body">Your letter must be 10 pages or less (5 double-sided sheets of paper).</p>
 
-		<div class="govuk-body">
-			{{ file_upload(
-			form.file,
-			allowed_file_extensions=['pdf'],
-			action=url_for('main.letter_template_attach_pages', service_id=current_service.id, template_id=template_id),
-			button_text='Choose file',
-			show_errors=False
-			)}}
-		</div>
-	</div>
+        <div class="govuk-body">
+            {{ file_upload(
+            form.file,
+            allowed_file_extensions=['pdf'],
+            action=url_for('main.letter_template_attach_pages', service_id=current_service.id, template_id=template_id),
+            button_text='Choose file',
+            show_errors=False
+            )}}
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -23,19 +23,11 @@
         <p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
         <p class="govuk-body">
             In total, your letter must be 10 pages or less (5 double-sided sheets of paper).
-            You can attach up to 9 pages.
-        </p>
-        <p class="govuk-body">
-            Attached pages will start on the next available page.
-            If you want to start your attachment on a new sheet of paper, add 2 line breaks
         </p>
         <p class="govuk-body">
             Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">letter
                 specification</a>.
         </p>
-        <p class="govuk-body">Page size and layout: A4 portrait (210 × 297 mm)</p>
-        <p class="govuk-body">Maximum file size: 2 MB</p>
-        <p class="govuk-body">Your letter must be 10 pages or less (5 double-sided sheets of paper).</p>
 
         <div class="govuk-body">
             {{ file_upload(

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -1,0 +1,51 @@
+{% extends "withnav_template.html" %}
+{% from "components/file-upload.html" import file_upload %}
+{% from "components/page-header.html" import page_header %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = "Attach pages" %}
+
+{% block service_page_title %}
+	{{ page_title }}
+{% endblock %}
+
+{% block backLink %}
+{% if not error %}
+{{ govukBackLink({ "href": url_for('main.view_template', service_id=current_service.id, template_id=template_id) }) }}
+{% endif %}
+{% endblock %}
+
+{% block maincolumn_content %}
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-five-sixths">
+		{{ page_header(page_title) }}
+
+		<p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
+		<p class="govuk-body">
+			In total, your letter must be 10 pages or less (5 double-sided sheets of paper).
+			You can attach up to 9 pages.
+		</p>
+		<p class="govuk-body">
+			Attached pages will start on the next available page.
+			If you want to start your attachment on a new sheet of paper, add 2 line breaks
+		</p>
+		<p class="govuk-body">
+			Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">letter
+				specification</a>.
+		</p>
+		<p class="govuk-body">Page size and layout: A4 portrait (210 × 297 mm)</p>
+		<p class="govuk-body">Maximum file size: 2 MB</p>
+		<p class="govuk-body">Your letter must be 10 pages or less (5 double-sided sheets of paper).</p>
+
+		<div class="govuk-body">
+			{{ file_upload(
+			form.file,
+			allowed_file_extensions=['pdf'],
+			action=url_for('main.letter_template_attach_pages', service_id=current_service.id, template_id=template_id),
+			button_text='Choose file',
+			show_errors=False
+			)}}
+		</div>
+	</div>
+</div>
+{% endblock %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -44,6 +44,21 @@
     {% include 'views/templates/_template.html' %}
   </div>
 
+  {% if template.template_type == "letter" and page_count < 10 %}
+    <div class="bottom-gutter-1-2">
+      {{ govukButton({
+      "element": "a",
+      "text": "Attach pages",
+      "href": url_for(
+          '.letter_template_attach_pages',
+          service_id=current_service.id,
+          template_id=template.id
+        ),
+      "classes": "govuk-button--secondary govuk-!-margin-right-3"
+      }) }}
+    </div>
+  {% endif %}
+
   {% if template.template_type != 'broadcast' %}
     <div class="bottom-gutter-1-2">
       {{ copy_to_clipboard(template.id, name="Template ID", thing='template ID') }}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -45,7 +45,7 @@
   </div>
 
   {% if template.template_type == "letter" and page_count < 10 and show_attach_pages_button %}
-    <div class="bottom-gutter-1-2">
+    <div class="govuk-!-margin-bottom-3">
       {{ govukButton({
       "element": "a",
       "text": "Attach pages",
@@ -60,12 +60,12 @@
   {% endif %}
 
   {% if template.template_type != 'broadcast' %}
-    <div class="bottom-gutter-1-2">
+    <div class="govuk-!-margin-bottom-3">
       {{ copy_to_clipboard(template.id, name="Template ID", thing='template ID') }}
     </div>
   {% endif %}
 
-  <div class="bottom-gutter-1-2">
+  <div class="govuk-!-margin-bottom-3">
     {% if template._template.updated_at %}
       <h2 class="heading-small bottom-gutter-2-3 heading-inline">
         Last edited

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -54,7 +54,7 @@
           service_id=current_service.id,
           template_id=template.id
         ),
-      "classes": "govuk-button--secondary govuk-!-margin-right-3"
+      "classes": "govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-2"
       }) }}
     </div>
   {% endif %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -44,7 +44,7 @@
     {% include 'views/templates/_template.html' %}
   </div>
 
-  {% if template.template_type == "letter" and page_count < 10 %}
+  {% if template.template_type == "letter" and page_count < 10 and show_attach_pages_button %}
     <div class="bottom-gutter-1-2">
       {{ govukButton({
       "element": "a",

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -44,7 +44,7 @@
     {% include 'views/templates/_template.html' %}
   </div>
 
-  {% if template.template_type == "letter" and page_count < 10 and show_attach_pages_button %}
+  {% if template.template_type == "letter" and show_attach_pages_button %}
     <div class="govuk-!-margin-bottom-3">
       {{ govukButton({
       "element": "a",

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -791,6 +791,7 @@ def test_view_letter_template_has_attach_pages_button_if_template_below_10_pages
     template_page_count,
     template_type,
 ):
+    service_one["permissions"] = ["extra_letter_formatting"]
     mocker.patch("app.main.views.templates.get_page_count_for_letter", return_value=template_page_count)
     client_request.login(active_user_with_permissions)
     mocker.patch(
@@ -818,6 +819,8 @@ def test_view_letter_template_has_attach_pages_button_if_template_below_10_pages
 
 
 def test_GET_letter_template_attach_pages(client_request, service_one, fake_uuid, mocker):
+    service_one["permissions"] = ["extra_letter_formatting"]
+
     page = client_request.get(
         "main.letter_template_attach_pages",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -776,7 +776,6 @@ def test_view_letter_template_does_not_display_send_button_if_template_over_10_p
     assert page.select_one("h1", {"data-error-type": "letter-too-long"})
 
 
-@pytest.mark.parametrize("template_page_count", [6, 10])
 @pytest.mark.parametrize("template_type", ["letter", "email", "sms"])
 def test_view_letter_template_has_attach_pages_button_if_template_below_10_pages_long(
     client_request,
@@ -788,11 +787,10 @@ def test_view_letter_template_has_attach_pages_button_if_template_below_10_pages
     active_user_with_permissions,
     mocker,
     fake_uuid,
-    template_page_count,
     template_type,
 ):
     service_one["permissions"] = ["extra_letter_formatting"]
-    mocker.patch("app.main.views.templates.get_page_count_for_letter", return_value=template_page_count)
+    mocker.patch("app.main.views.templates.get_page_count_for_letter", return_value=1)
     client_request.login(active_user_with_permissions)
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -808,7 +806,7 @@ def test_view_letter_template_has_attach_pages_button_if_template_below_10_pages
 
     buttons = [b for b in page.select(".govuk-button--secondary") if normalize_spaces((b).text) == "Attach pages"]
 
-    if template_page_count < 10 and template_type == "letter":
+    if template_type == "letter":
         button = buttons[0]
         assert button.attrs["href"] == url_for(
             ".letter_template_attach_pages", service_id=SERVICE_ONE_ID, template_id=fake_uuid

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -817,6 +817,20 @@ def test_view_letter_template_has_attach_pages_button_if_template_below_10_pages
         assert len(buttons) == 0
 
 
+def test_GET_letter_template_attach_pages(client_request, service_one, fake_uuid, mocker):
+    page = client_request.get(
+        "main.letter_template_attach_pages",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+    )
+
+    assert page.select_one("h1").text.strip() == "Attach pages"
+    assert page.select_one("input.file-upload-field")
+    assert page.select_one("input.file-upload-field")["accept"] == ".pdf"
+    assert page.select("form button")
+    assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Choose file"
+
+
 def test_edit_letter_template_postage_page_displays_correctly(
     client_request,
     service_one,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -181,6 +181,7 @@ EXCLUDED_ENDPOINTS = set(
             "letter_branding",
             "letter_spec",
             "letter_template",
+            "letter_template_attach_pages",
             "link_service_to_organisation",
             "live_services_csv",
             "live_services",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -293,6 +293,7 @@
     "/services/<uuid:service_id>/templates/<template_type:template_type>/folders/<uuid:template_folder_id>",
     "/services/<uuid:service_id>/templates/<uuid:template_id>",
     "/services/<uuid:service_id>/templates/<uuid:template_id>.<filetype>",
+    "/services/<uuid:service_id>/templates/<uuid:template_id>/attach-pages",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/delete",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit-postage",


### PR DESCRIPTION
Adds an "Attach pages" button to the template page. It links to the "Attach pages" page, that contains guidance and a "Choose file" upload button. All hidden behind a feature flag.

Questions: is letter specification right for this use case? Since the attachment doesn't need to have a first page with address block.

### Button:
<img width="937" alt="Screenshot 2023-03-10 at 13 57 07" src="https://user-images.githubusercontent.com/20957548/224334956-28517056-eab0-44a6-b7b4-0a1fbad2d606.png">

### New page:
<img width="1001" alt="Screenshot 2023-03-10 at 13 30 41" src="https://user-images.githubusercontent.com/20957548/224334980-968cbf08-f57f-4140-9746-6c2e66623419.png">


Story card: https://trello.com/c/R5LHg26V/291-add-attach-pages-letter-template-page