### PR TITLE
Check for allowed template type on `POST` as well as `GET` requests

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -613,6 +613,18 @@ def abort_403_if_not_admin_user():
 @user_has_permissions("manage_templates")
 def edit_service_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
+
+    if template["template_type"] not in current_service.available_template_types:
+        return redirect(
+            url_for(
+                ".action_blocked",
+                service_id=service_id,
+                notification_type=template["template_type"],
+                return_to="view_template",
+                template_id=template_id,
+            )
+        )
+
     template["template_content"] = template["content"]
     form = form_objects[template["template_type"]](**template)
     if form.validate_on_submit():
@@ -660,16 +672,6 @@ def edit_service_template(service_id, template_id):
         else:
             return redirect(url_for("main.view_template", service_id=service_id, template_id=template_id))
 
-    if template["template_type"] not in current_service.available_template_types:
-        return redirect(
-            url_for(
-                ".action_blocked",
-                service_id=service_id,
-                notification_type=template["template_type"],
-                return_to="view_template",
-                template_id=template_id,
-            )
-        )
     return render_template(
         f"views/edit-{template['template_type']}-template.html",
         form=form,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -670,14 +670,13 @@ def edit_service_template(service_id, template_id):
                 template_id=template_id,
             )
         )
-    else:
-        return render_template(
-            f"views/edit-{template['template_type']}-template.html",
-            form=form,
-            template=template,
-            heading_action="Edit",
-            back_link=url_for("main.view_template", service_id=current_service.id, template_id=template["id"]),
-        )
+    return render_template(
+        f"views/edit-{template['template_type']}-template.html",
+        form=form,
+        template=template,
+        heading_action="Edit",
+        back_link=url_for("main.view_template", service_id=current_service.id, template_id=template["id"]),
+    )
 
 
 @main.route(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2114,6 +2114,7 @@ def test_should_not_allow_template_edits_without_correct_permission(
 )
 def test_should_show_interstitial_when_making_breaking_change(
     client_request,
+    service_one,
     mock_update_service_template,
     mock_get_user_by_email,
     mock_get_api_keys,
@@ -2124,6 +2125,8 @@ def test_should_show_interstitial_when_making_breaking_change(
     expected_paragraphs,
     template_type,
 ):
+    service_one["permissions"] += [template_type]
+
     email_template = create_template(
         template_id=fake_uuid, template_type=template_type, subject="Your ((thing)) is due soon", content=old_content
     )


### PR DESCRIPTION
This check stops you viewing the page to edit a template if your service doesn’t have that type of template switched on. It doesn’t stop you actually editing the template if you can craft a post request.

This doesn’t mean anyone can do anything malicious, but the position of the check in the code doesn’t properly express its intention.

This commit moves it nearer the top, the same as in `add_service_template`:
https://github.com/alphagov/notifications-admin/blob/f4ed8e130633183b9fc798db2d95cc48932a2754/app/main/views/templates.py#L559-L570

This means it will now catch both `POST` and `GET` requests.