### PR TITLE
Don’t clear cache for all templates when editing a single template

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -145,8 +145,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.update_service(service_id, **properties)
 
     @cache.delete("service-{service_id}")
-    @cache.delete("service-{service_id}-templates")
-    @cache.delete_by_pattern("service-{service_id}-template-*")
+    @cache.delete_by_pattern("service-{service_id}-template*")
     def archive_service(self, service_id, cached_service_user_ids):
         if cached_service_user_ids:
             redis_client.delete(*map("user-{}".format, cached_service_user_ids))
@@ -183,7 +182,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(endpoint, data)
 
     @cache.delete("service-{service_id}-templates")
-    @cache.delete_by_pattern("service-{service_id}-template-*")
+    @cache.delete_by_pattern("service-{service_id}-template-{template_id}*")
     def update_service_template(self, *, service_id, template_id, name=None, content=None, subject=None):
         """
         Update a service template.
@@ -200,7 +199,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(endpoint, data)
 
     @cache.delete("service-{service_id}-templates")
-    @cache.delete_by_pattern("service-{service_id}-template-*")
+    @cache.delete_by_pattern("service-{service_id}-template-{id_}*")
     def redact_service_template(self, service_id, id_):
         return self.post(
             f"/service/{service_id}/template/{id_}",
@@ -208,7 +207,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         )
 
     @cache.delete("service-{service_id}-templates")
-    @cache.delete_by_pattern("service-{service_id}-template-*")
+    @cache.delete_by_pattern("service-{service_id}-template-{template_id}*")
     def update_service_template_sender(self, service_id, template_id, reply_to):
         data = {
             "reply_to": reply_to,
@@ -217,7 +216,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(f"/service/{service_id}/template/{template_id}", data)
 
     @cache.delete("service-{service_id}-templates")
-    @cache.delete_by_pattern("service-{service_id}-template-*")
+    @cache.delete_by_pattern("service-{service_id}-template-{template_id}*")
     def update_service_template_postage(self, service_id, template_id, postage):
         return self.post(f"/service/{service_id}/template/{template_id}", _attach_current_user({"postage": postage}))
 
@@ -265,7 +264,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         )
 
     @cache.delete("service-{service_id}-templates")
-    @cache.delete_by_pattern("service-{service_id}-template-*")
+    @cache.delete_by_pattern("service-{service_id}-template-{template_id}*")
     def delete_service_template(self, service_id, template_id):
         """
         Set a service template's archived flag to True

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -25,7 +25,7 @@ def test_client_posts_archived_true_when_deleting_template(mocker):
 
     client.delete_service_template(SERVICE_ONE_ID, FAKE_TEMPLATE_ID)
     mock_post.assert_called_once_with(expected_url, data=expected_data)
-    assert call(f"service-{SERVICE_ONE_ID}-template-*") in mock_redis_delete_by_pattern.call_args_list
+    assert call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*") in mock_redis_delete_by_pattern.call_args_list
 
 
 def test_client_gets_service(mocker):
@@ -406,7 +406,7 @@ def test_deletes_service_cache(
 
 
 @pytest.mark.parametrize(
-    "method, extra_args, extra_kwargs, expected_cache_deletes",
+    "method, extra_args, extra_kwargs, expected_cache_deletes, expected_cache_deletes_by_pattern",
     [
         (
             "create_service_template",
@@ -415,6 +415,7 @@ def test_deletes_service_cache(
             [
                 f"service-{SERVICE_ONE_ID}-templates",
             ],
+            [],
         ),
         (
             "update_service_template",
@@ -428,6 +429,9 @@ def test_deletes_service_cache(
             [
                 f"service-{SERVICE_ONE_ID}-templates",
             ],
+            [
+                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
+            ],
         ),
         (
             "redact_service_template",
@@ -435,6 +439,9 @@ def test_deletes_service_cache(
             {},
             [
                 f"service-{SERVICE_ONE_ID}-templates",
+            ],
+            [
+                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
             ],
         ),
         (
@@ -444,6 +451,9 @@ def test_deletes_service_cache(
             [
                 f"service-{SERVICE_ONE_ID}-templates",
             ],
+            [
+                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
+            ],
         ),
         (
             "update_service_template_postage",
@@ -451,6 +461,9 @@ def test_deletes_service_cache(
             {},
             [
                 f"service-{SERVICE_ONE_ID}-templates",
+            ],
+            [
+                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
             ],
         ),
         (
@@ -460,14 +473,19 @@ def test_deletes_service_cache(
             [
                 f"service-{SERVICE_ONE_ID}-templates",
             ],
+            [
+                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
+            ],
         ),
         (
             "archive_service",
             [SERVICE_ONE_ID, []],
             {},
             [
-                f"service-{SERVICE_ONE_ID}-templates",
                 f"service-{SERVICE_ONE_ID}",
+            ],
+            [
+                f"service-{SERVICE_ONE_ID}-template*",
             ],
         ),
     ],
@@ -480,6 +498,7 @@ def test_deletes_caches_when_modifying_templates(
     extra_args,
     extra_kwargs,
     expected_cache_deletes,
+    expected_cache_deletes_by_pattern,
 ):
     mocker.patch("app.notify_client.current_user", id="1")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
@@ -490,10 +509,8 @@ def test_deletes_caches_when_modifying_templates(
 
     assert mock_redis_delete.call_args_list == [call(x) for x in expected_cache_deletes]
     assert len(mock_request.call_args_list) == 1
-    if method != "create_service_template":
-        # no deletes for template cach on create_service_template
-        assert len(mock_redis_delete_by_pattern.call_args_list) == 1
-        assert mock_redis_delete_by_pattern.call_args_list[0] == call(f"service-{SERVICE_ONE_ID}-template-*")
+
+    assert mock_redis_delete_by_pattern.call_args_list == [call(x) for x in expected_cache_deletes_by_pattern]
 
 
 def test_deletes_cached_users_when_archiving_service(mocker, mock_get_service_templates):
@@ -505,7 +522,7 @@ def test_deletes_cached_users_when_archiving_service(mocker, mock_get_service_te
     service_api_client.archive_service(SERVICE_ONE_ID, ["my-user-id1", "my-user-id2"])
 
     assert call("user-my-user-id1", "user-my-user-id2") in mock_redis_delete.call_args_list
-    assert call(f"service-{SERVICE_ONE_ID}-template-*") in mock_redis_delete_by_pattern.call_args_list
+    assert call(f"service-{SERVICE_ONE_ID}-template*") in mock_redis_delete_by_pattern.call_args_list
 
 
 def test_deletes_cached_users_when_changing_broadcast_service_settings(mocker):

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -412,9 +412,7 @@ def test_deletes_service_cache(
             "create_service_template",
             ["name", "type_", "content", SERVICE_ONE_ID],
             {},
-            [
-                f"service-{SERVICE_ONE_ID}-templates",
-            ],
+            [f"service-{SERVICE_ONE_ID}-templates"],
             [],
         ),
         (
@@ -426,67 +424,43 @@ def test_deletes_service_cache(
                 "service_id": SERVICE_ONE_ID,
                 "template_id": FAKE_TEMPLATE_ID,
             },
-            [
-                f"service-{SERVICE_ONE_ID}-templates",
-            ],
-            [
-                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
-            ],
+            [f"service-{SERVICE_ONE_ID}-templates"],
+            [f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*"],
         ),
         (
             "redact_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             {},
-            [
-                f"service-{SERVICE_ONE_ID}-templates",
-            ],
-            [
-                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
-            ],
+            [f"service-{SERVICE_ONE_ID}-templates"],
+            [f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*"],
         ),
         (
             "update_service_template_sender",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, "foo"],
             {},
-            [
-                f"service-{SERVICE_ONE_ID}-templates",
-            ],
-            [
-                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
-            ],
+            [f"service-{SERVICE_ONE_ID}-templates"],
+            [f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*"],
         ),
         (
             "update_service_template_postage",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, "first"],
             {},
-            [
-                f"service-{SERVICE_ONE_ID}-templates",
-            ],
-            [
-                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
-            ],
+            [f"service-{SERVICE_ONE_ID}-templates"],
+            [f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*"],
         ),
         (
             "delete_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             {},
-            [
-                f"service-{SERVICE_ONE_ID}-templates",
-            ],
-            [
-                f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*",
-            ],
+            [f"service-{SERVICE_ONE_ID}-templates"],
+            [f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*"],
         ),
         (
             "archive_service",
             [SERVICE_ONE_ID, []],
             {},
-            [
-                f"service-{SERVICE_ONE_ID}",
-            ],
-            [
-                f"service-{SERVICE_ONE_ID}-template*",
-            ],
+            [f"service-{SERVICE_ONE_ID}"],
+            [f"service-{SERVICE_ONE_ID}-template*"],
         ),
     ],
 )


### PR DESCRIPTION
At the moment, when we edit a template we clear the Redis cache for:
- All templates (because we might have changed the name of a single template for example)
- Each individual template belonging to a service

This is overkill, because editing one template shouldn’t mean the cache needs to be cleared for a different template.

The original intent of doing the pattern delete (in https://github.com/alphagov/notifications-admin/commit/01a3df6edce08e3cf0cca42b60dcf95127155497) was to delete the cache for all _versions_ of an individual template, not every individual template.

This commit updates the pattern so that it only targets a single template, but will still delete keys like:
- `…template-1234-version-None`
- `…template-1234-version-1`
- `…template-1234-versions`
- `…template-1234-page-count`

This should improve performance because we will keep most templates cached for longer.