### PR TITLE
Clear templates cache when uploading attachment

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -989,6 +989,7 @@ def letter_template_attach_pages(service_id, template_id):
         if attachment_page_count + template_page_count <= 10:
             try:
                 _save_letter_attachment(
+                    service_id=service_id,
                     template_id=template_id,
                     upload_id=upload_id,
                     original_filename=original_filename,
@@ -1025,7 +1026,7 @@ def letter_template_attach_pages(service_id, template_id):
     )
 
 
-def _save_letter_attachment(*, template_id, upload_id, original_filename, sanitise_response):
+def _save_letter_attachment(*, service_id, template_id, upload_id, original_filename, sanitise_response):
     response_json = sanitise_response.json()
     attachment_page_count = response_json["page_count"]
     file_contents = base64.b64decode(response_json["file"].encode())
@@ -1050,6 +1051,7 @@ def _save_letter_attachment(*, template_id, upload_id, original_filename, saniti
         original_filename=original_filename,
         page_count=attachment_page_count,
         template_id=template_id,
+        service_id=service_id,
     )
 
     pages_content = "1 page" if attachment_page_count == 1 else f"{attachment_page_count} pages"

--- a/app/notify_client/letter_attachment_client.py
+++ b/app/notify_client/letter_attachment_client.py
@@ -1,13 +1,15 @@
 from flask_login import current_user
 
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, cache
 
 
 class LetterAttachmentClient(NotifyAdminAPIClient):
     def get_letter_attachment(self, letter_attachment_id):
         return self.get(url=f"/letter-attachment/{letter_attachment_id}")
 
-    def create_letter_attachment(self, *, upload_id, original_filename, page_count, template_id):
+    @cache.delete("service-{service_id}-templates")
+    @cache.delete_by_pattern("service-{service_id}-template-*")
+    def create_letter_attachment(self, *, upload_id, original_filename, page_count, template_id, service_id):
         data = {
             "upload_id": str(upload_id),
             "original_filename": original_filename,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1003,6 +1003,7 @@ def test_post_attach_pages_redirects_to_template_view_when_validation_successful
     upload_id = mock_sanitise.call_args[1]["upload_id"]
 
     mock_save.assert_called_once_with(
+        service_id=service_one["id"],
         template_id=template_id,
         upload_id=upload_id,
         original_filename="tests/test_pdf_files/one_page_pdf.pdf",
@@ -1029,6 +1030,7 @@ def test_save_letter_attachment_saves_to_s3_and_db_and_redirects(notify_admin, s
     g.current_service = Service(service_one)
 
     _save_letter_attachment(
+        service_id=service_one["id"],
         template_id=template_id,
         upload_id=upload_id,
         original_filename="foo.pdf",
@@ -1045,6 +1047,7 @@ def test_save_letter_attachment_saves_to_s3_and_db_and_redirects(notify_admin, s
     mock_save_to_db.assert_called_once_with(
         upload_id=upload_id,
         template_id=template_id,
+        service_id=service_one["id"],
         page_count=attachment_page_count,
         original_filename="foo.pdf",
     )


### PR DESCRIPTION
When we attach a PDF to a letter template, we need to invalidate that cache so that the `letter_attachment` attribute on templates can get updated.