### PR TITLE
Return a `Template` model from the `Service` model

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -18,6 +18,7 @@ from app.notify_client.service_api_client import service_api_client
 from app.notify_client.template_folder_api_client import template_folder_api_client
 from app.utils import get_default_sms_sender
 from app.utils.constants import SIGN_IN_METHOD_TEXT, SIGN_IN_METHOD_TEXT_OR_EMAIL
+from app.utils.templates import get_template
 
 
 class Service(JSONModel):
@@ -208,8 +209,9 @@ class Service(JSONModel):
     def all_template_ids(self):
         return {template["id"] for template in self.all_templates}
 
-    def get_template(self, template_id, version=None):
-        return service_api_client.get_service_template(self.id, template_id, version)["data"]
+    def get_template(self, template_id, version=None, **kwargs):
+        template = service_api_client.get_service_template(self.id, template_id, version)["data"]
+        return get_template(template, service=self, **kwargs)
 
     def get_template_folder_with_user_permission_or_403(self, folder_id, user):
         template_folder = self.get_template_folder(folder_id)
@@ -219,10 +221,10 @@ class Service(JSONModel):
 
         return template_folder
 
-    def get_template_with_user_permission_or_403(self, template_id, user):
-        template = self.get_template(template_id)
+    def get_template_with_user_permission_or_403(self, template_id, user, **kwargs):
+        template = self.get_template(template_id, **kwargs)
 
-        self.get_template_folder_with_user_permission_or_403(template["folder"], user)
+        self.get_template_folder_with_user_permission_or_403(template.get_raw("folder"), user)
 
         return template
 

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -89,12 +89,12 @@ def unicode_truncate(s, length):
     return encoded.decode("utf-8", "ignore")
 
 
-def should_skip_template_page(db_template):
+def should_skip_template_page(template):
     return (
         current_user.has_permissions("send_messages")
         and not current_user.has_permissions("manage_templates", "manage_api_keys")
-        and db_template["template_type"] != "letter"
-        and not db_template["archived"]
+        and template.template_type != "letter"
+        and not template.get_raw("archived")
     )
 
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1778,7 +1778,7 @@ def test_send_one_off_sms_message_redirects(
     user,
 ):
     mocker.patch("app.user_api_client.get_user", return_value=user)
-    template = {"data": {"template_type": "sms", "folder": None}}
+    template = {"data": {"template_type": "sms", "folder": None, "content": "foo"}}
     mocker.patch("app.service_api_client.get_service_template", return_value=template)
 
     client_request.get(
@@ -2187,7 +2187,7 @@ def test_send_one_off_clears_session(
     service_one,
     fake_uuid,
 ):
-    template = {"data": {"template_type": "sms", "folder": None}}
+    template = {"data": {"template_type": "sms", "folder": None, "content": "foo"}}
     mocker.patch("app.service_api_client.get_service_template", return_value=template)
 
     with client_request.session_transaction() as session:

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -773,7 +773,8 @@ def test_user_access_denied_to_template_actions_without_folder_permission(
 ):
 
     mock = mocker.patch(
-        "app.models.service.Service.get_template_with_user_permission_or_403", side_effect=lambda *args: abort(403)
+        "app.models.service.Service.get_template_with_user_permission_or_403",
+        side_effect=lambda *args, **kwargs: abort(403),
     )
 
     template_id = str(uuid.uuid4())
@@ -784,8 +785,11 @@ def test_user_access_denied_to_template_actions_without_folder_permission(
         _expected_status=403,
         _test_page_title=False,
     )
-
-    mock.assert_called_once_with(template_id, User(active_user_with_permissions))
+    assert len(mock.call_args_list) == 1
+    assert mock.call_args[0][0] == template_id
+    assert mock.call_args[0][1] == User(active_user_with_permissions)
+    # In some cases `get_template_with_user_permission_or_403` will also be called with
+    # `letter_preview_url` so we can’t assert on the complete `call_args` here
 
 
 def test_rename_folder(client_request, active_user_with_permissions, service_one, mock_get_template_folders, mocker):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1000,6 +1000,7 @@ def _template(template_type, name, parent=None, template_id=None):
         "name": name,
         "template_type": template_type,
         "folder": parent,
+        "content": "foo",
     }
 
 


### PR DESCRIPTION
At the moment when we have a variable like `template` it’s sometimes a `dict` straight from the API and it’s sometimes an instance of a model from utils like `LetterImageTemplate` or `EmailPreviewTemplate`.

This commit makes the model-based approach the default. This is better because:
- it follows the pattern we use for users, services, branding, etc.
- it means we can add useful methods and properties to the model, which are easily reusable across the codebase
- it avoids the looseness of dictionaries where there’s no guarantee that specific keys will be present

There’s still more work to do to remove or prevent any interaction with the underlying `dict`, but this gets us most of the way there.