### PR TITLE
Fix how copy to clipboard announces updates

### DIFF
--- a/tests/javascripts/copyToClipboard.test.js
+++ b/tests/javascripts/copyToClipboard.test.js
@@ -154,7 +154,7 @@ describe('copy to clipboard', () => {
 
           expect(component.querySelector('.copy-to-clipboard__value').textContent).toBe('00000000-0000-0000-0000-000000000000');
 
-        });        
+        });
 
       });
 
@@ -261,7 +261,7 @@ describe('copy to clipboard', () => {
 
           expect(liveRegionHiddenText.length).toEqual(2);
           expect(liveRegionHiddenText[0].textContent).toEqual('Some Thing ');
-          expect(liveRegionHiddenText[1].textContent).toEqual(', press button to show in page');
+          expect(liveRegionHiddenText[1].textContent).toEqual(', use button to show in page');
 
         });
 


### PR DESCRIPTION
Fix for this issue:

https://trello.com/c/58NoKaMt/380-copy-to-clipboard-doesnt-work-with-screenreaders

Basically, a fix for some problems with the changes in [the last attempt to fix the fact that users of the NVDA and JAWS screen readers didn't hear anything to confirm something had happened when you clicked the button](https://github.com/alphagov/notifications-admin/pull/3591).

## Problems with the last changes

The existing implementation mixed announcements for its status and the new content of the button when you clicked the button on Voiceover. On NVDA and JAWS no status was announced at all.

I think this was because:
1. when the component updates, all its HTML is replaced rather than changed
2. because all the HTML is replaced, focus is lost so the button is re-focused

Number 1. included replacing a live-region, which I think broke it in NVDA and JAWS (correctly).

Number 2. meant the content of the button and the status update, when it worked, both needed announcing at the same time. In NVDA and JAWS the button always won, probably because focus usually comes from an interaction so should win.

This commit tries to fix these problems by:
- changing the HTML when it updates rather than replacing it
- changing the content and class attribute of the button instead of the whole thing

This seems to fix the issues listed here on Voiceover, NVDA and JAWS.

Final note: I changed the contents of the live region to say 'use button' from 'press button' because you can move to that text and, when you do, 'press button' can sound like what you hear when you move to a button and so is confusing.

## Copy to clipboard with these changes

You start with it looking like this:

<img width="415" alt="copy-to-clipboard-default-state" src="https://github.com/alphagov/notifications-admin/assets/87140/ae9e73bd-3619-4723-884a-afce2137d481">

Clicking the button once changes it to this:

<img width="406" alt="copy-to-clip-board-after-copy" src="https://github.com/alphagov/notifications-admin/assets/87140/13e544ff-d256-425b-8d5b-83cbaeac67ab">

Clicking the button again changes it back to this:

<img width="415" alt="copy-to-clipboard-default-state" src="https://github.com/alphagov/notifications-admin/assets/87140/ae9e73bd-3619-4723-884a-afce2137d481">

[On JAWS, the most used screen reader, that process sounds like this](https://drive.google.com/file/d/1nQg-wJWcNGM6WFCGsnVEDNVzzMGHd24r/view?usp=sharing) (Google Drive link)

## Notes for reviewers

I acknowledge that testing this is hard, because most of our team don't have my familiarity with screen readers. That being the case, I suggest reviewers:
- try using the copy to clipboard component while using a screen reader if they are comfortable doing so
- if not, just review the code changes