### PR TITLE
Letter attachment design tweaks

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -1,5 +1,11 @@
 .template-container {
   position: relative;
+
+  &--with-attach-pages-button {
+    .letter {
+      margin-bottom: 0;
+    }
+  }
 }
 
 %edit-template-link,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -105,7 +105,9 @@ def view_template(service_id, template_id):
         letter_too_long=is_letter_too_long(page_count),
         letter_max_pages=LETTER_MAX_PAGE_COUNT,
         page_count=page_count,
-        show_attach_pages_button=(True if current_service.has_permission("extra_letter_formatting") else False),
+        show_attach_pages_button=(
+            template["template_type"] == "letter" and current_service.has_permission("extra_letter_formatting")
+        ),
     )
 
 

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -62,7 +62,7 @@
     </div>
   {% endif %}
 </div>
-<div class="govuk-grid-column-full template-container">
+<div class="govuk-grid-column-full template-container {% if show_attach_pages_button %}template-container--with-attach-pages-button{% endif %}">
   {% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %}
     {% if not current_service.letter_branding_id %}
       <a href="{{ url_for(".letter_branding_options", service_id=current_service.id, from_template=template.id) }}" class="govuk-link govuk-link--inverse edit-template-link-letter-branding">Add logo</a>

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -17,8 +17,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-five-sixths">
         {% if error %}
             {% call banner_wrapper(type='dangerous') %}
                 <h1 class="banner-title">{{ error.title }}</h1>
@@ -48,6 +46,4 @@
             show_errors=False
             )}}
         </div>
-    </div>
-</div>
 {% endblock %}

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -18,12 +18,14 @@
 
 {% block maincolumn_content %}
     {% if error %}
-        {% call banner_wrapper(type='dangerous') %}
-            <h1 class="banner-title">{{ error.title }}</h1>
-            {% if error.detail %}
-                <p class="govuk-body">{{ error.detail | safe }}</p>
-            {% endif %}
-        {% endcall %}
+        <div class="govuk-!-margin-bottom-4">
+            {% call banner_wrapper(type='dangerous') %}
+                <h1 class="banner-title">{{ error.title }}</h1>
+                {% if error.detail %}
+                    <p class="govuk-body">{{ error.detail | safe }}</p>
+                {% endif %}
+            {% endcall %}
+        </div>
     {% else %}
         {{ page_header(page_title) }}
     {% endif %}

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -11,9 +11,7 @@
 {% endblock %}
 
 {% block backLink %}
-{% if not error %}
-{{ govukBackLink({ "href": url_for('main.view_template', service_id=current_service.id, template_id=template_id) }) }}
-{% endif %}
+    {{ govukBackLink({ "href": url_for('main.view_template', service_id=current_service.id, template_id=template_id) }) }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -17,33 +17,33 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-        {% if error %}
-            {% call banner_wrapper(type='dangerous') %}
-                <h1 class="banner-title">{{ error.title }}</h1>
-                {% if error.detail %}
-                    <p class="govuk-body">{{ error.detail | safe }}</p>
-                {% endif %}
-            {% endcall %}
-        {% else %}
-            {{ page_header(page_title) }}
-        {% endif %}
+    {% if error %}
+        {% call banner_wrapper(type='dangerous') %}
+            <h1 class="banner-title">{{ error.title }}</h1>
+            {% if error.detail %}
+                <p class="govuk-body">{{ error.detail | safe }}</p>
+            {% endif %}
+        {% endcall %}
+    {% else %}
+        {{ page_header(page_title) }}
+    {% endif %}
 
-        <p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
-        <p class="govuk-body">
-            In total, your letter must be 10 pages or less (5 double-sided sheets of paper).
-        </p>
-        <p class="govuk-body">
-            Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">letter
-                specification</a>.
-        </p>
+    <p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
+    <p class="govuk-body">
+        In total, your letter must be 10 pages or less (5 double-sided sheets of paper).
+    </p>
+    <p class="govuk-body">
+        Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">letter
+            specification</a>.
+    </p>
 
-        <div class="govuk-body">
-            {{ file_upload(
-            form.file,
-            allowed_file_extensions=['pdf'],
-            action=url_for('main.letter_template_attach_pages', service_id=current_service.id, template_id=template_id),
-            button_text='Upload your file again' if error else 'Choose file',
-            show_errors=False
-            )}}
-        </div>
+    <div class="govuk-body">
+        {{ file_upload(
+        form.file,
+        allowed_file_extensions=['pdf'],
+        action=url_for('main.letter_template_attach_pages', service_id=current_service.id, template_id=template_id),
+        button_text='Upload your file again' if error else 'Choose file',
+        show_errors=False
+        )}}
+    </div>
 {% endblock %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -44,7 +44,7 @@
     {% include 'views/templates/_template.html' %}
   </div>
 
-  {% if template.template_type == "letter" and show_attach_pages_button %}
+  {% if show_attach_pages_button %}
     <div class="govuk-!-margin-bottom-3">
       {{ govukButton({
       "element": "a",

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -45,7 +45,7 @@
   </div>
 
   {% if show_attach_pages_button %}
-    <div class="govuk-!-margin-bottom-3">
+    <div class="js-stick-at-bottom-when-scrolling">
       {{ govukButton({
       "element": "a",
       "text": "Attach pages",

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -45,17 +45,19 @@
   </div>
 
   {% if show_attach_pages_button %}
-    <div class="js-stick-at-bottom-when-scrolling">
-      {{ govukButton({
-      "element": "a",
-      "text": "Attach pages",
-      "href": url_for(
-          '.letter_template_attach_pages',
-          service_id=current_service.id,
-          template_id=template.id
-        ),
-      "classes": "govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-2"
-      }) }}
+    <div class="govuk-!-margin-bottom-2">
+      <div class="js-stick-at-bottom-when-scrolling">
+        {{ govukButton({
+        "element": "a",
+        "text": "Attach pages",
+        "href": url_for(
+            '.letter_template_attach_pages',
+            service_id=current_service.id,
+            template_id=template.id
+          ),
+        "classes": "govuk-button--secondary"
+        }) }}
+      </div>
     </div>
   {% endif %}
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -806,15 +806,17 @@ def test_view_letter_template_has_attach_pages_button(
     )
 
     buttons = [b for b in page.select(".govuk-button--secondary") if normalize_spaces((b).text) == "Attach pages"]
+    template_container = page.select(".template-container.template-container--with-attach-pages-button")
 
     if template_type == "letter":
         button = buttons[0]
         assert button.attrs["href"] == url_for(
             ".letter_template_attach_pages", service_id=SERVICE_ONE_ID, template_id=fake_uuid
         )
-
+        assert template_container
     else:
         assert len(buttons) == 0
+        assert not template_container
 
 
 def test_GET_letter_template_attach_pages(client_request, service_one, fake_uuid, mocker):


### PR DESCRIPTION
# Template page

The ‘Attach pages’ button is now sticky and has better spacing around it.

Before | After
---|---
<img width="1087" alt="image" src="https://user-images.githubusercontent.com/355079/233649916-dcbb7cd9-c612-40c1-bcbd-5302fb69d6e2.png"> | <img width="1113" alt="image" src="https://user-images.githubusercontent.com/355079/233649852-014590df-0e22-416c-bdce-5646d00224c9.png">

# Upload attachment page (with error)

The guidance and error banner are now full width (wrapping to a narrower column is only needed for longer passages of text). The page has a back link to match the ‘Upload a letter’ page.

Before | After
---|---
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/355079/233650229-e5a0dc9c-97d0-4b5b-8f17-5fbd33129b86.png"> | <img width="1020" alt="image" src="https://user-images.githubusercontent.com/355079/233650348-31541e8d-cd71-4a84-847c-fc480f29ce9c.png">
