### PR TITLE
Update expressions using '_' to use `do`

### DIFF
--- a/app/templates/components/error-summary.html
+++ b/app/templates/components/error-summary.html
@@ -5,10 +5,10 @@
     {% set errors = [] %}
     {% for field_name, error_list in form.errors.items() %}
       {% if field_name %}
-        {% set _ = errors.append({"href": "#" + form[field_name].id, "text": error_list[0]}) %}
+        {% do errors.append({"href": "#" + form[field_name].id, "text": error_list[0]}) %}
       {% else %}
         {# field_name is None for form level errors #}
-        {% set _ = errors.append({"text": error_list[0]}) %}
+        {% do errors.append({"text": error_list[0]}) %}
       {% endif %}
     {% endfor %}
 

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -18,20 +18,20 @@
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
       {% set button_data = {"text": button_text, "classes": "page-footer__button"} %}
-      {% if destructive %}{% set _ = button_data.update({"classes": "govuk-button--warning page-footer__button"}) %}{% endif %}
-      {% if centered_button %}{% set _ = button_data.update({"classes": "page-footer__button--centred"}) %}{% endif %}
+      {% if destructive %}{% do button_data.update({"classes": "govuk-button--warning page-footer__button"}) %}{% endif %}
+      {% if centered_button %}{% do button_data.update({"classes": "page-footer__button--centred"}) %}{% endif %}
       {% if button_url %}
-        {% set _ = button_data.update({
+        {% do button_data.update({
           "classes": "govuk-button--secondary",
           "href": button_url }) %}
       {% endif %}
-      {% if button_name %}{% set _ = button_data.update({"name": button_name}) %}{% endif %}
-      {% if button_value %}{% set _ = button_data.update({"value": button_value}) %}{% endif %}
+      {% if button_name %}{% do button_data.update({"name": button_name}) %}{% endif %}
+      {% if button_value %}{% do button_data.update({"value": button_value}) %}{% endif %}
       {% if button_text_hidden_suffix %}
         {% set html %}
           {{ button_text }}<span class="govuk-visually-hidden"> {{button_text_hidden_suffix}}</span>
         {% endset %}
-        {% set _ = button_data.update({
+        {% do button_data.update({
           "text": "",
           "html": html
         }) %}

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -77,7 +77,7 @@
           "template-list-item-hidden-by-default" if item.ancestors else "template-list-item-without-ancestors"),
         "after": item_link_content ~ item_meta
       } %}
-      {% set _ = checkboxes_data.append(checkbox_config) %}
+      {% do checkboxes_data.append(checkbox_config) %}
 
       {% if not current_user.has_permissions('manage_templates') %}
         <div class="template-list-item {%- if item.ancestors %} template-list-item-hidden-by-default {%- else %} template-list-item-without-ancestors{%- endif %}">

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -108,7 +108,7 @@
   ]%}
 
  {% if current_user.can_use_webauthn %}
-  {% set _ = rows.append(
+  {% do rows.append(
     {
       "key": {
         "classes": "notify-summary-list__key notify-summary-list__key--one-quarter",
@@ -133,7 +133,7 @@
  {% endif %}
 
  {% if current_user.platform_admin or session.get('disable_platform_admin_view') %}
-  {% set _ = rows.append(
+  {% do rows.append(
     {
       "key": {
         "classes": "notify-summary-list__key notify-summary-list__key--one-quarter",


### PR DESCRIPTION
## Dependencies
 * [x] https://github.com/alphagov/notifications-admin/pull/4722

Jinja doesn't have syntax to let you just run an
expression that doesn't assign anything by
default. We have occasionally needed to do this,
usually to do things like build lists dynamically, so had to hack it by assigning the result to the
'_' variable, the "I don't care" variable in
Python.

We added the `do` Jinja extension in this pull
request:

https://github.com/alphagov/notifications-admin/pull/4722/files#diff-9cec7b11237bc29d77a439e81c9b7acfac003d8e8855731eb6bc130b5a8ce602R610

`do` solves the problem of using non-assigning
expressions and makes it explicit what's happening so we should use that instead. These changes do
that.