### PR TITLE
Catch expired session POST CSRF error

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ import pathlib
 from time import monotonic
 
 import jinja2
+import werkzeug
 from flask import (
     current_app,
     flash,
@@ -462,7 +463,10 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
         if "user_id" not in session:
             application.logger.warning("csrf.session_expired: Redirecting user to log in page")
 
-            return application.login_manager.unauthorized()
+            try:
+                return application.login_manager.unauthorized()
+            except werkzeug.exceptions.Unauthorized as e:
+                return handle_no_permissions(e)
 
         application.logger.warning(
             "csrf.invalid_token: Aborting request, user_id: {user_id}", extra={"user_id": session["user_id"]}

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -3,6 +3,8 @@ from flask import Response, url_for
 from flask_wtf.csrf import CSRFError
 from notifications_python_client.errors import HTTPError
 
+from tests.conftest import set_config_values
+
 
 def test_bad_url_returns_page_not_found(client_request):
     page = client_request.get_url(
@@ -61,6 +63,21 @@ def test_csrf_redirects_to_sign_in_page_if_not_signed_in(client_request, mocker)
         "/cookies",
         _expected_redirect=url_for("main.sign_in", next="/cookies"),
     )
+
+
+def test_no_session_for_json_endpoint_returns_401(
+    notify_admin,
+    client_request,
+    service_one,
+):
+    with set_config_values(notify_admin, dict(WTF_CSRF_ENABLED=True)):
+        client_request.logout()
+        client_request.post_response(
+            "json_updates.get_notifications_page_partials_as_json",
+            service_id=service_one["id"],
+            message_type="email",
+            _expected_status=401,
+        )
 
 
 def test_405_returns_something_went_wrong_page(client_request, mocker):


### PR DESCRIPTION
Some of our .json endpoints get POSTed to, which triggers CSRF checks. If a user's session has expireed, they have no CSRF token in their session, triggering the CSRFError handler `handle_csrf`. This hands off to `application.login_manager.unauthorized()`, which - for JSON endpoints - will abort with HTTPStatus.UNAUTHORIZED. The internals of this raise a (Werkzeug) error, expected to be picked up by an errorhandler. However, we're already inside an errohandler, so it instead causes a 500.

Let's catch the werkzeug error that can be thrown by the login manager and manually redirect to the no_permissions (401) handler.