### PR TITLE
Hide/restrict 'make services live' permission

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -51,7 +51,7 @@ from wtforms.validators import (
     Regexp,
 )
 
-from app import asset_fingerprinter
+from app import asset_fingerprinter, current_organisation
 from app.formatters import (
     format_auth_type,
     format_thousands,
@@ -970,6 +970,13 @@ class OrganisationUserPermissionsForm(StripWhitespaceForm):
         form = cls(
             permissions_field=user.permissions_for_organisation(organisation.id) & organisation_user_permission_names,
         )
+
+        # Remove any permissions that an org doesn't have access to
+        form.permissions_field.choices = [
+            (value, label)
+            for value, label in form.permissions_field.choices
+            if current_organisation.can_use_org_user_permission(value)
+        ]
 
         return form
 

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -4,6 +4,7 @@ from typing import Optional
 from flask import abort
 from werkzeug.utils import cached_property
 
+from app.constants import PERMISSION_CAN_MAKE_SERVICES_LIVE
 from app.models import JSONModel, ModelList, SerialisedModelCollection
 from app.models.branding import (
     EmailBranding,
@@ -238,6 +239,17 @@ class Organisation(JSONModel):
         if updated_at:
             updated_at = datetime.datetime.fromisoformat(updated_at)
         return response["services"], updated_at
+
+    def can_use_org_user_permission(self, permission: str):
+        """Validate whether an organisation can see/access/edit a given org permission
+
+        This is used currently because the 'approve own go live requests' is behind an org-level feature flag.
+        Once that feature flag is removed we might be able to remove this method altogether as it's possibly not
+        something that needs to live forever."""
+        if permission == PERMISSION_CAN_MAKE_SERVICES_LIVE:
+            return self.can_approve_own_go_live_requests
+
+        return True
 
 
 class Organisations(SerialisedModelCollection):

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -44,10 +44,12 @@
             {% if user.is_invited_user == false %}
             <ul class="tick-cross__list">
               {% for permission, label in permissions %}
-                {{ tick_cross(
-                  user.has_permission_for_organisation(current_org.id, permission),
-                  label
-                ) }}
+                {% if current_org.can_use_org_user_permission(permission) %}
+                  {{ tick_cross(
+                    user.has_permission_for_organisation(current_org.id, permission),
+                    label
+                  ) }}
+                {% endif %}
               {% endfor %}
             </ul>
             {% endif %}

--- a/tests/app/models/test_organisation.py
+++ b/tests/app/models/test_organisation.py
@@ -1,5 +1,6 @@
 import pytest
 
+from app.constants import PERMISSION_CAN_MAKE_SERVICES_LIVE
 from app.models.organisation import Organisation
 from tests import organisation_json
 
@@ -10,3 +11,11 @@ from tests import organisation_json
 def test_organisation_billing_details(purchase_order_number, expected_result):
     organisation = Organisation(organisation_json(purchase_order_number=purchase_order_number))
     assert organisation.billing_details == expected_result
+
+
+@pytest.mark.parametrize("can_approve_own_go_live_requests", (True, False))
+def test_can_use_org_user_permissions(can_approve_own_go_live_requests):
+    organisation = Organisation(organisation_json(can_approve_own_go_live_requests=can_approve_own_go_live_requests))
+    assert (
+        organisation.can_use_org_user_permission(PERMISSION_CAN_MAKE_SERVICES_LIVE) is can_approve_own_go_live_requests
+    )


### PR DESCRIPTION
The ability for organisation users to make services live is guarded by the 'can approve own go live requests' org-level permission. Let's hide and restrict editing of the 'can make services live' org user permission based on the org-level permission.


| x | Team members | Edit user |
|---|---|---|
| Current state / new state when org has permission | <img width="1002" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/9e747bc6-aa42-41d0-b27a-d3d84fe65fc4"> | <img width="994" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/78d0e5f3-5f7b-4246-ad23-3101660bf551"> |
| New state when org does not have permission | <img width="1012" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/3d7ed954-2019-480d-8ce2-4e92c2982fe2"> | <img width="1001" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/54e72fea-6e2e-4b8a-a2a8-827446e13e2b"> |