### PR TITLE
Remove date stamp from main Pricing page

### DIFF
--- a/app/templates/views/guidance/pricing/index.html
+++ b/app/templates/views/guidance/pricing/index.html
@@ -13,12 +13,6 @@
 
   <h1 class="heading-large">Pricing</h1>
 
-    {{ content_metadata(
-      data={
-        "Last updated": "24 January 2023"
-      }
-    ) }}
-
   <p class="govuk-body">It’s free to send emails through GOV.UK Notify. There’s also no monthly charge, no setup fee and no procurement cost.</p>
   <p class="govuk-body">You will only have to pay if you:</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/app/templates/views/guidance/pricing/index.html
+++ b/app/templates/views/guidance/pricing/index.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/content-metadata.html" import content_metadata %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Pricing information' %}
 


### PR DESCRIPTION
It doesn’t really make sense to include the ‘Last updated’ date on the [main pricing page](https://www.notifications.service.gov.uk/pricing), because it doesn’t include any actual prices.

The content metadata for this page is already out of sync with the [text message pricing page](https://www.notifications.service.gov.uk/pricing/text-messages).

Over time this gap will increase and be potentially confusing for users.