### PR TITLE
Add page for DVLA billing report

### DIFF
--- a/app/navigation.py
+++ b/app/navigation.py
@@ -106,6 +106,7 @@ class HeaderNavigation(Navigation):
             "notifications_sent_by_service",
             "get_billing_report",
             "get_daily_volumes",
+            "get_dvla_billing_report",
             "get_daily_sms_provider_volumes",
             "get_volumes_by_service",
             "organisations",

--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -29,6 +29,15 @@ class BillingAPIClient(NotifyAdminAPIClient):
             },
         )
 
+    def get_data_for_dvla_billing_report(self, start_date, end_date):
+        return self.get(
+            url="/platform-stats/data-for-dvla-billing-report",
+            params={
+                "start_date": str(start_date),
+                "end_date": str(end_date),
+            },
+        )
+
     def get_data_for_volumes_by_service_report(self, start_date, end_date):
         return self.get(
             url="/platform-stats/volumes-by-service",

--- a/app/templates/views/platform-admin/get-dvla-billing-report.html
+++ b/app/templates/views/platform-admin/get-dvla-billing-report.html
@@ -1,0 +1,49 @@
+{% extends "views/platform-admin/_base_template.html" %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/table.html" import mapping_table, row, text_field %}
+
+{% block per_page_title %}
+  DVLA Billing Report
+{% endblock %}
+
+{% block platform_admin_content %}
+
+  <h1 class="heading-large">
+    DVLA Billing Report
+  </h1>
+
+  {% call form_wrapper() %}
+    {{ form.start_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
+    {{ form.end_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
+    {{ page_footer('Download report (CSV)') }}
+  {% endcall %}
+
+  <h2 class="heading-medium">
+    Data included in the report
+  </h2>
+<div class="bottom-gutter-3-2">
+    {% call mapping_table(
+      caption='Descriptions of billing report data',
+      field_headings=['Name', 'Description'],
+      field_headings_visible=True,
+      caption_visible=False
+    ) %}
+      {% for column_heading, description in [
+        ('despatch date', 'The date these letters were despatched by DVLA'),
+        ('postage', 'The postage of the letters (eg first, second, europe, rest-of-world)'),
+        ('DVLA cost threshold', 'A DVLA-internal pricing threshold (sorted, unsorted).'),
+        ('sheets', 'The number of sheets for each letter (1-5 pages)'),
+        ('rate (£)', 'The unit cost per letter in £ (GBP)'),
+        ('letters', 'The number of letters sent'),
+        ('cost (£)', 'The cost for sending these letters in £ (GBP)'),
+      ] %}
+        {% call row() %}
+          {{ text_field(column_heading) }}
+          {{ text_field(description) }}
+        {% endcall %}
+      {% endfor %}
+    {% endcall %}
+  </div>
+
+{% endblock %}

--- a/app/templates/views/platform-admin/reports.html
+++ b/app/templates/views/platform-admin/reports.html
@@ -20,6 +20,9 @@
   <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.get_billing_report') }}">Billing Report</a>
 </p>
 <p class="govuk-body">
+  <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.get_dvla_billing_report') }}">DVLA Billing Report</a>
+</p>
+<p class="govuk-body">
   <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.get_volumes_by_service') }}">Volumes by service Report</a>
 </p>
 <p class="govuk-body">

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -969,6 +969,77 @@ def test_get_billing_report_calls_api_and_download_data(client_request, platform
     )
 
 
+class TestGetDvlaBillingReport:
+    def test_when_no_results_for_date(self, client_request, platform_admin_user, mocker):
+        client_request.login(platform_admin_user)
+
+        mocker.patch(
+            "app.main.views.platform_admin.billing_api_client.get_data_for_dvla_billing_report", return_value=[]
+        )
+
+        page = client_request.post(
+            "main.get_dvla_billing_report",
+            _expected_status=200,
+            _data={"start_date": "2023-06-01", "end_date": "2023-06-01"},
+        )
+
+        error = page.select_one(".banner-dangerous")
+        assert normalize_spaces(error.text) == "No results for dates"
+
+    def test_calls_api_and_downloads_data(self, client_request, platform_admin_user, mocker):
+        mocker.patch(
+            "app.main.views.platform_admin.billing_api_client.get_data_for_dvla_billing_report",
+            return_value=[
+                {
+                    "date": "2023-06-01",
+                    "postage": "first",
+                    "cost_threshold": "sorted",
+                    "sheets": 1,
+                    "rate": 1.0,
+                    "letters": 10,
+                    "cost": 10.0,
+                },
+                {
+                    "date": "2023-06-01",
+                    "postage": "second",
+                    "cost_threshold": "sorted",
+                    "sheets": 1,
+                    "rate": 0.5,
+                    "letters": 50,
+                    "cost": 25.0,
+                },
+                {
+                    "date": "2023-06-01",
+                    "postage": "second",
+                    "cost_threshold": "unsorted",
+                    "sheets": 3,
+                    "rate": 0.75,
+                    "letters": 5,
+                    "cost": 3.75,
+                },
+            ],
+        )
+
+        client_request.login(platform_admin_user)
+        response = client_request.post_response(
+            "main.get_dvla_billing_report",
+            _data={"start_date": "2023-06-01", "end_date": "2023-06-01"},
+            _expected_status=200,
+        )
+
+        assert response.content_type == "text/csv; charset=utf-8"
+        assert response.headers["Content-Disposition"] == (
+            'attachment; filename="DVLA Billing Report from 2023-06-01 to 2023-06-01.csv"'
+        )
+
+        assert response.get_data(as_text=True) == (
+            "despatch date,postage,DVLA cost threshold,sheets,rate (£),letters,cost (£)\r\n"
+            "2023-06-01,first,sorted,1,1.0,10,10.0\r\n"
+            "2023-06-01,second,sorted,1,0.5,50,25.0\r\n"
+            "2023-06-01,second,unsorted,3,0.75,5,3.75\r\n"
+        )
+
+
 def test_get_notifications_sent_by_service_calls_api_and_downloads_data(
     mocker,
     client_request,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -130,6 +130,7 @@ EXCLUDED_ENDPOINTS = set(
             "get_billing_report",
             "get_daily_sms_provider_volumes",
             "get_daily_volumes",
+            "get_dvla_billing_report",
             "get_example_csv",
             "get_volumes_by_service",
             "go_to_dashboard_after_tour",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -97,6 +97,7 @@
     "/platform-admin/reports",
     "/platform-admin/reports/daily-sms-provider-volumes-report",
     "/platform-admin/reports/daily-volumes-report",
+    "/platform-admin/reports/dvla-billing",
     "/platform-admin/reports/live-services.csv",
     "/platform-admin/reports/notifications-sent-by-service",
     "/platform-admin/reports/usage-for-all-services",


### PR DESCRIPTION
## Note: requires https://github.com/alphagov/notifications-api/pull/3813

Broadly a copy/paste from the org/services billing report, but fetches letter despatch billing info which we will use to reconcile with DVLA.

<img width="1134" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/93892281-5014-42b2-920f-865eb2582b2e">
