### PR TITLE
Support subheadings in emails

### DIFF
--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -5,7 +5,7 @@
   To put a heading in your template, use a hash:
 </p>
 <div class="govuk-!-margin-bottom-6">
-  {{ govukInsetText({"text": "# This is a headig", "classes": "govuk-!-margin-top-0"})}}
+  {{ govukInsetText({"text": "# This is a heading", "classes": "govuk-!-margin-top-0"})}}
 </div>
 <p class="bottom-gutter-1-3">
   To put a subheading in your template, use 2 hashes:

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -2,10 +2,16 @@
 
 <h2 class="heading-medium">Formatting</h2>
 <p class="bottom-gutter-1-3">
-  To put a title in your template, use a hash:
+  To put a heading in your template, use a hash:
 </p>
 <div class="govuk-!-margin-bottom-6">
-  {{ govukInsetText({"text": "# This is a title", "classes": "govuk-!-margin-top-0"})}}
+  {{ govukInsetText({"text": "# This is a headig", "classes": "govuk-!-margin-top-0"})}}
+</div>
+<p class="bottom-gutter-1-3">
+  To put a subheading in your template, use 2 hashes:
+</p>
+<div class="govuk-!-margin-bottom-6">
+  {{ govukInsetText({"text": "## This is a subheading", "classes": "govuk-!-margin-top-0"})}}
 </div>
 <p class="bottom-gutter-1-3">
   To make bullet points, use asterisks:

--- a/app/templates/views/guidance/using-notify/formatting.html
+++ b/app/templates/views/guidance/using-notify/formatting.html
@@ -22,6 +22,7 @@
   <p class="govuk-body">Email templates can include:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>headings</li>
+    <li>subheadings</li>
     <li>bullets</li>
     <li>inset text</li>
     <li>horizontal rules</li>

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.4.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@63.4.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
Pulls in the latest utils version, which adds support for subheadings via `##`.

Also pulls in the the content changes from https://github.com/alphagov/notifications-admin/pull/4719.

Should be merged approximately the same time as / just after the [API PR](https://github.com/alphagov/notifications-api/pull/3817)

<img width="787" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/fd17c5fe-2665-4896-94b4-407f6b9a1180">

<img width="649" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/8e403af8-043f-4efc-89de-1bc4804996b2">
