### PR TITLE
Save letter attachments to the database

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -100,6 +100,7 @@ from app.notify_client.events_api_client import events_api_client
 from app.notify_client.inbound_number_client import inbound_number_client
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.job_api_client import job_api_client
+from app.notify_client.letter_attachment_client import letter_attachment_client
 from app.notify_client.letter_branding_client import letter_branding_client
 from app.notify_client.letter_jobs_client import letter_jobs_client
 from app.notify_client.notification_api_client import notification_api_client
@@ -180,6 +181,7 @@ def create_app(application):
         inbound_number_client,
         invite_api_client,
         job_api_client,
+        letter_attachment_client,
         letter_branding_client,
         letter_jobs_client,
         notification_api_client,

--- a/app/config.py
+++ b/app/config.py
@@ -74,6 +74,7 @@ class Config:
     S3_BUCKET_MOU = "local-mou"
     S3_BUCKET_TRANSIENT_UPLOADED_LETTERS = "local-transient-uploaded-letters"
     S3_BUCKET_PRECOMPILED_ORIGINALS_BACKUP_LETTERS = "local-precompiled-originals-backup-letters"
+    S3_BUCKET_LETTER_ATTACHMENTS = "local-letter-attachments"
     ROUTE_SECRET_KEY_1 = os.environ.get("ROUTE_SECRET_KEY_1", "")
     ROUTE_SECRET_KEY_2 = os.environ.get("ROUTE_SECRET_KEY_2", "")
     CHECK_PROXY_HEADER = False
@@ -118,6 +119,7 @@ class Development(Config):
     S3_BUCKET_MOU = "notify.tools-mou"
     S3_BUCKET_TRANSIENT_UPLOADED_LETTERS = "development-transient-uploaded-letters"
     S3_BUCKET_PRECOMPILED_ORIGINALS_BACKUP_LETTERS = "development-letters-precompiled-originals-backup"
+    S3_BUCKET_LETTER_ATTACHMENTS = "development-letter-attachments"
 
     LOGO_CDN_DOMAIN = "static-logos.notify.tools"
 
@@ -146,6 +148,7 @@ class Test(Development):
     S3_BUCKET_MOU = "test-mou"
     S3_BUCKET_TRANSIENT_UPLOADED_LETTERS = "test-transient-uploaded-letters"
     S3_BUCKET_PRECOMPILED_ORIGINALS_BACKUP_LETTERS = "test-letters-precompiled-originals-backup"
+    S3_BUCKET_LETTER_ATTACHMENTS = "test-letter-attachments"
     LOGO_CDN_DOMAIN = "static-logos.test.com"
     NOTIFY_ENVIRONMENT = "test"
     API_HOST_NAME = "http://you-forgot-to-mock-an-api-call-to"
@@ -167,6 +170,7 @@ class Preview(Config):
     S3_BUCKET_MOU = "notify.works-mou"
     S3_BUCKET_TRANSIENT_UPLOADED_LETTERS = "preview-transient-uploaded-letters"
     S3_BUCKET_PRECOMPILED_ORIGINALS_BACKUP_LETTERS = "preview-letters-precompiled-originals-backup"
+    S3_BUCKET_LETTER_ATTACHMENTS = "preview-letter-attachments"
     LOGO_CDN_DOMAIN = "static-logos.notify.works"
     NOTIFY_ENVIRONMENT = "preview"
     CHECK_PROXY_HEADER = False
@@ -186,6 +190,7 @@ class Staging(Config):
     S3_BUCKET_MOU = "staging-notify.works-mou"
     S3_BUCKET_TRANSIENT_UPLOADED_LETTERS = "staging-transient-uploaded-letters"
     S3_BUCKET_PRECOMPILED_ORIGINALS_BACKUP_LETTERS = "staging-letters-precompiled-originals-backup"
+    S3_BUCKET_LETTER_ATTACHMENTS = "staging-letter-attachments"
     LOGO_CDN_DOMAIN = "static-logos.staging-notify.works"
     NOTIFY_ENVIRONMENT = "staging"
     CHECK_PROXY_HEADER = False
@@ -202,6 +207,7 @@ class Production(Config):
     S3_BUCKET_MOU = "notifications.service.gov.uk-mou"
     S3_BUCKET_TRANSIENT_UPLOADED_LETTERS = "production-transient-uploaded-letters"
     S3_BUCKET_PRECOMPILED_ORIGINALS_BACKUP_LETTERS = "production-letters-precompiled-originals-backup"
+    S3_BUCKET_LETTER_ATTACHMENTS = "production-letter-attachments"
     LOGO_CDN_DOMAIN = "static-logos.notifications.service.gov.uk"
     NOTIFY_ENVIRONMENT = "production"
     CHECK_PROXY_HEADER = False

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -23,6 +23,7 @@ from requests import RequestException
 from app import (
     current_service,
     format_delta,
+    letter_attachment_client,
     nl2br,
     service_api_client,
     template_folder_api_client,
@@ -1000,6 +1001,13 @@ def letter_template_attach_pages(service_id, template_id):
             backup_original_letter_to_s3(
                 file_contents,
                 upload_id=upload_id,
+            )
+
+            letter_attachment_client.create_letter_attachment(
+                upload_id=upload_id,
+                original_filename=original_filename,
+                page_count=page_count,
+                template_id=template_id,
             )
 
             pages_content = "1 page" if attachment_page_count == 1 else f"{attachment_page_count} pages"

--- a/app/notify_client/letter_attachment_client.py
+++ b/app/notify_client/letter_attachment_client.py
@@ -1,0 +1,21 @@
+from flask_login import current_user
+
+from app.notify_client import NotifyAdminAPIClient
+
+
+class LetterAttachmentClient(NotifyAdminAPIClient):
+    def get_letter_attachment(self, letter_attachment_id):
+        return self.get(url=f"/letter-attachment/{letter_attachment_id}")
+
+    def create_letter_attachment(self, *, upload_id, original_filename, page_count, template_id):
+        data = {
+            "upload_id": str(upload_id),
+            "original_filename": original_filename,
+            "page_count": page_count,
+            "template_id": str(template_id),
+            "created_by_id": str(current_user.id),
+        }
+        return self.post(url="/letter-attachment", data=data)
+
+
+letter_attachment_client = LetterAttachmentClient()

--- a/app/s3_client/s3_letter_upload_client.py
+++ b/app/s3_client/s3_letter_upload_client.py
@@ -87,3 +87,19 @@ def get_letter_pdf_and_metadata(service_id, file_id):
 def get_letter_metadata(service_id, file_id):
     s3_object = get_letter_s3_object(service_id, file_id)
     return LetterMetadata(s3_object["Metadata"])
+
+
+def upload_letter_attachment_to_s3(data, *, file_location, page_count, original_filename):
+    # Use of urllib.parse.quote encodes metadata into ascii, which is required by s3.
+    # Making sure data for displaying to users is decoded is taken care of by LetterMetadata
+    metadata = {
+        "page_count": str(page_count),
+        "filename": urllib.parse.quote(original_filename),
+    }
+    utils_s3upload(
+        filedata=data,
+        region=current_app.config["AWS_REGION"],
+        bucket_name=current_app.config["S3_BUCKET_LETTER_ATTACHMENTS"],
+        file_location=file_location,
+        metadata=metadata,
+    )

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -953,11 +953,14 @@ def test_post_attach_pages_redirects_to_template_view_when_validation_successful
     mock_upload = mocker.patch("app.main.views.templates.upload_letter_attachment_to_s3")
     mock_backup = mocker.patch("app.main.views.templates.backup_original_letter_to_s3")
 
+    mock_save_to_db = mocker.patch("app.letter_attachment_client.create_letter_attachment")
+
+    template_id = sample_uuid()
     with open("tests/test_pdf_files/one_page_pdf.pdf", "rb") as file:
         page = client_request.post(
             "main.letter_template_attach_pages",
             service_id=SERVICE_ONE_ID,
-            template_id=sample_uuid(),
+            template_id=template_id,
             _data={"file": file},
             _follow_redirects=True,
         )
@@ -973,6 +976,12 @@ def test_post_attach_pages_redirects_to_template_view_when_validation_successful
         original_filename="tests/test_pdf_files/one_page_pdf.pdf",
     )
     mock_backup.assert_called_once_with(b"The sanitised content", upload_id=upload_id)
+    mock_save_to_db.assert_called_once_with(
+        upload_id=upload_id,
+        template_id=template_id,
+        page_count=page_count,
+        original_filename="tests/test_pdf_files/one_page_pdf.pdf",
+    )
 
 
 def test_edit_letter_template_postage_page_displays_correctly(


### PR DESCRIPTION
Things this PR does:

* saves the attachment to the new bucket in s3. we stick a bunch of stuff in the metadata to keep it available, but i'm not sure how necessary that is given we're also saving everything to the database
* saves an original to the transient bucket in case we need to investigate weird font issues. we already do this for precompiled letters
* saves the details to the database.

Things this PR doesn't do:

* handling errors from the API app - do we expect them to practically happen, or is it okay to display a "something went wrong" page for those. The only one I'm kinda interested in handling separately would be if the template already has an attachment, perhaps.
* significantly overhaul more of the save attachment function. i want to clean up the error handling, make the flow a bit easier to read, remove the calls to pdf_page_count, see if the template page count call can be done in a smarter way, and possibly more