### PR TITLE
Fix colour contrast of `disabled` radio button text

### DIFF
--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -115,3 +115,16 @@
     margin-right: 15px;
   }
 }
+
+.govuk-radios__input:disabled + .govuk-radios__label,
+.govuk-radios__input:disabled ~ .govuk-hint {
+  opacity: 1;
+  color: $govuk-secondary-text-colour;
+}
+
+.govuk-radios__input:disabled + .govuk-radios__label {
+  &:before {
+    border-color: $govuk-secondary-text-colour;
+    background-color: govuk-colour("light-grey");
+  }
+}


### PR DESCRIPTION
We have noticed that when radio buttons have the `disabled` attribute set<sup>1</sup>, the text does not meet WCAG standards<sup>2</sup> for colour contrast. This is true for the label<sup>3</sup>, and worse for the hint text<sup>4</sup>:

<img width="771" alt="image" src="https://github.com/alphagov/govuk-design-system-backlog/assets/355079/baca12a7-e733-48e8-badc-276839db6101">

This is caused by some CSS in GOV.UK Frontend<sup>5</sup>.

I propose:
- using the secondary text colour for
  - the radio button itself
  - the label text
  - the hint text
- using a light grey fill to give an additional visual cue that the choice can’t be filled in by clicking it

Which looks like: 

<img width="771" alt="image" src="https://github.com/alphagov/govuk-design-system-backlog/assets/355079/08fe5d6c-1bfc-4437-ba3b-dd0fa2224fea">

Colour alone isn’t used here to differentiate – there is still the semantics of the `disabled` attribute itself, the different cursor behaviour, and the content of the hint text.

***

1. Using `disabled` is not often the best way to do things (and is not documented in the Design System) but sometimes it’s appropriate
2. WCAG 2.0 AA requires a contrast ratio of 4.5:1 for ‘normal text’
3. `$govuk-text-colour` with `opacity: .5` applied computes to a value of  `#858585`, which gives a contrast ratio of 3.69:1 against a white background
4. `$govuk-secondary-text-colour` with `opacity: .5` applied computes to a value of  `#a8acae`, which gives a contrast ratio of 2.28:1 against a white background
5. https://github.com/alphagov/govuk-frontend/blob/fbed2b59889aff35fd1c65f1cd5ad368a5e4ddfe/packages/govuk-frontend/src/govuk/components/radios/_index.scss#L137

***

Card: https://trello.com/c/7Q6pMovq/381-fix-contrast-ratio-of-text-and-hint-for-disabled-radio-buttons