### PR TITLE
Make the ‘Platform admin settings’ heading bigger

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -310,9 +310,9 @@
 
     {% if current_user.platform_admin %}
 
-      <div class="settings-table body-copy-table top-gutter-4-3">
+      <div class="settings-table body-copy-table">
 
-        <h2 class="heading-medium">Platform admin settings</h2>
+        <h2 class="govuk-heading-l govuk-!-margin-bottom-4 govuk-!-margin-top-8">Platform admin settings</h2>
 
         {% call mapping_table(
           caption='Settings',


### PR DESCRIPTION
This helps differentiate it from the regular, user-facing, settings.

Uses the newer GOV.UK Frontend class names, with some overrides to keep the spacing tighter below and looser above.

Before | After
---|---
<img width="771" alt="image" src="https://user-images.githubusercontent.com/355079/229569820-7b0e74d0-05b6-4323-a219-13ec8f7d3cff.png"> | <img width="769" alt="image" src="https://user-images.githubusercontent.com/355079/229569718-6fa4ed55-0912-49d4-bec3-1504da17a5ab.png">
