### PR TITLE
Bump utils to 62.0.1

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1271,6 +1271,9 @@ class LetterAddressForm(StripWhitespaceForm):
         if address.has_too_many_lines:
             raise ValidationError(f"Address must be no more than {PostalAddress.MAX_LINES} lines long")
 
+        if address.has_invalid_country_for_bfpo_address:
+            raise ValidationError("The last line of a BFPO address must not be a country.")
+
         if not address.has_valid_last_line:
             if self.allow_international_letters:
                 raise ValidationError("Last line of the address must be a UK postcode or another country")

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -73,6 +73,8 @@
                   No content for this message
                 {% elif item.message_too_long %}
                   Message is too long
+                {% elif item.as_postal_address.has_invalid_country_for_bfpo_address %}
+                  The last line of a BFPO address must not be a country.
                 {% elif not item.as_postal_address.has_enough_lines %}
                   Address must be at least {{ letter_min_address_lines }} lines long
                 {% elif item.as_postal_address.has_too_many_lines %}

--- a/app/utils/letters.py
+++ b/app/utils/letters.py
@@ -149,6 +149,11 @@ LETTER_VALIDATION_MESSAGES = {
             "following characters: @ ( ) = [ ] ” \\ / , < > ~"
         ),
     },
+    "has-country-for-bfpo-address": {
+        "title": "There’s a problem with the address for this letter",
+        "detail": "The last line of a BFPO address must not be a country.",
+        "summary": "Validation failed because the last line of the BFPO address is a country.",
+    },
     "notify-tag-found-in-content": {
         "title": "There’s a problem with your letter",
         "detail": "Your file includes a letter you’ve downloaded from Notify.<br>You need to edit {invalid_pages}.",

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.0.1
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,7 +124,7 @@ newrelic==8.5.0
     # via -r requirements.in
 notifications-python-client==6.4.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@61.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.0.1
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -655,6 +655,48 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
     ]
 
 
+def test_upload_csv_file_with_bad_bfpo_postal_address_shows_check_page_with_errors(
+    client_request,
+    service_one,
+    mocker,
+    mock_get_service_letter_template,
+    mock_s3_set_metadata,
+    mock_s3_get_metadata,
+    mock_s3_upload,
+    mock_get_users_by_service,
+    mock_get_service_statistics,
+    mock_get_job_doesnt_exist,
+    mock_get_jobs,
+    fake_uuid,
+):
+    service_one["permissions"] += ["letter", "international_letters"]
+    mocker.patch("app.main.views.send.get_page_count_for_letter", return_value=9)
+    mocker.patch(
+        "app.main.views.send.s3download",
+        return_value="""
+            address line 1,address line 2,address line 3,address line 4,
+            Firstname Lastname, BFPO1234, BF1 1AA, USA
+        """,
+    )
+
+    page = client_request.post(
+        "main.send_messages",
+        service_id=service_one["id"],
+        template_id=fake_uuid,
+        _data={"file": (BytesIO("".encode("utf-8")), "example.csv")},
+        _content_type="multipart/form-data",
+        _follow_redirects=True,
+    )
+
+    assert normalize_spaces(page.select_one(".banner-dangerous").text) == (
+        "There’s a problem with example.csv You need to fix 1 address."
+    )
+    assert [normalize_spaces(row.text) for row in page.select("tbody tr")] == [
+        "2 The last line of a BFPO address must not be a country.",
+        "Firstname Lastname BFPO1234 BF1 1AA USA",
+    ]
+
+
 def test_upload_csv_file_with_international_letters_permission_shows_appropriate_errors(
     client_request,
     service_one,
@@ -2315,6 +2357,11 @@ def test_send_one_off_letter_address_populates_address_fields_in_session(
             "a\n(b\nSW1A 1AA",
             [],
             "Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < > ~",
+        ),
+        (
+            "a\nb\nBFPO 1234\nBFPO\nBF1 1AA\nUSA",
+            [],
+            "The last line of a BFPO address must not be a country.",
         ),
     ],
 )


### PR DESCRIPTION
This pulls in a new `normalised_lines` format for BFPO addresses. We now put the BFPO number on the last line, after the postcode (if present).

This is more in line with the format for BFPO addresses as recommended on GOV.UK, so should be preferrable for our print provider/Royal Mail.

---

See also https://github.com/alphagov/notifications-utils/pull/1022