### PR TITLE
Remove `LetterPreviewTemplate` (again)

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -581,7 +581,7 @@ def send_from_contact_list(service_id, template_id, contact_list_id):
     )
 
 
-def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_pdf=False):
+def _check_messages(service_id, template_id, upload_id, preview_row):
 
     try:
         # The happy path is that the job doesn’t already exist, so the
@@ -624,9 +624,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
             upload_id=upload_id,
             filetype="png",
             row_index=preview_row,
-        )
-        if not letters_as_pdf
-        else None,
+        ),
         email_reply_to=email_reply_to,
         sms_sender=sms_sender,
         # In this case, we don't provide template values when calculating the page count
@@ -760,7 +758,7 @@ def check_messages_preview(service_id, template_id, upload_id, filetype, row_ind
     else:
         abort(404)
 
-    template = _check_messages(service_id, template_id, upload_id, row_index, letters_as_pdf=True)["template"]
+    template = _check_messages(service_id, template_id, upload_id, row_index)["template"]
     return TemplatePreview.from_utils_template(template, filetype, page=page)
 
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -176,7 +176,11 @@ def send_messages(service_id, template_id):
 @main.route("/services/<uuid:service_id>/send/<uuid:template_id>.csv", methods=["GET"])
 @user_has_permissions("send_messages", "manage_templates")
 def get_example_csv(service_id, template_id):
-    template = get_template(service_api_client.get_service_template(service_id, template_id)["data"], current_service)
+    template = get_template(
+        service_api_client.get_service_template(service_id, template_id)["data"],
+        current_service,
+        letter_preview_url="https://www.example.com",
+    )
     return (
         Spreadsheet.from_rows(
             [get_spreadsheet_column_headings_from_template(template), get_example_csv_rows(template)]

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -627,10 +627,14 @@ def edit_service_template(service_id, template_id):
             "template_type": template["template_type"],
             "id": template["id"],
             "reply_to_text": template["reply_to_text"],
+            "postage": None,
         }
 
-        new_template = get_template(new_template_data, current_service)
-        template_change = get_template(template, current_service).compare_to(new_template)
+        new_template = get_template(new_template_data, current_service, letter_preview_url="https://www.example.com")
+
+        template_change = get_template(
+            template, current_service, letter_preview_url="https://www.example.com"
+        ).compare_to(new_template)
 
         if template_change.placeholders_added and not request.form.get("confirm") and current_service.api_keys:
             return render_template(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -287,7 +287,7 @@ def letter_branding_preview_image(filename):
     return TemplatePreview.from_example_template(template, filename)
 
 
-def _view_template_version(service_id, template_id, version, letters_as_pdf=False):
+def _view_template_version(service_id, template_id, version):
     return dict(
         template=get_template(
             current_service.get_template(template_id, version=version),
@@ -298,9 +298,7 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
                 template_id=template_id,
                 version=version,
                 filetype="png",
-            )
-            if not letters_as_pdf
-            else None,
+            ),
         )
     )
 

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -1,9 +1,7 @@
-from flask import current_app
 from notifications_utils.template import (
     BroadcastPreviewTemplate,
     EmailPreviewTemplate,
     LetterImageTemplate,
-    LetterPreviewTemplate,
     SMSPreviewTemplate,
 )
 
@@ -49,21 +47,13 @@ def get_template(
             redact_missing_personalisation=redact_missing_personalisation,
         )
     if "letter" == template["template_type"]:
-        if letter_preview_url:
-            return LetterImageTemplate(
-                template,
-                image_url=letter_preview_url,
-                page_count=int(page_count),
-                contact_block=template["reply_to_text"],
-                postage=template["postage"],
-            )
-        else:
-            return LetterPreviewTemplate(
-                template,
-                contact_block=template["reply_to_text"],
-                admin_base_url=current_app.config["ADMIN_BASE_URL"],
-                redact_missing_personalisation=redact_missing_personalisation,
-            )
+        return LetterImageTemplate(
+            template,
+            image_url=letter_preview_url,
+            page_count=int(page_count),
+            contact_block=template["reply_to_text"],
+            postage=template["postage"],
+        )
     if "broadcast" == template["template_type"]:
         return BroadcastPreviewTemplate(
             template,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2446,6 +2446,43 @@ def test_download_example_csv(
     assert "text/csv" in response.headers["Content-Type"]
 
 
+def test_download_example_csv_for_letter_template(
+    client_request,
+    mocker,
+    api_user_active,
+    mock_login,
+    mock_get_service,
+    mock_get_service_template_with_placeholders_same_as_recipient,
+    mock_has_permissions,
+    fake_uuid,
+):
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={
+            "data": template_json(
+                service_id=SERVICE_ONE_ID,
+                id_=fake_uuid,
+                name="Two week reminder",
+                subject="Hello ((address line 1))",
+                type_="letter",
+                content="((name)) ((date))",
+            )
+        },
+    )
+    response = client_request.get_response(
+        "main.get_example_csv",
+        service_id=fake_uuid,
+        template_id=fake_uuid,
+        follow_redirects=True,
+    )
+    assert response.get_data(as_text=True) == (
+        "address line 1,address line 2,address line 3,address line 4,address line 5,address line 6,address line 7,"
+        "name,date\r\n"
+        "A. Name,123 Example Street,XM4 5HQ,,,,,example,example\r\n"
+    )
+    assert "text/csv" in response.headers["Content-Type"]
+
+
 def test_upload_csvfile_with_valid_phone_shows_all_numbers(
     client_request,
     mock_get_service_template,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -17,7 +17,6 @@ from notifications_python_client.errors import HTTPError
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.template import (
     LetterImageTemplate,
-    LetterPreviewTemplate,
     SMSPreviewTemplate,
 )
 from xlrd.biffh import XLRDError
@@ -2822,7 +2821,7 @@ def test_should_show_preview_letter_message(
     assert response.get_data(as_text=True) == "foo"
     mocked_preview.assert_called_once()
     assert mocked_preview.call_args[0][0].id == template_id
-    assert type(mocked_preview.call_args[0][0]) == LetterPreviewTemplate
+    assert type(mocked_preview.call_args[0][0]) == LetterImageTemplate
     assert mocked_preview.call_args[0][1] == filetype
     assert mocked_preview.call_args[0][0].values == expected_values
     assert mocked_preview.call_args[1] == {"page": expected_page}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2073,6 +2073,13 @@ def test_should_not_allow_template_edits_without_correct_permission(
 
 
 @pytest.mark.parametrize(
+    "template_type",
+    (
+        "email",
+        "letter",
+    ),
+)
+@pytest.mark.parametrize(
     "old_content, new_content, expected_paragraphs",
     [
         (
@@ -2104,9 +2111,10 @@ def test_should_show_interstitial_when_making_breaking_change(
     new_content,
     old_content,
     expected_paragraphs,
+    template_type,
 ):
     email_template = create_template(
-        template_id=fake_uuid, template_type="email", subject="Your ((thing)) is due soon", content=old_content
+        template_id=fake_uuid, template_type=template_type, subject="Your ((thing)) is due soon", content=old_content
     )
     mocker.patch("app.service_api_client.get_service_template", return_value={"data": email_template})
 


### PR DESCRIPTION
This pull request:
- fixes two places where we didn’t have test coverage when the template was for a letter
- reimplements #4694