### PR TITLE
Add newer frontend build command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ make run-flask
 
 Then visit [localhost:6012](http://localhost:6012).
 
-Any Python code changes you make should be picked up automatically in development. If you're developing JavaScript code, run `npm run watch` to achieve the same.
+Any Python code changes you make should be picked up automatically in development. If you're developing JavaScript or CSS code, run `make watch-frontend` to achieve the same.
 
 ## To test the application
 


### PR DESCRIPTION
Command was added in https://github.com/alphagov/notifications-admin/pull/4060

It’s a bit more robust than running the `npm` command directly.

Also make it clear that this covers CSS code as well as Javascript.