### PR TITLE
Remove `Service.volumes`

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -397,7 +397,7 @@ class Service(JSONModel):
 
     @property
     def volumes_by_channel(self):
-        return ((channel, getattr(self, f"volume_{channel}")) for channel in ("email", "sms", "letter"))
+        return {channel: getattr(self, f"volume_{channel}") for channel in ("email", "sms", "letter")}
 
     @property
     def go_live_checklist_completed(self):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -383,19 +383,6 @@ class Service(JSONModel):
         return service_api_client.get_letter_contact(self.id, id)
 
     @property
-    def volumes(self):
-        return sum(
-            filter(
-                None,
-                (
-                    self.volume_email,
-                    self.volume_sms,
-                    self.volume_letter,
-                ),
-            )
-        )
-
-    @property
     def volumes_by_channel(self):
         return {channel: getattr(self, f"volume_{channel}") for channel in ("email", "sms", "letter")}
 
@@ -403,7 +390,7 @@ class Service(JSONModel):
     def go_live_checklist_completed(self):
         return all(
             (
-                bool(self.volumes),
+                any(self.volumes_by_channel.values()),
                 self.has_team_members,
                 self.has_templates,
                 not self.needs_to_add_email_reply_to_address,

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -243,13 +243,7 @@ class Service(JSONModel):
 
     @property
     def has_estimated_usage(self):
-        return self.consent_to_research is not None and any(
-            (
-                self.volume_email,
-                self.volume_sms,
-                self.volume_letter,
-            )
-        )
+        return self.consent_to_research is not None and any(self.volumes_by_channel.values())
 
     def has_templates_of_type(self, template_type):
         return any(template for template in self.all_templates if template["template_type"] == template_type)

--- a/app/templates/views/make-service-live.html
+++ b/app/templates/views/make-service-live.html
@@ -24,7 +24,7 @@
         They estimate this service will send:
       </p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-        {% for channel, volumes in current_service.volumes_by_channel %}
+        {% for channel, volumes in current_service.volumes_by_channel.items() %}
           <li>
             {% if volumes %}
               {{ volumes|message_count(channel) }} per year


### PR DESCRIPTION
It’s only used in one place, and by refactoring so that we can access `Service.volumes_by_channel.values()` it’s non-complex enough that we can just inline it rather than make it a separate property.