### PR TITLE
convert radios in app/templates/views/manage-users/permissions.html

### DIFF
--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -1,4 +1,3 @@
-{% from "components/radios.html" import radios %}
 {% import "components/svgs.html" as svgs %}
 
 {# this may be called from invite page (where no user exists) #}
@@ -27,13 +26,7 @@
     <p class="bottom-gutter">
       This user will login with a security key.
     </p>
-  {% elif not user.mobile_number %}
-    {{ radios(
-      form.login_authentication,
-      disable=['sms_auth'],
-      option_hints={'sms_auth': 'Not available because this team member has not added a phone&nbsp;number to their profile'|safe}
-    ) }}
   {% else %}
-    {{ radios(form.login_authentication) }}
+    {{ form.login_authentication }}
   {% endif %}
 {% endif %}

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -491,16 +491,14 @@ def test_manage_users_page_does_not_links_to_user_profile_page_if_user_only_invi
             None,
             """
             Text message code
-            Not available because this team member has not added a
-            phone number to their profile
-        """,
+            """,
         ),
         (
             False,
             "07700 900762",
             """
             Text message code
-        """,
+            """,
         ),
     ],
 )


### PR DESCRIPTION
This PR migrates the radio buttons on manage-users/permissions.html page to GOVUK FE as stipulated in [this](https://trello.com/c/clOirfB6/140-migrate-all-remaining-radios-to-govuk-frontend-except-those-for-moving-templates-folders) ticket.
Subsequent PRs will deal with the other files listed on the ticket.
I have attached before and after pictures
<img width="750" alt="permissions-a-before" src="https://github.com/alphagov/notifications-admin/assets/32799090/bdbaea81-423f-4679-a735-8fc6f546ef57">
<img width="824" alt="permissions-a-after" src="https://github.com/alphagov/notifications-admin/assets/32799090/f2b20788-64be-46fe-b958-bf1369ab82e0">
<img width="852" alt="permissions-b-before" src="https://github.com/alphagov/notifications-admin/assets/32799090/67f3f674-9697-4de8-880b-be16bf009e53">
<img width="1037" alt="permissions-b-a
<img width="631" alt="create-api-keys-after" src="https://github.com/alphagov/notifications-admin/assets/32799090/d0ad86ee-69e1-4d01-a655-82adff3537c0">
fter" src="https://github.com/alphagov/notifications-admin/assets/32799090/c1f95eb0-1db3-4417-b2a9-5ea8695abb82">
<img width="674" alt="create-api-key-before" src="https://github.com/alphagov/notifications-admin/assets/32799090
<img width="631" alt="create-api-keys-after" src="https://github.com/alphagov/notifications-admin/assets/32799090/d1fd8cf7-834a-4318-ac6c-a744418efce3">
/c8b69d93-4338-467e-9152-6f8d873aa884">

The opacity for the GOVUK radio component is currently set to 0.5 which cannot be overridden, hence the hint texts are lighter than before. A separate ticket will be raised to address that issue.
