### PR TITLE
Preview notifications with attachment

### DIFF
--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -2,7 +2,7 @@ import base64
 from io import BytesIO
 
 import requests
-from flask import current_app, json
+from flask import abort, current_app, json
 from notifications_utils.pdf import extract_page_from_pdf
 
 from app import current_service
@@ -84,9 +84,20 @@ class TemplatePreview:
             page=page,
         )
 
+    @classmethod
+    def from_notification(cls, notification: dict, filetype: str, page=None):
+        if notification["template"]["is_precompiled_letter"]:
+            abort(400)
+
+        return cls.from_database_object(
+            notification["template"],
+            filetype,
+            notification["personalisation"],
+            page=page,
+        )
+
 
 def get_page_count_for_letter(template, values=None):
-
     if template["template_type"] != "letter":
         return None
 

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -92,6 +92,14 @@ def test_from_database_object_makes_request(
     request_mock.assert_called_once_with(expected_url, json=data, headers=headers)
 
 
+def test_from_notification_has_correct_args():
+    raise AssertionError()
+
+
+def test_from_notification_rejects_precompiled_templates():
+    raise AssertionError()
+
+
 @pytest.mark.parametrize(
     "page_number, expected_url",
     [

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -3,6 +3,7 @@ from functools import partial
 from unittest.mock import Mock
 
 import pytest
+import werkzeug
 from notifications_utils.template import LetterPreviewTemplate
 
 from app import load_service_before_request
@@ -12,6 +13,7 @@ from app.template_previews import (
     get_page_count_for_letter,
     sanitise_letter,
 )
+from tests.conftest import create_notification
 
 
 @pytest.mark.parametrize(
@@ -70,16 +72,16 @@ def test_from_database_object_makes_request(
     # `service` is in the `_request_ctx_stack` to avoid an error
     load_service_before_request()
 
-    resp = Mock(content="a", status_code="b", headers={"content-type": "image/png"})
-    request_mock = mocker.patch("app.template_previews.requests.post", return_value=resp)
+    request_mock_returns = Mock(content="a", status_code="b", headers={"content-type": "image/png"})
+    request_mock = mocker.patch("app.template_previews.requests.post", return_value=request_mock_returns)
     mocker.patch("app.template_previews.current_service", letter_branding=letter_branding)
     template = mock_get_service_letter_template("123", "456")["data"]
 
-    ret = partial_call(template=template)
+    response = partial_call(template=template)
 
-    assert ret[0] == "a"
-    assert ret[1] == "b"
-    assert list(ret[2]) == [("content-type", "image/png")]
+    assert response[0] == "a"
+    assert response[1] == "b"
+    assert list(response[2]) == [("content-type", "image/png")]
 
     data = {
         "letter_contact_block": None,
@@ -92,12 +94,48 @@ def test_from_database_object_makes_request(
     request_mock.assert_called_once_with(expected_url, json=data, headers=headers)
 
 
-def test_from_notification_has_correct_args():
-    raise AssertionError()
+def test_from_notification_has_correct_args(mocker, client_request):
+    # This test is calling `current_service` outside a Flask endpoint, so we need to make sure
+    # `service` is in the `_request_ctx_stack` to avoid an error
+    load_service_before_request()
+
+    request_mock_returns = Mock(content="a", status_code="b", headers={"content-type": "image/png"})
+    request_mock = mocker.patch("app.template_previews.requests.post", return_value=request_mock_returns)
+    mocker.patch("app.template_previews.current_service", letter_branding=LetterBranding({"filename": "hm-government"}))
+
+    notification = create_notification(
+        service_id="abcd",
+        template_type="letter",
+        template_name="sample template",
+        is_precompiled_letter=False,
+    )
+    response = TemplatePreview.from_notification(notification, "png")
+
+    assert response[0] == "a"
+    assert response[1] == "b"
+    assert list(response[2]) == [("content-type", "image/png")]
+
+    data = {
+        "letter_contact_block": None,
+        "template": notification["template"],
+        "values": {"name": "Jo"},
+        "filename": "hm-government",
+    }
+    headers = {"Authorization": "Token my-secret-key"}
+
+    request_mock.assert_called_once_with("http://localhost:9999/preview.png", json=data, headers=headers)
 
 
-def test_from_notification_rejects_precompiled_templates():
-    raise AssertionError()
+def test_from_notification_rejects_precompiled_templates(mocker):
+    notification = create_notification(
+        service_id="abcd",
+        template_type="letter",
+        template_name="sample template",
+        is_precompiled_letter=True,
+    )
+
+    with pytest.raises(werkzeug.exceptions.BadRequest):
+        TemplatePreview.from_notification(notification, "png")
 
 
 @pytest.mark.parametrize(
@@ -107,7 +145,7 @@ def test_from_notification_rejects_precompiled_templates():
         ("2", "http://localhost:9999/precompiled-preview.png"),
     ],
 )
-def test_from_valid_pdf_file_makes_request(mocker, page_number, expected_url):
+def test_from_valid_pdf_file_makes_request(mocker, client_request, page_number, expected_url):
     mocker.patch("app.template_previews.extract_page_from_pdf", return_value=b"pdf page")
     request_mock = mocker.patch(
         "app.template_previews.requests.post",
@@ -124,7 +162,7 @@ def test_from_valid_pdf_file_makes_request(mocker, page_number, expected_url):
     )
 
 
-def test_from_invalid_pdf_file_makes_request(mocker):
+def test_from_invalid_pdf_file_makes_request(mocker, client_request):
     mocker.patch("app.template_previews.extract_page_from_pdf", return_value=b"pdf page")
     request_mock = mocker.patch(
         "app.template_previews.requests.post",
@@ -168,7 +206,7 @@ def test_page_count_unpacks_from_json_response(
     mock_template_preview.assert_called_once_with(*expected_template_preview_args)
 
 
-def test_from_example_template_makes_request(mocker):
+def test_from_example_template_makes_request(mocker, client_request):
     request_mock = mocker.patch("app.template_previews.requests.post")
     template = {}
     filename = "geo"
@@ -185,6 +223,7 @@ def test_from_example_template_makes_request(mocker):
 @pytest.mark.parametrize("allow_international_letters, query_param_value", [[False, "false"], [True, "true"]])
 def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file(
     mocker,
+    client_request,
     allow_international_letters,
     query_param_value,
     fake_uuid,
@@ -206,6 +245,7 @@ def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file(
 
 def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file_for_an_attachment(
     mocker,
+    client_request,
     fake_uuid,
 ):
     request_mock = mocker.patch("app.template_previews.requests.post")


### PR DESCRIPTION
We have the template-preview so that it renders the attachment, when the template preview PR[^1] is merged this will immediately work for the check page before you hit save.

When this PR is merged, this will also roll out stitching the attatchment ot the letter for the png preview/download a pdf button you can see after your notification has been saved. (whether via API, upload, job, etc).

Previously we went via the API[^2] to fetch this preview, however, we can refactor this to go directly to the template-preview app using the TemplatePreview class - this is consistent with how all the other PNG/PDF previews are rendered on the admin app.

The only remaining usage of the previously mentioned API endpoint[^2] is for precompiled letters - the API is the only place with the logic to know which bucket a letter pdf file will be in based on the status/key type/etc. This could be a candidate for a future refactor 😉 

[^1]: https://github.com/alphagov/notifications-template-preview/pull/737
[^2]: https://github.com/alphagov/notifications-api/blob/main/app/template/rest.py#L235