### PR TITLE
Set SERVER_NAME for local dev

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -109,6 +109,7 @@ class Config:
 
 
 class Development(Config):
+    SERVER_NAME = os.getenv("SERVER_NAME")
     NOTIFY_LOG_PATH = "application.log"
     DEBUG = True
     SESSION_COOKIE_SECURE = False


### PR DESCRIPTION
Adding this to all of our apps (for local/dev configuration) so that we can get URLs built on a `.localhost` domain when running via docker-compose.