### PR TITLE
Store whole address in recipient field for one off letters

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1080,4 +1080,6 @@ def get_recipient():
     if {"recipient", "placeholders"} - set(session.keys()):
         return None
 
-    return session["recipient"] or InsensitiveDict(session["placeholders"]).get("address line 1")
+    return (
+        session["recipient"] or PostalAddress.from_personalisation(InsensitiveDict(session["placeholders"])).normalised
+    )

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3728,10 +3728,20 @@ def test_send_notification_submits_data(
 
 
 @pytest.mark.parametrize(
-    "placeholders",
+    "placeholders, expected_recipient",
     (
-        {"address line 1": "Foo"},
-        {"ADDRESSLINE_1": "Foo"},
+        (
+            {"address line 1": "Foo"},
+            "Foo",
+        ),
+        (
+            {
+                "ADDRESSLINE_1": "Foo",
+                "address_line_2": "Bar",
+                "address line 6": "Baz",
+            },
+            "Foo\nBar\nBaz",
+        ),
     ),
 )
 def test_send_notification_submits_data_for_letter(
@@ -3740,13 +3750,14 @@ def test_send_notification_submits_data_for_letter(
     mock_send_notification,
     mock_get_service_letter_template,
     placeholders,
+    expected_recipient,
 ):
     with client_request.session_transaction() as session:
         session["recipient"] = None
         session["placeholders"] = placeholders
 
     client_request.post("main.send_notification", service_id=SERVICE_ONE_ID, template_id=fake_uuid)
-    assert mock_send_notification.call_args[1]["recipient"] == "Foo"
+    assert mock_send_notification.call_args[1]["recipient"] == expected_recipient
 
 
 def test_send_notification_clears_session(


### PR DESCRIPTION
We introduced sending one-off, templates letters from the admin app in https://github.com/alphagov/notifications-admin/pull/2434

Because all notifications require something in the `to` field, we chose the first line of the address:
https://github.com/alphagov/notifications-admin/commit/3a62946ecd2ab2982d479481f96bf1df487442f8#diff-7365e34b1112e69a28e0c0ff051358e5bb02b41796dc9fadf259f7cff070cc0cR909

At the time this is how other templates letters (sent via API or spreadsheet upload) worked.

Since then we have changed to instead store the whole address, including line breaks in the `to` field. Additionally the API populates, the `normalised_to` field with a lowercase, no whitespace translation which which we use to search by recipient. This happened in https://github.com/alphagov/notifications-api/pull/2814

However when we made this change we missed out on applying it to one-off templated letters, which are a bit different because the admin app passes the address to the API, rather than the API getting it from a client or from the spreadsheet.

This commit updates the admin app to pass in the whole address – not just the first line –  meaning that one-off templated letters will be searchable like any other.

The API will receive this data here:
https://github.com/alphagov/notifications-api/blob/0a407733173b35ebc6a76fcf0870c57fefafa686/app/service/send_notification.py#L95

And create the normalised equivalent here:
https://github.com/alphagov/notifications-api/blob/0a407733173b35ebc6a76fcf0870c57fefafa686/app/notifications/process_notifications.py#L146