### PR TITLE
Expand DAC acronym in accessibility statement

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -12,7 +12,7 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "27 June 2023",
+      "Last updated": "28 June 2023",
       "Next review due": "28 July 2023"
     }
     ) }}
@@ -170,7 +170,7 @@
   </h2>
 
   <p class="govuk-body">
-    The parts of the website used to send text messages, emails and letters were last tested in February 2021. The emails we send out, the web pages users see when they are sent a file by Notify and a sample letter PDF were last tested on 11 March 2019. Both tests were carried out by DAC.
+    The parts of the website used to send text messages, emails and letters were last tested in February 2021. The emails we send out, the web pages users see when they are sent a file by Notify and a sample letter PDF were last tested on 11 March 2019. Both tests were carried out by the Digital Accessibility Centre.
   </p>
 
   <p class="govuk-body">


### PR DESCRIPTION
This used to be shown in the full form higher up in the statement, so the acronym could be used. This is no longer the case and there are now no other uses so this should just be expanded.