### PR TITLE
Fix spacing of attach pages button

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -2,8 +2,8 @@
   position: relative;
 
   &--with-attach-pages-button {
-    .letter {
-      margin-bottom: 0;
+    .page--last {
+      margin-bottom: govuk-spacing(4);
     }
   }
 }

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.4.1
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.4.1
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
This was set to `0` before because there was a containing element which added some space.

Now this containing element isn’t present we need to add the spacing here instead.

Matches the intention of the work done in https://github.com/alphagov/notifications-admin/pull/4691

# Before

<img width="810" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/938befa0-556d-47a3-86f5-131caad110a7">

# Before (with `page--last`) class added

<img width="811" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/ccafd836-1242-4d9d-b0fa-4899e355a142">

# After

<img width="810" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/c7fc8cae-39a1-4d6d-9416-86e532508f6d">


# Depends on

- [x] https://github.com/alphagov/notifications-utils/pull/1031
- [x] https://github.com/alphagov/notifications-utils/pull/1032