### PR TITLE
Remove `LetterPreviewTemplate`

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -577,7 +577,7 @@ def send_from_contact_list(service_id, template_id, contact_list_id):
     )
 
 
-def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_pdf=False):
+def _check_messages(service_id, template_id, upload_id, preview_row):
 
     try:
         # The happy path is that the job doesn’t already exist, so the
@@ -620,9 +620,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
             upload_id=upload_id,
             filetype="png",
             row_index=preview_row,
-        )
-        if not letters_as_pdf
-        else None,
+        ),
         email_reply_to=email_reply_to,
         sms_sender=sms_sender,
         # In this case, we don't provide template values when calculating the page count

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -756,7 +756,7 @@ def check_messages_preview(service_id, template_id, upload_id, filetype, row_ind
     else:
         abort(404)
 
-    template = _check_messages(service_id, template_id, upload_id, row_index, letters_as_pdf=True)["template"]
+    template = _check_messages(service_id, template_id, upload_id, row_index)["template"]
     return TemplatePreview.from_utils_template(template, filetype, page=page)
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -275,7 +275,7 @@ def letter_branding_preview_image(filename):
     return TemplatePreview.from_example_template(template, filename)
 
 
-def _view_template_version(service_id, template_id, version, letters_as_pdf=False):
+def _view_template_version(service_id, template_id, version):
     return dict(
         template=get_template(
             current_service.get_template(template_id, version=version),
@@ -286,9 +286,7 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
                 template_id=template_id,
                 version=version,
                 filetype="png",
-            )
-            if not letters_as_pdf
-            else None,
+            ),
         )
     )
 

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -1,9 +1,7 @@
-from flask import current_app
 from notifications_utils.template import (
     BroadcastPreviewTemplate,
     EmailPreviewTemplate,
     LetterImageTemplate,
-    LetterPreviewTemplate,
     SMSPreviewTemplate,
 )
 
@@ -49,21 +47,13 @@ def get_template(
             redact_missing_personalisation=redact_missing_personalisation,
         )
     if "letter" == template["template_type"]:
-        if letter_preview_url:
-            return LetterImageTemplate(
-                template,
-                image_url=letter_preview_url,
-                page_count=int(page_count),
-                contact_block=template["reply_to_text"],
-                postage=template["postage"],
-            )
-        else:
-            return LetterPreviewTemplate(
-                template,
-                contact_block=template["reply_to_text"],
-                admin_base_url=current_app.config["ADMIN_BASE_URL"],
-                redact_missing_personalisation=redact_missing_personalisation,
-            )
+        return LetterImageTemplate(
+            template,
+            image_url=letter_preview_url,
+            page_count=int(page_count),
+            contact_block=template["reply_to_text"],
+            postage=template["postage"],
+        )
     if "broadcast" == template["template_type"]:
         return BroadcastPreviewTemplate(
             template,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -17,7 +17,6 @@ from notifications_python_client.errors import HTTPError
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.template import (
     LetterImageTemplate,
-    LetterPreviewTemplate,
     SMSPreviewTemplate,
 )
 from xlrd.biffh import XLRDError
@@ -2785,7 +2784,7 @@ def test_should_show_preview_letter_message(
     assert response.get_data(as_text=True) == "foo"
     mocked_preview.assert_called_once()
     assert mocked_preview.call_args[0][0].id == template_id
-    assert type(mocked_preview.call_args[0][0]) == LetterPreviewTemplate
+    assert type(mocked_preview.call_args[0][0]) == LetterImageTemplate
     assert mocked_preview.call_args[0][1] == filetype
     assert mocked_preview.call_args[0][0].values == expected_values
     assert mocked_preview.call_args[1] == {"page": expected_page}


### PR DESCRIPTION
In the old days the admin app could render a letter template in 2 ways:

1. as a series of `<img>` tags, one for each page as the letter
2. as HTML, which could be passed to a HTML-to-PDF convertor for making into a PDF

Since then we have moved 2. into the template preview app. So the admin app only needs to render some `<img>` tags (using the `LetterImageTemplate` class). Any PDFs or image files that it serves come from the template preview app and get passed through.

The template preview app still uses the `LetterPreviewTemplate` class to do this, by rendering HTML which is converted into a PDF. But the admin app no longer needs to use this class for anything.