### PR TITLE
Remove fake `image_url` argument values

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -179,7 +179,6 @@ def get_example_csv(service_id, template_id):
     template = get_template(
         service_api_client.get_service_template(service_id, template_id)["data"],
         current_service,
-        letter_preview_url="https://www.example.com",
     )
     return (
         Spreadsheet.from_rows(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -628,11 +628,9 @@ def edit_service_template(service_id, template_id):
             "postage": None,
         }
 
-        new_template = get_template(new_template_data, current_service, letter_preview_url="https://www.example.com")
+        new_template = get_template(new_template_data, current_service)
 
-        template_change = get_template(
-            template, current_service, letter_preview_url="https://www.example.com"
-        ).compare_to(new_template)
+        template_change = get_template(template, current_service).compare_to(new_template)
 
         if template_change.placeholders_added and not request.form.get("confirm") and current_service.api_keys:
             return render_template(

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -13,7 +13,7 @@ def get_sample_template(template_type):
         return SMSPreviewTemplate({"content": "any", "template_type": "sms"})
     if template_type == "letter":
         return LetterImageTemplate(
-            {"content": "any", "subject": "", "template_type": "letter"}, postage="second", image_url="x", page_count=1
+            {"content": "any", "subject": "", "template_type": "letter"}, postage="second", page_count=1
         )
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.1.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.1.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
Previously, `image_url` was a required argument. This meant that we always needed to provide a value, even if we were never going to generate any URLs for previewing the template.

Now that’s it’s no longer a required argument, we don’t need to litter our code with fake values like `example.com`.

***

Depends on:

- [x] https://github.com/alphagov/notifications-utils