### PR TITLE
Add categories to Zendesk tickets we create

### DIFF
--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -52,6 +52,7 @@ def create_email_branding_zendesk_ticket(detail=None):
         org_id=current_service.organisation_id,
         org_type=current_service.organisation_type,
         service_id=current_service.id,
+        ticket_categories=["notify_email_letter_branding"],
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 
@@ -200,6 +201,7 @@ def email_branding_enter_government_identity_logo_text(service_id):
             org_id=current_service.organisation_id,
             org_type=current_service.organisation_type,
             service_id=current_service.id,
+            ticket_categories=["notify_email_letter_branding"],
         )
         zendesk_client.send_ticket_to_zendesk(ticket)
         flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")
@@ -622,6 +624,7 @@ def letter_branding_request(service_id):
             org_id=current_service.organisation_id,
             org_type=current_service.organisation_type,
             service_id=current_service.id,
+            ticket_categories=["notify_email_letter_branding"],
         )
         zendesk_client.send_ticket_to_zendesk(ticket)
         flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -187,6 +187,7 @@ def submit_request_to_go_live(service_id):
         org_id=current_service.organisation_id,
         org_type=current_service.organisation_type,
         service_id=current_service.id,
+        ticket_categories=["notify_go_live_request"],
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -775,6 +775,7 @@ def test_email_branding_request_submit(
         org_id=None,
         org_type="nhs_local",
         service_id=SERVICE_ONE_ID,
+        ticket_categories=["notify_email_letter_branding"],
     )
     mock_send_ticket_to_zendesk.assert_called_once()
     assert normalize_spaces(page.select_one(".banner-default").text) == (

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -322,6 +322,7 @@ def test_POST_letter_branding_request_creates_zendesk_ticket(
     assert zendesk_ticket.org_id == org_id
     assert zendesk_ticket.org_type == "central"
     assert zendesk_ticket.service_id == SERVICE_ONE_ID
+    assert zendesk_ticket.ticket_categories == ["notify_email_letter_branding"]
 
 
 def test_GET_letter_branding_upload_branding_renders_form(

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -1690,6 +1690,7 @@ def test_should_redirect_after_request_to_go_live(
         org_id=None,
         org_type="central",
         service_id=SERVICE_ONE_ID,
+        ticket_categories=["notify_go_live_request"],
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 
@@ -1768,6 +1769,7 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
         org_id=ORGANISATION_ID,
         org_type="central",
         service_id=SERVICE_ONE_ID,
+        ticket_categories=["notify_go_live_request"],
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 


### PR DESCRIPTION
We’re trying to add categories to all the Zendesk tickets we get. When these tickets are ones that we create (rather than ones where the user is providing the content of the ticket) we can do this automatically because we already know what the ticket is about.