### PR TITLE
Use flynt to switch to f-strings

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,6 @@
 8a9ee35a0a4d9e1f8a8547af382ff4db630ddd5f
 508d2d2568fa116ab65a5de56284c6bb6c4e46a5
 13422afdfbe9ae9c52100b49d069be4fcdcd3182
+
+# Ignore bulk reformatting to f-strings from flynt
+fa3c94d74db7f03f33837595633ff04b405d1abe

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -405,7 +405,7 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
     def _error_response(error_code, error_page_template=None):
         if error_page_template is None:
             error_page_template = error_code
-        resp = make_response(render_template("error/{0}.html".format(error_page_template)), error_code)
+        resp = make_response(render_template(f"error/{error_page_template}.html"), error_code)
         return useful_headers_after_request(resp)
 
     @application.errorhandler(HTTPError)
@@ -458,7 +458,7 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
 
     @application.errorhandler(CSRFError)
     def handle_csrf(reason):
-        application.logger.warning("csrf.error_message: {}".format(reason))
+        application.logger.warning(f"csrf.error_message: {reason}")
 
         if "user_id" not in session:
             application.logger.warning("csrf.session_expired: Redirecting user to log in page")

--- a/app/broadcast_areas/create-broadcast-areas-db.py
+++ b/app/broadcast_areas/create-broadcast-areas-db.py
@@ -41,7 +41,7 @@ def simplify_geometry(feature):
     elif feature["type"] == "MultiPolygon":
         return [polygon for polygon, *_holes in feature["coordinates"]]
     else:
-        raise Exception("Unknown type: {}".format(feature["type"]))
+        raise Exception(f"Unknown type: {feature['type']}")
 
 
 def clean_up_invalid_polygons(polygons, indent="    "):

--- a/app/broadcast_areas/repo.py
+++ b/app/broadcast_areas/repo.py
@@ -135,13 +135,11 @@ class BroadcastAreasRepository:
         return sorted(libraries)
 
     def get_areas(self, area_ids):
-        q = """
+        q = f"""
         SELECT id, name, count_of_phones, broadcast_area_library_id
         FROM broadcast_areas
-        WHERE id IN ({})
-        """.format(
-            ",".join("?" * len(area_ids))
-        )
+        WHERE id IN ({','.join('?' * len(area_ids))})
+        """
 
         results = self.query(q, *area_ids)
 

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -29,33 +29,27 @@ def convert_to_boolean(value):
 
 
 def format_datetime(date):
-    return "{} at {}".format(format_date(date), format_time(date))
+    return f"{format_date(date)} at {format_time(date)}"
 
 
 def format_datetime_24h(date):
-    return "{} at {}".format(
-        format_date(date),
-        format_time_24h(date),
-    )
+    return f"{format_date(date)} at {format_time_24h(date)}"
 
 
 def format_datetime_normal(date):
-    return "{} at {}".format(format_date_normal(date), format_time(date))
+    return f"{format_date_normal(date)} at {format_time(date)}"
 
 
 def format_datetime_short(date):
-    return "{} at {}".format(format_date_short(date), format_time(date))
+    return f"{format_date_short(date)} at {format_time(date)}"
 
 
 def format_datetime_relative(date):
-    return "{} at {}".format(get_human_day(date), format_time(date))
+    return f"{get_human_day(date)} at {format_time(date)}"
 
 
 def format_datetime_numeric(date):
-    return "{} {}".format(
-        format_date_numeric(date),
-        format_time_24h(date),
-    )
+    return f"{format_date_numeric(date)} {format_time_24h(date)}"
 
 
 def format_date_numeric(date):
@@ -84,10 +78,7 @@ def get_human_day(time, date_prefix=""):
             _format_datetime_short(date),
             date.strftime("%Y"),
         ).strip()
-    return "{} {}".format(
-        date_prefix,
-        _format_datetime_short(date),
-    ).strip()
+    return f"{date_prefix} {_format_datetime_short(date)}".strip()
 
 
 def format_time(date):
@@ -118,10 +109,7 @@ def format_date_human(date):
 
 
 def format_datetime_human(date, date_prefix=""):
-    return "{} at {}".format(
-        get_human_day(date, date_prefix="on"),
-        format_time(date),
-    )
+    return f"{get_human_day(date, date_prefix='on')} at {format_time(date)}"
 
 
 def format_day_of_week(date):
@@ -135,7 +123,7 @@ def _format_datetime_short(datetime):
 def naturaltime_without_indefinite_article(date):
     return re.sub(
         "an? (.*) ago",
-        lambda match: "1 {} ago".format(match.group(1)),
+        lambda match: f"1 {match.group(1)} ago",
         humanize.naturaltime(date),
     )
 
@@ -215,7 +203,7 @@ def format_notification_status(status, template_type):
 
 
 def format_notification_status_as_time(status, created, updated):
-    return dict.fromkeys({"created", "pending", "sending"}, " since {}".format(created)).get(status, updated)
+    return dict.fromkeys({"created", "pending", "sending"}, f" since {created}").get(status, updated)
 
 
 def format_notification_status_as_field_status(status, notification_type):
@@ -307,7 +295,7 @@ def linkable_name(value):
 
 def format_thousands(value):
     if isinstance(value, Number):
-        return "{:,.0f}".format(value)
+        return f"{value:,.0f}"
     if value is None:
         return ""
     return value

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -115,7 +115,7 @@ def get_human_day(time, prefix_today_with="T"):
     #  Add 1 hour to get ‘midnight today’ instead of ‘midnight tomorrow’
     time = (time - timedelta(hours=1)).strftime("%A")
     if time == datetime.utcnow().strftime("%A"):
-        return "{}oday".format(prefix_today_with)
+        return f"{prefix_today_with}oday"
     if time == (datetime.utcnow() + timedelta(days=1)).strftime("%A"):
         return "Tomorrow"
     return time
@@ -1002,7 +1002,7 @@ class RenameOrganisationForm(StripWhitespaceForm):
 class AddGPOrganisationForm(StripWhitespaceForm):
     def __init__(self, *args, service_name="unknown", **kwargs):
         super().__init__(*args, **kwargs)
-        self.same_as_service_name.label.text = "Is your GP practice called ‘{}’?".format(service_name)
+        self.same_as_service_name.label.text = f"Is your GP practice called ‘{service_name}’?"
         self.service_name = service_name
 
     def get_organisation_name(self):
@@ -1622,7 +1622,7 @@ class ServiceLetterContactBlockForm(StripWhitespaceForm):
     def validate_letter_contact_block(self, field):
         line_count = field.data.strip().count("\n")
         if line_count >= 10:
-            raise ValidationError("Contains {} lines, maximum is 10".format(line_count + 1))
+            raise ValidationError(f"Contains {line_count + 1} lines, maximum is 10")
 
 
 class OnOffSettingForm(StripWhitespaceForm):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -34,7 +34,7 @@ class CsvFileValidator:
 
     def __call__(self, form, field):
         if not Spreadsheet.can_handle(field.data.filename):
-            raise ValidationError("{} is not a spreadsheet that Notify can read".format(field.data.filename))
+            raise ValidationError(f"{field.data.filename} is not a spreadsheet that Notify can read")
 
 
 class ValidGovEmail:

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -110,7 +110,7 @@ def revoke_api_key(service_id, key_id):
     if request.method == "GET":
         flash(
             [
-                "Are you sure you want to revoke ‘{}’?".format(key_name),
+                f"Are you sure you want to revoke ‘{key_name}’?",
                 "You will not be able to use this API key to connect to GOV.UK Notify.",
             ],
             "revoke this API key",
@@ -120,7 +120,7 @@ def revoke_api_key(service_id, key_id):
         )
     elif request.method == "POST":
         api_key_api_client.revoke_api_key(service_id=service_id, key_id=key_id)
-        flash("‘{}’ was revoked".format(key_name), "default_with_tick")
+        flash(f"‘{key_name}’ was revoked", "default_with_tick")
         return redirect(url_for(".api_keys", service_id=service_id))
 
 

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -361,7 +361,7 @@ def yyyy_mm_to_datetime(string):
 def aggregate_status_types(counts_dict):
     return get_dashboard_totals(
         {
-            "{}_counts".format(message_type): {
+            f"{message_type}_counts": {
                 "failed": sum(stats.get(status, 0) for status in FAILURE_STATUSES),
                 "requested": sum(stats.get(status, 0) for status in REQUESTED_STATUSES),
             }
@@ -459,7 +459,7 @@ def get_tuples_of_financial_years(
             "financial year",
             year,
             partial_url(year=year),
-            "{} to {}".format(year, year + 1),
+            f"{year} to {year + 1}",
         )
         for year in reversed(range(start, end + 1))
     )

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -134,7 +134,7 @@ def cancel_letter_job(service_id, job_id):
             flash(e.message, "dangerous")
             return redirect(url_for("main.view_job", service_id=service_id, job_id=job_id))
         flash(
-            "Cancelled {} letters from {}".format(format_thousands(number_of_letters), job.original_file_name),
+            f"Cancelled {format_thousands(number_of_letters)} letters from {job.original_file_name}",
             "default_with_tick",
         )
         return redirect(url_for("main.service_dashboard", service_id=service_id))
@@ -199,7 +199,7 @@ def get_notifications_page_partials_as_json(service_id, message_type=None):
 def _get_notifications_dashboard_partials_data(service_id, message_type):
     page = get_page_from_request()
     if page is None:
-        abort(404, "Invalid page argument ({}).".format(request.args.get("page")))
+        abort(404, f"Invalid page argument ({request.args.get('page')}).")
     filter_args = parse_filter_args(request.args)
     filter_args["status"] = set_status_filters(filter_args)
     service_data_retention_days = None

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -89,7 +89,7 @@ def invite_user(service_id, user_id=None):
             form.folder_permissions.data,
         )
 
-        flash("Invite sent to {}".format(invited_user.email_address), "default_with_tick")
+        flash(f"Invite sent to {invited_user.email_address}", "default_with_tick")
         return redirect(url_for(".manage_users", service_id=service_id))
 
     return render_template(
@@ -156,7 +156,7 @@ def remove_user_from_service(service_id, user_id):
 def edit_user_email(service_id, user_id):
     user = current_service.get_team_member(user_id)
     user_email = user.email_address
-    session_key = "team_member_email_change-{}".format(user_id)
+    session_key = f"team_member_email_change-{user_id}"
 
     if is_gov_user(user_email):
         form = ChangeEmailForm(User.already_registered, email_address=user_email)
@@ -178,7 +178,7 @@ def edit_user_email(service_id, user_id):
 @user_has_permissions("manage_service")
 def confirm_edit_user_email(service_id, user_id):
     user = current_service.get_team_member(user_id)
-    session_key = "team_member_email_change-{}".format(user_id)
+    session_key = f"team_member_email_change-{user_id}"
     if session_key in session:
         new_email = session[session_key]
     else:

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -176,7 +176,7 @@ def download_organisation_usage_report(org_id):
 
     org_usage_data = [list(unit_column_names.values()) + list(monetary_column_names.values())] + [
         [service[attribute] for attribute in unit_column_names.keys()]
-        + ["{:,.2f}".format(service[attribute]) for attribute in monetary_column_names.keys()]
+        + [f"{service[attribute]:,.2f}" for attribute in monetary_column_names.keys()]
         for service in services_usage
     ]
 
@@ -224,7 +224,7 @@ def invite_org_user(org_id):
         email_address = form.email_address.data
         invited_org_user = InvitedOrgUser.create(current_user.id, org_id, email_address)
 
-        flash("Invite sent to {}".format(invited_org_user.email_address), "default_with_tick")
+        flash(f"Invite sent to {invited_org_user.email_address}", "default_with_tick")
         return redirect(url_for(".manage_org_users", org_id=org_id))
 
     return render_template("views/organisations/organisation/users/invite-org-user.html", form=form)

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -105,7 +105,7 @@ def is_over_threshold(number, total, threshold):
 
 def get_status_box_data(stats, key, label, threshold=FAILURE_THRESHOLD):
     return {
-        "number": "{:,}".format(stats["failures"][key]),
+        "number": f"{stats['failures'][key]:,}",
         "label": label,
         "failing": is_over_threshold(stats["failures"][key], stats["total"], threshold),
         "percentage": get_formatted_percentage(stats["failures"][key], stats["total"]),
@@ -200,7 +200,7 @@ def platform_admin_services():
         include_from_test_key=include_from_test_key,
         form=form,
         services=list(format_stats_by_service(services)),
-        page_title="{} services".format("Trial mode" if request.endpoint == "main.trial_services" else "Live"),
+        page_title=f"{'Trial mode' if request.endpoint == 'main.trial_services' else 'Live'} services",
         global_stats=create_global_stats(services),
     )
 
@@ -515,7 +515,7 @@ def get_daily_sms_provider_volumes():
 def platform_admin_list_complaints():
     page = get_page_from_request()
     if page is None:
-        abort(404, "Invalid page argument ({}).".format(request.args.get("page")))
+        abort(404, f"Invalid page argument ({request.args.get('page')}).")
 
     response = complaint_api_client.get_all_complaints(page=page)
 
@@ -552,11 +552,11 @@ def platform_admin_returned_letters():
                 error_references = [
                     re.match("references (.*) does not match", e["message"]).group(1) for e in error.message
                 ]
-                form.references.errors.append("Invalid references: {}".format(", ".join(error_references)))
+                form.references.errors.append(f"Invalid references: {', '.join(error_references)}")
             else:
                 raise error
         else:
-            flash("Submitted {} letter references".format(len(references)), "default")
+            flash(f"Submitted {len(references)} letter references", "default")
             return redirect(url_for(".platform_admin_returned_letters"))
     return render_template(
         "views/platform-admin/returned-letters.html",

--- a/app/main/views/returned_letters.py
+++ b/app/main/views/returned_letters.py
@@ -65,6 +65,6 @@ def returned_letters_report(service_id, reported_at):
         200,
         {
             "Content-Type": "text/csv; charset=utf-8",
-            "Content-Disposition": 'inline; filename="{} returned letters.csv"'.format(reported_at),
+            "Content-Disposition": f'inline; filename="{reported_at} returned letters.csv"',
         },
     )

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -146,7 +146,7 @@ def send_messages(service_id, template_id):
             )
         except (UnicodeDecodeError, BadZipFile, XLRDError):
             current_app.logger.warning("Could not read %s", form.file.data.filename, exc_info=True)
-            flash("Could not read {}. Try using a different file format.".format(form.file.data.filename))
+            flash(f"Could not read {form.file.data.filename}. Try using a different file format.")
         except XLDateError:
             current_app.logger.warning("Could not parse numbers/dates in %s", form.file.data.filename, exc_info=True)
             flash(
@@ -184,7 +184,7 @@ def get_example_csv(service_id, template_id):
         200,
         {
             "Content-Type": "text/csv; charset=utf-8",
-            "Content-Disposition": 'inline; filename="{}.csv"'.format(template.name),
+            "Content-Disposition": f'inline; filename="{template.name}.csv"',
         },
     )
 
@@ -845,7 +845,7 @@ def all_placeholders_in_session(placeholders):
 
 def get_send_test_page_title(template_type, entering_recipient, name=None):
     if entering_recipient:
-        return "Send ‘{}’".format(name)
+        return f"Send ‘{name}’"
     return "Personalise this message"
 
 
@@ -893,7 +893,7 @@ def get_skip_link(step_index, template):
         and current_user.has_permissions("manage_templates", "manage_service")
     ):
         return (
-            "Use my {}".format(first_column_headings[template.template_type][0]),
+            f"Use my {first_column_headings[template.template_type][0]}",
             url_for(".send_one_off_to_myself", service_id=current_service.id, template_id=template.id),
         )
 
@@ -1026,9 +1026,7 @@ def send_notification(service_id, template_id):
             sender_id=session.get("sender_id", None),
         )
     except HTTPError as exception:
-        current_app.logger.info(
-            'Service {} could not send notification: "{}"'.format(current_service.id, exception.message)
-        )
+        current_app.logger.info(f'Service {current_service.id} could not send notification: "{exception.message}"')
         return render_template(
             "views/notifications/check.html",
             **_check_notification(service_id, template_id, exception),

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -374,13 +374,13 @@ def archive_service(service_id):
         create_archive_service_event(service_id=service_id, archived_by_id=current_user.id)
 
         flash(
-            "‘{}’ was deleted".format(current_service.name),
+            f"‘{current_service.name}’ was deleted",
             "default_with_tick",
         )
         return redirect(url_for(".choose_account"))
     else:
         flash(
-            "Are you sure you want to delete ‘{}’? There’s no way to undo this.".format(current_service.name),
+            f"Are you sure you want to delete ‘{current_service.name}’? There’s no way to undo this.",
             "delete",
         )
         return service_settings(service_id)
@@ -637,7 +637,7 @@ def service_set_sms_prefix(service_id):
 
     form = SMSPrefixForm(enabled=current_service.prefix_sms)
 
-    form.enabled.label.text = "Start all text messages with ‘{}:’".format(current_service.name)
+    form.enabled.label.text = f"Start all text messages with ‘{current_service.name}:’"
 
     if form.validate_on_submit():
         current_service.update(prefix_sms=form.enabled.data)
@@ -753,7 +753,7 @@ def service_set_channel(service_id, channel):
         return redirect(url_for(".service_settings", service_id=service_id))
 
     return render_template(
-        "views/service-settings/set-{}.html".format(channel),
+        f"views/service-settings/set-{channel}.html",
         form=form,
         sms_rate=CURRENT_SMS_RATE,
     )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -417,7 +417,7 @@ def copy_template(service_id, template_id):
         )
 
     return render_template(
-        "views/edit-{}-template.html".format(template["template_type"]),
+        f"views/edit-{template['template_type']}-template.html",
         form=form,
         template=template,
         heading_action="Add",
@@ -431,13 +431,13 @@ def _get_template_copy_name(template, existing_templates):
     template_names = [existing["name"] for existing in existing_templates]
 
     for index in reversed(range(1, 10)):
-        if "{} (copy {})".format(template["name"], index) in template_names:
-            return "{} (copy {})".format(template["name"], index + 1)
+        if f"{template['name']} (copy {index})" in template_names:
+            return f"{template['name']} (copy {index + 1})"
 
-    if "{} (copy)".format(template["name"]) in template_names:
-        return "{} (copy 2)".format(template["name"])
+    if f"{template['name']} (copy)" in template_names:
+        return f"{template['name']} (copy 2)"
 
-    return "{} (copy)".format(template["name"])
+    return f"{template['name']} (copy)"
 
 
 @main.route(("/services/<uuid:service_id>/templates/action-blocked/" "<template_type:notification_type>/<return_to>"))
@@ -533,7 +533,7 @@ def delete_template_folder(service_id, template_folder_id):
             else:
                 abort(500, e)
     else:
-        flash("Are you sure you want to delete the ‘{}’ folder?".format(template_folder["name"]), "delete")
+        flash(f"Are you sure you want to delete the ‘{template_folder['name']}’ folder?", "delete")
         return manage_template_folder(service_id, template_folder_id)
 
 
@@ -585,7 +585,7 @@ def add_service_template(service_id, template_type, template_folder_id=None):
             )
 
     return render_template(
-        "views/edit-{}-template.html".format(template_type),
+        f"views/edit-{template_type}-template.html",
         form=form,
         template_type=template_type,
         template_folder_id=template_folder_id,
@@ -658,7 +658,7 @@ def edit_service_template(service_id, template_id):
         )
     else:
         return render_template(
-            "views/edit-{}-template.html".format(template["template_type"]),
+            f"views/edit-{template['template_type']}-template.html",
             form=form,
             template=template,
             heading_action="Edit",
@@ -747,7 +747,7 @@ def delete_service_template(service_id, template_id):
         message = (
             "This template has never been used."
             if not last_used_notification
-            else "This template was last used {}.".format(format_delta(last_used_notification))
+            else f"This template was last used {format_delta(last_used_notification)}."
         )
 
     except HTTPError as e:
@@ -756,7 +756,7 @@ def delete_service_template(service_id, template_id):
         else:
             raise e
 
-    flash(["Are you sure you want to delete ‘{}’?".format(template["name"]), message, template["name"]], "delete")
+    flash([f"Are you sure you want to delete ‘{template['name']}’?", message, template["name"]], "delete")
     return render_template(
         "views/templates/template.html",
         template=get_template(
@@ -937,7 +937,7 @@ def letter_template_attach_pages(service_id, template_id):
             # handles malformed files nicely - is this done yet?
             attachment_page_count = pdf_page_count(BytesIO(pdf_file_bytes))
         except PdfReadError:
-            current_app.logger.info("Invalid PDF uploaded for service_id: {}".format(service_id))
+            current_app.logger.info(f"Invalid PDF uploaded for service_id: {service_id}")
             return _invalid_upload_error(
                 template_id=template_id,
                 error={

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -95,7 +95,7 @@ def uploads(service_id):
 def uploaded_letters(service_id, letter_print_day):
     page = get_page_from_request()
     if page is None:
-        abort(404, "Invalid page argument ({}).".format(request.args.get("page")))
+        abort(404, f"Invalid page argument ({request.args.get('page')}).")
     uploaded_letters = upload_api_client.get_letters_by_service_and_print_day(
         current_service.id,
         letter_print_day=letter_print_day,
@@ -160,7 +160,7 @@ def upload_letter(service_id):
             # TODO: get page count from the sanitise response once template preview handles malformed files nicely
             page_count = pdf_page_count(BytesIO(pdf_file_bytes))
         except PdfReadError:
-            current_app.logger.info("Invalid PDF uploaded for service_id: {}".format(service_id))
+            current_app.logger.info(f"Invalid PDF uploaded for service_id: {service_id}")
             return _invalid_upload_error(
                 "There’s a problem with your file",
                 "Notify cannot read this PDF.<br>Save a new copy of your file and try again.",
@@ -387,7 +387,7 @@ def upload_contact_list(service_id):
                 )
             )
         except (UnicodeDecodeError, BadZipFile, XLRDError):
-            flash("Could not read {}. Try using a different file format.".format(form.file.data.filename))
+            flash(f"Could not read {form.file.data.filename}. Try using a different file format.")
         except (XLDateError):
             flash(
                 (

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -37,7 +37,7 @@ class ServiceCreationEvent(Event):
     relevant = True
 
     def __str__(self):
-        return "Created this service and called it ‘{}’".format(self.item["name"])
+        return f"Created this service and called it ‘{self.item['name']}’"
 
 
 class ServiceEvent(Event):
@@ -50,7 +50,7 @@ class ServiceEvent(Event):
 
     @property
     def _formatter(self):
-        return getattr(self, "format_{}".format(self.key), None)
+        return getattr(self, f"format_{self.key}", None)
 
     def format_restricted(self):
         if self.value_to is False:
@@ -65,7 +65,7 @@ class ServiceEvent(Event):
             return "Unsuspended this service"
 
     def format_contact_link(self):
-        return "Set the contact details for this service to ‘{}’".format(self.value_to)
+        return f"Set the contact details for this service to ‘{self.value_to}’"
 
     def format_message_limit(self):
         return "{} this service’s daily message limit from {} to {}".format(
@@ -96,7 +96,7 @@ class ServiceEvent(Event):
         )
 
     def format_name(self):
-        return "Renamed this service from ‘{}’ to ‘{}’".format(self.value_from, self.value_to)
+        return f"Renamed this service from ‘{self.value_from}’ to ‘{self.value_to}’"
 
     def format_permissions(self):
         added = list(sorted(set(self.value_to) - set(self.value_from)))
@@ -107,9 +107,9 @@ class ServiceEvent(Event):
                 formatted_list(added),
             )
         if added:
-            return "Added {} to this service’s permissions".format(formatted_list(added))
+            return f"Added {formatted_list(added)} to this service’s permissions"
         if removed:
-            return "Removed {} from this service’s permissions".format(formatted_list(removed))
+            return f"Removed {formatted_list(removed)} from this service’s permissions"
 
     def format_prefix_sms(self):
         if self.value_to is True:
@@ -130,9 +130,9 @@ class APIKeyEvent(Event):
 
     def __str__(self):
         if self.item["updated_at"]:
-            return "Revoked the ‘{}’ API key".format(self.item["name"])
+            return f"Revoked the ‘{self.item['name']}’ API key"
         else:
-            return "Created an API key called ‘{}’".format(self.item["name"])
+            return f"Created an API key called ‘{self.item['name']}’"
 
 
 class APIKeyEvents(ModelList):

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -334,12 +334,12 @@ class TemplateListFolder(TemplateListItem):
         if self.number_of_templates == 1:
             yield "1 template"
         elif self.number_of_templates > 1:
-            yield "{} templates".format(self.number_of_templates)
+            yield f"{self.number_of_templates} templates"
 
         if self.number_of_folders == 1:
             yield "1 folder"
         elif self.number_of_folders > 1:
-            yield "{} folders".format(self.number_of_folders)
+            yield f"{self.number_of_folders} folders"
 
     @property
     def hint(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -215,7 +215,7 @@ class User(BaseUser, UserMixin):
     def has_permissions(self, *permissions, restrict_admin_usage=False, allow_org_user=False):
         unknown_permissions = set(permissions) - all_ui_permissions
         if unknown_permissions:
-            raise TypeError("{} are not valid permissions".format(list(unknown_permissions)))
+            raise TypeError(f"{list(unknown_permissions)} are not valid permissions")
 
         # Service id is always set on the request for service specific views.
         service_id = _get_service_id_from_view_args()

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -29,7 +29,7 @@ class Navigation:
 
     @staticmethod
     def get_endpoint_with_blueprint(endpoint):
-        return endpoint if "." in endpoint else "main.{}".format(endpoint)
+        return endpoint if "." in endpoint else f"main.{endpoint}"
 
 
 class HeaderNavigation(Navigation):

--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -26,9 +26,9 @@ class NotifyAdminAPIClient(BaseAPIClient):
     def generate_headers(self, api_token):
         headers = {
             "Content-type": "application/json",
-            "Authorization": "Bearer {}".format(api_token),
+            "Authorization": f"Bearer {api_token}",
             "X-Custom-Forwarder": self.route_secret,
-            "User-agent": "NOTIFY-API-PYTHON-CLIENT/{}".format(__version__),
+            "User-agent": f"NOTIFY-API-PYTHON-CLIENT/{__version__}",
         }
         return self._add_request_id_header(headers)
 

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -8,17 +8,17 @@ KEY_TYPE_TEST = "test"
 
 class ApiKeyApiClient(NotifyAdminAPIClient):
     def get_api_keys(self, service_id):
-        return self.get(url="/service/{}/api-keys".format(service_id))
+        return self.get(url=f"/service/{service_id}/api-keys")
 
     def create_api_key(self, service_id, key_name, key_type):
         data = {"name": key_name, "key_type": key_type}
         data = _attach_current_user(data)
-        key = self.post(url="/service/{}/api-key".format(service_id), data=data)
+        key = self.post(url=f"/service/{service_id}/api-key", data=data)
         return key["data"]
 
     def revoke_api_key(self, service_id, key_id):
         data = _attach_current_user({})
-        return self.post(url="/service/{0}/api-key/revoke/{1}".format(service_id, key_id), data=data)
+        return self.post(url=f"/service/{service_id}/api-key/revoke/{key_id}", data=data)
 
 
 api_key_api_client = ApiKeyApiClient()

--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -3,14 +3,14 @@ from app.notify_client import NotifyAdminAPIClient
 
 class BillingAPIClient(NotifyAdminAPIClient):
     def get_monthly_usage_for_service(self, service_id, year):
-        return self.get("/service/{0}/billing/monthly-usage".format(service_id), params=dict(year=year))
+        return self.get(f"/service/{service_id}/billing/monthly-usage", params=dict(year=year))
 
     def get_annual_usage_for_service(self, service_id, year=None):
-        return self.get("/service/{0}/billing/yearly-usage-summary".format(service_id), params=dict(year=year))
+        return self.get(f"/service/{service_id}/billing/yearly-usage-summary", params=dict(year=year))
 
     def get_free_sms_fragment_limit_for_year(self, service_id, year=None):
         result = self.get(
-            "/service/{0}/billing/free-sms-fragment-limit".format(service_id), params=dict(financial_year_start=year)
+            f"/service/{service_id}/billing/free-sms-fragment-limit", params=dict(financial_year_start=year)
         )
         return result["free_sms_fragment_limit"]
 
@@ -18,7 +18,7 @@ class BillingAPIClient(NotifyAdminAPIClient):
         # year = None will update current and future year in the API
         data = {"financial_year_start": year, "free_sms_fragment_limit": free_sms_fragment_limit}
 
-        return self.post(url="/service/{0}/billing/free-sms-fragment-limit".format(service_id), data=data)
+        return self.post(url=f"/service/{service_id}/billing/free-sms-fragment-limit", data=data)
 
     def get_data_for_billing_report(self, start_date, end_date):
         return self.get(

--- a/app/notify_client/contact_list_api_client.py
+++ b/app/notify_client/contact_list_api_client.py
@@ -19,7 +19,7 @@ class ContactListApiClient(NotifyAdminAPIClient):
         }
 
         data = _attach_current_user(data)
-        job = self.post(url="/service/{}/contact-list".format(service_id), data=data)
+        job = self.post(url=f"/service/{service_id}/contact-list", data=data)
 
         return job
 

--- a/app/notify_client/inbound_number_client.py
+++ b/app/notify_client/inbound_number_client.py
@@ -9,7 +9,7 @@ class InboundNumberClient(NotifyAdminAPIClient):
         return self.get("/inbound-number")
 
     def get_inbound_sms_number_for_service(self, service_id):
-        return self.get("/inbound-number/service/{}".format(service_id))
+        return self.get(f"/inbound-number/service/{service_id}")
 
     @cache.delete("service-{service_id}")
     @cache.delete_by_pattern("service-{service_id}-template-*")

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -22,7 +22,7 @@ class InviteApiClient(NotifyAdminAPIClient):
             "folder_permissions": folder_permissions,
         }
         data = _attach_current_user(data)
-        resp = self.post(url="/service/{}/invite".format(service_id), data=data)
+        resp = self.post(url=f"/service/{service_id}/invite", data=data)
         return resp["data"]
 
     def update_invite(self, *, service_id, invite_id, auth_type):
@@ -33,7 +33,7 @@ class InviteApiClient(NotifyAdminAPIClient):
         return resp["data"]
 
     def get_invites_for_service(self, service_id):
-        return self.get("/service/{}/invite".format(service_id))["data"]
+        return self.get(f"/service/{service_id}/invite")["data"]
 
     def get_invited_user(self, invited_user_id):
         return self.get(f"/invite/service/{invited_user_id}")["data"]
@@ -43,7 +43,7 @@ class InviteApiClient(NotifyAdminAPIClient):
 
     def get_count_of_invites_with_permission(self, service_id, permission):
         if permission not in all_ui_permissions:
-            raise TypeError("{} is not a valid permission".format(permission))
+            raise TypeError(f"{permission} is not a valid permission")
         return len(
             [
                 invited_user
@@ -53,18 +53,18 @@ class InviteApiClient(NotifyAdminAPIClient):
         )
 
     def check_token(self, token):
-        return self.get(url="/invite/service/check/{}".format(token))["data"]
+        return self.get(url=f"/invite/service/check/{token}")["data"]
 
     def cancel_invited_user(self, service_id, invited_user_id):
         data = {"status": "cancelled"}
         data = _attach_current_user(data)
-        self.post(url="/service/{0}/invite/{1}".format(service_id, invited_user_id), data=data)
+        self.post(url=f"/service/{service_id}/invite/{invited_user_id}", data=data)
 
     @cache.delete("service-{service_id}")
     @cache.delete("user-{invited_user_id}")
     def accept_invite(self, service_id, invited_user_id):
         data = {"status": "accepted"}
-        self.post(url="/service/{0}/invite/{1}".format(service_id, invited_user_id), data=data)
+        self.post(url=f"/service/{service_id}/invite/{invited_user_id}", data=data)
 
 
 invite_api_client = InviteApiClient()

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -21,7 +21,7 @@ class JobApiClient(NotifyAdminAPIClient):
 
     def get_job(self, service_id, job_id):
         params = {}
-        job = self.get(url="/service/{}/job/{}".format(service_id, job_id), params=params)
+        job = self.get(url=f"/service/{service_id}/job/{job_id}", params=params)
 
         return job
 
@@ -34,13 +34,13 @@ class JobApiClient(NotifyAdminAPIClient):
         if contact_list_id is not None:
             params["contact_list_id"] = contact_list_id
 
-        return self.get(url="/service/{}/job".format(service_id), params=params)
+        return self.get(url=f"/service/{service_id}/job", params=params)
 
     def get_uploads(self, service_id, limit_days=None, page=1):
         params = {"page": page}
         if limit_days is not None:
             params["limit_days"] = limit_days
-        return self.get(url="/service/{}/upload".format(service_id), params=params)
+        return self.get(url=f"/service/{service_id}/upload", params=params)
 
     def has_sent_previously(self, service_id, template_id, template_version, original_file_name):
         return (template_id, template_version, original_file_name) in (
@@ -93,10 +93,10 @@ class JobApiClient(NotifyAdminAPIClient):
             data.update({"contact_list_id": contact_list_id})
 
         data = _attach_current_user(data)
-        job = self.post(url="/service/{}/job".format(service_id), data=data)
+        job = self.post(url=f"/service/{service_id}/job", data=data)
 
         redis_client.set(
-            "has_jobs-{}".format(service_id),
+            f"has_jobs-{service_id}",
             b"true",
             ex=int(cache.DEFAULT_TTL),
         )
@@ -105,11 +105,11 @@ class JobApiClient(NotifyAdminAPIClient):
 
     @cache.delete("has_jobs-{service_id}")
     def cancel_job(self, service_id, job_id):
-        return self.post(url="/service/{}/job/{}/cancel".format(service_id, job_id), data={})
+        return self.post(url=f"/service/{service_id}/job/{job_id}/cancel", data={})
 
     @cache.delete("has_jobs-{service_id}")
     def cancel_letter_job(self, service_id, job_id):
-        return self.post(url="/service/{}/job/{}/cancel-letter-job".format(service_id, job_id), data={})
+        return self.post(url=f"/service/{service_id}/job/{job_id}/cancel-letter-job", data={})
 
 
 job_api_client = JobApiClient()

--- a/app/notify_client/letter_branding_client.py
+++ b/app/notify_client/letter_branding_client.py
@@ -4,7 +4,7 @@ from app.notify_client import NotifyAdminAPIClient, cache
 class LetterBrandingClient(NotifyAdminAPIClient):
     @cache.set("letter_branding-{branding_id}")
     def get_letter_branding(self, branding_id):
-        return self.get(url="/letter-branding/{}".format(branding_id))
+        return self.get(url=f"/letter-branding/{branding_id}")
 
     @cache.set("letter_branding")
     def get_all_letter_branding(self):

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -39,11 +39,11 @@ class NotificationApiClient(NotifyAdminAPIClient):
         kwargs = {"data": params} if to else {"params": params}
 
         if job_id:
-            return method(url="/service/{}/job/{}/notifications".format(service_id, job_id), **kwargs)
+            return method(url=f"/service/{service_id}/job/{job_id}/notifications", **kwargs)
         else:
             if limit_days is not None:
                 params["limit_days"] = limit_days
-            return method(url="/service/{}/notifications".format(service_id), **kwargs)
+            return method(url=f"/service/{service_id}/notifications", **kwargs)
 
     def send_notification(self, service_id, *, template_id, recipient, personalisation, sender_id):
         data = {
@@ -54,15 +54,15 @@ class NotificationApiClient(NotifyAdminAPIClient):
         if sender_id:
             data["sender_id"] = sender_id
         data = _attach_current_user(data)
-        return self.post(url="/service/{}/send-notification".format(service_id), data=data)
+        return self.post(url=f"/service/{service_id}/send-notification", data=data)
 
     def send_precompiled_letter(self, service_id, filename, file_id, postage, recipient_address):
         data = {"filename": filename, "file_id": file_id, "postage": postage, "recipient_address": recipient_address}
         data = _attach_current_user(data)
-        return self.post(url="/service/{}/send-pdf-letter".format(service_id), data=data)
+        return self.post(url=f"/service/{service_id}/send-pdf-letter", data=data)
 
     def get_notification(self, service_id, notification_id):
-        return self.get(url="/service/{}/notifications/{}".format(service_id, notification_id))
+        return self.get(url=f"/service/{service_id}/notifications/{notification_id}")
 
     def get_api_notifications_for_service(self, service_id):
         ret = self.get_notifications_for_service(
@@ -90,7 +90,7 @@ class NotificationApiClient(NotifyAdminAPIClient):
         return self.get(url=get_url)
 
     def update_notification_to_cancelled(self, service_id, notification_id):
-        return self.post(url="/service/{}/notifications/{}/cancel".format(service_id, notification_id), data={})
+        return self.post(url=f"/service/{service_id}/notifications/{notification_id}/cancel", data={})
 
     def get_notification_status_by_service(self, start_date, end_date):
         return self.get(
@@ -102,7 +102,7 @@ class NotificationApiClient(NotifyAdminAPIClient):
         )
 
     def get_notification_count_for_job_id(self, *, service_id, job_id):
-        return self.get(url="/service/{}/job/{}/notification_count".format(service_id, job_id))["count"]
+        return self.get(url=f"/service/{service_id}/job/{job_id}/notification_count")["count"]
 
 
 notification_api_client = NotificationApiClient()

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -14,11 +14,11 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
             "invite_link_host": self.admin_url,
         }
         data = _attach_current_user(data)
-        resp = self.post(url="/organisation/{}/invite".format(org_id), data=data)
+        resp = self.post(url=f"/organisation/{org_id}/invite", data=data)
         return resp["data"]
 
     def get_invites_for_organisation(self, org_id):
-        endpoint = "/organisation/{}/invite".format(org_id)
+        endpoint = f"/organisation/{org_id}/invite"
         resp = self.get(endpoint)
         return resp["data"]
 
@@ -29,17 +29,17 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
         return self.get(f"/invite/organisation/{invited_user_id}")["data"]
 
     def check_token(self, token):
-        resp = self.get(url="/invite/organisation/check/{}".format(token))
+        resp = self.get(url=f"/invite/organisation/check/{token}")
         return resp["data"]
 
     def cancel_invited_user(self, org_id, invited_user_id):
         data = {"status": "cancelled"}
         data = _attach_current_user(data)
-        self.post(url="/organisation/{0}/invite/{1}".format(org_id, invited_user_id), data=data)
+        self.post(url=f"/organisation/{org_id}/invite/{invited_user_id}", data=data)
 
     def accept_invite(self, org_id, invited_user_id):
         data = {"status": "accepted"}
-        self.post(url="/organisation/{0}/invite/{1}".format(org_id, invited_user_id), data=data)
+        self.post(url=f"/organisation/{org_id}/invite/{invited_user_id}", data=data)
 
 
 org_invite_api_client = OrgInviteApiClient()

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -16,7 +16,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
         return list(chain.from_iterable(organisation["domains"] for organisation in self.get_organisations()))
 
     def get_organisation(self, org_id):
-        return self.get(url="/organisations/{}".format(org_id))
+        return self.get(url=f"/organisations/{org_id}")
 
     @cache.set("organisation-{org_id}-name")
     def get_organisation_name(self, org_id):
@@ -25,7 +25,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
     def get_organisation_by_domain(self, domain):
         try:
             return self.get(
-                url="/organisations/by-domain?domain={}".format(domain),
+                url=f"/organisations/by-domain?domain={domain}",
             )
         except HTTPError as error:
             if error.status_code == 404:
@@ -47,7 +47,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
     @cache.delete("domains")
     @cache.delete("organisations")
     def update_organisation(self, org_id, cached_service_ids=None, **kwargs):
-        api_response = self.post(url="/organisations/{}".format(org_id), data=kwargs)
+        api_response = self.post(url=f"/organisations/{org_id}", data=kwargs)
 
         if cached_service_ids:
             redis_client.delete(*map("service-{}".format, cached_service_ids))
@@ -84,10 +84,10 @@ class OrganisationsClient(NotifyAdminAPIClient):
     @cache.delete("organisations")
     def update_service_organisation(self, service_id, org_id):
         data = {"service_id": service_id}
-        return self.post(url="/organisations/{}/service".format(org_id), data=data)
+        return self.post(url=f"/organisations/{org_id}/service", data=data)
 
     def get_organisation_services(self, org_id):
-        return self.get(url="/organisations/{}/services".format(org_id))
+        return self.get(url=f"/organisations/{org_id}/services")
 
     @cache.delete("user-{user_id}")
     def remove_user_from_organisation(self, org_id, user_id):

--- a/app/notify_client/provider_client.py
+++ b/app/notify_client/provider_client.py
@@ -6,15 +6,15 @@ class ProviderClient(NotifyAdminAPIClient):
         return self.get(url="/provider-details")
 
     def get_provider_by_id(self, provider_id):
-        return self.get(url="/provider-details/{}".format(provider_id))
+        return self.get(url=f"/provider-details/{provider_id}")
 
     def get_provider_versions(self, provider_id):
-        return self.get(url="/provider-details/{}/versions".format(provider_id))
+        return self.get(url=f"/provider-details/{provider_id}/versions")
 
     def update_provider(self, provider_id, priority):
         data = {"priority": priority}
         data = _attach_current_user(data)
-        return self.post(url="/provider-details/{}".format(provider_id), data=data)
+        return self.post(url=f"/provider-details/{provider_id}", data=data)
 
 
 provider_client = ProviderClient()

--- a/app/notify_client/template_folder_api_client.py
+++ b/app/notify_client/template_folder_api_client.py
@@ -6,11 +6,11 @@ class TemplateFolderAPIClient(NotifyAdminAPIClient):
     @cache.delete("service-{service_id}-template-folders")
     def create_template_folder(self, service_id, name, parent_id=None):
         data = {"name": name, "parent_id": parent_id}
-        return self.post("/service/{}/template-folder".format(service_id), data)["data"]["id"]
+        return self.post(f"/service/{service_id}/template-folder", data)["data"]["id"]
 
     @cache.set("service-{service_id}-template-folders")
     def get_template_folders(self, service_id):
-        return self.get("/service/{}/template-folder".format(service_id))["template_folders"]
+        return self.get(f"/service/{service_id}/template-folder")["template_folders"]
 
     def get_template_folder(self, service_id, folder_id):
         if folder_id is None:
@@ -27,9 +27,9 @@ class TemplateFolderAPIClient(NotifyAdminAPIClient):
     def move_to_folder(self, service_id, folder_id, template_ids, folder_ids):
 
         if folder_id:
-            url = "/service/{}/template-folder/{}/contents".format(service_id, folder_id)
+            url = f"/service/{service_id}/template-folder/{folder_id}/contents"
         else:
-            url = "/service/{}/template-folder/contents".format(service_id)
+            url = f"/service/{service_id}/template-folder/contents"
 
         self.post(
             url,
@@ -47,11 +47,11 @@ class TemplateFolderAPIClient(NotifyAdminAPIClient):
         data = {"name": name}
         if users_with_permission:
             data["users_with_permission"] = users_with_permission
-        self.post("/service/{}/template-folder/{}".format(service_id, template_folder_id), data)
+        self.post(f"/service/{service_id}/template-folder/{template_folder_id}", data)
 
     @cache.delete("service-{service_id}-template-folders")
     def delete_template_folder(self, service_id, template_folder_id):
-        self.delete("/service/{}/template-folder/{}".format(service_id, template_folder_id), {})
+        self.delete(f"/service/{service_id}/template-folder/{template_folder_id}", {})
 
 
 template_folder_api_client = TemplateFolderAPIClient()

--- a/app/notify_client/template_statistics_api_client.py
+++ b/app/notify_client/template_statistics_api_client.py
@@ -7,18 +7,14 @@ class TemplateStatisticsApiClient(NotifyAdminAPIClient):
         if limit_days is not None:
             params["limit_days"] = limit_days
 
-        return self.get(url="/service/{}/template-statistics".format(service_id), params=params)["data"]
+        return self.get(url=f"/service/{service_id}/template-statistics", params=params)["data"]
 
     def get_monthly_template_usage_for_service(self, service_id, year):
 
-        return self.get(url="/service/{}/notifications/templates_usage/monthly?year={}".format(service_id, year))[
-            "stats"
-        ]
+        return self.get(url=f"/service/{service_id}/notifications/templates_usage/monthly?year={year}")["stats"]
 
     def get_last_used_date_for_template(self, service_id, template_id):
-        return self.get(url="/service/{}/template-statistics/last-used/{}".format(service_id, template_id))[
-            "last_date_used"
-        ]
+        return self.get(url=f"/service/{service_id}/template-statistics/last-used/{template_id}")["last_date_used"]
 
 
 template_statistics_client = TemplateStatisticsApiClient()

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -35,7 +35,7 @@ class UserApiClient(NotifyAdminAPIClient):
 
     @cache.set("user-{user_id}")
     def _get_user(self, user_id):
-        return self.get("/user/{}".format(user_id))
+        return self.get(f"/user/{user_id}")
 
     def get_user_by_email(self, email_address):
         user_data = self.post("/user/email", data={"email": email_address})
@@ -54,33 +54,33 @@ class UserApiClient(NotifyAdminAPIClient):
         data = dict(kwargs)
         disallowed_attributes = set(data.keys()) - ALLOWED_ATTRIBUTES
         if disallowed_attributes:
-            raise TypeError("Not allowed to update user attributes: {}".format(", ".join(disallowed_attributes)))
+            raise TypeError(f"Not allowed to update user attributes: {', '.join(disallowed_attributes)}")
 
-        url = "/user/{}".format(user_id)
+        url = f"/user/{user_id}"
         user_data = self.post(url, data=data)
         return user_data["data"]
 
     @cache.delete("user-{user_id}")
     def archive_user(self, user_id):
-        return self.post("/user/{}/archive".format(user_id), data=None)
+        return self.post(f"/user/{user_id}/archive", data=None)
 
     @cache.delete("user-{user_id}")
     def reset_failed_login_count(self, user_id):
-        url = "/user/{}/reset-failed-login-count".format(user_id)
+        url = f"/user/{user_id}/reset-failed-login-count"
         user_data = self.post(url, data={})
         return user_data["data"]
 
     @cache.delete("user-{user_id}")
     def update_password(self, user_id, password):
         data = {"_password": password}
-        url = "/user/{}/update-password".format(user_id)
+        url = f"/user/{user_id}/update-password"
         user_data = self.post(url, data=data)
         return user_data["data"]
 
     @cache.delete("user-{user_id}")
     def verify_password(self, user_id, password):
         try:
-            url = "/user/{}/verify/password".format(user_id)
+            url = f"/user/{user_id}/verify/password"
             data = {"password": password}
             self.post(url, data=data)
             return True
@@ -94,7 +94,7 @@ class UserApiClient(NotifyAdminAPIClient):
             data["next"] = next_string
         if code_type == "email":
             data["email_auth_link_host"] = self.admin_url
-        endpoint = "/user/{0}/{1}-code".format(user_id, code_type)
+        endpoint = f"/user/{user_id}/{code_type}-code"
         self.post(endpoint, data=data)
 
     def send_verify_email(self, user_id, to):
@@ -102,18 +102,18 @@ class UserApiClient(NotifyAdminAPIClient):
             "to": to,
             "admin_base_url": self.admin_url,
         }
-        endpoint = "/user/{0}/email-verification".format(user_id)
+        endpoint = f"/user/{user_id}/email-verification"
         self.post(endpoint, data=data)
 
     def send_already_registered_email(self, user_id, to):
         data = {"email": to}
-        endpoint = "/user/{0}/email-already-registered".format(user_id)
+        endpoint = f"/user/{user_id}/email-already-registered"
         self.post(endpoint, data=data)
 
     @cache.delete("user-{user_id}")
     def check_verify_code(self, user_id, code, code_type):
         data = {"code_type": code_type, "code": code}
-        endpoint = "/user/{}/verify/code".format(user_id)
+        endpoint = f"/user/{user_id}/verify/code"
         try:
             self.post(endpoint, data=data)
             return True, ""
@@ -135,11 +135,11 @@ class UserApiClient(NotifyAdminAPIClient):
             raise e
 
     def get_users_for_service(self, service_id):
-        endpoint = "/service/{}/users".format(service_id)
+        endpoint = f"/service/{service_id}/users"
         return self.get(endpoint)["data"]
 
     def get_users_for_organisation(self, org_id):
-        endpoint = "/organisations/{}/users".format(org_id)
+        endpoint = f"/organisations/{org_id}/users"
         return self.get(endpoint)["data"]
 
     @cache.delete("service-{service_id}")
@@ -147,7 +147,7 @@ class UserApiClient(NotifyAdminAPIClient):
     @cache.delete("user-{user_id}")
     def add_user_to_service(self, service_id, user_id, permissions, folder_permissions):
         # permissions passed in are the combined UI permissions, not DB permissions
-        endpoint = "/service/{}/users/{}".format(service_id, user_id)
+        endpoint = f"/service/{service_id}/users/{user_id}"
         data = {
             "permissions": [{"permission": x} for x in translate_permissions_from_ui_to_db(permissions)],
             "folder_permissions": folder_permissions,
@@ -157,7 +157,7 @@ class UserApiClient(NotifyAdminAPIClient):
 
     @cache.delete("user-{user_id}")
     def add_user_to_organisation(self, org_id, user_id):
-        resp = self.post("/organisations/{}/users/{}".format(org_id, user_id), data={})
+        resp = self.post(f"/organisations/{org_id}/users/{user_id}", data={})
         return resp["data"]
 
     @cache.delete("service-{service_id}-template-folders")
@@ -171,7 +171,7 @@ class UserApiClient(NotifyAdminAPIClient):
         if folder_permissions is not None:
             data["folder_permissions"] = folder_permissions
 
-        endpoint = "/user/{}/service/{}/permission".format(user_id, service_id)
+        endpoint = f"/user/{user_id}/service/{service_id}/permission"
         self.post(endpoint, data=data)
 
     def send_reset_password_url(self, email_address, next_string=None):
@@ -192,15 +192,15 @@ class UserApiClient(NotifyAdminAPIClient):
 
     @cache.delete("user-{user_id}")
     def activate_user(self, user_id):
-        return self.post("/user/{}/activate".format(user_id), data=None)
+        return self.post(f"/user/{user_id}/activate", data=None)
 
     def send_change_email_verification(self, user_id, new_email):
-        endpoint = "/user/{}/change-email-verification".format(user_id)
+        endpoint = f"/user/{user_id}/change-email-verification"
         data = {"email": new_email}
         self.post(endpoint, data)
 
     def get_organisations_and_services_for_user(self, user_id):
-        endpoint = "/user/{}/organisations-and-services".format(user_id)
+        endpoint = f"/user/{user_id}/organisations-and-services"
         return self.get(endpoint)
 
     def get_webauthn_credentials_for_user(self, user_id):

--- a/app/s3_client/logo_client.py
+++ b/app/s3_client/logo_client.py
@@ -115,7 +115,7 @@ class LogoClient:
         # TaggingDirective='REPLACE' here will strip all tags from the S3 object - ie removes the 'delete-after-7-days'
         # tag, so this new version won't get cleaned up by our lifecycle policy.
         self._get_object(permanent_logo_key).copy_from(
-            CopySource="{}/{}".format(self.bucket_name, temporary_logo_key), TaggingDirective="REPLACE"
+            CopySource=f"{self.bucket_name}/{temporary_logo_key}", TaggingDirective="REPLACE"
         )
 
         return permanent_logo_key

--- a/app/s3_client/s3_csv_client.py
+++ b/app/s3_client/s3_csv_client.py
@@ -38,9 +38,7 @@ def s3download(service_id, upload_id, bucket=None):
         key = get_csv_upload(service_id, upload_id, bucket)
         contents = key.get()["Body"].read().decode("utf-8")
     except botocore.exceptions.ClientError as e:
-        current_app.logger.error(
-            "Unable to download s3 file {}".format(FILE_LOCATION_STRUCTURE.format(service_id, upload_id))
-        )
+        current_app.logger.error(f"Unable to download s3 file {FILE_LOCATION_STRUCTURE.format(service_id, upload_id)}")
         raise e
     return contents
 
@@ -59,7 +57,5 @@ def get_csv_metadata(service_id, upload_id, bucket=None):
         key = get_csv_upload(service_id, upload_id, bucket)
         return key.get()["Metadata"]
     except botocore.exceptions.ClientError as e:
-        current_app.logger.error(
-            "Unable to download s3 file {}".format(FILE_LOCATION_STRUCTURE.format(service_id, upload_id))
-        )
+        current_app.logger.error(f"Unable to download s3 file {FILE_LOCATION_STRUCTURE.format(service_id, upload_id)}")
         raise e

--- a/app/s3_client/s3_letter_upload_client.py
+++ b/app/s3_client/s3_letter_upload_client.py
@@ -12,7 +12,7 @@ class LetterNotFoundError(Exception):
 
 
 def get_transient_letter_file_location(service_id, upload_id):
-    return "service-{}/{}.pdf".format(service_id, upload_id)
+    return f"service-{service_id}/{upload_id}.pdf"
 
 
 def backup_original_letter_to_s3(

--- a/app/s3_client/s3_mou_client.py
+++ b/app/s3_client/s3_mou_client.py
@@ -18,5 +18,5 @@ def get_mou(organisation_is_crown):
             "as_attachment": True,
         }
     except botocore.exceptions.ClientError as exception:
-        current_app.logger.error("Unable to download s3 file {}/{}".format(bucket, filename))
+        current_app.logger.error(f"Unable to download s3 file {bucket}/{filename}")
         raise exception

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -31,7 +31,7 @@ def add_rates_to(delivery_statistics):
             delivery_statistics["sms_failed"], delivery_statistics["sms_requested"]
         ),
         week_end_datetime=parser.parse(delivery_statistics.get("week_end", str(datetime.utcnow()))),
-        **delivery_statistics
+        **delivery_statistics,
     )
 
 
@@ -39,14 +39,14 @@ def get_formatted_percentage(x, tot):
     """
     Return a percentage to one decimal place (respecting )
     """
-    return "{0:.1f}".format((float(x) / tot * 100)) if tot else "0"
+    return f"{float(x) / tot * 100:.1f}" if tot else "0"
 
 
 def get_formatted_percentage_two_dp(x, tot):
     """
     Return a percentage to two decimal places
     """
-    return "{0:.2f}".format((float(x) / tot * 100)) if tot else "0"
+    return f"{float(x) / tot * 100:.2f}" if tot else "0"
 
 
 def statistics_by_state(statistics):

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -30,7 +30,7 @@ class TemplatePreview:
                 "?page={}".format(page) if page else "",
             ),
             json=data,
-            headers={"Authorization": "Token {}".format(current_app.config["TEMPLATE_PREVIEW_API_KEY"])},
+            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
         )
         return resp.content, resp.status_code, cls.get_allowed_headers(resp.headers)
 
@@ -43,7 +43,7 @@ class TemplatePreview:
                 current_app.config["TEMPLATE_PREVIEW_API_HOST"], "?hide_notify=true" if page == "1" else ""
             ),
             data=base64.b64encode(pdf_page).decode("utf-8"),
-            headers={"Authorization": "Token {}".format(current_app.config["TEMPLATE_PREVIEW_API_KEY"])},
+            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
         )
         return resp.content, resp.status_code, cls.get_allowed_headers(resp.headers)
 
@@ -56,7 +56,7 @@ class TemplatePreview:
                 current_app.config["TEMPLATE_PREVIEW_API_HOST"], "?page_number={}".format(page)
             ),
             data=pdf_page,
-            headers={"Authorization": "Token {}".format(current_app.config["TEMPLATE_PREVIEW_API_KEY"])},
+            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
         )
         return resp.content, resp.status_code, cls.get_allowed_headers(resp.headers)
 
@@ -69,9 +69,9 @@ class TemplatePreview:
             "filename": filename,
         }
         resp = requests.post(
-            "{}/preview.png".format(current_app.config["TEMPLATE_PREVIEW_API_HOST"]),
+            f"{current_app.config['TEMPLATE_PREVIEW_API_HOST']}/preview.png",
             json=data,
-            headers={"Authorization": "Token {}".format(current_app.config["TEMPLATE_PREVIEW_API_KEY"])},
+            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
         )
         return resp.content, resp.status_code, cls.get_allowed_headers(resp.headers)
 
@@ -107,5 +107,5 @@ def sanitise_letter(pdf_file, *, upload_id, allow_international_letters, is_an_a
     return requests.post(
         url,
         data=pdf_file,
-        headers={"Authorization": "Token {}".format(current_app.config["TEMPLATE_PREVIEW_API_KEY"])},
+        headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
     )

--- a/app/url_converters.py
+++ b/app/url_converters.py
@@ -10,7 +10,7 @@ from app.models.service import Service
 
 class TemplateTypeConverter(BaseConverter):
 
-    regex = "(?:{})".format("|".join(Service.TEMPLATE_TYPES))
+    regex = f"(?:{'|'.join(Service.TEMPLATE_TYPES)})"
 
 
 class TicketTypeConverter(BaseConverter):

--- a/app/utils/pagination.py
+++ b/app/utils/pagination.py
@@ -23,5 +23,5 @@ def generate_previous_next_dict(view, service_id, page, title, url_args):
     return {
         "url": url_for(view, service_id=service_id, page=page, **url_args),
         "title": title,
-        "label": "page {}".format(page),
+        "label": f"page {page}",
     }

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -33,7 +33,7 @@ def get_template(
         return EmailPreviewTemplate(
             template,
             from_name=service.name,
-            from_address="{}@notifications.service.gov.uk".format(service.email_from),
+            from_address=f"{service.email_from}@notifications.service.gov.uk",
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
             reply_to=email_reply_to,

--- a/app/utils/user.py
+++ b/app/utils/user.py
@@ -9,7 +9,7 @@ from app.notify_client.organisations_api_client import organisations_client
 user_is_logged_in = login_required
 
 
-with open("{}/email_domains.txt".format(os.path.dirname(os.path.realpath(__file__)))) as email_domains:
+with open(f"{os.path.dirname(os.path.realpath(__file__))}/email_domains.txt") as email_domains:
     GOVERNMENT_EMAIL_DOMAIN_NAMES = [line.strip() for line in email_domains]
 
 
@@ -62,8 +62,8 @@ def _email_address_ends_with(email_address, known_domains):
     return any(
         email_address.lower().endswith(
             (
-                "@{}".format(known),
-                ".{}".format(known),
+                f"@{known}",
+                f".{known}",
             )
         )
         for known in known_domains

--- a/get_zendesk_tickets.py
+++ b/get_zendesk_tickets.py
@@ -23,7 +23,7 @@ ZENDESK_API_KEY = os.environ.get("ZENDESK_API_KEY")
 
 def get_tickets():
     ZENDESK_TICKET_URL = "https://govuk.zendesk.com/api/v2/search.json?query={}"
-    query_params = "type:ticket group:{}".format(NOTIFY_GROUP_ID)
+    query_params = f"type:ticket group:{NOTIFY_GROUP_ID}"
     query_params = urllib.parse.quote(query_params)
 
     next_page = ZENDESK_TICKET_URL.format(query_params)
@@ -43,7 +43,7 @@ def get_tickets():
             response = requests.get(
                 next_page,
                 headers={"Content-type": "application/json"},
-                auth=("{}/token".format(NOTIFY_ZENDESK_EMAIL), ZENDESK_API_KEY),
+                auth=(f"{NOTIFY_ZENDESK_EMAIL}/token", ZENDESK_API_KEY),
             )
             data = response.json()
             print(data)
@@ -69,7 +69,7 @@ def get_tickets():
 
 def get_tickets_without_service_id():
     ZENDESK_TICKET_URL = "https://govuk.zendesk.com/api/v2/search.json?query={}"
-    query_params = "type:ticket group:{}".format(NOTIFY_GROUP_ID)
+    query_params = f"type:ticket group:{NOTIFY_GROUP_ID}"
     query_params = urllib.parse.quote(query_params)
 
     next_page = ZENDESK_TICKET_URL.format(query_params)
@@ -87,7 +87,7 @@ def get_tickets_without_service_id():
             response = requests.get(
                 next_page,
                 headers={"Content-type": "application/json"},
-                auth=("{}/token".format(NOTIFY_ZENDESK_EMAIL), ZENDESK_API_KEY),
+                auth=(f"{NOTIFY_ZENDESK_EMAIL}/token", ZENDESK_API_KEY),
             )
             data = response.json()
             print(data)
@@ -112,7 +112,7 @@ def get_tickets_without_service_id():
 
 def get_tickets_with_description():
     ZENDESK_TICKET_URL = "https://govuk.zendesk.com/api/v2/search.json?query={}"
-    query_params = "type:ticket group:{}, created>2019-07-01".format(NOTIFY_GROUP_ID)
+    query_params = f"type:ticket group:{NOTIFY_GROUP_ID}, created>2019-07-01"
     query_params = urllib.parse.quote(query_params)
 
     next_page = ZENDESK_TICKET_URL.format(query_params)
@@ -131,7 +131,7 @@ def get_tickets_with_description():
             response = requests.get(
                 next_page,
                 headers={"Content-type": "application/json"},
-                auth=("{}/token".format(NOTIFY_ZENDESK_EMAIL), ZENDESK_API_KEY),
+                auth=(f"{NOTIFY_ZENDESK_EMAIL}/token", ZENDESK_API_KEY),
             )
             data = response.json()
             print(data)

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -10,7 +10,7 @@ from gds_metrics.gunicorn import child_exit  # noqa
 workers = 5
 worker_class = "eventlet"
 errorlog = "/home/vcap/logs/gunicorn_error.log"
-bind = "0.0.0.0:{}".format(os.getenv("PORT"))
+bind = f"0.0.0.0:{os.getenv('PORT')}"
 disable_redirect_access_to_syslog = True
 gunicorn.SERVER_SOFTWARE = "None"
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -522,9 +522,9 @@ def notification_json(  # noqa: C901
 
     if with_links:
         links = {
-            "prev": "/service/{}/notifications?page=0".format(service_id),
-            "next": "/service/{}/notifications?page=1".format(service_id),
-            "last": "/service/{}/notifications?page=2".format(service_id),
+            "prev": f"/service/{service_id}/notifications?page=0",
+            "next": f"/service/{service_id}/notifications?page=1",
+            "last": f"/service/{service_id}/notifications?page=2",
         }
 
     job_payload = None
@@ -634,9 +634,9 @@ def validate_route_permission(
             elif method == "POST":
                 resp = client.post(route)
             else:
-                pytest.fail("Invalid method call {}".format(method))
+                pytest.fail(f"Invalid method call {method}")
             if resp.status_code != response_code:
-                pytest.fail("Invalid permissions set for endpoint {}".format(route))
+                pytest.fail(f"Invalid permissions set for endpoint {route}")
     return resp
 
 
@@ -658,9 +658,9 @@ def validate_route_permission_with_client(mocker, client, method, response_code,
     elif method == "POST":
         resp = client.post_response_from_url(route, _expected_status=response_code)
     else:
-        pytest.fail("Invalid method call {}".format(method))
+        pytest.fail(f"Invalid method call {method}")
     if resp.status_code != response_code:
-        pytest.fail("Invalid permissions set for endpoint {}".format(route))
+        pytest.fail(f"Invalid permissions set for endpoint {route}")
     return resp
 
 

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -245,7 +245,7 @@ def get_name_of_decorator_from_ast_node(node):
         return get_name_of_decorator_from_ast_node(node.func)
     if isinstance(node, ast.Attribute):
         return node.value.id
-    return "{}.{}".format(node.func.value.id, node.func.attr)
+    return f"{node.func.value.id}.{node.func.attr}"
 
 
 def get_decorators_for_function(function):
@@ -269,11 +269,11 @@ def get_routes_and_decorators(argument_name=None):
                 if "main.route" in decorators and (
                     not argument_name or argument_name in inspect.signature(function).parameters.keys()
                 ):
-                    yield "{}.{}".format(module_name, function_name), decorators
+                    yield f"{module_name}.{function_name}", decorators
 
 
 def format_decorators(decorators, indent=8):
-    return "\n".join("{}@{}".format(" " * indent, decorator) for decorator in decorators)
+    return "\n".join(f"{' ' * indent}@{decorator}" for decorator in decorators)
 
 
 def test_code_to_extract_decorators_works_with_known_examples():

--- a/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
+++ b/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
@@ -7,8 +7,8 @@ from tests import user_json
 def user_with_orgs_and_services(num_orgs, num_services, platform_admin=False):
     return user_json(
         name="leo",
-        organisations=["org{}".format(i) for i in range(1, num_orgs + 1)],
-        services=["service{}".format(i) for i in range(1, num_services + 1)],
+        organisations=[f"org{i}" for i in range(1, num_orgs + 1)],
+        services=[f"service{i}" for i in range(1, num_services + 1)],
         platform_admin=platform_admin,
     )
 

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -25,7 +25,7 @@ def test_invite_org_user(
 
     mock_invite_org_user.assert_called_once_with(
         sample_org_invite["invited_by"],
-        "{}".format(ORGANISATION_ID),
+        f"{ORGANISATION_ID}",
         "test@example.gov.uk",
     )
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1293,11 +1293,11 @@ def test_view_organisation_settings(
     for index, option in enumerate(expected_options):
         option_values = {
             "value": radios[index]["value"],
-            "label": normalize_spaces(page.select_one("label[for={}]".format(radios[index]["id"])).text),
+            "label": normalize_spaces(page.select_one(f"label[for={radios[index]['id']}]").text),
         }
         if "hint" in option:
             option_values["hint"] = normalize_spaces(
-                page.select_one("label[for={}] + .govuk-hint".format(radios[index]["id"])).text
+                page.select_one(f"label[for={radios[index]['id']}] + .govuk-hint").text
             )
         assert option_values == option
 

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -85,7 +85,7 @@ def test_email_branding_options_page_when_no_branding_is_set(
     button_text = normalize_spaces(page.select_one(".page-footer button").text)
 
     assert [
-        (radio["value"], page.select_one("label[for={}]".format(radio["id"])).text.strip())
+        (radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip())
         for radio in page.select("input[type=radio]")
     ] == [(EmailBranding.NHS_ID, "NHS"), ("something_else", "Something else")]
 
@@ -153,7 +153,7 @@ def test_email_branding_options_page_shows_branding_pool_options_if_branding_poo
     page = client_request.get(".email_branding_options", service_id=SERVICE_ONE_ID)
 
     assert [
-        (radio["value"], page.select_one("label[for={}]".format(radio["id"])).text.strip())
+        (radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip())
         for radio in page.select("input[type=radio]")
     ] == expected_options
 

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -88,7 +88,7 @@ def test_letter_branding_options_page_when_no_branding_is_set(
     assert button_text == "Continue"
 
     assert [
-        (radio["value"], page.select_one("label[for={}]".format(radio["id"])).text.strip())
+        (radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip())
         for radio in page.select("input[type=radio]")
     ] == expected_options
 
@@ -111,11 +111,11 @@ def test_letter_branding_options_page_when_branding_is_set_already(
     [
         (
             None,
-            "/services/{}/service-settings".format(SERVICE_ONE_ID),
+            f"/services/{SERVICE_ONE_ID}/service-settings",
         ),
         (
             TEMPLATE_ONE_ID,
-            "/services/{}/templates/{}".format(SERVICE_ONE_ID, TEMPLATE_ONE_ID),
+            f"/services/{SERVICE_ONE_ID}/templates/{TEMPLATE_ONE_ID}",
         ),
     ],
 )

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -814,7 +814,7 @@ def test_show_switch_service_to_count_as_live_page(
         service_id=SERVICE_ONE_ID,
     )
     assert page.select_one("[checked]")["value"] == selected
-    assert page.select_one("label[for={}]".format(page.select_one("[checked]")["id"])).text.strip() == labelled
+    assert page.select_one(f"label[for={page.select_one('[checked]')['id']}]").text.strip() == labelled
 
 
 @pytest.mark.parametrize(
@@ -911,7 +911,7 @@ def test_should_check_if_estimated_volumes_provided(
 
     for volume, channel in zip(volumes, ("sms", "email", "letter")):
         mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
+            f"app.models.service.Service.volume_{channel}",
             create=True,
             new_callable=PropertyMock,
             return_value=volume,
@@ -968,7 +968,7 @@ def test_should_check_for_reply_to_on_go_live(
 
     for channel, volume in (("email", volume_email), ("sms", 0), ("letter", 1)):
         mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
+            f"app.models.service.Service.volume_{channel}",
             create=True,
             new_callable=PropertyMock,
             return_value=volume,
@@ -1093,7 +1093,7 @@ def test_should_not_show_go_live_button_if_checklist_not_complete(
 
     for channel in ("email", "sms", "letter"):
         mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
+            f"app.models.service.Service.volume_{channel}",
             create=True,
             new_callable=PropertyMock,
             return_value=0,
@@ -1259,7 +1259,7 @@ def test_should_check_for_sms_sender_on_go_live(
 
     for channel, volume in (("email", 0), ("sms", estimated_sms_volume)):
         mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
+            f"app.models.service.Service.volume_{channel}",
             create=True,
             new_callable=PropertyMock,
             return_value=volume,
@@ -1316,7 +1316,7 @@ def test_should_check_for_mou_on_request_to_go_live(
     )
     for channel in {"email", "sms", "letter"}:
         mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
+            f"app.models.service.Service.volume_{channel}",
             create=True,
             new_callable=PropertyMock,
             return_value=None,
@@ -1364,7 +1364,7 @@ def test_gp_without_organisation_is_shown_agreement_step(
     )
     for channel in {"email", "sms", "letter"}:
         mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
+            f"app.models.service.Service.volume_{channel}",
             create=True,
             new_callable=PropertyMock,
             return_value=None,
@@ -1452,7 +1452,7 @@ def test_should_show_estimate_volumes(
 ):
     for channel, volume in volumes:
         mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
+            f"app.models.service.Service.volume_{channel}",
             create=True,
             new_callable=PropertyMock,
             return_value=volume,
@@ -1485,9 +1485,9 @@ def test_should_show_estimate_volumes(
             displayed_volumes[2],
         ),
     ):
-        assert normalize_spaces(page.select_one("label[for=volume_{}]".format(channel)).text) == label
-        assert normalize_spaces(page.select_one("#volume_{}-hint".format(channel)).text) == hint
-        assert page.select_one("#volume_{}".format(channel)).get("value") == value
+        assert normalize_spaces(page.select_one(f"label[for=volume_{channel}]").text) == label
+        assert normalize_spaces(page.select_one(f"#volume_{channel}-hint").text) == hint
+        assert page.select_one(f"#volume_{channel}").get("value") == value
 
     assert len(page.select("input[type=radio]")) == 2
 
@@ -1826,7 +1826,7 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
 ):
     for channel in {"email", "sms", "letter"}:
         mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
+            f"app.models.service.Service.volume_{channel}",
             create=True,
             new_callable=PropertyMock,
             return_value=1,
@@ -2013,9 +2013,7 @@ def test_ready_to_go_live(
         "shouldnt_use_govuk_as_sms_sender",
         "sms_sender_is_govuk",
     }:
-        mocker.patch("app.models.service.Service.{}".format(prop), new_callable=PropertyMock).return_value = locals()[
-            prop
-        ]
+        mocker.patch(f"app.models.service.Service.{prop}", new_callable=PropertyMock).return_value = locals()[prop]
 
     for channel, volume in (
         ("sms", volume_sms),
@@ -2023,7 +2021,7 @@ def test_ready_to_go_live(
         ("letter", volume_letter),
     ):
         mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
+            f"app.models.service.Service.volume_{channel}",
             create=True,
             new_callable=PropertyMock,
             return_value=volume,
@@ -2418,7 +2416,7 @@ def test_add_reply_to_email_address_sends_test_notification(
             service_id=SERVICE_ONE_ID,
             notification_id="123",
         )
-        + "?is_default={}".format(api_default_args),
+        + f"?is_default={api_default_args}",
     )
     mock_verify.assert_called_once_with(SERVICE_ONE_ID, "test@example.com")
 
@@ -2487,9 +2485,9 @@ def test_service_verify_reply_to_address(
         "main.service_verify_reply_to_address",
         service_id=SERVICE_ONE_ID,
         notification_id=notification["id"],
-        _optional_args="?is_default={}{}".format(is_default, replace),
+        _optional_args=f"?is_default={is_default}{replace}",
     )
-    assert page.select_one("h1").text == "{} email reply-to address".format(expected_header)
+    assert page.select_one("h1").text == f"{expected_header} email reply-to address"
     back_link = page.select_one(".govuk-back-link")
     assert back_link.text.strip() == "Back"
     if replace:
@@ -2535,7 +2533,7 @@ def test_add_reply_to_email_address_fails_if_notification_not_delivered_in_45_se
         "main.service_verify_reply_to_address",
         service_id=SERVICE_ONE_ID,
         notification_id=notification["id"],
-        _optional_args="?is_default={}".format(False),
+        _optional_args=f"?is_default={False}",
     )
     expected_banner = page.select_one("div.banner-dangerous")
     assert "There’s a problem with your reply-to address" in expected_banner.text.strip()
@@ -4354,7 +4352,7 @@ def test_archive_service_after_confirm(
         _follow_redirects=True,
     )
 
-    mock_api.assert_called_once_with("/service/{}/archive".format(SERVICE_ONE_ID), data=None)
+    mock_api.assert_called_once_with(f"/service/{SERVICE_ONE_ID}/archive", data=None)
     mock_event.assert_called_once_with(service_id=SERVICE_ONE_ID, archived_by_id=user["id"])
 
     assert normalize_spaces(page.select_one("h1").text) == "Choose service"
@@ -5210,7 +5208,7 @@ def test_select_organisation(
 
     assert len(page.select(".govuk-radios__item")) == 3
     for i in range(0, 3):
-        assert normalize_spaces(page.select(".govuk-radios__item label")[i].text) == "Org {}".format(i + 1)
+        assert normalize_spaces(page.select(".govuk-radios__item label")[i].text) == f"Org {i + 1}"
 
 
 def test_select_organisation_shows_message_if_no_orgs(

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -588,7 +588,7 @@ def test_get_status_filters_constructs_links(client_request):
     ret = get_status_filters(Service({"id": "foo"}), "sms", STATISTICS)
 
     link = ret[0][2]
-    assert link == "/services/foo/notifications/sms?status={}".format("sending,delivered,failed")
+    assert link == "/services/foo/notifications/sms?status=sending,delivered,failed"
 
 
 def test_html_contains_notification_id(

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -177,7 +177,7 @@ def test_download_service_agreement(
     if expected_file_served:
         assert response.get_data() == b"foo"
         assert response.headers["Content-Type"] == "application/pdf"
-        assert response.headers["Content-Disposition"] == ('attachment; filename="{}"'.format(expected_file_served))
+        assert response.headers["Content-Disposition"] == f'attachment; filename="{expected_file_served}"'
         mock_get_s3_object.assert_called_once_with("test-mou", expected_file_fetched)
     else:
         assert not expected_file_fetched

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -266,7 +266,7 @@ def test_should_create_api_key_with_type_normal(
     )
 
     post.assert_called_once_with(
-        url="/service/{}/api-key".format(SERVICE_ONE_ID),
+        url=f"/service/{SERVICE_ONE_ID}/api-key",
         data={"name": "Some default key name 1/2", "key_type": "normal", "created_by": api_user_active["id"]},
     )
 

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -17,7 +17,7 @@ def test_should_render_email_verification_resend_show_email_address_and_resend_v
     page = client_request.get("main.resend_email_verification")
 
     assert page.select_one("h1").string == "Check your email"
-    expected = "A new confirmation email has been sent to {}".format(api_user_active["email_address"])
+    expected = f"A new confirmation email has been sent to {api_user_active['email_address']}"
 
     message = page.select("main p")[0].text
     assert message == expected

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -109,10 +109,10 @@ def test_redirect_from_old_dashboard(
     mocker,
 ):
     mocker.patch("app.user_api_client.get_user", return_value=user)
-    expected_location = "/services/{}".format(SERVICE_ONE_ID)
+    expected_location = f"/services/{SERVICE_ONE_ID}"
 
     client_request.get_url(
-        "/services/{}/dashboard".format(SERVICE_ONE_ID),
+        f"/services/{SERVICE_ONE_ID}/dashboard",
         _expected_redirect=expected_location,
     )
 
@@ -678,7 +678,7 @@ def test_should_not_show_recent_templates_on_dashboard_if_only_one_template_used
     expected_count = stats[0]["count"]
     assert expected_count == 50
     assert normalize_spaces(page.select_one("#total-sms .big-number-smaller").text) == (
-        "{} text messages sent".format(expected_count)
+        f"{expected_count} text messages sent"
     )
 
 
@@ -1550,7 +1550,7 @@ def test_aggregate_status_types(dict_in, expected_failed, expected_requested):
 def test_get_tuples_of_financial_years():
     assert list(
         get_tuples_of_financial_years(
-            lambda year: "http://example.com?year={}".format(year),
+            lambda year: f"http://example.com?year={year}",
             start=2040,
             end=2041,
         )
@@ -1565,7 +1565,7 @@ def test_get_tuples_of_financial_years_defaults_to_2015():
         2015
         in list(
             get_tuples_of_financial_years(
-                lambda year: "http://example.com?year={}".format(year),
+                lambda year: f"http://example.com?year={year}",
                 end=2040,
             )
         )[-1]

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -289,7 +289,7 @@ def test_archive_user_posts_to_user_client(
         ),
     )
 
-    mock_user_client.assert_called_once_with("/user/{}/archive".format(api_user_active["id"]), data=None)
+    mock_user_client.assert_called_once_with(f"/user/{api_user_active['id']}/archive", data=None)
 
     assert mock_events.called
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -121,7 +121,7 @@ def test_static_pages(
     mock_get_organisation_by_domain,
     view,
 ):
-    request = partial(client_request.get, "main.{}".format(view))
+    request = partial(client_request.get, f"main.{view}")
 
     # Check the page loads when user is signed in
     page = request()

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1724,7 +1724,7 @@ def test_edit_user_email_page(
     page = client_request.get("main.edit_user_email", service_id=service_one["id"], user_id=sample_uuid())
 
     assert page.select_one("h1").text == "Change team member’s email address"
-    assert page.select("p[id=user_name]")[0].text == "This will change the email address for {}.".format(user["name"])
+    assert page.select("p[id=user_name]")[0].text == f"This will change the email address for {user['name']}."
     assert page.select("input[type=email]")[0].attrs["value"] == user["email_address"]
     assert normalize_spaces(page.select("form button")[0].text) == "Save"
 
@@ -1759,7 +1759,7 @@ def test_edit_user_email_redirects_to_confirmation(
         ),
     )
     with client_request.session_transaction() as session:
-        assert session["team_member_email_change-{}".format(active_user_with_permissions["id"])] == "test@user.gov.uk"
+        assert session[f"team_member_email_change-{active_user_with_permissions['id']}"] == "test@user.gov.uk"
 
 
 def test_edit_user_email_without_changing_goes_back_to_team_members(
@@ -1850,7 +1850,7 @@ def test_edit_user_email_cannot_change_a_gov_email_address_to_a_non_gov_email_ad
     )
     assert "Enter a public sector email address" in page.select_one(".govuk-error-message").text
     with client_request.session_transaction() as session:
-        assert "team_member_email_change-{}".format(active_user_with_permissions["id"]) not in session
+        assert f"team_member_email_change-{active_user_with_permissions['id']}" not in session
 
 
 def test_confirm_edit_user_email_page(
@@ -1861,7 +1861,7 @@ def test_confirm_edit_user_email_page(
 ):
     new_email = "new_email@gov.uk"
     with client_request.session_transaction() as session:
-        session["team_member_email_change-{}".format(active_user_with_permissions["id"])] = new_email
+        session[f"team_member_email_change-{active_user_with_permissions['id']}"] = new_email
 
     page = client_request.get(
         "main.confirm_edit_user_email",
@@ -1873,7 +1873,7 @@ def test_confirm_edit_user_email_page(
     for text in [
         "New email address:",
         new_email,
-        "We will send {} an email to tell them about the change.".format(active_user_with_permissions["name"]),
+        f"We will send {active_user_with_permissions['name']} an email to tell them about the change.",
     ]:
         assert text in page.text
     assert "Confirm" in page.text
@@ -1924,7 +1924,7 @@ def test_confirm_edit_user_email_changes_user_email(
 
     new_email = "new_email@gov.uk"
     with client_request.session_transaction() as session:
-        session["team_member_email_change-{}".format(api_user_active["id"])] = new_email
+        session[f"team_member_email_change-{api_user_active['id']}"] = new_email
 
     client_request.post(
         "main.confirm_edit_user_email",
@@ -2077,7 +2077,7 @@ def test_confirm_edit_user_mobile_number_page(
     for text in [
         "New mobile number:",
         new_number,
-        "We will send {} a text message to tell them about the change.".format(active_user_with_permissions["name"]),
+        f"We will send {active_user_with_permissions['name']} a text message to tell them about the change.",
     ]:
         assert text in page.text
     assert "Confirm" in page.text

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -276,7 +276,7 @@ def test_notification_page_shows_page_for_letter_notification(
 
     assert len(letter_images) == count_of_pages
     for index in range(count_of_pages):
-        assert page.select("img")[index]["src"].endswith(".png?page={}".format(index + 1))
+        assert page.select("img")[index]["src"].endswith(f".png?page={index + 1}")
 
     assert len(mock_page_count.call_args_list) == 1
     assert mock_page_count.call_args_list[0][0][0]["name"] == "sample template"
@@ -756,7 +756,7 @@ def test_notification_page_has_link_to_send_another_for_sms(
         ".conversation",
         service_id=SERVICE_ONE_ID,
         notification_id=fake_uuid,
-        _anchor="n{}".format(fake_uuid),
+        _anchor=f"n{fake_uuid}",
     )
 
     if link_expected:

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -946,7 +946,7 @@ def test_get_billing_report_calls_api_and_download_data(client_request, platform
 
     assert response.content_type == "text/csv; charset=utf-8"
     assert response.headers["Content-Disposition"] == (
-        'attachment; filename="Billing Report from {} to {}.csv"'.format("2019-01-01", "2019-03-31")
+        'attachment; filename="Billing Report from 2019-01-01 to 2019-03-31.csv"'
     )
 
     assert response.get_data(as_text=True) == (
@@ -997,7 +997,7 @@ def test_get_notifications_sent_by_service_calls_api_and_downloads_data(
 
     assert response.content_type == "text/csv; charset=utf-8"
     assert response.headers["Content-Disposition"] == (
-        'attachment; filename="{} to {} notification status per service report.csv"'.format(start_date, end_date)
+        f'attachment; filename="{start_date} to {end_date} notification status per service report.csv"'
     )
     assert response.get_data(as_text=True) == (
         "date_created,service_id,service_name,notification_type,count_sending,count_delivered,"
@@ -1045,7 +1045,7 @@ def test_get_volumes_by_service_report_calls_api_and_download_data(client_reques
 
     assert response.content_type == "text/csv; charset=utf-8"
     assert response.headers["Content-Disposition"] == (
-        'attachment; filename="Volumes by service report from {} to {}.csv"'.format("2019-01-01", "2019-03-31")
+        'attachment; filename="Volumes by service report from 2019-01-01 to 2019-03-31.csv"'
     )
 
     assert response.get_data(as_text=True) == (
@@ -1099,7 +1099,7 @@ def test_get_daily_volumes_report_calls_api_and_download_data(client_request, pl
 
     assert response.content_type == "text/csv; charset=utf-8"
     assert response.headers["Content-Disposition"] == (
-        'attachment; filename="Daily volumes report from {} to {}.csv"'.format("2019-01-01", "2019-03-31")
+        'attachment; filename="Daily volumes report from 2019-01-01 to 2019-03-31.csv"'
     )
 
     assert response.get_data(as_text=True) == (
@@ -1144,7 +1144,7 @@ def test_get_daily_sms_provider_volumes_report_calls_api_and_download_data(clien
 
     assert response.content_type == "text/csv; charset=utf-8"
     assert response.headers["Content-Disposition"] == (
-        'attachment; filename="Daily SMS provider volumes report from {} to {}.csv"'.format("2019-01-01", "2019-03-31")
+        'attachment; filename="Daily SMS provider volumes report from 2019-01-01 to 2019-03-31.csv"'
     )
 
     assert response.get_data(as_text=True) == (

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -364,7 +364,7 @@ def test_upload_files_in_different_formats(
     else:
         assert not mock_s3_upload.called
         assert normalize_spaces(page.select_one(".banner-dangerous").text) == (
-            "Could not read {}. Try using a different file format.".format(filename)
+            f"Could not read {filename}. Try using a different file format."
         )
         assert f"{filename} persisted in S3 as {sample_uuid()}" not in [r.message for r in caplog.records]
         assert f"Could not read {filename}" in [r.message for r in caplog.records]
@@ -2463,9 +2463,7 @@ def test_upload_csvfile_with_valid_phone_shows_all_numbers(
 
     mocker.patch(
         "app.main.views.send.s3download",
-        return_value="\n".join(
-            ["phone number"] + ["07700 9007{0:02d}".format(final_two) for final_two in range(0, 53)]
-        ),
+        return_value="\n".join(["phone number"] + [f"07700 9007{final_two:02d}" for final_two in range(0, 53)]),
     )
     mock_get_notification_count = mocker.patch("app.service_api_client.get_notification_count", return_value=0)
     page = client_request.post(

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -588,7 +588,7 @@ def test_get_manage_folder_page(
     assert page.select_one("input[name=name]")["value"] == "folder_two"
     delete_link = page.select_one("a.govuk-link--destructive")
     assert normalize_spaces(delete_link.text) == "Delete this folder"
-    expected_delete_url = "/services/{}/templates/folders/{}/delete".format(service_one["id"], folder_id)
+    expected_delete_url = f"/services/{service_one['id']}/templates/folders/{folder_id}/delete"
     assert expected_delete_url in delete_link["href"]
 
 
@@ -1025,7 +1025,7 @@ def test_should_show_checkboxes_for_selecting_templates(
     assert len(checkboxes) == 4
 
     assert checkboxes[0]["value"] == TEMPLATE_ONE_ID
-    assert checkboxes[0]["id"] == "templates-or-folder-{}".format(TEMPLATE_ONE_ID)
+    assert checkboxes[0]["id"] == f"templates-or-folder-{TEMPLATE_ONE_ID}"
 
     for index in (1, 2, 3):
         assert checkboxes[index]["value"] != TEMPLATE_ONE_ID
@@ -1386,7 +1386,7 @@ def test_no_action_if_user_fills_in_ambiguous_fields(
     assert mock_move_to_template_folder.called is False
     assert mock_create_template_folder.called is False
 
-    assert page.select_one("button[value={}]".format(data["operation"]))
+    assert page.select_one(f"button[value={data['operation']}]")
 
     assert [
         "email",

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -872,7 +872,7 @@ def test_post_attach_pages_errors_when_content_outside_printable_area(
 
         mock_s3_upload.assert_called_once_with(
             file_contents,
-            file_location="service-{}/{}.pdf".format(SERVICE_ONE_ID, fake_uuid),
+            file_location=f"service-{SERVICE_ONE_ID}/{fake_uuid}.pdf",
             status="invalid",
             page_count=1,
             filename="tests/test_pdf_files/one_page_pdf.pdf",

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -75,7 +75,7 @@ def test_should_login_user_and_should_redirect_to_next_url(
 
     client_request.post(
         "main.two_factor_sms",
-        next="/services/{}".format(SERVICE_ONE_ID),
+        next=f"/services/{SERVICE_ONE_ID}",
         _data={"sms_code": "12345"},
         _expected_redirect=url_for(
             "main.service_dashboard",

--- a/tests/app/main/views/uploads/test_upload_hub.py
+++ b/tests/app/main/views/uploads/test_upload_hub.py
@@ -124,9 +124,7 @@ def test_get_upload_hub_page(
     assert normalize_spaces(uploads[1].text.strip()) == (
         "some.csv Sent 1 January 2016 at 11:09am 0 sending 8 delivered 2 failed"
     )
-    assert uploads[1].select_one("a.file-list-filename-large")["href"] == (
-        "/services/{}/jobs/job_id_1".format(SERVICE_ONE_ID)
-    )
+    assert uploads[1].select_one("a.file-list-filename-large")["href"] == (f"/services/{SERVICE_ONE_ID}/jobs/job_id_1")
 
     assert normalize_spaces(uploads[2].text.strip()) == (
         "some.pdf Sent 1 January 2016 at 11:09am Firstname Lastname 123 Example Street"
@@ -135,7 +133,7 @@ def test_get_upload_hub_page(
         '<p class="govuk-body letter-recipient-summary"> ' "Firstname Lastname<br/> 123 Example Street<br/> " "</p>"
     )
     assert uploads[2].select_one("a.file-list-filename-large")["href"] == (
-        "/services/{}/notification/letter_id_1".format(SERVICE_ONE_ID)
+        f"/services/{SERVICE_ONE_ID}/notification/letter_id_1"
     )
 
 

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -74,7 +74,7 @@ def test_post_upload_letter_redirects_for_valid_file(
 
     mock_s3_upload.assert_called_once_with(
         b"The sanitised content",
-        file_location="service-{}/{}.pdf".format(SERVICE_ONE_ID, fake_uuid),
+        file_location=f"service-{SERVICE_ONE_ID}/{fake_uuid}.pdf",
         status="valid",
         page_count=1,
         filename="tests/test_pdf_files/one_page_pdf.pdf",
@@ -364,7 +364,7 @@ def test_post_upload_letter_with_invalid_file(mocker, client_request, fake_uuid)
 
         mock_s3_upload.assert_called_once_with(
             file_contents,
-            file_location="service-{}/{}.pdf".format(SERVICE_ONE_ID, fake_uuid),
+            file_location=f"service-{SERVICE_ONE_ID}/{fake_uuid}.pdf",
             status="invalid",
             page_count=1,
             filename="tests/test_pdf_files/one_page_pdf.pdf",

--- a/tests/app/notify_client/test_billing_client.py
+++ b/tests/app/notify_client/test_billing_client.py
@@ -7,7 +7,7 @@ from app.notify_client.billing_api_client import BillingAPIClient
 
 def test_get_free_sms_fragment_limit_for_year_correct_endpoint(mocker, api_user_active):
     service_id = uuid.uuid4()
-    expected_url = "/service/{}/billing/free-sms-fragment-limit".format(service_id)
+    expected_url = f"/service/{service_id}/billing/free-sms-fragment-limit"
     client = BillingAPIClient()
 
     mock_get = mocker.patch("app.notify_client.billing_api_client.BillingAPIClient.get")
@@ -24,9 +24,7 @@ def test_post_free_sms_fragment_limit_for_current_year_endpoint(mocker, api_user
 
     client.create_or_update_free_sms_fragment_limit(service_id=service_id, free_sms_fragment_limit=1111)
 
-    mock_post.assert_called_once_with(
-        url="/service/{}/billing/free-sms-fragment-limit".format(service_id), data=sms_limit_data
-    )
+    mock_post.assert_called_once_with(url=f"/service/{service_id}/billing/free-sms-fragment-limit", data=sms_limit_data)
 
 
 def test_post_free_sms_fragment_limit_for_year_endpoint(mocker, api_user_active):
@@ -36,9 +34,7 @@ def test_post_free_sms_fragment_limit_for_year_endpoint(mocker, api_user_active)
     client = BillingAPIClient()
 
     client.create_or_update_free_sms_fragment_limit(service_id=service_id, free_sms_fragment_limit=1111, year=2017)
-    mock_post.assert_called_once_with(
-        url="/service/{}/billing/free-sms-fragment-limit".format(service_id), data=sms_limit_data
-    )
+    mock_post.assert_called_once_with(url=f"/service/{service_id}/billing/free-sms-fragment-limit", data=sms_limit_data)
 
 
 @pytest.mark.parametrize(

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -15,10 +15,10 @@ def test_get_email_branding(mocker, fake_uuid):
         "app.extensions.RedisClient.set",
     )
     EmailBrandingClient().get_email_branding(fake_uuid)
-    mock_get.assert_called_once_with(url="/email-branding/{}".format(fake_uuid))
-    mock_redis_get.assert_called_once_with("email_branding-{}".format(fake_uuid))
+    mock_get.assert_called_once_with(url=f"/email-branding/{fake_uuid}")
+    mock_redis_get.assert_called_once_with(f"email_branding-{fake_uuid}")
     mock_redis_set.assert_called_once_with(
-        "email_branding-{}".format(fake_uuid),
+        f"email_branding-{fake_uuid}",
         '{"foo": "bar"}',
         ex=604800,
     )
@@ -98,9 +98,9 @@ def test_update_email_branding(mocker, fake_uuid):
         updated_by_id=org_data["updated_by"],
     )
 
-    mock_post.assert_called_once_with(url="/email-branding/{}".format(fake_uuid), data=org_data)
+    mock_post.assert_called_once_with(url=f"/email-branding/{fake_uuid}", data=org_data)
     assert mock_redis_delete.call_args_list == [
-        call("email_branding-{}".format(fake_uuid)),
+        call(f"email_branding-{fake_uuid}"),
         call("email_branding"),
     ]
     assert mock_redis_delete_by_pattern.call_args_list == [call("organisation-*-email-branding-pool")]

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -34,7 +34,7 @@ def test_client_creates_invite(
     invite_api_client.create_invite("12345", "67890", "test@example.com", {"send_messages"}, "sms_auth", [fake_uuid])
 
     mock_post.assert_called_once_with(
-        url="/service/{}/invite".format("67890"),
+        url="/service/67890/invite",
         data={
             "auth_type": "sms_auth",
             "email_address": "test@example.com",
@@ -79,7 +79,7 @@ def test_client_returns_invite(mocker, sample_invite):
 
     expected_data = {"data": [sample_invite]}
 
-    expected_url = "/service/{}/invite".format(service_id)
+    expected_url = f"/service/{service_id}/invite"
 
     mock_get = mocker.patch("app.notify_client.invite_api_client.InviteApiClient.get", return_value=expected_data)
 

--- a/tests/app/notify_client/test_job_client.py
+++ b/tests/app/notify_client/test_job_client.py
@@ -15,7 +15,7 @@ def test_client_creates_job_data_correctly(mocker, fake_uuid):
 
     expected_data = {"id": job_id, "created_by": "1"}
 
-    expected_url = "/service/{}/job".format(service_id)
+    expected_url = f"/service/{service_id}/job"
 
     client = JobApiClient()
     mock_post = mocker.patch(
@@ -26,7 +26,7 @@ def test_client_creates_job_data_correctly(mocker, fake_uuid):
     client.create_job(service_id, job_id)
     mock_post.assert_called_once_with(url=expected_url, data=expected_data)
     mock_redis_set.assert_called_once_with(
-        "has_jobs-{}".format(service_id),
+        f"has_jobs-{service_id}",
         b"true",
         ex=604800,
     )
@@ -62,7 +62,7 @@ def test_client_gets_job_by_service_and_job(mocker):
     service_id = "service_id"
     job_id = "job_id"
 
-    expected_url = "/service/{}/job/{}".format(service_id, job_id)
+    expected_url = f"/service/{service_id}/job/{job_id}"
 
     client = JobApiClient()
     mock_get = mocker.patch("app.notify_client.job_api_client.JobApiClient.get")
@@ -122,7 +122,7 @@ def test_client_parses_job_stats(mocker):
         }
     }
 
-    expected_url = "/service/{}/job/{}".format(service_id, job_id)
+    expected_url = f"/service/{service_id}/job/{job_id}"
 
     mock_get = mocker.patch("app.notify_client.job_api_client.JobApiClient.get", return_value=expected_data)
 
@@ -159,7 +159,7 @@ def test_client_parses_empty_job_stats(mocker):
         }
     }
 
-    expected_url = "/service/{}/job/{}".format(service_id, job_id)
+    expected_url = f"/service/{service_id}/job/{job_id}"
 
     mock_get = mocker.patch("app.notify_client.job_api_client.JobApiClient.get", return_value=expected_data)
 
@@ -235,7 +235,7 @@ def test_client_parses_job_stats_for_service(mocker):
         ]
     }
 
-    expected_url = "/service/{}/job".format(service_id)
+    expected_url = f"/service/{service_id}/job"
 
     mock_get = mocker.patch("app.notify_client.job_api_client.JobApiClient.get", return_value=expected_data)
 
@@ -299,7 +299,7 @@ def test_client_parses_empty_job_stats_for_service(mocker):
         ]
     }
 
-    expected_url = "/service/{}/job".format(service_id)
+    expected_url = f"/service/{service_id}/job"
 
     mock_get = mocker.patch("app.notify_client.job_api_client.JobApiClient.get", return_value=expected_data)
 
@@ -323,7 +323,7 @@ def test_cancel_job(mocker):
 
     JobApiClient().cancel_job("service_id", "job_id")
 
-    mock_post.assert_called_once_with(url="/service/{}/job/{}/cancel".format("service_id", "job_id"), data={})
+    mock_post.assert_called_once_with(url="/service/service_id/job/job_id/cancel", data={})
 
 
 @pytest.mark.parametrize(
@@ -350,9 +350,9 @@ def test_has_jobs_sets_cache(
 
     JobApiClient().has_jobs(fake_uuid)
 
-    mock_get.assert_called_once_with(url="/service/{}/job".format(fake_uuid), params={"page": 1})
+    mock_get.assert_called_once_with(url=f"/service/{fake_uuid}/job", params={"page": 1})
     mock_redis_set.assert_called_once_with(
-        "has_jobs-{}".format(fake_uuid),
+        f"has_jobs-{fake_uuid}",
         expected_cache_value,
         ex=604800,
     )
@@ -379,4 +379,4 @@ def test_has_jobs_returns_from_cache(
 
     assert JobApiClient().has_jobs(fake_uuid) is return_value
     assert not mock_get.called
-    mock_redis_get.assert_called_once_with("has_jobs-{}".format(fake_uuid))
+    mock_redis_get.assert_called_once_with(f"has_jobs-{fake_uuid}")

--- a/tests/app/notify_client/test_letter_branding_client.py
+++ b/tests/app/notify_client/test_letter_branding_client.py
@@ -12,10 +12,10 @@ def test_get_letter_branding(mocker, fake_uuid):
 
     LetterBrandingClient().get_letter_branding(fake_uuid)
 
-    mock_get.assert_called_once_with(url="/letter-branding/{}".format(fake_uuid))
-    mock_redis_get.assert_called_once_with("letter_branding-{}".format(fake_uuid))
+    mock_get.assert_called_once_with(url=f"/letter-branding/{fake_uuid}")
+    mock_redis_get.assert_called_once_with(f"letter_branding-{fake_uuid}")
     mock_redis_set.assert_called_once_with(
-        "letter_branding-{}".format(fake_uuid),
+        f"letter_branding-{fake_uuid}",
         '{"foo": "bar"}',
         ex=604800,
     )

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -189,7 +189,7 @@ def test_update_organisation_when_not_updating_org_type(
 
     organisations_client.update_organisation(fake_uuid, **post_data)
 
-    mock_post.assert_called_with(url="/organisations/{}".format(fake_uuid), data=post_data)
+    mock_post.assert_called_with(url=f"/organisations/{fake_uuid}", data=post_data)
     assert mock_redis_delete.call_args_list == expected_cache_delete_calls
 
 
@@ -203,7 +203,7 @@ def test_update_organisation_when_updating_org_type_and_org_has_services(mocker,
         organisation_type="central",
     )
 
-    mock_post.assert_called_with(url="/organisations/{}".format(fake_uuid), data={"organisation_type": "central"})
+    mock_post.assert_called_with(url=f"/organisations/{fake_uuid}", data={"organisation_type": "central"})
     assert mock_redis_delete.call_args_list == [
         call("service-a", "service-b", "service-c"),
         call("organisations"),
@@ -221,7 +221,7 @@ def test_update_organisation_when_updating_org_type_but_org_has_no_services(mock
         organisation_type="central",
     )
 
-    mock_post.assert_called_with(url="/organisations/{}".format(fake_uuid), data={"organisation_type": "central"})
+    mock_post.assert_called_with(url=f"/organisations/{fake_uuid}", data={"organisation_type": "central"})
     assert mock_redis_delete.call_args_list == [
         call("organisations"),
         call("domains"),
@@ -271,9 +271,9 @@ def test_update_service_organisation_deletes_cache(mocker, fake_uuid):
     assert sorted(mock_redis_delete.call_args_list) == [
         call("live-service-and-organisation-counts"),
         call("organisations"),
-        call("service-{}".format(fake_uuid)),
+        call(f"service-{fake_uuid}"),
     ]
-    mock_post.assert_called_with(url="/organisations/{}/service".format(fake_uuid), data=ANY)
+    mock_post.assert_called_with(url=f"/organisations/{fake_uuid}/service", data=ANY)
 
 
 def test_remove_user_from_organisation_deletes_user_cache(mocker):

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -14,7 +14,7 @@ def test_client_posts_archived_true_when_deleting_template(mocker):
     mocker.patch("app.notify_client.current_user", id="1")
     mock_redis_delete_by_pattern = mocker.patch("app.extensions.RedisClient.delete_by_pattern")
     expected_data = {"archived": True, "created_by": "1"}
-    expected_url = "/service/{}/template/{}".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID)
+    expected_url = f"/service/{SERVICE_ONE_ID}/template/{FAKE_TEMPLATE_ID}"
 
     client = ServiceAPIClient()
     mock_post = mocker.patch("app.notify_client.service_api_client.ServiceAPIClient.post")
@@ -98,7 +98,7 @@ def test_get_precompiled_template(mocker):
     mock_get = mocker.patch.object(client, "get")
 
     client.get_precompiled_template(SERVICE_ONE_ID)
-    mock_get.assert_called_once_with("/service/{}/template/precompiled".format(SERVICE_ONE_ID))
+    mock_get.assert_called_once_with(f"/service/{SERVICE_ONE_ID}/template/precompiled")
 
 
 @pytest.mark.parametrize(
@@ -167,7 +167,7 @@ def test_client_returns_count_of_service_templates(
         (
             service_api_client.get_service,
             [SERVICE_ONE_ID],
-            [call("service-{}".format(SERVICE_ONE_ID))],
+            [call(f"service-{SERVICE_ONE_ID}")],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -176,12 +176,12 @@ def test_client_returns_count_of_service_templates(
         (
             service_api_client.get_service,
             [SERVICE_ONE_ID],
-            [call("service-{}".format(SERVICE_ONE_ID))],
+            [call(f"service-{SERVICE_ONE_ID}")],
             None,
-            [call("/service/{}".format(SERVICE_ONE_ID))],
+            [call(f"/service/{SERVICE_ONE_ID}")],
             [
                 call(
-                    "service-{}".format(SERVICE_ONE_ID),
+                    f"service-{SERVICE_ONE_ID}",
                     '{"data_from": "api"}',
                     ex=604800,
                 )
@@ -191,7 +191,7 @@ def test_client_returns_count_of_service_templates(
         (
             service_api_client.get_service_template,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
-            [call("service-{}-template-{}-version-None".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID))],
+            [call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None")],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -201,13 +201,13 @@ def test_client_returns_count_of_service_templates(
             service_api_client.get_service_template,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [
-                call("service-{}-template-{}-version-None".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID)),
+                call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None"),
             ],
             None,
-            [call("/service/{}/template/{}".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID))],
+            [call(f"/service/{SERVICE_ONE_ID}/template/{FAKE_TEMPLATE_ID}")],
             [
                 call(
-                    "service-{}-template-{}-version-None".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
+                    f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None",
                     '{"data_from": "api"}',
                     ex=604800,
                 ),
@@ -217,7 +217,7 @@ def test_client_returns_count_of_service_templates(
         (
             service_api_client.get_service_template,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 1],
-            [call("service-{}-template-{}-version-1".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID))],
+            [call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1")],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -227,13 +227,13 @@ def test_client_returns_count_of_service_templates(
             service_api_client.get_service_template,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 1],
             [
-                call("service-{}-template-{}-version-1".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID)),
+                call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1"),
             ],
             None,
-            [call("/service/{}/template/{}/version/1".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID))],
+            [call(f"/service/{SERVICE_ONE_ID}/template/{FAKE_TEMPLATE_ID}/version/1")],
             [
                 call(
-                    "service-{}-template-{}-version-1".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
+                    f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1",
                     '{"data_from": "api"}',
                     ex=604800,
                 ),
@@ -243,7 +243,7 @@ def test_client_returns_count_of_service_templates(
         (
             service_api_client.get_service_templates,
             [SERVICE_ONE_ID],
-            [call("service-{}-templates".format(SERVICE_ONE_ID))],
+            [call(f"service-{SERVICE_ONE_ID}-templates")],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -252,12 +252,12 @@ def test_client_returns_count_of_service_templates(
         (
             service_api_client.get_service_templates,
             [SERVICE_ONE_ID],
-            [call("service-{}-templates".format(SERVICE_ONE_ID))],
+            [call(f"service-{SERVICE_ONE_ID}-templates")],
             None,
-            [call("/service/{}/template?detailed=False".format(SERVICE_ONE_ID))],
+            [call(f"/service/{SERVICE_ONE_ID}/template?detailed=False")],
             [
                 call(
-                    "service-{}-templates".format(SERVICE_ONE_ID),
+                    f"service-{SERVICE_ONE_ID}-templates",
                     '{"data_from": "api"}',
                     ex=604800,
                 )
@@ -267,7 +267,7 @@ def test_client_returns_count_of_service_templates(
         (
             service_api_client.get_service_template_versions,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
-            [call("service-{}-template-{}-versions".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID))],
+            [call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions")],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -277,13 +277,13 @@ def test_client_returns_count_of_service_templates(
             service_api_client.get_service_template_versions,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [
-                call("service-{}-template-{}-versions".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID)),
+                call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions"),
             ],
             None,
-            [call("/service/{}/template/{}/versions".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID))],
+            [call(f"/service/{SERVICE_ONE_ID}/template/{FAKE_TEMPLATE_ID}/versions")],
             [
                 call(
-                    "service-{}-template-{}-versions".format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
+                    f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions",
                     '{"data_from": "api"}',
                     ex=604800,
                 ),
@@ -293,12 +293,12 @@ def test_client_returns_count_of_service_templates(
         (
             service_api_client.get_returned_letter_summary,
             [SERVICE_ONE_ID],
-            [call("service-{}-returned-letters-summary".format(SERVICE_ONE_ID))],
+            [call(f"service-{SERVICE_ONE_ID}-returned-letters-summary")],
             None,
-            [call("service/{}/returned-letter-summary".format(SERVICE_ONE_ID))],
+            [call(f"service/{SERVICE_ONE_ID}/returned-letter-summary")],
             [
                 call(
-                    "service-{}-returned-letters-summary".format(SERVICE_ONE_ID),
+                    f"service-{SERVICE_ONE_ID}-returned-letters-summary",
                     '{"data_from": "api"}',
                     ex=604800,
                 )
@@ -308,12 +308,12 @@ def test_client_returns_count_of_service_templates(
         (
             service_api_client.get_returned_letter_statistics,
             [SERVICE_ONE_ID],
-            [call("service-{}-returned-letters-statistics".format(SERVICE_ONE_ID))],
+            [call(f"service-{SERVICE_ONE_ID}-returned-letters-statistics")],
             None,
-            [call("service/{}/returned-letter-statistics".format(SERVICE_ONE_ID))],
+            [call(f"service/{SERVICE_ONE_ID}/returned-letter-statistics")],
             [
                 call(
-                    "service-{}-returned-letters-statistics".format(SERVICE_ONE_ID),
+                    f"service-{SERVICE_ONE_ID}-returned-letters-statistics",
                     '{"data_from": "api"}',
                     ex=604800,
                 )
@@ -394,7 +394,7 @@ def test_deletes_service_cache(
 
     getattr(client, method)(*extra_args, **extra_kwargs)
 
-    assert call("service-{}".format(SERVICE_ONE_ID)) in mock_redis_delete.call_args_list
+    assert call(f"service-{SERVICE_ONE_ID}") in mock_redis_delete.call_args_list
     assert len(mock_request.call_args_list) == 1
 
 
@@ -406,7 +406,7 @@ def test_deletes_service_cache(
             ["name", "type_", "content", SERVICE_ONE_ID],
             {},
             [
-                "service-{}-templates".format(SERVICE_ONE_ID),
+                f"service-{SERVICE_ONE_ID}-templates",
             ],
         ),
         (
@@ -419,7 +419,7 @@ def test_deletes_service_cache(
                 "template_id": FAKE_TEMPLATE_ID,
             },
             [
-                "service-{}-templates".format(SERVICE_ONE_ID),
+                f"service-{SERVICE_ONE_ID}-templates",
             ],
         ),
         (
@@ -427,7 +427,7 @@ def test_deletes_service_cache(
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             {},
             [
-                "service-{}-templates".format(SERVICE_ONE_ID),
+                f"service-{SERVICE_ONE_ID}-templates",
             ],
         ),
         (
@@ -435,7 +435,7 @@ def test_deletes_service_cache(
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, "foo"],
             {},
             [
-                "service-{}-templates".format(SERVICE_ONE_ID),
+                f"service-{SERVICE_ONE_ID}-templates",
             ],
         ),
         (
@@ -443,7 +443,7 @@ def test_deletes_service_cache(
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, "first"],
             {},
             [
-                "service-{}-templates".format(SERVICE_ONE_ID),
+                f"service-{SERVICE_ONE_ID}-templates",
             ],
         ),
         (
@@ -451,7 +451,7 @@ def test_deletes_service_cache(
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             {},
             [
-                "service-{}-templates".format(SERVICE_ONE_ID),
+                f"service-{SERVICE_ONE_ID}-templates",
             ],
         ),
         (
@@ -459,8 +459,8 @@ def test_deletes_service_cache(
             [SERVICE_ONE_ID, []],
             {},
             [
-                "service-{}-templates".format(SERVICE_ONE_ID),
-                "service-{}".format(SERVICE_ONE_ID),
+                f"service-{SERVICE_ONE_ID}-templates",
+                f"service-{SERVICE_ONE_ID}",
             ],
         ),
     ],
@@ -551,7 +551,7 @@ def test_client_doesnt_delete_service_template_cache_when_none_exist(
     service_api_client.update_reply_to_email_address(SERVICE_ONE_ID, uuid4(), "foo@bar.com")
 
     assert len(mock_redis_delete.call_args_list) == 1
-    assert mock_redis_delete.call_args_list[0] == call("service-{}".format(SERVICE_ONE_ID))
+    assert mock_redis_delete.call_args_list[0] == call(f"service-{SERVICE_ONE_ID}")
 
     assert len(mock_redis_delete_by_pattern.call_args_list) == 1
 

--- a/tests/app/notify_client/test_template_folder_client.py
+++ b/tests/app/notify_client/test_template_folder_client.py
@@ -12,7 +12,7 @@ def test_create_template_folder_calls_correct_api_endpoint(mocker, parent_id):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
 
     some_service_id = uuid.uuid4()
-    expected_url = "/service/{}/template-folder".format(some_service_id)
+    expected_url = f"/service/{some_service_id}/template-folder"
     data = {"name": "foo", "parent_id": parent_id}
 
     client = TemplateFolderAPIClient()
@@ -22,7 +22,7 @@ def test_create_template_folder_calls_correct_api_endpoint(mocker, parent_id):
     client.create_template_folder(some_service_id, name="foo", parent_id=parent_id)
 
     mock_post.assert_called_once_with(expected_url, data)
-    mock_redis_delete.assert_called_once_with("service-{}-template-folders".format(some_service_id))
+    mock_redis_delete.assert_called_once_with(f"service-{some_service_id}-template-folders")
 
 
 def test_get_template_folders_calls_correct_api_endpoint(mocker):
@@ -33,8 +33,8 @@ def test_get_template_folders_calls_correct_api_endpoint(mocker):
     )
 
     some_service_id = uuid.uuid4()
-    expected_url = "/service/{}/template-folder".format(some_service_id)
-    redis_key = "service-{}-template-folders".format(some_service_id)
+    expected_url = f"/service/{some_service_id}/template-folder"
+    redis_key = f"service-{some_service_id}-template-folders"
 
     client = TemplateFolderAPIClient()
 
@@ -63,7 +63,7 @@ def test_move_templates_and_folders(mocker):
     )
 
     mock_api_post.assert_called_once_with(
-        "/service/{}/template-folder/{}/contents".format(some_service_id, some_folder_id),
+        f"/service/{some_service_id}/template-folder/{some_folder_id}/contents",
         {
             "folders": ["1", "2", "3"],
             "templates": ["a", "b", "c"],
@@ -75,8 +75,8 @@ def test_move_templates_and_folders(mocker):
             f"service-{some_service_id}-template-b-version-None",
             f"service-{some_service_id}-template-c-version-None",
         ),
-        call("service-{}-templates".format(some_service_id)),
-        call("service-{}-template-folders".format(some_service_id)),
+        call(f"service-{some_service_id}-templates"),
+        call(f"service-{some_service_id}-template-folders"),
     ]
 
 
@@ -94,7 +94,7 @@ def test_move_templates_and_folders_to_root(mocker):
     )
 
     mock_api_post.assert_called_once_with(
-        "/service/{}/template-folder/contents".format(some_service_id),
+        f"/service/{some_service_id}/template-folder/contents",
         {
             "folders": ["1", "2", "3"],
             "templates": ["a", "b", "c"],
@@ -107,7 +107,7 @@ def test_update_template_folder_calls_correct_api_endpoint(mocker):
 
     some_service_id = uuid.uuid4()
     template_folder_id = uuid.uuid4()
-    expected_url = "/service/{}/template-folder/{}".format(some_service_id, template_folder_id)
+    expected_url = f"/service/{some_service_id}/template-folder/{template_folder_id}"
     data = {"name": "foo", "users_with_permission": ["some_id"]}
 
     client = TemplateFolderAPIClient()
@@ -117,7 +117,7 @@ def test_update_template_folder_calls_correct_api_endpoint(mocker):
     client.update_template_folder(some_service_id, template_folder_id, name="foo", users_with_permission=["some_id"])
 
     mock_post.assert_called_once_with(expected_url, data)
-    mock_redis_delete.assert_called_once_with("service-{}-template-folders".format(some_service_id))
+    mock_redis_delete.assert_called_once_with(f"service-{some_service_id}-template-folders")
 
 
 def test_delete_template_folder_calls_correct_api_endpoint(mocker):
@@ -125,7 +125,7 @@ def test_delete_template_folder_calls_correct_api_endpoint(mocker):
 
     some_service_id = uuid.uuid4()
     template_folder_id = uuid.uuid4()
-    expected_url = "/service/{}/template-folder/{}".format(some_service_id, template_folder_id)
+    expected_url = f"/service/{some_service_id}/template-folder/{template_folder_id}"
 
     client = TemplateFolderAPIClient()
 
@@ -134,4 +134,4 @@ def test_delete_template_folder_calls_correct_api_endpoint(mocker):
     client.delete_template_folder(some_service_id, template_folder_id)
 
     mock_delete.assert_called_once_with(expected_url, {})
-    mock_redis_delete.assert_called_once_with("service-{}-template-folders".format(some_service_id))
+    mock_redis_delete.assert_called_once_with(f"service-{some_service_id}-template-folders")

--- a/tests/app/notify_client/test_template_statistics_client.py
+++ b/tests/app/notify_client/test_template_statistics_client.py
@@ -6,7 +6,7 @@ from app.notify_client.template_statistics_api_client import TemplateStatisticsA
 def test_template_statistics_client_calls_correct_api_endpoint_for_service(mocker, api_user_active):
 
     some_service_id = uuid.uuid4()
-    expected_url = "/service/{}/template-statistics".format(some_service_id)
+    expected_url = f"/service/{some_service_id}/template-statistics"
 
     client = TemplateStatisticsApiClient()
 
@@ -20,7 +20,7 @@ def test_template_statistics_client_calls_correct_api_endpoint_for_service(mocke
 def test_template_statistics_client_calls_correct_api_endpoint_for_template(mocker, api_user_active):
     some_service_id = uuid.uuid4()
     some_template_id = uuid.uuid4()
-    expected_url = "/service/{}/template-statistics/last-used/{}".format(some_service_id, some_template_id)
+    expected_url = f"/service/{some_service_id}/template-statistics/last-used/{some_template_id}"
 
     client = TemplateStatisticsApiClient()
     mock_get = mocker.patch("app.notify_client.template_statistics_api_client.TemplateStatisticsApiClient.get")

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -29,7 +29,7 @@ def test_client_gets_all_users_for_service(
 
     users = user_api_client.get_users_for_service(SERVICE_ONE_ID)
 
-    mock_get.assert_called_once_with("/service/{}/users".format(SERVICE_ONE_ID))
+    mock_get.assert_called_once_with(f"/service/{SERVICE_ONE_ID}/users")
     assert len(users) == 1
     assert users[0]["id"] == fake_uuid
 
@@ -55,7 +55,7 @@ def test_client_only_updates_allowed_attributes(mocker):
 
 
 def test_client_updates_password_separately(mocker, api_user_active):
-    expected_url = "/user/{}/update-password".format(api_user_active["id"])
+    expected_url = f"/user/{api_user_active['id']}/update-password"
     expected_params = {"_password": "newpassword"}
     user_api_client.max_failed_login_count = 1  # doesn't matter for this test
     mock_update_password = mocker.patch("app.notify_client.user_api_client.UserApiClient.post")
@@ -70,7 +70,7 @@ def test_client_activates_if_pending(mocker, api_user_pending):
 
     user_api_client.activate_user(api_user_pending["id"])
 
-    mock_post.assert_called_once_with("/user/{}/activate".format(api_user_pending["id"]), data=None)
+    mock_post.assert_called_once_with(f"/user/{api_user_pending['id']}/activate", data=None)
 
 
 def test_client_passes_admin_url_when_sending_email_auth(
@@ -83,7 +83,7 @@ def test_client_passes_admin_url_when_sending_email_auth(
     user_api_client.send_verify_code(fake_uuid, "email", "ignored@example.com")
 
     mock_post.assert_called_once_with(
-        "/user/{}/email-code".format(fake_uuid),
+        f"/user/{fake_uuid}/email-code",
         data={
             "to": "ignored@example.com",
             "email_auth_link_host": "http://localhost:6012",
@@ -135,17 +135,17 @@ def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(n
     ),
     [
         (
-            [call("user-{}".format(user_id))],
+            [call(f"user-{user_id}")],
             b'{"data": "from cache"}',
             [],
             [],
             "from cache",
         ),
         (
-            [call("user-{}".format(user_id))],
+            [call(f"user-{user_id}")],
             None,
-            [call("/user/{}".format(user_id))],
-            [call("user-{}".format(user_id), '{"data": "from api"}', ex=604800)],
+            [call(f"/user/{user_id}")],
+            [call(f"user-{user_id}", '{"data": "from api"}', ex=604800)],
             "from api",
         ),
     ],
@@ -212,7 +212,7 @@ def test_deletes_user_cache(notify_admin, mock_get_user, mocker, client, method,
 
     getattr(client, method)(*extra_args, **extra_kwargs)
 
-    assert call("user-{}".format(user_id)) in mock_redis_delete.call_args_list
+    assert call(f"user-{user_id}") in mock_redis_delete.call_args_list
     assert len(mock_request.call_args_list) == 1
 
 
@@ -223,7 +223,7 @@ def test_add_user_to_service_calls_correct_endpoint_and_deletes_keys_from_cache(
     user_id = uuid.uuid4()
     folder_id = uuid.uuid4()
 
-    expected_url = "/service/{}/users/{}".format(service_id, user_id)
+    expected_url = f"/service/{service_id}/users/{user_id}"
     data = {"permissions": [], "folder_permissions": [folder_id]}
 
     mock_post = mocker.patch("app.notify_client.user_api_client.UserApiClient.post")
@@ -232,9 +232,9 @@ def test_add_user_to_service_calls_correct_endpoint_and_deletes_keys_from_cache(
 
     mock_post.assert_called_once_with(expected_url, data=data)
     assert mock_redis_delete.call_args_list == [
-        call("user-{user_id}".format(user_id=user_id)),
-        call("service-{service_id}-template-folders".format(service_id=service_id)),
-        call("service-{service_id}".format(service_id=service_id)),
+        call(f"user-{user_id}"),
+        call(f"service-{service_id}-template-folders"),
+        call(f"service-{service_id}"),
     ]
 
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -414,7 +414,7 @@ def test_navigation_items_are_properly_defined(navigation_instance):
         )
         assert (
             navigation_instance.endpoints_with_navigation.count(endpoint) == 1
-        ), "{} found more than once in {}.mapping".format(endpoint, type(navigation_instance).__name__)
+        ), f"{endpoint} found more than once in {type(navigation_instance).__name__}.mapping"
 
 
 def test_excluded_endpoints_are_all_found_in_app():
@@ -515,13 +515,13 @@ def test_navigation_urls(
 ):
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
     assert [a["href"] for a in page.select(".navigation a")] == [
-        "/services/{}".format(SERVICE_ONE_ID),
-        "/services/{}/templates".format(SERVICE_ONE_ID),
-        "/services/{}/uploads".format(SERVICE_ONE_ID),
-        "/services/{}/users".format(SERVICE_ONE_ID),
-        "/services/{}/usage".format(SERVICE_ONE_ID),
-        "/services/{}/service-settings".format(SERVICE_ONE_ID),
-        "/services/{}/api".format(SERVICE_ONE_ID),
+        f"/services/{SERVICE_ONE_ID}",
+        f"/services/{SERVICE_ONE_ID}/templates",
+        f"/services/{SERVICE_ONE_ID}/uploads",
+        f"/services/{SERVICE_ONE_ID}/users",
+        f"/services/{SERVICE_ONE_ID}/usage",
+        f"/services/{SERVICE_ONE_ID}/service-settings",
+        f"/services/{SERVICE_ONE_ID}/api",
     ]
 
 
@@ -538,11 +538,11 @@ def test_navigation_for_services_with_broadcast_permission(
 
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
     assert [a["href"] for a in page.select(".navigation a")] == [
-        "/services/{}/current-alerts".format(SERVICE_ONE_ID),
-        "/services/{}/past-alerts".format(SERVICE_ONE_ID),
-        "/services/{}/rejected-alerts".format(SERVICE_ONE_ID),
-        "/services/{}/templates".format(SERVICE_ONE_ID),
-        "/services/{}/users".format(SERVICE_ONE_ID),
+        f"/services/{SERVICE_ONE_ID}/current-alerts",
+        f"/services/{SERVICE_ONE_ID}/past-alerts",
+        f"/services/{SERVICE_ONE_ID}/rejected-alerts",
+        f"/services/{SERVICE_ONE_ID}/templates",
+        f"/services/{SERVICE_ONE_ID}/users",
     ]
 
 
@@ -559,13 +559,13 @@ def test_navigation_for_services_with_broadcast_permission_platform_admin(
     client_request.login(platform_admin_user)
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
     assert [a["href"] for a in page.select(".navigation a")] == [
-        "/services/{}/current-alerts".format(SERVICE_ONE_ID),
-        "/services/{}/past-alerts".format(SERVICE_ONE_ID),
-        "/services/{}/rejected-alerts".format(SERVICE_ONE_ID),
-        "/services/{}/templates".format(SERVICE_ONE_ID),
-        "/services/{}/users".format(SERVICE_ONE_ID),
-        "/services/{}/service-settings".format(SERVICE_ONE_ID),
-        "/services/{}/api/keys".format(SERVICE_ONE_ID),
+        f"/services/{SERVICE_ONE_ID}/current-alerts",
+        f"/services/{SERVICE_ONE_ID}/past-alerts",
+        f"/services/{SERVICE_ONE_ID}/rejected-alerts",
+        f"/services/{SERVICE_ONE_ID}/templates",
+        f"/services/{SERVICE_ONE_ID}/users",
+        f"/services/{SERVICE_ONE_ID}/service-settings",
+        f"/services/{SERVICE_ONE_ID}/api/keys",
     ]
 
 

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -31,9 +31,9 @@ def _get_notifications_csv(
         links = {}
         if with_links:
             links = {
-                "prev": "/service/{}/notifications?page=0".format(service_id),
-                "next": "/service/{}/notifications?page=1".format(service_id),
-                "last": "/service/{}/notifications?page=2".format(service_id),
+                "prev": f"/service/{service_id}/notifications?page=0",
+                "next": f"/service/{service_id}/notifications?page=1",
+                "last": f"/service/{service_id}/notifications?page=2",
             }
 
         data = {

--- a/tests/app/utils/test_letters.py
+++ b/tests/app/utils/test_letters.py
@@ -83,7 +83,7 @@ def test_get_letter_printing_statement_when_letter_prints_tomorrow(created_at, c
 def test_get_letter_printing_statement_for_letter_that_has_been_sent(created_at, print_day):
     statement = get_letter_printing_statement("delivered", created_at)
 
-    assert statement == "Printed {} at 5:30pm".format(print_day)
+    assert statement == f"Printed {print_day} at 5:30pm"
 
 
 def test_get_letter_validation_error_for_unknown_error():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -650,7 +650,7 @@ def mock_update_service(mocker):
 @pytest.fixture(scope="function")
 def mock_update_service_raise_httperror_duplicate_name(mocker):
     def _update(service_id, **kwargs):
-        json_mock = Mock(return_value={"message": {"name": ["Duplicate service name '{}'".format(kwargs.get("name"))]}})
+        json_mock = Mock(return_value={"message": {"name": [f"Duplicate service name '{kwargs.get('name')}'"]}})
         resp_mock = Mock(status_code=400, json=json_mock)
         http_error = HTTPError(response=resp_mock, message="Default message")
         raise http_error
@@ -961,10 +961,10 @@ def create_service_templates(service_id, number_of_templates=6):
             template_json(
                 service_id=service_id,
                 id_=TEMPLATE_ONE_ID if _ == 1 else str(generate_uuid()),
-                name="{}_template_{}".format(template_type, template_number),
+                name=f"{template_type}_template_{template_number}",
                 type_=template_type,
-                content="{} template {} content".format(template_type, template_number),
-                subject="{} template {} subject".format(template_type, template_number)
+                content=f"{template_type} template {template_number} content",
+                subject=f"{template_type} template {template_number} subject"
                 if template_type in ["email", "letter"]
                 else None,
             )
@@ -1577,8 +1577,8 @@ def mock_get_jobs(mocker, api_user_active, fake_uuid):
         return {
             "data": [job for job in jobs if job["job_status"] in statuses],
             "links": {
-                "prev": "services/{}/jobs?page={}".format(service_id, page - 1),
-                "next": "services/{}/jobs?page={}".format(service_id, page + 1),
+                "prev": f"services/{service_id}/jobs?page={page - 1}",
+                "next": f"services/{service_id}/jobs?page={page + 1}",
             },
         }
 
@@ -1635,8 +1635,8 @@ def mock_get_uploads(mocker, api_user_active):
         return {
             "data": uploads,
             "links": {
-                "prev": "services/{}/uploads?page={}".format(service_id, page - 1),
-                "next": "services/{}/uploads?page={}".format(service_id, page + 1),
+                "prev": f"services/{service_id}/uploads?page={page - 1}",
+                "next": f"services/{service_id}/uploads?page={page + 1}",
             },
         }
 
@@ -1737,8 +1737,8 @@ def mock_get_uploaded_letters(mocker):
             "notifications": uploads,
             "total": 1234,
             "links": {
-                "prev": "services/{}/uploads?page={}".format(service_id, page - 1),
-                "next": "services/{}/uploads?page={}".format(service_id, page + 1),
+                "prev": f"services/{service_id}/uploads?page={page - 1}",
+                "next": f"services/{service_id}/uploads?page={page + 1}",
             },
         }
 
@@ -2134,7 +2134,7 @@ def mock_get_invites_for_service(mocker, service_one, sample_invite):
         data = []
         for i in range(0, 5):
             invite = copy.copy(sample_invite)
-            invite["email_address"] = "user_{}@testnotify.gov.uk".format(i)
+            invite["email_address"] = f"user_{i}@testnotify.gov.uk"
             data.append(invite)
         return data
 
@@ -2434,10 +2434,10 @@ def create_email_brandings(number_of_brandings, non_standard_values=None, shuffl
     brandings = [
         {
             "id": str(idx),
-            "name": "org {}".format(idx),
-            "text": "org {}".format(idx),
+            "name": f"org {idx}",
+            "text": f"org {idx}",
             "colour": None,
-            "logo": "logo{}.png".format(idx),
+            "logo": f"logo{idx}.png",
             "brand_type": "org",
         }
         for idx in range(1, number_of_brandings + 1)
@@ -3356,7 +3356,7 @@ def mock_get_invites_for_organisation(mocker, sample_org_invite):
         data = []
         for i in range(0, 5):
             invite = copy.copy(sample_org_invite)
-            invite["email_address"] = "user_{}@testnotify.gov.uk".format(i)
+            invite["email_address"] = f"user_{i}@testnotify.gov.uk"
             data.append(invite)
         return data
 
@@ -3429,7 +3429,7 @@ def mock_get_non_empty_organisations_and_services_for_user(mocker, organisation_
     def _make_services(name, trial_mode=False):
         return [
             {
-                "name": "{} {}".format(name, i),
+                "name": f"{name} {i}",
                 "id": SERVICE_TWO_ID,
                 "restricted": trial_mode,
                 "organisation": None,
@@ -3471,7 +3471,7 @@ def mock_get_just_services_for_user(mocker, organisation_one, api_user_active):
     def _make_services(name, trial_mode=False):
         return [
             {
-                "name": "{} {}".format(name, i + 1),
+                "name": f"{name} {i + 1}",
                 "id": id,
                 "restricted": trial_mode,
                 "organisation": None,


### PR DESCRIPTION
[flynt](https://github.com/ikamensh/flynt) is a project that provides an autoformatter for converting from %-formatted and "".format() strings to modern f-strings.

I've noticed a few PRs lately where we piecemeal convert a few parts of the codebase over to f-strings, so this is an attempt to stop that being a bitty manual process.

The command I used was `flynt .`:
```
Flynt run has finished. Stats:

Execution time:                            2.237s
Files checked:                             286
Files modified:                            87
Character count reduction:                 2966238 (99.99%)

Per expression type:
No old style (`%`) expressions attempted.
`.format(...)` calls attempted:            474/478 (99.2%)
No concatenations attempted.
No static string joins attempted.
F-string expressions created:              437
```