### PR TITLE
Set org user permissions on invite

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -2,7 +2,6 @@ from flask import abort, flash, redirect, render_template, session, url_for
 from flask_login import current_user
 from markupsafe import Markup
 
-from app.constants import PERMISSION_CAN_MAKE_SERVICES_LIVE
 from app.main import main
 from app.models.organisation import Organisation
 from app.models.service import Service
@@ -124,7 +123,7 @@ def accept_org_invite(token):
         invited_org_user.accept_invite()
         if existing_user not in organisation_users:
             existing_user.add_to_organisation(
-                organisation_id=invited_org_user.organisation, permissions=[PERMISSION_CAN_MAKE_SERVICES_LIVE]
+                organisation_id=invited_org_user.organisation, permissions=invited_org_user.permissions
             )
         return redirect(url_for("main.organisation_dashboard", org_id=invited_org_user.organisation))
     else:

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -40,7 +40,7 @@ from app.models.user import InvitedOrgUser
 from app.s3_client.s3_mou_client import get_mou
 from app.utils.csv import Spreadsheet
 from app.utils.user import user_has_permissions, user_is_platform_admin
-from app.utils.user_permissions import organisation_user_permission_names, organisation_user_permission_options
+from app.utils.user_permissions import organisation_user_permission_options
 
 
 @main.route("/organisations", methods=["GET"])
@@ -222,10 +222,13 @@ def manage_org_users(org_id):
 @user_has_permissions()
 def invite_org_user(org_id):
     form = InviteOrgUserForm(inviter_email_address=current_user.email_address)
+
     if form.validate_on_submit():
-        email_address = form.email_address.data
         invited_org_user = InvitedOrgUser.create(
-            current_user.id, org_id, email_address, list(organisation_user_permission_names)
+            invite_from_id=current_user.id,
+            org_id=org_id,
+            email_address=form.email_address.data,
+            permissions=form.permissions_field.data,
         )
 
         flash(f"Invite sent to {invited_org_user.email_address}", "default_with_tick")

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -228,7 +228,7 @@ def invite_org_user(org_id):
             invite_from_id=current_user.id,
             org_id=org_id,
             email_address=form.email_address.data,
-            permissions=form.permissions_field.data,
+            permissions=list(form.permissions),
         )
 
         flash(f"Invite sent to {invited_org_user.email_address}", "default_with_tick")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -666,11 +666,8 @@ class InvitedOrgUser(BaseUser):
         return self._permissions
 
     @permissions.setter
-    def permissions(self, permissions):
-        if isinstance(permissions, list):
-            self._permissions = permissions
-        else:
-            self._permissions = [p for p in permissions.split(",") if p]
+    def permissions(self, permissions: list[str]):
+        self._permissions = permissions
 
     def has_permission_for_organisation(self, organisation_id, permission):
         if self.status == "cancelled":

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -607,6 +607,7 @@ class InvitedOrgUser(BaseUser):
         "email_address",
         "status",
         "created_at",
+        "permissions",
     }
 
     def __init__(self, _dict):
@@ -658,6 +659,11 @@ class InvitedOrgUser(BaseUser):
 
     def is_editable_by(self, other):
         return False
+
+    def has_permission_for_organisation(self, organisation_id, permission):
+        if self.status == "cancelled":
+            return False
+        return self.organisation == organisation_id and permission in self.permissions
 
 
 class AnonymousUser(AnonymousUserMixin):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -613,6 +613,7 @@ class InvitedOrgUser(BaseUser):
     def __init__(self, _dict):
         super().__init__(_dict)
         self._invited_by = _dict["invited_by"]
+        self.permissions = _dict["permissions"]
 
     def __eq__(self, other):
         return (self.id, self.organisation, self._invited_by, self.email_address, self.status) == (
@@ -659,6 +660,17 @@ class InvitedOrgUser(BaseUser):
 
     def is_editable_by(self, other):
         return False
+
+    @property
+    def permissions(self):
+        return self._permissions
+
+    @permissions.setter
+    def permissions(self, permissions):
+        if isinstance(permissions, list):
+            self._permissions = permissions
+        else:
+            self._permissions = [p for p in permissions.split(",") if p]
 
     def has_permission_for_organisation(self, organisation_id, permission):
         if self.status == "cancelled":

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -529,7 +529,7 @@ class InvitedUser(BaseUser):
         if isinstance(permissions, list):
             self._permissions = permissions
         else:
-            self._permissions = permissions.split(",")
+            self._permissions = [p for p in permissions.split(",") if p]
         self._permissions = translate_permissions_from_db_to_ui(self.permissions)
 
     @property

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -40,8 +40,6 @@
               </span>
             </h2>
 
-            {# Remove this guard condition when invited users can get permissions from the API #}
-            {% if user.is_invited_user == false %}
             <ul class="tick-cross__list">
               {% for permission, label in permissions %}
                 {% if current_org.can_use_org_user_permission(permission) %}
@@ -52,7 +50,6 @@
                 {% endif %}
               {% endfor %}
             </ul>
-            {% endif %}
 
           </div>
           <div class="govuk-grid-column-one-quarter">

--- a/app/templates/views/organisations/organisation/users/invite-org-user.html
+++ b/app/templates/views/organisations/organisation/users/invite-org-user.html
@@ -4,6 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "components/error-summary.html" import errorSummary %}
 
 {% block org_page_title %}
   Invite a team member
@@ -15,8 +16,12 @@
 
 {% block maincolumn_content %}
 
+  {{ errorSummary(form) }}
+
   {{ page_header("Invite a team member") }}
+
   {% call form_wrapper() %}
+
     {{ form.email_address(
       param_extensions={
         "classes": "govuk-!-width-full"
@@ -24,15 +29,7 @@
       error_message_with_html=True
     ) }}
 
-    <div class="bottom-gutter">
-		  <p class="form-label">
-		    {{ current_org.name }} team members can:
-		  </p>
-		  <ul class="govuk-list govuk-list--bullet">
-		    <li>see usage and team members for each service</li>
-        <li>invite other team members</li>
-		  </ul>
-		</div>
+    {{ form.permissions_field }}
 
     {{ page_footer('Send invitation email') }}
   {% endcall %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -378,7 +378,7 @@ def invite_json(
     }
 
 
-def org_invite_json(id_, invited_by, org_id, email_address, created_at, status, permissions):
+def org_invite_json(*, id_, invited_by, org_id, email_address, created_at, status, permissions):
     return {
         "id": id_,
         "invited_by": invited_by,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -378,7 +378,7 @@ def invite_json(
     }
 
 
-def org_invite_json(id_, invited_by, org_id, email_address, created_at, status):
+def org_invite_json(id_, invited_by, org_id, email_address, created_at, status, permissions):
     return {
         "id": id_,
         "invited_by": invited_by,
@@ -386,6 +386,7 @@ def org_invite_json(id_, invited_by, org_id, email_address, created_at, status):
         "email_address": email_address,
         "status": status,
         "created_at": created_at,
+        "permissions": permissions,
     }
 
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -799,14 +799,14 @@ def test_manage_org_users_shows_correct_link_next_to_each_user(
 
     users = page.select(".user-list-item")
 
-    # The first user is an invited user, so has the link to cancel the invitation.
-    # The second two users are active users, so have the link to be removed from the org
-    assert (
-        normalize_spaces(users[0].text)
-        == "invited_user@test.gov.uk (invited) Cancel invitation for invited_user@test.gov.uk"
-    )
-
     if can_approve_own_go_live_requests:
+        # The first user is an invited user, so has the link to cancel the invitation.
+        # The second two users are active users, so have the link to be removed from the org
+        assert normalize_spaces(users[0].text) == (
+            "invited_user@test.gov.uk (invited) "
+            "Can Make new services live Cancel invitation for invited_user@test.gov.uk"
+        )
+
         assert (
             normalize_spaces(users[1].text)
             == "Test User 1 test@gov.uk Cannot Make new services live Change details for Test User 1 test@gov.uk"
@@ -816,6 +816,13 @@ def test_manage_org_users_shows_correct_link_next_to_each_user(
             == "Test User 2 testt@gov.uk Cannot Make new services live Change details for Test User 2 testt@gov.uk"
         )
     else:
+        # The first user is an invited user, so has the link to cancel the invitation.
+        # The second two users are active users, so have the link to be removed from the org
+        assert (
+            normalize_spaces(users[0].text)
+            == "invited_user@test.gov.uk (invited) Cancel invitation for invited_user@test.gov.uk"
+        )
+
         assert normalize_spaces(users[1].text) == "Test User 1 test@gov.uk Change details for Test User 1 test@gov.uk"
         assert normalize_spaces(users[2].text) == "Test User 2 testt@gov.uk Change details for Test User 2 testt@gov.uk"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3371,7 +3371,15 @@ def sample_org_invite(mocker, organisation_one):
     status = "pending"
     permissions = ["can_make_services_live"]
 
-    return org_invite_json(id_, invited_by, organisation, email_address, created_at, status, permissions)
+    return org_invite_json(
+        id_=id_,
+        invited_by=invited_by,
+        org_id=organisation,
+        email_address=email_address,
+        created_at=created_at,
+        status=status,
+        permissions=permissions,
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3369,8 +3369,9 @@ def sample_org_invite(mocker, organisation_one):
     organisation = organisation_one["id"]
     created_at = str(datetime.utcnow())
     status = "pending"
+    permissions = ["can_make_services_live"]
 
-    return org_invite_json(id_, invited_by, organisation, email_address, created_at, status)
+    return org_invite_json(id_, invited_by, organisation, email_address, created_at, status, permissions)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
* [x] To merge after: https://github.com/alphagov/notifications-api/pull/3830

---

Adds a form to the 'invite user to org' page which allows setting permissions (currently just whether the user can make services live).

Also show these permissions for invited users on the org team members page.

And finally, respect those invited org user permissions when the invite is actually accepted (currently it's just hard-coded to give them the permission).

Some refactoring, including adding an error summary to the invite org user page.

## Look at it
![2023-06-23 09 31 37](https://github.com/alphagov/notifications-admin/assets/2920760/0d79166b-11ee-453d-9f7e-0382d3632899)