### PR TITLE
Cache page count for templated letters in Redis

### DIFF
--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -35,7 +35,8 @@ class TemplatedLetterImageTemplate(UtilsLetterImageTemplate):
         cache_key = f"service-{self._template['service']}-template-{self.id}-page-count"
 
         if cached_value := redis_client.get(cache_key):
-            return cached_value
+            self._page_count = int(cached_value)
+            return self._page_count
 
         self._page_count = get_page_count_for_letter(self._template)
 

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -23,8 +23,11 @@ class TemplatedLetterImageTemplate(UtilsLetterImageTemplate):
     def page_count(self):
         from app.template_previews import get_page_count_for_letter
 
-        if self._page_count is None:
-            self._page_count = get_page_count_for_letter(self._template, self.values)
+        if self._page_count:
+            return self._page_count
+
+        self._page_count = get_page_count_for_letter(self._template, self.values)
+
         return self._page_count
 
     @property

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -47,6 +47,35 @@ def test_get_page_count_for_letter_caches(
     assert len(mock_get_page_count.call_args_list) == 1
 
 
+def test_get_page_count_for_letter_returns_cached_value(
+    client_request,
+    service_one,
+    api_user_active,
+    mocker,
+    fake_uuid,
+):
+    client_request.login(api_user_active, service_one)
+
+    mock_redis_get = mocker.patch(
+        "app.extensions.RedisClient.get",
+        return_value="5",
+    )
+
+    template = TemplatedLetterImageTemplate(
+        template_json(
+            service_id=SERVICE_ONE_ID,
+            id_=fake_uuid,
+            type_="letter",
+        )
+    )
+
+    for _ in range(3):
+        assert template.page_count == 5
+
+    # Redis only gets called once because the instance also caches the value
+    mock_redis_get.assert_called_once_with(f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-page-count")
+
+
 def test_get_page_count_for_letter_does_not_cache_for_personalised_letters(
     client_request,
     service_one,

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -1,10 +1,75 @@
 import pytest
 from notifications_utils.template import Template
 
-from app.utils.templates import get_sample_template
+from app.utils.templates import TemplatedLetterImageTemplate, get_sample_template
+from tests import template_json
+from tests.conftest import SERVICE_ONE_ID
 
 
 @pytest.mark.parametrize("template_type", ["sms", "letter", "email"])
 def test_get_sample_template_returns_template(template_type):
     template = get_sample_template(template_type)
     assert isinstance(template, Template)
+
+
+def test_get_page_count_for_letter_caches(
+    client_request,
+    service_one,
+    api_user_active,
+    mocker,
+    fake_uuid,
+):
+    client_request.login(api_user_active, service_one)
+
+    mock_redis_get = mocker.patch(
+        "app.extensions.RedisClient.get",
+        return_value=None,
+    )
+    mock_redis_set = mocker.patch(
+        "app.extensions.RedisClient.set",
+    )
+    mock_get_page_count = mocker.patch("app.template_previews.get_page_count_for_letter", return_value=5)
+
+    template = TemplatedLetterImageTemplate(
+        template_json(
+            service_id=SERVICE_ONE_ID,
+            id_=fake_uuid,
+            type_="letter",
+        )
+    )
+
+    for _ in range(3):
+        assert template.page_count == 5
+
+    # Redis and template preview only get called once each because the instance also caches the value
+    mock_redis_get.assert_called_once_with(f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-page-count")
+    mock_redis_set.assert_called_once_with(f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-page-count", 5, ex=2_419_200)
+    assert len(mock_get_page_count.call_args_list) == 1
+
+
+def test_get_page_count_for_letter_does_not_cache_for_personalised_letters(
+    client_request,
+    service_one,
+    api_user_active,
+    mocker,
+    fake_uuid,
+):
+    client_request.login(api_user_active, service_one)
+
+    mock_get_page_count = mocker.patch("app.template_previews.get_page_count_for_letter", return_value=5)
+
+    template = TemplatedLetterImageTemplate(
+        template_json(
+            service_id=SERVICE_ONE_ID,
+            id_=fake_uuid,
+            type_="letter",
+        )
+    )
+
+    for _ in range(3):
+        # We’re changing the values so the page count might change
+        template.values = {"foo": "bar"}
+        assert template.page_count == 5
+
+    # No calls to Redis here
+    assert len(mock_get_page_count.call_args_list) == 3


### PR DESCRIPTION
Getting the page count for a letter means:
- the admin app calls template preview
- template preview either
  - renders the HTML to a PDF
  - gets the cached version of the above from S3
- template preview counts the number of pages in the PDF
- template preview returns the count to the admin app

This is quick, but probably not as quick as going straight to Redis. Which is what this commit does.

We can’t do this for letters which are personalised, because the personalisation might change the page count of the letter.