### PR TITLE
Move the ‘get ready to send’ button for letter templates

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -49,6 +49,12 @@
   left: 51px; // Aligns to left of logo area
 }
 
+.edit-template-link-get-ready-to-send {
+  @extend %edit-template-link;
+  top: 232px; // covers MDI barcode and aligns to bottom of contact block
+  left: 51px; // Aligns to left of logo area
+}
+
 .template-content-count {
   @include govuk-font(19, $tabular: true);
   color: $govuk-secondary-text-colour;

--- a/app/templates/views/templates/_letter_template.html
+++ b/app/templates/views/templates/_letter_template.html
@@ -11,7 +11,7 @@
 <div class="template-container {% if current_service.has_permission("extra_letter_formatting") %}template-container--with-attach-pages-button{% endif %}">
   {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not letter_too_long %}
     <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item edit-template-link-get-ready-to-send">
-      Get ready to send<span class="govuk-visually-hidden"> a message using this template</span>
+      Get ready to send<span class="govuk-visually-hidden"> a letter using this template</span>
     </a>
   {% endif %}
   {% if current_user.has_permissions('manage_templates') %}

--- a/app/templates/views/templates/_letter_template.html
+++ b/app/templates/views/templates/_letter_template.html
@@ -17,6 +17,11 @@
 {% endif %}
 
 <div class="template-container {% if current_service.has_permission("extra_letter_formatting") %}template-container--with-attach-pages-button{% endif %}">
+  {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not letter_too_long %}
+    <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
+      Get ready to send<span class="govuk-visually-hidden"> a message using this template</span>
+    </a>
+  {% endif %}
   {% if current_user.has_permissions('manage_templates') %}
     {% if not current_service.letter_branding_id %}
       <a href="{{ url_for(".letter_branding_options", service_id=current_service.id, from_template=template.id) }}" class="govuk-link govuk-link--inverse edit-template-link-letter-branding">Add logo</a>

--- a/app/templates/views/templates/_letter_template.html
+++ b/app/templates/views/templates/_letter_template.html
@@ -6,19 +6,11 @@
         {% include "partials/check/letter-too-long.html" %}
     {% endcall %}
   </div>
-{% elif current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
-      <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
-        Get ready to send<span class="govuk-visually-hidden"> a message using this template</span>
-      </a>
-    </div>
-  </div>
 {% endif %}
 
 <div class="template-container {% if current_service.has_permission("extra_letter_formatting") %}template-container--with-attach-pages-button{% endif %}">
   {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not letter_too_long %}
-    <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
+    <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item edit-template-link-get-ready-to-send">
       Get ready to send<span class="govuk-visually-hidden"> a message using this template</span>
     </a>
   {% endif %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1176,6 +1176,68 @@ def test_should_be_able_to_view_a_template_with_links(
     assert normalize_spaces(page.select_one("main p").text) == (permissions_warning_to_be_shown or "To: phone number")
 
 
+def test_should_be_able_to_view_a_letter_template_with_links(
+    mocker,
+    client_request,
+    mock_get_service_letter_template,
+    mock_get_template_folders,
+    active_user_with_permissions,
+    single_letter_contact_block,
+    fake_uuid,
+):
+    mocker.patch("app.main.views.templates.get_page_count_for_letter", return_value=1)
+
+    page = client_request.get(
+        "main.view_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+
+    assert [(link["href"], normalize_spaces(link.text)) for link in page.select("a[class*=edit-template-link]")] == [
+        (
+            url_for(
+                "main.set_sender",
+                service_id=SERVICE_ONE_ID,
+                template_id=fake_uuid,
+            ),
+            "Get ready to send a letter using this template",
+        ),
+        (
+            url_for(
+                "main.letter_branding_options",
+                service_id=SERVICE_ONE_ID,
+                from_template=fake_uuid,
+            ),
+            "Add logo",
+        ),
+        (
+            url_for(
+                "main.edit_template_postage",
+                service_id=SERVICE_ONE_ID,
+                template_id=fake_uuid,
+            ),
+            "Change postage",
+        ),
+        (
+            url_for(
+                "main.edit_service_template",
+                service_id=SERVICE_ONE_ID,
+                template_id=fake_uuid,
+            ),
+            "Edit letter template",
+        ),
+        (
+            url_for(
+                "main.set_template_sender",
+                service_id=SERVICE_ONE_ID,
+                template_id=fake_uuid,
+            ),
+            "Edit letter contact block",
+        ),
+    ]
+
+
 def test_view_broadcast_template(
     client_request,
     service_one,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -694,9 +694,9 @@ def test_letter_with_default_branding_has_add_logo_button(
         _test_page_title=False,
     )
 
-    first_edit_link = page.select_one(".template-container a")
-    assert first_edit_link["href"] == expected_link(service_id=SERVICE_ONE_ID)
-    assert first_edit_link.text == expected_link_text
+    edit_links = page.select(".template-container a")
+    assert edit_links[1]["href"] == expected_link(service_id=SERVICE_ONE_ID)
+    assert edit_links[1].text == expected_link_text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Before | After
---|---
<img width="811" alt="image" src="https://user-images.githubusercontent.com/355079/233119830-a93bebc9-663f-4e95-be96-1dcf53d3f0c0.png"> | <img width="811" alt="image" src="https://user-images.githubusercontent.com/355079/233119637-d0cfda48-6a92-4c16-a1b2-f5f3c6be54bc.png">

In user research we found that this didn’t make it any harder to find.

It has the advantage of:
- being consistent with the position of other buttons on the page which are next to the thing they modify
- being consistent with the appearance of other buttons on the page which are only as wide as the text they contain
- taking up less space, something we’ve lost by adding the sticky ‘Attach pages’ button