### PR TITLE
Fix comparison between 'thing' and 'name'

### DIFF
--- a/app/assets/javascripts/copyToClipboard.js
+++ b/app/assets/javascripts/copyToClipboard.js
@@ -99,7 +99,7 @@
       // if the name is distinct from the thing:
       // - it will be used in the rendering
       // - the value won't be identified by a heading so needs its own label
-      if (name !== stateOptions.thing) {
+      if (name.toLowerCase() !== stateOptions.thing.toLowerCase()) {
         stateOptions.name = name;
         stateOptions.valueLabel = true;
       }


### PR DESCRIPTION
Fix for an issue with https://github.com/alphagov/notifications-admin/pull/4715

## TLDR

Check the copy-to-clipboard buttons on the template and reply-to email addresses pages. The former shouldn't have extra, non-visible, text added to the button. The later should, using the email address.

## Longer explanation

We have 2 types of copy-to-clipboard buttons:
1. those that copy a value that is the only one of its type on the page (ie. a template ID on a template page)
2. those that copy a value which is one of a several on the page for that type of thing (ie. a reply-to email address on the Reply-to email addresses page in service settings)

We use 2 things to differentiate between these
types:
1. the 'thing' (the type of thing it is)
2. the 'name' (the name of that version of the thing)

If the 'thing' and the 'name' match, it means
it's the only one of its type on the page so we
leave as is. If they don't, it means we have to
add some text which uses the 'name' to identify
each specific one.

The logic that worked this out didn't compare the
same type of strings so was broken. This fixes it.