### PR TITLE
Allow different fields on a template to be updated independently

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -630,10 +630,10 @@ def edit_service_template(service_id, template_id):
         try:
             service_api_client.update_service_template(
                 template_id,
-                form.name.data,
-                form.template_content.data,
-                service_id,
-                subject,
+                service_id=service_id,
+                name=form.name.data,
+                content=form.template_content.data,
+                subject=subject,
             )
         except HTTPError as e:
             if e.status_code == 400:

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -631,7 +631,6 @@ def edit_service_template(service_id, template_id):
             service_api_client.update_service_template(
                 template_id,
                 form.name.data,
-                template["template_type"],
                 form.template_content.data,
                 service_id,
                 subject,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -629,8 +629,8 @@ def edit_service_template(service_id, template_id):
             )
         try:
             service_api_client.update_service_template(
-                template_id,
                 service_id=service_id,
+                template_id=template_id,
                 name=form.name.data,
                 content=form.template_content.data,
                 subject=subject,

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -184,7 +184,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
     @cache.delete("service-{service_id}-templates")
     @cache.delete_by_pattern("service-{service_id}-template-*")
-    def update_service_template(self, id_, name, content, service_id, subject=None):
+    def update_service_template(self, id_, *, name, content, service_id, subject=None):
         """
         Update a service template.
         """

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -184,11 +184,15 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
     @cache.delete("service-{service_id}-templates")
     @cache.delete_by_pattern("service-{service_id}-template-*")
-    def update_service_template(self, id_, *, name, content, service_id, subject=None):
+    def update_service_template(self, id_, *, service_id, name=None, content=None, subject=None):
         """
         Update a service template.
         """
-        data = {"name": name, "content": content}
+        data = {}
+        if content:
+            data["content"] = content
+        if name:
+            data["name"] = name
         if subject:
             data["subject"] = subject
         data = _attach_current_user(data)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -184,11 +184,11 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
     @cache.delete("service-{service_id}-templates")
     @cache.delete_by_pattern("service-{service_id}-template-*")
-    def update_service_template(self, id_, name, type_, content, service_id, subject=None):
+    def update_service_template(self, id_, name, content, service_id, subject=None):
         """
         Update a service template.
         """
-        data = {"id": id_, "name": name, "template_type": type_, "content": content, "service": service_id}
+        data = {"name": name, "content": content}
         if subject:
             data.update({"subject": subject})
         data = _attach_current_user(data)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -184,7 +184,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
     @cache.delete("service-{service_id}-templates")
     @cache.delete_by_pattern("service-{service_id}-template-*")
-    def update_service_template(self, id_, *, service_id, name=None, content=None, subject=None):
+    def update_service_template(self, *, service_id, template_id, name=None, content=None, subject=None):
         """
         Update a service template.
         """
@@ -196,7 +196,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         if subject:
             data["subject"] = subject
         data = _attach_current_user(data)
-        endpoint = f"/service/{service_id}/template/{id_}"
+        endpoint = f"/service/{service_id}/template/{template_id}"
         return self.post(endpoint, data)
 
     @cache.delete("service-{service_id}-templates")

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -190,7 +190,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         data = {"name": name, "content": content}
         if subject:
-            data.update({"subject": subject})
+            data["subject"] = subject
         data = _attach_current_user(data)
         endpoint = f"/service/{service_id}/template/{id_}"
         return self.post(endpoint, data)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -41,10 +41,10 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         Retrieve a service.
         """
-        return self.get("/service/{0}".format(service_id))
+        return self.get(f"/service/{service_id}")
 
     def get_service_statistics(self, service_id, limit_days=None):
-        return self.get("/service/{0}/statistics".format(service_id), params={"limit_days": limit_days})["data"]
+        return self.get(f"/service/{service_id}/statistics", params={"limit_days": limit_days})["data"]
 
     def get_services(self, params_dict=None):
         """
@@ -108,10 +108,10 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "volume_letter",
             "volume_sms",
         }
-        if disallowed_attributes:
-            raise TypeError("Not allowed to update service attributes: {}".format(", ".join(disallowed_attributes)))
+        if disallowed_attributes := ", ".join(disallowed_attributes):
+            raise TypeError(f"Not allowed to update service attributes: {disallowed_attributes}")
 
-        endpoint = "/service/{0}".format(service_id)
+        endpoint = f"/service/{service_id}"
         return self.post(endpoint, data)
 
     @cache.delete("live-service-and-organisation-counts")
@@ -150,7 +150,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def archive_service(self, service_id, cached_service_user_ids):
         if cached_service_user_ids:
             redis_client.delete(*map("user-{}".format, cached_service_user_ids))
-        return self.post("/service/{}/archive".format(service_id), data=None)
+        return self.post(f"/service/{service_id}/archive", data=None)
 
     @cache.delete("service-{service_id}")
     @cache.delete("user-{user_id}")
@@ -158,7 +158,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         Remove a user from a service
         """
-        endpoint = "/service/{service_id}/users/{user_id}".format(service_id=service_id, user_id=user_id)
+        endpoint = f"/service/{service_id}/users/{user_id}"
         data = _attach_current_user({})
         return self.delete(endpoint, data)
 
@@ -179,7 +179,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         if parent_folder_id:
             data.update({"parent_folder_id": parent_folder_id})
         data = _attach_current_user(data)
-        endpoint = "/service/{0}/template".format(service_id)
+        endpoint = f"/service/{service_id}/template"
         return self.post(endpoint, data)
 
     @cache.delete("service-{service_id}-templates")
@@ -192,14 +192,14 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         if subject:
             data.update({"subject": subject})
         data = _attach_current_user(data)
-        endpoint = "/service/{0}/template/{1}".format(service_id, id_)
+        endpoint = f"/service/{service_id}/template/{id_}"
         return self.post(endpoint, data)
 
     @cache.delete("service-{service_id}-templates")
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def redact_service_template(self, service_id, id_):
         return self.post(
-            "/service/{}/template/{}".format(service_id, id_),
+            f"/service/{service_id}/template/{id_}",
             _attach_current_user({"redact_personalisation": True}),
         )
 
@@ -210,23 +210,21 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "reply_to": reply_to,
         }
         data = _attach_current_user(data)
-        return self.post("/service/{0}/template/{1}".format(service_id, template_id), data)
+        return self.post(f"/service/{service_id}/template/{template_id}", data)
 
     @cache.delete("service-{service_id}-templates")
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def update_service_template_postage(self, service_id, template_id, postage):
-        return self.post(
-            "/service/{0}/template/{1}".format(service_id, template_id), _attach_current_user({"postage": postage})
-        )
+        return self.post(f"/service/{service_id}/template/{template_id}", _attach_current_user({"postage": postage}))
 
     @cache.set("service-{service_id}-template-{template_id}-version-{version}")
     def get_service_template(self, service_id, template_id, version=None):
         """
         Retrieve a service template.
         """
-        endpoint = "/service/{service_id}/template/{template_id}".format(service_id=service_id, template_id=template_id)
+        endpoint = f"/service/{service_id}/template/{template_id}"
         if version:
-            endpoint = "{base}/version/{version}".format(base=endpoint, version=version)
+            endpoint = f"{endpoint}/version/{version}"
         return self.get(endpoint)
 
     @cache.set("service-{service_id}-template-{template_id}-versions")
@@ -234,23 +232,21 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         Retrieve a list of versions for a template
         """
-        endpoint = "/service/{service_id}/template/{template_id}/versions".format(
-            service_id=service_id, template_id=template_id
-        )
+        endpoint = f"/service/{service_id}/template/{template_id}/versions"
         return self.get(endpoint)
 
     def get_precompiled_template(self, service_id):
         """
         Returns the precompiled template for a service, creating it if it doesn't already exist
         """
-        return self.get("/service/{}/template/precompiled".format(service_id))
+        return self.get(f"/service/{service_id}/template/precompiled")
 
     @cache.set("service-{service_id}-templates")
     def get_service_templates(self, service_id):
         """
         Retrieve all templates for service.
         """
-        endpoint = "/service/{service_id}/template?detailed=False".format(service_id=service_id)
+        endpoint = f"/service/{service_id}/template?detailed=False"
         return self.get(endpoint)
 
     # This doesn’t need caching because it calls through to a method which is cached
@@ -269,14 +265,14 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         Set a service template's archived flag to True
         """
-        endpoint = "/service/{0}/template/{1}".format(service_id, template_id)
+        endpoint = f"/service/{service_id}/template/{template_id}"
         data = {"archived": True}
         data = _attach_current_user(data)
         return self.post(endpoint, data=data)
 
     # Temp access of service history data. Includes service and api key history
     def get_service_history(self, service_id):
-        return self.get("/service/{0}/history".format(service_id))["data"]
+        return self.get(f"/service/{service_id}/history")["data"]
 
     def get_service_service_history(self, service_id):
         return self.get_service_history(service_id)["service_history"]
@@ -285,76 +281,67 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.get_service_history(service_id)["api_key_history"]
 
     def get_monthly_notification_stats(self, service_id, year):
-        return self.get(url="/service/{}/notifications/monthly?year={}".format(service_id, year))
+        return self.get(f"/service/{service_id}/notifications/monthly?year={year}")
 
     def get_guest_list(self, service_id):
-        return self.get(url="/service/{}/guest-list".format(service_id))
+        return self.get(f"/service/{service_id}/guest-list")
 
     @cache.delete("service-{service_id}")
     def update_guest_list(self, service_id, data):
-        return self.put(url="/service/{}/guest-list".format(service_id), data=data)
+        return self.put(f"/service/{service_id}/guest-list", data=data)
 
     def get_inbound_sms(self, service_id, user_number=""):
         # POST prevents the user phone number leaking into our logs
         return self.post(
-            "/service/{}/inbound-sms".format(
-                service_id,
-            ),
+            f"/service/{service_id}/inbound-sms",
             data={"phone_number": user_number},
         )
 
     def get_most_recent_inbound_sms(self, service_id, page=None):
         return self.get(
-            "/service/{}/inbound-sms/most-recent".format(
-                service_id,
-            ),
+            f"/service/{service_id}/inbound-sms/most-recent",
             params={"page": page},
         )
 
     def get_inbound_sms_by_id(self, service_id, notification_id):
-        return self.get(
-            "/service/{}/inbound-sms/{}".format(
-                service_id,
-                notification_id,
-            )
-        )
+        return self.get(f"/service/{service_id}/inbound-sms/{notification_id}")
 
     def get_inbound_sms_summary(self, service_id):
-        return self.get("/service/{}/inbound-sms/summary".format(service_id))
+        return self.get(f"/service/{service_id}/inbound-sms/summary")
 
     @cache.delete("service-{service_id}")
     def create_service_inbound_api(self, service_id, url, bearer_token, user_id):
         data = {"url": url, "bearer_token": bearer_token, "updated_by_id": user_id}
-        return self.post("/service/{}/inbound-api".format(service_id), data)
+        return self.post(f"/service/{service_id}/inbound-api", data)
 
     @cache.delete("service-{service_id}")
     def update_service_inbound_api(self, service_id, url, bearer_token, user_id, inbound_api_id):
         data = {"url": url, "updated_by_id": user_id}
         if bearer_token:
             data["bearer_token"] = bearer_token
-        return self.post("/service/{}/inbound-api/{}".format(service_id, inbound_api_id), data)
+        return self.post(f"/service/{service_id}/inbound-api/{inbound_api_id}", data)
 
     def get_service_inbound_api(self, service_id, inbound_sms_api_id):
-        return self.get("/service/{}/inbound-api/{}".format(service_id, inbound_sms_api_id))["data"]
+        return self.get(f"/service/{service_id}/inbound-api/{inbound_sms_api_id}")["data"]
 
     @cache.delete("service-{service_id}")
     def delete_service_inbound_api(self, service_id, callback_api_id):
-        return self.delete("/service/{}/inbound-api/{}".format(service_id, callback_api_id))
+        return self.delete(f"/service/{service_id}/inbound-api/{callback_api_id}")
 
     def get_reply_to_email_addresses(self, service_id):
-        return self.get("/service/{}/email-reply-to".format(service_id))
+        return self.get(f"/service/{service_id}/email-reply-to")
 
     def get_reply_to_email_address(self, service_id, reply_to_email_id):
-        return self.get("/service/{}/email-reply-to/{}".format(service_id, reply_to_email_id))
+        return self.get(f"/service/{service_id}/email-reply-to/{reply_to_email_id}")
 
     def verify_reply_to_email_address(self, service_id, email_address):
-        return self.post("/service/{}/email-reply-to/verify".format(service_id), data={"email": email_address})
+        return self.post(f"/service/{service_id}/email-reply-to/verify", data={"email": email_address})
 
     @cache.delete("service-{service_id}")
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def add_reply_to_email_address(self, service_id, email_address, is_default=False):
         return self.post(
-            "/service/{}/email-reply-to".format(service_id),
+            f"/service/{service_id}/email-reply-to",
             data={"email_address": email_address, "is_default": is_default},
         )
 
@@ -362,29 +349,26 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def update_reply_to_email_address(self, service_id, reply_to_email_id, email_address, is_default=False):
         return self.post(
-            "/service/{}/email-reply-to/{}".format(
-                service_id,
-                reply_to_email_id,
-            ),
+            f"/service/{service_id}/email-reply-to/{reply_to_email_id}",
             data={"email_address": email_address, "is_default": is_default},
         )
 
     @cache.delete("service-{service_id}")
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def delete_reply_to_email_address(self, service_id, reply_to_email_id):
-        return self.post("/service/{}/email-reply-to/{}/archive".format(service_id, reply_to_email_id), data=None)
+        return self.post(f"/service/{service_id}/email-reply-to/{reply_to_email_id}/archive", data=None)
 
     def get_letter_contacts(self, service_id):
-        return self.get("/service/{}/letter-contact".format(service_id))
+        return self.get(f"/service/{service_id}/letter-contact")
 
     def get_letter_contact(self, service_id, letter_contact_id):
-        return self.get("/service/{}/letter-contact/{}".format(service_id, letter_contact_id))
+        return self.get(f"/service/{service_id}/letter-contact/{letter_contact_id}")
 
     @cache.delete("service-{service_id}")
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def add_letter_contact(self, service_id, contact_block, is_default=False):
         return self.post(
-            "/service/{}/letter-contact".format(service_id),
+            f"/service/{service_id}/letter-contact",
             data={"contact_block": contact_block, "is_default": is_default},
         )
 
@@ -392,23 +376,20 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def update_letter_contact(self, service_id, letter_contact_id, contact_block, is_default=False):
         return self.post(
-            "/service/{}/letter-contact/{}".format(
-                service_id,
-                letter_contact_id,
-            ),
+            f"/service/{service_id}/letter-contact/{letter_contact_id}",
             data={"contact_block": contact_block, "is_default": is_default},
         )
 
     @cache.delete("service-{service_id}")
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def delete_letter_contact(self, service_id, letter_contact_id):
-        return self.post("/service/{}/letter-contact/{}/archive".format(service_id, letter_contact_id), data=None)
+        return self.post(f"/service/{service_id}/letter-contact/{letter_contact_id}/archive", data=None)
 
     def get_sms_senders(self, service_id):
-        return self.get("/service/{}/sms-sender".format(service_id))
+        return self.get(f"/service/{service_id}/sms-sender")
 
     def get_sms_sender(self, service_id, sms_sender_id):
-        return self.get("/service/{}/sms-sender/{}".format(service_id, sms_sender_id))
+        return self.get(f"/service/{service_id}/sms-sender/{sms_sender_id}")
 
     @cache.delete("service-{service_id}")
     @cache.delete_by_pattern("service-{service_id}-template-*")
@@ -421,59 +402,59 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def update_sms_sender(self, service_id, sms_sender_id, sms_sender, is_default=False):
         return self.post(
-            "/service/{}/sms-sender/{}".format(service_id, sms_sender_id),
+            f"/service/{service_id}/sms-sender/{sms_sender_id}",
             data={"sms_sender": sms_sender, "is_default": is_default},
         )
 
     @cache.delete("service-{service_id}")
     @cache.delete_by_pattern("service-{service_id}-template-*")
     def delete_sms_sender(self, service_id, sms_sender_id):
-        return self.post("/service/{}/sms-sender/{}/archive".format(service_id, sms_sender_id), data=None)
+        return self.post(f"/service/{service_id}/sms-sender/{sms_sender_id}/archive", data=None)
 
     def get_service_callback_api(self, service_id, callback_api_id):
-        return self.get("/service/{}/delivery-receipt-api/{}".format(service_id, callback_api_id))["data"]
+        return self.get(f"/service/{service_id}/delivery-receipt-api/{callback_api_id}")["data"]
 
     @cache.delete("service-{service_id}")
     def update_service_callback_api(self, service_id, url, bearer_token, user_id, callback_api_id):
         data = {"url": url, "updated_by_id": user_id}
         if bearer_token:
             data["bearer_token"] = bearer_token
-        return self.post("/service/{}/delivery-receipt-api/{}".format(service_id, callback_api_id), data)
+        return self.post(f"/service/{service_id}/delivery-receipt-api/{callback_api_id}", data)
 
     @cache.delete("service-{service_id}")
     def delete_service_callback_api(self, service_id, callback_api_id):
-        return self.delete("/service/{}/delivery-receipt-api/{}".format(service_id, callback_api_id))
+        return self.delete(f"/service/{service_id}/delivery-receipt-api/{callback_api_id}")
 
     @cache.delete("service-{service_id}")
     def create_service_callback_api(self, service_id, url, bearer_token, user_id):
         data = {"url": url, "bearer_token": bearer_token, "updated_by_id": user_id}
-        return self.post("/service/{}/delivery-receipt-api".format(service_id), data)
+        return self.post(f"/service/{service_id}/delivery-receipt-api", data)
 
     @cache.delete("service-{service_id}-data-retention")
     def create_service_data_retention(self, service_id, notification_type, days_of_retention):
         data = {"notification_type": notification_type, "days_of_retention": days_of_retention}
 
-        return self.post("/service/{}/data-retention".format(service_id), data)
+        return self.post(f"/service/{service_id}/data-retention", data)
 
     @cache.delete("service-{service_id}-data-retention")
     def update_service_data_retention(self, service_id, data_retention_id, days_of_retention):
         data = {"days_of_retention": days_of_retention}
-        return self.post("/service/{}/data-retention/{}".format(service_id, data_retention_id), data)
+        return self.post(f"/service/{service_id}/data-retention/{data_retention_id}", data)
 
     @cache.set("service-{service_id}-data-retention")
     def get_service_data_retention(self, service_id):
-        return self.get("/service/{}/data-retention".format(service_id))
+        return self.get(f"/service/{service_id}/data-retention")
 
     @cache.set("service-{service_id}-returned-letters-statistics")
     def get_returned_letter_statistics(self, service_id):
-        return self.get("service/{}/returned-letter-statistics".format(service_id))
+        return self.get(f"service/{service_id}/returned-letter-statistics")
 
     @cache.set("service-{service_id}-returned-letters-summary")
     def get_returned_letter_summary(self, service_id):
-        return self.get("service/{}/returned-letter-summary".format(service_id))
+        return self.get(f"service/{service_id}/returned-letter-summary")
 
     def get_returned_letters(self, service_id, reported_at):
-        return self.get("service/{}/returned-letters?reported_at={}".format(service_id, reported_at))
+        return self.get(f"service/{service_id}/returned-letters?reported_at={reported_at}")
 
     @cache.delete("service-{service_id}")
     def set_service_broadcast_settings(
@@ -493,7 +474,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "provider_restriction": provider_restriction,
         }
 
-        return self.post("/service/{}/set-as-broadcast-service".format(service_id), data)
+        return self.post(f"/service/{service_id}/set-as-broadcast-service", data)
 
     def get_notification_count(self, service_id, notification_type):
         # if cache is not set return 0

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1788,10 +1788,10 @@ def test_should_redirect_when_saving_a_template(
     )
     mock_update_service_template.assert_called_with(
         fake_uuid,
-        name,
-        content,
-        SERVICE_ONE_ID,
-        None,
+        name=name,
+        content=content,
+        service_id=SERVICE_ONE_ID,
+        subject=None,
     )
 
 
@@ -2027,10 +2027,10 @@ def test_should_redirect_when_saving_a_template_email(
     )
     mock_update_service_template.assert_called_with(
         fake_uuid,
-        name,
-        content,
-        SERVICE_ONE_ID,
-        subject,
+        name=name,
+        content=content,
+        service_id=SERVICE_ONE_ID,
+        subject=subject,
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1787,10 +1787,10 @@ def test_should_redirect_when_saving_a_template(
         ),
     )
     mock_update_service_template.assert_called_with(
-        fake_uuid,
+        template_id=fake_uuid,
+        service_id=SERVICE_ONE_ID,
         name=name,
         content=content,
-        service_id=SERVICE_ONE_ID,
         subject=None,
     )
 
@@ -2026,10 +2026,10 @@ def test_should_redirect_when_saving_a_template_email(
         ),
     )
     mock_update_service_template.assert_called_with(
-        fake_uuid,
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
         name=name,
         content=content,
-        service_id=SERVICE_ONE_ID,
         subject=subject,
     )
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1789,7 +1789,6 @@ def test_should_redirect_when_saving_a_template(
     mock_update_service_template.assert_called_with(
         fake_uuid,
         name,
-        "sms",
         content,
         SERVICE_ONE_ID,
         None,
@@ -2029,7 +2028,6 @@ def test_should_redirect_when_saving_a_template_email(
     mock_update_service_template.assert_called_with(
         fake_uuid,
         name,
-        "email",
         content,
         SERVICE_ONE_ID,
         subject,

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -410,7 +410,7 @@ def test_deletes_service_cache(
         ),
         (
             "update_service_template",
-            [FAKE_TEMPLATE_ID, "foo", "sms", "bar", SERVICE_ONE_ID],
+            [FAKE_TEMPLATE_ID, "foo", "bar", SERVICE_ONE_ID],
             [
                 "service-{}-templates".format(SERVICE_ONE_ID),
             ],

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -511,7 +511,7 @@ def test_client_gets_guest_list(mocker):
 
     assert response == ["a", "b", "c"]
     mock_get.assert_called_once_with(
-        url="/service/foo/guest-list",
+        "/service/foo/guest-list",
     )
 
 
@@ -522,7 +522,7 @@ def test_client_updates_guest_list(mocker):
     client.update_guest_list("foo", data=["a", "b", "c"])
 
     mock_put.assert_called_once_with(
-        url="/service/foo/guest-list",
+        "/service/foo/guest-list",
         data=["a", "b", "c"],
     )
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -411,11 +411,12 @@ def test_deletes_service_cache(
         ),
         (
             "update_service_template",
-            [FAKE_TEMPLATE_ID],
+            [],
             {
                 "name": "foo",
                 "content": "bar",
                 "service_id": SERVICE_ONE_ID,
+                "template_id": FAKE_TEMPLATE_ID,
             },
             [
                 "service-{}-templates".format(SERVICE_ONE_ID),

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -399,18 +399,24 @@ def test_deletes_service_cache(
 
 
 @pytest.mark.parametrize(
-    "method, extra_args, expected_cache_deletes",
+    "method, extra_args, extra_kwargs, expected_cache_deletes",
     [
         (
             "create_service_template",
             ["name", "type_", "content", SERVICE_ONE_ID],
+            {},
             [
                 "service-{}-templates".format(SERVICE_ONE_ID),
             ],
         ),
         (
             "update_service_template",
-            [FAKE_TEMPLATE_ID, "foo", "bar", SERVICE_ONE_ID],
+            [FAKE_TEMPLATE_ID],
+            {
+                "name": "foo",
+                "content": "bar",
+                "service_id": SERVICE_ONE_ID,
+            },
             [
                 "service-{}-templates".format(SERVICE_ONE_ID),
             ],
@@ -418,6 +424,7 @@ def test_deletes_service_cache(
         (
             "redact_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
+            {},
             [
                 "service-{}-templates".format(SERVICE_ONE_ID),
             ],
@@ -425,6 +432,7 @@ def test_deletes_service_cache(
         (
             "update_service_template_sender",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, "foo"],
+            {},
             [
                 "service-{}-templates".format(SERVICE_ONE_ID),
             ],
@@ -432,6 +440,7 @@ def test_deletes_service_cache(
         (
             "update_service_template_postage",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, "first"],
+            {},
             [
                 "service-{}-templates".format(SERVICE_ONE_ID),
             ],
@@ -439,6 +448,7 @@ def test_deletes_service_cache(
         (
             "delete_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
+            {},
             [
                 "service-{}-templates".format(SERVICE_ONE_ID),
             ],
@@ -446,6 +456,7 @@ def test_deletes_service_cache(
         (
             "archive_service",
             [SERVICE_ONE_ID, []],
+            {},
             [
                 "service-{}-templates".format(SERVICE_ONE_ID),
                 "service-{}".format(SERVICE_ONE_ID),
@@ -459,6 +470,7 @@ def test_deletes_caches_when_modifying_templates(
     mocker,
     method,
     extra_args,
+    extra_kwargs,
     expected_cache_deletes,
 ):
     mocker.patch("app.notify_client.current_user", id="1")
@@ -466,7 +478,7 @@ def test_deletes_caches_when_modifying_templates(
     mock_redis_delete_by_pattern = mocker.patch("app.extensions.RedisClient.delete_by_pattern")
     mock_request = mocker.patch("notifications_python_client.base.BaseAPIClient.request")
 
-    getattr(service_api_client, method)(*extra_args)
+    getattr(service_api_client, method)(*extra_args, **extra_kwargs)
 
     assert mock_redis_delete.call_args_list == [call(x) for x in expected_cache_deletes]
     assert len(mock_request.call_args_list) == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -906,8 +906,8 @@ def mock_create_service_template(mocker, fake_uuid):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template(mocker):
-    def _update(id_, name, type_, content, service, subject=None):
-        template = template_json(service_id=service, id_=id_, name=name, type_=type_, content=content, subject=subject)
+    def _update(id_, name, content, service, subject=None):
+        template = template_json(service_id=service, id_=id_, name=name, content=content, subject=subject)
         return {"data": template}
 
     return mocker.patch("app.service_api_client.update_service_template", side_effect=_update)
@@ -933,7 +933,7 @@ def mock_create_service_template_content_too_big(mocker):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template_400_content_too_big(mocker):
-    def _update(id_, name, type_, content, service, subject=None):
+    def _update(id_, name, content, service, subject=None):
         json_mock = Mock(
             return_value={
                 "message": {"content": ["Content has a character count greater than the limit of 459"]},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -906,8 +906,8 @@ def mock_create_service_template(mocker, fake_uuid):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template(mocker):
-    def _update(id_, name, content, service, subject=None):
-        template = template_json(service_id=service, id_=id_, name=name, content=content, subject=subject)
+    def _update(id_, *, name, content, service_id, subject=None):
+        template = template_json(service_id=service_id, id_=id_, name=name, content=content, subject=subject)
         return {"data": template}
 
     return mocker.patch("app.service_api_client.update_service_template", side_effect=_update)
@@ -933,7 +933,7 @@ def mock_create_service_template_content_too_big(mocker):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template_400_content_too_big(mocker):
-    def _update(id_, name, content, service, subject=None):
+    def _update(id_, *, name, content, service_id, subject=None):
         json_mock = Mock(
             return_value={
                 "message": {"content": ["Content has a character count greater than the limit of 459"]},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -906,10 +906,8 @@ def mock_create_service_template(mocker, fake_uuid):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template(mocker):
-    def _update(id_, name, type_, content, service, subject=None, postage=None):
-        template = template_json(
-            service_id=service, id_=id_, name=name, type_=type_, content=content, subject=subject, postage=postage
-        )
+    def _update(id_, name, type_, content, service, subject=None):
+        template = template_json(service_id=service, id_=id_, name=name, type_=type_, content=content, subject=subject)
         return {"data": template}
 
     return mocker.patch("app.service_api_client.update_service_template", side_effect=_update)
@@ -935,7 +933,7 @@ def mock_create_service_template_content_too_big(mocker):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template_400_content_too_big(mocker):
-    def _update(id_, name, type_, content, service, subject=None, postage=None):
+    def _update(id_, name, type_, content, service, subject=None):
         json_mock = Mock(
             return_value={
                 "message": {"content": ["Content has a character count greater than the limit of 459"]},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -906,8 +906,8 @@ def mock_create_service_template(mocker, fake_uuid):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template(mocker):
-    def _update(id_, *, service_id, name=None, content=None, subject=None):
-        template = template_json(service_id=service_id, id_=id_, name=name, content=content, subject=subject)
+    def _update(*, service_id, template_id, name=None, content=None, subject=None):
+        template = template_json(service_id=service_id, id_=template_id, name=name, content=content, subject=subject)
         return {"data": template}
 
     return mocker.patch("app.service_api_client.update_service_template", side_effect=_update)
@@ -933,7 +933,7 @@ def mock_create_service_template_content_too_big(mocker):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template_400_content_too_big(mocker):
-    def _update(id_, *, service_id, name=None, content=None, subject=None):
+    def _update(*, service_id, template_id, name=None, content=None, subject=None):
         json_mock = Mock(
             return_value={
                 "message": {"content": ["Content has a character count greater than the limit of 459"]},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -906,7 +906,7 @@ def mock_create_service_template(mocker, fake_uuid):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template(mocker):
-    def _update(id_, *, name, content, service_id, subject=None):
+    def _update(id_, *, service_id, name=None, content=None, subject=None):
         template = template_json(service_id=service_id, id_=id_, name=name, content=content, subject=subject)
         return {"data": template}
 
@@ -933,7 +933,7 @@ def mock_create_service_template_content_too_big(mocker):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template_400_content_too_big(mocker):
-    def _update(id_, *, name, content, service_id, subject=None):
+    def _update(id_, *, service_id, name=None, content=None, subject=None):
         json_mock = Mock(
             return_value={
                 "message": {"content": ["Content has a character count greater than the limit of 459"]},


### PR DESCRIPTION
This will let us update the `name`, `subject`, and `content` of a template independently.

This doesn’t change any current functionality. In a future pull request we can use this to add a page for renaming letters.

The API seems happy enough to accept a partial object – [the `post_update_template_schema` in the API doesn’t specify any fields as `required`](https://github.com/alphagov/notifications-api/blob/cae3164bfe5bdcdbbbd5117e31f74c3118ef663c/app/template/template_schemas.py#L25-L44). And, as an example, we already don’t update `postage` when we edit a template.
