### PR TITLE
Make the default email-as-a-password behaviour clearer

### DIFF
--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -23,7 +23,7 @@
   </ul>
 
   <h2 class="heading-medium">Protect personal information about your users</h2>
-  <p class="govuk-body">When a recipient clicks the link in the email you’ve sent them, they have to enter their email address before they can download the file. This security feature is optional.</p>
+  <p class="govuk-body">When the recipient clicks the link in the email, they will be asked to enter their email address. Only someone who knows the recipient’s email address can download the file. This security feature is optional.</p>
   <p class="govuk-body">You can also choose the length of time that a file is available to download.</p>
 
   <h2 class="heading-medium">How to send files by email</h2>

--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -23,7 +23,7 @@
   </ul>
 
   <h2 class="heading-medium">Protect personal information about your users</h2>
-  <p class="govuk-body">When the recipient clicks the link in the email, they will be asked to enter their email address. Only someone who knows the recipient’s email address can download the file. This security feature is optional.</p>
+  <p class="govuk-body">When the recipient clicks the link in the email, they will need to enter their email address. Only someone who knows the recipient’s email address can download the file. This security feature is optional.</p>
   <p class="govuk-body">You can also choose the length of time that a file is available to download.</p>
 
   <h2 class="heading-medium">How to send files by email</h2>

--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -23,7 +23,7 @@
   </ul>
 
   <h2 class="heading-medium">Protect personal information about your users</h2>
-  <p class="govuk-body">When a recipient clicks the link in the email you’ve sent them, you can ask them to enter their email address. Only someone who knows the recipient’s email address can download the file.</p>
+  <p class="govuk-body">When a recipient clicks the link in the email you’ve sent them, they have to enter their email address before they can download the file. This security feature is optional.</p>
   <p class="govuk-body">You can also choose the length of time that a file is available to download.</p>
 
   <h2 class="heading-medium">How to send files by email</h2>


### PR DESCRIPTION
The PR updates the content to make the default behaviour for email-as-a-password clearer.