### PR TITLE
Update link guidance

### DIFF
--- a/app/templates/partials/templates/guidance-links.html
+++ b/app/templates/partials/templates/guidance-links.html
@@ -2,9 +2,17 @@
 
 <h2 class="heading-medium">Links and URLs</h2>
 <p class="bottom-gutter-1-3">
-  Always use full URLs, starting with https://
+  If the recipient is not expecting to receive an email from you, write the URL in full, starting with https://
 </p>
 {{ govukInsetText({
   "text": "Apply now at https://www.gov.uk/example",
   "classes": "govuk-!-margin-top-0"})
 }}
+<p class="bottom-gutter-1-3">
+  To convert text into a link, use square brackets [] around the link text and round brackets () around the full URL. Make sure there are no spaces between the brackets or the link will not work. For example:
+</p>
+{{ govukInsetText({
+  "text": "[Apply now](https://www.gov.uk/example)",
+  "classes": "govuk-!-margin-top-0"})
+}}
+


### PR DESCRIPTION
Updates link guidance in line with the new guidance page: https://www.notifications.service.gov.uk/using-notify/links-and-URLs

This is a short-term update, until we redesign the edit page guidance.