### PR TITLE
Update dates for oustanding issues

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -12,8 +12,8 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "24 May 2023",
-      "Next review due": "24 June 2023"
+      "Last updated": "27 June 2023",
+      "Next review due": "28 July 2023"
     }
     ) }}
     {# Last non-functional changes: 24 Mar 2023 #}
@@ -108,13 +108,13 @@
       Our validation errors cause problems for screen readers. This means it can be hard to know when an error has occurred or what to do next. We have started working on this issue. We are still exploring how much work it will take to fix it.
     </li>
     <li>
-      The JAWS screen reader announces template folder page headings as multiple sentences. We are investigating this issue and plan to fix it by June 2023.
+      The JAWS screen reader announces template folder page headings as multiple sentences. We are investigating this issue and plan to fix it in September 2023.
     </li>
     <li>
-      Choosing the date and time you want to send a message using a screen reader can be confusing. We plan to fix this in May 2023.
+      Choosing the date and time you want to send a message using a screen reader can be confusing. We have begun work on this issue and plan to fix it in July 2023.
     </li>
     <li>
-      Expanding and collapsing groups of checkboxes using a screen reader can be confusing. We plan to fix this in June 2023.
+      Expanding and collapsing groups of checkboxes using a screen reader can be confusing. We plan to fix this in August 2023.
     </li>
   </ol>
 
@@ -138,7 +138,7 @@
   </p>
 
   <p class="govuk-body">
-    We’ll continue to investigate the cause of this issue and, if possible, fix it in July 2023.
+    We’ll continue to investigate the cause of this issue and, if possible, fix it in September 2023.
   </p>
 
   <h3 class="heading-small" id="status-page">


### PR DESCRIPTION
Makes the following changes:
1. update the issue with the time/date picker to reflect that work has begun
2. bump the date on the collapsable checkboxes issue to be the next piece of work we pick up
3. don't change the issue with our forms validation as we are still planning out the work
4. move all other issues up to fit into the remaining time