### PR TITLE
Validate total template length after letter attachment 

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -13,7 +13,6 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
-from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils import LETTER_MAX_PAGE_COUNT, SMS_CHAR_COUNT_LIMIT
 from notifications_utils.pdf import is_letter_too_long, pdf_page_count
@@ -996,11 +995,9 @@ def letter_template_attach_pages(service_id, template_id):
             )
 
         form.file.errors.append(
-            Markup(
-                get_letter_validation_error("letter-too-long", page_count=template_page_count + attachment_page_count)[
-                    "detail"
-                ]
-            )
+            "Letters must be 10 pages or less (5 double-sided sheets of paper). "
+            "In total, your letter template and the file you attached are "
+            f"{template_page_count + attachment_page_count} pages long."
         )
 
     if form.file.errors:

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -13,6 +13,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils import LETTER_MAX_PAGE_COUNT, SMS_CHAR_COUNT_LIMIT
 from notifications_utils.pdf import is_letter_too_long, pdf_page_count
@@ -916,7 +917,7 @@ def get_template_sender_form_dict(service_id, template):
 @user_has_permissions("manage_templates")
 @service_has_permission("extra_letter_formatting")
 def letter_template_attach_pages(service_id, template_id):
-    _ = current_service.get_template(template_id)
+    template = current_service.get_template(template_id)
     form = PDFUploadForm()
     error = {}
 
@@ -936,7 +937,7 @@ def letter_template_attach_pages(service_id, template_id):
         try:
             # TODO: get page count from the sanitise response once template preview
             # handles malformed files nicely - is this done yet?
-            page_count = pdf_page_count(BytesIO(pdf_file_bytes))
+            attachment_page_count = pdf_page_count(BytesIO(pdf_file_bytes))
         except PdfReadError:
             current_app.logger.info("Invalid PDF uploaded for service_id: {}".format(service_id))
             return _invalid_upload_error(
@@ -968,31 +969,37 @@ def letter_template_attach_pages(service_id, template_id):
                     pdf_file_bytes,
                     file_location=file_location,
                     status=status,
-                    page_count=page_count,
+                    page_count=attachment_page_count,
                     filename=original_filename,
                     message=validation_failed_message,
                     invalid_pages=invalid_pages,
                 )
                 return _invalid_upload_error(
                     template_id=template_id,
-                    error=get_letter_validation_error(validation_failed_message, invalid_pages, page_count),
+                    error=get_letter_validation_error(validation_failed_message, invalid_pages, attachment_page_count),
                 )
 
             raise
 
         # TODO in next PR: upload letter to S3
-        pages_content = "1 page" if page_count == 1 else f"{page_count} pages"
+        template_page_count = get_page_count_for_letter(template)
+        if attachment_page_count + template_page_count <= 10:
+            pages_content = "1 page" if attachment_page_count == 1 else f"{attachment_page_count} pages"
+            flash(f"You have attached {pages_content} to the end of your letter", "default_with_tick")
 
-        flash(
-            f"You have attached {pages_content} to the end of your letter",
-            "default_with_tick",
-        )
+            return redirect(
+                url_for(
+                    "main.view_template",
+                    service_id=current_service.id,
+                    template_id=template_id,
+                )
+            )
 
-        return redirect(
-            url_for(
-                "main.view_template",
-                service_id=current_service.id,
-                template_id=template_id,
+        form.file.errors.append(
+            Markup(
+                get_letter_validation_error("letter-too-long", page_count=template_page_count + attachment_page_count)[
+                    "detail"
+                ]
             )
         )
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -916,6 +916,7 @@ def get_template_sender_form_dict(service_id, template):
 @user_has_permissions("manage_templates")
 @service_has_permission("extra_letter_formatting")
 def letter_template_attach_pages(service_id, template_id):
+    _ = current_service.get_template(template_id)
     form = PDFUploadForm()
     error = {}
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -977,25 +977,24 @@ def letter_template_attach_pages(service_id, template_id):
                     template_id=template_id,
                     error=get_letter_validation_error(validation_failed_message, invalid_pages, page_count),
                 )
-            else:
-                raise ex
-        else:
 
-            # TODO in next PR: upload letter to S3
-            pages_content = "1 page" if page_count == 1 else f"{page_count} pages"
+            raise
 
-            flash(
-                f"You have attached {pages_content} to the end of your letter",
-                "default_with_tick",
+        # TODO in next PR: upload letter to S3
+        pages_content = "1 page" if page_count == 1 else f"{page_count} pages"
+
+        flash(
+            f"You have attached {pages_content} to the end of your letter",
+            "default_with_tick",
+        )
+
+        return redirect(
+            url_for(
+                "main.view_template",
+                service_id=current_service.id,
+                template_id=template_id,
             )
-
-            return redirect(
-                url_for(
-                    "main.view_template",
-                    service_id=current_service.id,
-                    template_id=template_id,
-                )
-            )
+        )
 
     if form.file.errors:
         error = get_error_from_upload_form(form.file.errors[0])

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -912,7 +912,8 @@ def test_post_attach_pages_errors_when_base_template_plus_attachment_too_long(
         )
 
     assert page.select_one(".banner-dangerous h1").text == (
-        "Letters must be 10 pages or less (5 double-sided sheets of paper). Your letter is 19 pages long."
+        "Letters must be 10 pages or less (5 double-sided sheets of paper). "
+        "In total, your letter template and the file you attached are 19 pages long."
     )
     assert page.select_one("form").attrs["action"] == url_for(
         "main.letter_template_attach_pages", service_id=SERVICE_ONE_ID, template_id=sample_uuid()

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -891,6 +891,35 @@ def test_post_attach_pages_errors_when_content_outside_printable_area(
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 
 
+def test_post_attach_pages_errors_when_base_template_plus_attachment_too_long(
+    mocker, client_request, fake_uuid, service_one, mock_get_template_version
+):
+    service_one["permissions"] = ["extra_letter_formatting"]
+    mocker.patch("uuid.uuid4", return_value=fake_uuid)
+    mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
+    mocker.patch("app.main.views.templates.upload_letter_to_s3")
+
+    mocker.patch("app.main.views.templates.sanitise_letter")
+    mocker.patch("app.main.views.templates.get_page_count_for_letter", return_value=9)
+
+    with open("tests/test_pdf_files/multi_page_pdf.pdf", "rb") as file:
+        page = client_request.post(
+            "main.letter_template_attach_pages",
+            service_id=SERVICE_ONE_ID,
+            template_id=sample_uuid(),
+            _data={"file": file},
+            _expected_status=400,
+        )
+
+    assert page.select_one(".banner-dangerous h1").text == (
+        "Letters must be 10 pages or less (5 double-sided sheets of paper). Your letter is 19 pages long."
+    )
+    assert page.select_one("form").attrs["action"] == url_for(
+        "main.letter_template_attach_pages", service_id=SERVICE_ONE_ID, template_id=sample_uuid()
+    )
+    assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
+
+
 @pytest.mark.parametrize("page_count, expected_pages_content", [(1, "1 page"), (2, "2 pages")])
 def test_post_attach_pages_redirects_to_template_view_when_validation_successful(
     mocker,

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -236,7 +236,9 @@ def test_upload_international_letter_shows_preview_with_no_choice_of_postage(
         ("main.letter_template_attach_pages", {"service_id": SERVICE_ONE_ID, "template_id": sample_uuid()}),
     ],
 )
-def test_uploading_a_pdf_shows_error_when_file_is_not_a_pdf(client_request, service_one, mocker, endpoint, kwargs):
+def test_uploading_a_pdf_shows_error_when_file_is_not_a_pdf(
+    client_request, service_one, mocker, endpoint, kwargs, mock_get_template_version
+):
     service_one["permissions"] = ["extra_letter_formatting"]
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
@@ -254,7 +256,9 @@ def test_uploading_a_pdf_shows_error_when_file_is_not_a_pdf(client_request, serv
         ("main.letter_template_attach_pages", {"service_id": SERVICE_ONE_ID, "template_id": sample_uuid()}),
     ],
 )
-def test_uploading_a_pdf_shows_error_when_no_file_uploaded(client_request, service_one, endpoint, kwargs):
+def test_uploading_a_pdf_shows_error_when_no_file_uploaded(
+    client_request, service_one, endpoint, kwargs, mock_get_template_version
+):
     service_one["permissions"] = ["extra_letter_formatting"]
 
     page = client_request.post(endpoint, **kwargs, _data={"file": ""}, _expected_status=400)
@@ -269,7 +273,9 @@ def test_uploading_a_pdf_shows_error_when_no_file_uploaded(client_request, servi
         ("main.letter_template_attach_pages", {"service_id": SERVICE_ONE_ID, "template_id": sample_uuid()}),
     ],
 )
-def test_uploading_a_pdf_shows_error_when_file_contains_virus(mocker, client_request, service_one, endpoint, kwargs):
+def test_uploading_a_pdf_shows_error_when_file_contains_virus(
+    mocker, client_request, service_one, endpoint, kwargs, mock_get_template_version
+):
     service_one["permissions"] = ["extra_letter_formatting"]
     mocker.patch("app.extensions.antivirus_client.scan", return_value=False)
     mock_s3_backup = mocker.patch("app.main.views.uploads.backup_original_letter_to_s3")
@@ -288,7 +294,9 @@ def test_uploading_a_pdf_shows_error_when_file_contains_virus(mocker, client_req
         ("main.letter_template_attach_pages", {"service_id": SERVICE_ONE_ID, "template_id": sample_uuid()}),
     ],
 )
-def test_uploading_a_pdf_errors_when_file_is_too_big(mocker, client_request, service_one, endpoint, kwargs):
+def test_uploading_a_pdf_errors_when_file_is_too_big(
+    mocker, client_request, service_one, endpoint, kwargs, mock_get_template_version
+):
     service_one["permissions"] = ["extra_letter_formatting"]
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
@@ -306,7 +314,9 @@ def test_uploading_a_pdf_errors_when_file_is_too_big(mocker, client_request, ser
         ("main.letter_template_attach_pages", {"service_id": SERVICE_ONE_ID, "template_id": sample_uuid()}),
     ],
 )
-def test_post_choose_upload_file_when_file_is_malformed(mocker, client_request, service_one, endpoint, kwargs):
+def test_post_choose_upload_file_when_file_is_malformed(
+    mocker, client_request, service_one, endpoint, kwargs, mock_get_template_version
+):
     service_one["permissions"] = ["extra_letter_formatting"]
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 


### PR DESCRIPTION
## Commits 1+2
Minor refactors

## Commit 3 
Our print provider can only normally handle letters of 10 or fewer
pages, so let's try to validate that when an attachment is added to a
base template they remain within that limit.

## Show it
<img width="967" alt="image" src="https://user-images.githubusercontent.com/2920760/233355198-01d50fd7-cdd2-40a2-8c26-5ad40b8dc7f8.png">

Ignoring the display format of the error for now as there is a separate ticket about changing this to use an error summary.

Ticket: https://trello.com/c/gjq7kVcv/293-validate-that-letter-template-attachment-10-pages