### PR TITLE
Target even pages with class, not nth-of-type

### DIFF
--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -38,7 +38,7 @@ $iso-paper-ratio: 141.42135624%;
     box-shadow: inset 0 0 0 1px $govuk-border-colour;
   }
 
-  &:nth-of-type(even) {
+  &.page--even {
     margin-top: -1 * (govuk-spacing(6) + 1px);
   }
 

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.2.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ newrelic==8.5.0
     # via -r requirements.in
 notifications-python-client==6.4.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.2.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
[This pull request on
admin](https://github.com/alphagov/notifications-admin/pull/4648) introduced a visual bug due to its use of
`nth-of-type` assuming `.letter:nth-of-type(even)` would affect even-numbered elements matching this
selector: `div.letter`.

It actually matches even-numbered `div` elements,
filtered by whether they have the `letter` class
or not.

You will be able to match even-numbered pages in
CSS in future (see
https://css-tricks.com/css-nth-of-class-selector/) but until then I've added a class to all pages to
indicate if they are odd or even:

https://github.com/alphagov/notifications-utils/pull/1025

This uses the `page--even` class to fix the bug.