### PR TITLE
Display 'last updated at' for org dashboard

### DIFF
--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -16,7 +16,8 @@
 .column-main {
 
   .heading-large,
-  > .heading-medium {
+  > .heading-medium,
+  > .heading-with-aside--heading-medium {
     margin: govuk-spacing(3) 0 govuk-spacing(4) 0;
     word-wrap: break-word;
 
@@ -54,8 +55,42 @@ td {
   vertical-align: top;
 }
 
-.heading-medium {
+.heading-medium,
+.heading-with-aside--heading-medium {
   margin-top: govuk-spacing(6);
+}
+
+// TODO: refactor all this when GOVUK Elements typography is removed
+// Allow headings to have related content that sits alongside
+.heading-with-aside {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+// TODO: refactor all this when GOVUK Elements typography is removed
+// Transfer vertical spacing from heading onto container
+.heading-with-aside--heading-medium {
+  margin-bottom: govuk-spacing(6);
+
+  @include govuk-media-query($from: tablet) {
+    > .heading-medium {
+      margin: 0 govuk-spacing(6) 0 0;
+    }
+  }
+}
+
+// TODO: refactor all this when GOVUK Elements typography is removed
+.heading-aside {
+  @include govuk-font(16);
+  color: $govuk-secondary-text-colour;
+  margin: 0;
+  width: 100%; // force wrapping
+
+  @include govuk-media-query($from: tablet) {
+    width: auto;
+  }
 }
 
 .form-label {

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -136,7 +136,7 @@ def add_organisation_from_nhs_local_service(service_id):
 @user_has_permissions()
 def organisation_dashboard(org_id):
     year, current_financial_year = requested_and_current_financial_year(request)
-    services = current_organisation.services_and_usage(financial_year=year)["services"]
+    services, updated_at = current_organisation.services_and_usage(financial_year=year)
     return render_template(
         "views/organisations/organisation/index.html",
         services=services,
@@ -146,6 +146,7 @@ def organisation_dashboard(org_id):
             end=current_financial_year,
         ),
         selected_year=year,
+        updated_at=updated_at,
         search_form=SearchByNameForm() if len(services) > 7 else None,
         **{
             f"total_{key}": sum(service[key] for service in services)
@@ -159,7 +160,7 @@ def organisation_dashboard(org_id):
 @user_has_permissions()
 def download_organisation_usage_report(org_id):
     selected_year = request.args.get("selected_year")
-    services_usage = current_organisation.services_and_usage(financial_year=selected_year)["services"]
+    services_usage, _ = current_organisation.services_and_usage(financial_year=selected_year)
 
     unit_column_names = OrderedDict(
         [

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -1,4 +1,6 @@
+import datetime
 from collections import OrderedDict
+from typing import Optional
 
 from flask import abort
 from werkzeug.utils import cached_property
@@ -225,8 +227,12 @@ class Organisation(JSONModel):
     def associate_service(self, service_id):
         organisations_client.update_service_organisation(service_id, self.id)
 
-    def services_and_usage(self, financial_year):
-        return organisations_client.get_services_and_usage(self.id, financial_year)
+    def services_and_usage(self, financial_year) -> tuple[dict, Optional[datetime.date]]:
+        response = organisations_client.get_services_and_usage(self.id, financial_year)
+        updated_at = response.get("updated_at")
+        if updated_at:
+            updated_at = datetime.datetime.fromisoformat(updated_at)
+        return response["services"], updated_at
 
 
 class Organisations(SerialisedModelCollection):

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -9,15 +9,10 @@
 
 {% block maincolumn_content %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
-      <h1 class="heading-medium" id="page-header">Usage</h1>
-    </div>
-
+  <div class="heading-with-aside heading-with-aside--heading-medium">
+    <h1 class="heading-medium" id="page-header">Usage</h1>
     {% if updated_at %}
-      <div class="govuk-grid-column-one-half">
-        <p class="govuk-hint govuk-!-font-size-16 govuk-!-text-align-right govuk-!-margin-bottom-1 govuk-!-margin-top-7">Last updated {{ updated_at | format_datetime_relative }}</p>
-      </div>
+      <p class="heading-aside">Last updated {{ updated_at | format_datetime_relative }}</p>
     {% endif %}
   </div>
 

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -1,4 +1,3 @@
-{% from "components/page-header.html" import page_header %}
 {% from "components/big-number.html" import big_number %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/pill.html" import pill %}
@@ -10,7 +9,17 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header('Usage', size='medium') }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <h1 class="heading-medium" id="page-header">Usage</h1>
+    </div>
+
+    {% if updated_at %}
+      <div class="govuk-grid-column-one-half">
+        <p class="govuk-hint govuk-!-font-size-16 govuk-!-text-align-right govuk-!-margin-bottom-1 govuk-!-margin-top-7">Last updated {{ updated_at | format_datetime_relative }}</p>
+      </div>
+    {% endif %}
+  </div>
 
   <div class="bottom-gutter">
     {{ pill(years, selected_year, big_number_args={'smallest': True}) }}

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -474,9 +474,9 @@ def test_organisation_services_shows_live_services_and_usage(
     assert normalize_spaces(usage_rows[8].text) == "£0.00 spent on letters"
 
     # Ensure there’s no ‘this org has no services message’
-    hints = page.select(".govuk-hint")
-    assert len(hints) == 1
-    assert hints[0].text == "Last updated today at 8:00pm"
+    heading_aside = page.select(".heading-aside")
+    assert len(heading_aside) == 1
+    assert heading_aside[0].text == "Last updated today at 8:00pm"
 
 
 @freeze_time("2020-02-20 20:20")

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -235,7 +235,7 @@ def test_post_make_service_live_page_has_flash_message_after_redirect(
     expected_banner_class,
     expected_flash_message,
 ):
-    mocker.patch("app.organisations_client.get_services_and_usage", return_value={"services": []})
+    mocker.patch("app.organisations_client.get_services_and_usage", return_value={"services": [], "updated_at": None})
     service_one["has_active_go_live_request"] = True
     service_one["organisation"] = ORGANISATION_ID
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -502,7 +502,7 @@ def test_a_page_should_nave_selected_org_navigation_item(
     selected_nav_item,
     mocker,
 ):
-    mocker.patch("app.organisations_client.get_services_and_usage", return_value={"services": {}})
+    mocker.patch("app.organisations_client.get_services_and_usage", return_value={"services": [], "updated_at": None})
     page = client_request.get(endpoint, org_id=ORGANISATION_ID)
     selected_nav_items = page.select(".navigation a.selected")
     assert len(selected_nav_items) == 1


### PR DESCRIPTION
We are going to stop on-demand calculation of up-to-the-second billing data when users visit the org dashboard[^1]. Given this, we need to show an indication of when the data was last generated so that users know if it's a bit out of date.

We'll add a small "Updated at" line to the dashboard.

## example before redesign/words
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/2920760/235871175-a41bbd86-7d68-4825-b9e3-83cc92726599.png">


**TODO**: @quis working on the design element so expect the words/location of words to change.

[^1]: https://github.com/alphagov/notifications-api/pull/3775