### PR TITLE
Save letter attachment refactor

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1358,7 +1358,7 @@ class CsvUploadForm(StripWhitespaceForm):
         validators=[
             DataRequired(message="Please pick a file"),
             CsvFileValidator(),
-            FileSize(max_size=10e6, message="File must be smaller than 10Mb"),  # 10Mb
+            FileSize(max_size=10 * 1024 * 1024, message="File must be smaller than 10MB"),
         ],
     )
 
@@ -1798,7 +1798,7 @@ class LetterBrandingUploadBranding(StripWhitespaceForm):
         validators=[
             FileAllowed(["svg"], "Branding must be an SVG file"),
             DataRequired(message="You need to upload a file to submit"),
-            FileSize(max_size=(2 * 1024 * 1024), message="File must be smaller than 2MB"),
+            FileSize(max_size=2 * 1024 * 1024, message="File must be smaller than 2MB"),
             NoEmbeddedImagesInSVG(),
             NoTextInSVG(),
         ],
@@ -1816,7 +1816,7 @@ class EmailBrandingLogoUpload(StripWhitespaceForm):
         "Upload a logo",
         validators=[
             DataRequired(message="You need to upload a file to submit"),
-            FileSize(max_size=(2 * 1024 * 1024), message="File must be smaller than 2MB"),
+            FileSize(max_size=2 * 1024 * 1024, message="File must be smaller than 2MB"),
         ],
     )
 
@@ -1854,6 +1854,7 @@ class PDFUploadForm(StripWhitespaceForm):
         validators=[
             FileAllowed(["pdf"], "Save your letter as a PDF and try again."),
             DataRequired(message="You need to choose a file to upload"),
+            FileSize(max_size=2 * 1024 * 1024, message="File must be smaller than 2MB"),
         ],
     )
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -926,96 +926,7 @@ def letter_template_attach_pages(service_id, template_id):
     error = {}
 
     if form.validate_on_submit():
-        pdf_file_bytes = form.file.data.read()
-        original_filename = form.file.data.filename
-
-        if len(pdf_file_bytes) > MAX_FILE_UPLOAD_SIZE:
-            return _invalid_upload_error(
-                template_id=template_id,
-                error={
-                    "title": "Your file is too big",
-                    "detail": "Files must be smaller than 2MB.",
-                },
-            )
-
-        try:
-            # TODO: get page count from the sanitise response once template preview
-            # handles malformed files nicely - is this done yet?
-            attachment_page_count = pdf_page_count(BytesIO(pdf_file_bytes))
-        except PdfReadError:
-            current_app.logger.info(f"Invalid PDF uploaded for service_id: {service_id}")
-            return _invalid_upload_error(
-                template_id=template_id,
-                error={
-                    "title": "There’s a problem with your file",
-                    "detail": "Notify cannot read this PDF.<br>Save a new copy of your file and try again.",
-                },
-            )
-
-        upload_id = uuid.uuid4()
-        file_location = get_transient_letter_file_location(service_id, upload_id)
-
-        try:
-            response = sanitise_letter(
-                BytesIO(pdf_file_bytes),
-                upload_id=upload_id,
-                allow_international_letters=current_service.has_permission("international_letters"),
-                is_an_attachment=True,
-            )
-            response.raise_for_status()
-        except RequestException as ex:
-            if ex.response is not None and ex.response.status_code == 400:
-                validation_failed_message = response.json().get("message")
-                invalid_pages = response.json().get("invalid_pages")
-
-                status = "invalid"
-                upload_letter_to_s3(
-                    pdf_file_bytes,
-                    file_location=file_location,
-                    status=status,
-                    page_count=attachment_page_count,
-                    filename=original_filename,
-                    message=validation_failed_message,
-                    invalid_pages=invalid_pages,
-                )
-                return _invalid_upload_error(
-                    template_id=template_id,
-                    error=get_letter_validation_error(validation_failed_message, invalid_pages, attachment_page_count),
-                )
-
-            raise
-
-        template_page_count = get_page_count_for_letter(template)
-        if attachment_page_count + template_page_count <= 10:
-            try:
-                _save_letter_attachment(
-                    service_id=service_id,
-                    template_id=template_id,
-                    upload_id=upload_id,
-                    original_filename=original_filename,
-                    sanitise_response=response,
-                )
-                return redirect(
-                    url_for(
-                        "main.view_template",
-                        service_id=current_service.id,
-                        template_id=template_id,
-                    )
-                )
-            except HTTPError as e:
-                if e.status_code == 400 and e.message == "template-already-has-attachment":
-                    # TODO: decide on content. this might depend on what the management page looks like (as we might
-                    # want to redirect to the existing  to show the user the attachment that has already been added)
-                    form.file.errors.append("This template already has an attachment.")
-                else:
-                    raise
-
-        else:
-            form.file.errors.append(
-                "Letters must be 10 pages or less (5 double-sided sheets of paper). "
-                "In total, your letter template and the file you attached are "
-                f"{template_page_count + attachment_page_count} pages long."
-            )
+        return _process_letter_attachment_form(service_id, template, form)
 
     if form.file.errors:
         error = get_error_from_upload_form(form.file.errors[0])
@@ -1024,6 +935,100 @@ def letter_template_attach_pages(service_id, template_id):
         render_template("views/templates/attach-pages.html", form=form, template_id=template_id, error=error),
         400 if error else 200,
     )
+
+
+def _process_letter_attachment_form(service_id, template, form):
+    template_id = template["id"]
+    pdf_file_bytes = form.file.data.read()
+    original_filename = form.file.data.filename
+
+    if len(pdf_file_bytes) > MAX_FILE_UPLOAD_SIZE:
+        return _invalid_upload_error(
+            template_id=template_id,
+            error={
+                "title": "Your file is too big",
+                "detail": "Files must be smaller than 2MB.",
+            },
+        )
+
+    try:
+        # TODO: get page count from the sanitise response once template preview
+        # handles malformed files nicely - is this done yet?
+        attachment_page_count = pdf_page_count(BytesIO(pdf_file_bytes))
+    except PdfReadError:
+        current_app.logger.info(f"Invalid PDF uploaded for service_id: {service_id}")
+        return _invalid_upload_error(
+            template_id=template_id,
+            error={
+                "title": "There’s a problem with your file",
+                "detail": "Notify cannot read this PDF.<br>Save a new copy of your file and try again.",
+            },
+        )
+
+    upload_id = uuid.uuid4()
+    file_location = get_transient_letter_file_location(service_id, upload_id)
+
+    try:
+        response = sanitise_letter(
+            BytesIO(pdf_file_bytes),
+            upload_id=upload_id,
+            allow_international_letters=current_service.has_permission("international_letters"),
+            is_an_attachment=True,
+        )
+        response.raise_for_status()
+    except RequestException as ex:
+        if ex.response is not None and ex.response.status_code == 400:
+            validation_failed_message = response.json().get("message")
+            invalid_pages = response.json().get("invalid_pages")
+
+            status = "invalid"
+            upload_letter_to_s3(
+                pdf_file_bytes,
+                file_location=file_location,
+                status=status,
+                page_count=attachment_page_count,
+                filename=original_filename,
+                message=validation_failed_message,
+                invalid_pages=invalid_pages,
+            )
+            return _invalid_upload_error(
+                template_id=template_id,
+                error=get_letter_validation_error(validation_failed_message, invalid_pages, attachment_page_count),
+            )
+
+        raise
+
+    template_page_count = get_page_count_for_letter(template)
+    if attachment_page_count + template_page_count <= 10:
+        try:
+            _save_letter_attachment(
+                service_id=service_id,
+                template_id=template_id,
+                upload_id=upload_id,
+                original_filename=original_filename,
+                sanitise_response=response,
+            )
+            return redirect(
+                url_for(
+                    "main.view_template",
+                    service_id=current_service.id,
+                    template_id=template_id,
+                )
+            )
+        except HTTPError as e:
+            if e.status_code == 400 and e.message == "template-already-has-attachment":
+                # TODO: decide on content. this might depend on what the management page looks like (as we might
+                # want to redirect to the existing  to show the user the attachment that has already been added)
+                form.file.errors.append("This template already has an attachment.")
+            else:
+                raise
+
+    else:
+        form.file.errors.append(
+            "Letters must be 10 pages or less (5 double-sided sheets of paper). "
+            "In total, your letter template and the file you attached are "
+            f"{template_page_count + attachment_page_count} pages long."
+        )
 
 
 def _save_letter_attachment(*, service_id, template_id, upload_id, original_filename, sanitise_response):

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -64,7 +64,6 @@ from app.utils import (
     should_skip_template_page,
 )
 from app.utils.letters import (
-    MAX_FILE_UPLOAD_SIZE,
     get_error_from_upload_form,
     get_letter_validation_error,
 )
@@ -954,12 +953,6 @@ def _process_letter_attachment_form(service_id, template, form):
     template_id = template["id"]
     pdf_file_bytes = form.file.data.read()
     original_filename = form.file.data.filename
-
-    if len(pdf_file_bytes) > MAX_FILE_UPLOAD_SIZE:
-        raise LetterAttachmentFormError(
-            title="Your file is too big",
-            detail="Files must be smaller than 2MB.",
-        )
 
     try:
         # TODO: get page count from the sanitise response once template preview

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -48,7 +48,6 @@ from app.template_previews import TemplatePreview, sanitise_letter
 from app.utils import unicode_truncate
 from app.utils.csv import Spreadsheet, get_errors_for_csv
 from app.utils.letters import (
-    MAX_FILE_UPLOAD_SIZE,
     get_error_from_upload_form,
     get_letter_printing_statement,
     get_letter_validation_error,
@@ -152,9 +151,6 @@ def upload_letter(service_id):
     if form.validate_on_submit():
         pdf_file_bytes = form.file.data.read()
         original_filename = form.file.data.filename
-
-        if len(pdf_file_bytes) > MAX_FILE_UPLOAD_SIZE:
-            return _invalid_upload_error("Your file is too big", "Files must be smaller than 2MB.")
 
         try:
             # TODO: get page count from the sanitise response once template preview handles malformed files nicely

--- a/app/utils/letters.py
+++ b/app/utils/letters.py
@@ -12,8 +12,6 @@ from notifications_utils.timezones import (
     utc_string_to_aware_gmt_datetime,
 )
 
-MAX_FILE_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MB
-
 
 def printing_today_or_tomorrow(created_at):
     print_cutoff = convert_bst_to_utc(convert_utc_to_bst(datetime.utcnow()).replace(hour=17, minute=30)).replace(

--- a/app/utils/letters.py
+++ b/app/utils/letters.py
@@ -197,8 +197,9 @@ def get_error_from_upload_form(form_errors):
     error = {}
     if "PDF" in form_errors:
         error["title"] = "Wrong file type"
-        error["detail"] = form_errors
-    else:  # No file was uploaded error
-        error["title"] = form_errors
+    else:
+        error["title"] = "There is a problem"
+
+    error["detail"] = form_errors
 
     return error

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -945,7 +945,7 @@ def test_upload_csv_size_too_big(
         _follow_redirects=True,
     )
 
-    assert "File must be smaller than 10Mb" in page.text
+    assert "File must be smaller than 10MB" in page.text
 
 
 def test_upload_valid_csv_redirects_to_check_page(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -916,7 +916,8 @@ def test_post_attach_pages_errors_when_base_template_plus_attachment_too_long(
             _expected_status=400,
         )
 
-    assert page.select_one(".banner-dangerous h1").text == (
+    assert page.select_one(".banner-dangerous h1").text == "There is a problem"
+    assert page.select_one(".banner-dangerous p").text == (
         "Letters must be 10 pages or less (5 double-sided sheets of paper). "
         "In total, your letter template and the file you attached are 19 pages long."
     )
@@ -959,7 +960,7 @@ def test_post_attach_pages_errors_when_attachment_already_exists_for_template(
             _expected_status=400,
         )
 
-    assert page.select_one(".banner-dangerous h1").text == "This template already has an attachment."
+    assert page.select_one(".banner-dangerous p").text == "This template already has an attachment."
     assert page.select_one("form").attrs["action"] == url_for(
         "main.letter_template_attach_pages", service_id=SERVICE_ONE_ID, template_id=sample_uuid()
     )

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -262,7 +262,7 @@ def test_uploading_a_pdf_shows_error_when_no_file_uploaded(
     service_one["permissions"] = ["extra_letter_formatting"]
 
     page = client_request.post(endpoint, **kwargs, _data={"file": ""}, _expected_status=400)
-    assert page.select_one(".banner-dangerous h1").text == "You need to choose a file to upload"
+    assert page.select_one(".banner-dangerous p").text == "You need to choose a file to upload"
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 
 
@@ -282,7 +282,8 @@ def test_uploading_a_pdf_shows_error_when_file_contains_virus(
 
     with open("tests/test_pdf_files/one_page_pdf.pdf", "rb") as file:
         page = client_request.post(endpoint, **kwargs, _data={"file": file}, _expected_status=400)
-    assert page.select_one(".banner-dangerous h1").text == "Your file contains a virus"
+    assert page.select_one(".banner-dangerous h1").text == "There is a problem"
+    assert page.select_one(".banner-dangerous p").text == "Your file contains a virus"
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
     mock_s3_backup.assert_not_called()
 
@@ -303,7 +304,7 @@ def test_uploading_a_pdf_errors_when_file_is_too_big(
     with open("tests/test_pdf_files/big.pdf", "rb") as file:
         page = client_request.post(endpoint, **kwargs, _data={"file": file}, _expected_status=400)
     assert page.select_one(".banner-dangerous h1").text == "There is a problem"
-    assert page.select_one(".banner-dangerous p").text == "File must be smaller than 2MB."
+    assert page.select_one(".banner-dangerous p").text == "File must be smaller than 2MB"
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 
 

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -302,8 +302,8 @@ def test_uploading_a_pdf_errors_when_file_is_too_big(
 
     with open("tests/test_pdf_files/big.pdf", "rb") as file:
         page = client_request.post(endpoint, **kwargs, _data={"file": file}, _expected_status=400)
-    assert page.select_one(".banner-dangerous h1").text == "Your file is too big"
-    assert page.select_one(".banner-dangerous p").text == "Files must be smaller than 2MB."
+    assert page.select_one(".banner-dangerous h1").text == "There is a problem"
+    assert page.select_one(".banner-dangerous p").text == "File must be smaller than 2MB."
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 
 


### PR DESCRIPTION
This isn't the end of the error work or even the beginning - there's lots to do there on using the govuk component and behaving more consistently with how we handle other file upload errors. But I was doing a little tidy up to the code flow because it was making me mad, and ended up tweaking a couple of bits while I was there 💅

This was just an attempt to make the code a bit more readable by using exceptions as control flow. Previously we were either calling  `_invalid_upload_error`, which would render the page, or we were adding to `forms.file.errors` and just flowing down the function and then at the end we'd turn that in to an error object

The only observable changes this refactor should make are:

* minor tweaks in wording on file size errors (now consistent with errors elsewhere within notify)
* errors where we don't have a title and detail component now have a generic title as the h1 and the error message is now a detail equivalent 


| before | after
|-|-|
| ![image](https://user-images.githubusercontent.com/5020841/234887418-163563f5-e25b-4b26-ba20-abf20c4442ef.png) | ![image](https://user-images.githubusercontent.com/5020841/234887508-19587ca8-ed83-45ad-ba61-18cc2dea5073.png) |
|![image](https://user-images.githubusercontent.com/5020841/234890363-0a823319-0d4b-4217-9945-2f094927dfd3.png) | ![image](https://user-images.githubusercontent.com/5020841/234890422-11e4233a-8a23-401e-a6f7-52a703426189.png) | 

