### PR TITLE
don't explicitly list every js/scss file in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,42 +98,7 @@ const javascripts = () => {
     ]));
 
   // JS local to this application
-  const local = src([
-    paths.src + 'javascripts/modules.js',
-    paths.src + 'javascripts/govuk-frontend-toolkit/show-hide-content.js',
-    paths.src + 'javascripts/govuk/cookie-functions.js',
-    paths.src + 'javascripts/consent.js',
-    paths.src + 'javascripts/analytics/analytics.js',
-    paths.src + 'javascripts/analytics/init.js',
-    paths.src + 'javascripts/cookieMessage.js',
-    paths.src + 'javascripts/cookieSettings.js',
-    paths.src + 'javascripts/stick-to-window-when-scrolling.js',
-    paths.src + 'javascripts/copyToClipboard.js',
-    paths.src + 'javascripts/autofocus.js',
-    paths.src + 'javascripts/enhancedTextbox.js',
-    paths.src + 'javascripts/fileUpload.js',
-    paths.src + 'javascripts/radioSelect.js',
-    paths.src + 'javascripts/updateContent.js',
-    paths.src + 'javascripts/listEntry.js',
-    paths.src + 'javascripts/liveSearch.js',
-    paths.src + 'javascripts/errorTracking.js',
-    paths.src + 'javascripts/preventDuplicateFormSubmissions.js',
-    paths.src + 'javascripts/fullscreenTable.js',
-    paths.src + 'javascripts/radios-with-images.js',
-    paths.src + 'javascripts/previewPane.js',
-    paths.src + 'javascripts/colourPreview.js',
-    paths.src + 'javascripts/liveCheckboxControls.js',
-    paths.src + 'javascripts/templateFolderForm.js',
-    paths.src + 'javascripts/addBrandingOptionsForm.js',
-    paths.src + 'javascripts/setAuthTypeForm.js',
-    paths.src + 'javascripts/collapsibleCheckboxes.js',
-    paths.src + 'javascripts/registerSecurityKey.js',
-    paths.src + 'javascripts/authenticateSecurityKey.js',
-    paths.src + 'javascripts/updateStatus.js',
-    paths.src + 'javascripts/errorBanner.js',
-    paths.src + 'javascripts/homepage.js',
-    paths.src + 'javascripts/main.js',
-  ])
+  const local = src(paths.src + 'javascripts/**/*.js')
   .pipe(plugins.prettyerror())
   .pipe(plugins.babel({
     presets: ['@babel/preset-env']
@@ -149,11 +114,7 @@ const javascripts = () => {
 
 
 const sass = () => {
-  return src([
-      paths.src + '/stylesheets/main*.scss',
-      paths.src + '/stylesheets/map.scss',
-      paths.src + '/stylesheets/print.scss'
-    ])
+  return src(paths.src + '/stylesheets/*.scss')
     .pipe(plugins.prettyerror())
     .pipe(plugins.sass.sync({
       includePaths: [


### PR DESCRIPTION
in draft while i investigate the various order dependencies between js files

-------

instead, use globs to just grab everything.

note that we don't need `/**/*.scss` in the sass compilation since main.scss imports everything. we get errors if we glob all the nested components individually presumably because they rely on stuff set up in the outer main.scss files and similar

<table>
<tr> <th>Before</th> <th>After</th> </tr>
<tr>
<td>
<pre>
> ls -la app/static/javascripts
total 688
drwxr-xr-x  4 leohemsted  staff     128 28 Jun 15:55 .
drwxr-xr-x  7 leohemsted  staff     224 28 Jun 15:55 ..
-rw-r--r--  1 leohemsted  staff  206489 28 Jun 12:45 all.js
-rw-r--r--  1 leohemsted  staff  142601 28 Jun 12:45 leaflet.js
</pre>
</td>
<td>
<pre>
> ls -la app/static/javascripts
total 688
drwxr-xr-x  4 leohemsted  staff     128 28 Jun 15:57 .
drwxr-xr-x  7 leohemsted  staff     224 28 Jun 15:57 ..
-rw-r--r--  1 leohemsted  staff  206489 28 Jun 12:45 all.js
-rw-r--r--  1 leohemsted  staff  142601 28 Jun 12:45 leaflet.js
</pre>
</td>
</tr>
<tr>
<td>
<pre>
> ls -la app/static/stylesheets
total 464
drwxr-xr-x  5 leohemsted  staff     160 28 Jun 15:55 .
drwxr-xr-x  7 leohemsted  staff     224 28 Jun 15:55 ..
-rw-r--r--  1 leohemsted  staff  200155 28 Jun 15:55 main.css
-rw-r--r--  1 leohemsted  staff   12429 28 Jun 15:55 map.css
-rw-r--r--  1 leohemsted  staff   17934 28 Jun 15:55 print.css
</pre>
</td>
<td>
<pre>
> ls -la app/static/stylesheets
total 464
drwxr-xr-x  5 leohemsted  staff     160 28 Jun 15:57 .
drwxr-xr-x  7 leohemsted  staff     224 28 Jun 15:57 ..
-rw-r--r--  1 leohemsted  staff  200155 28 Jun 15:57 main.css
-rw-r--r--  1 leohemsted  staff   12429 28 Jun 15:57 map.css
-rw-r--r--  1 leohemsted  staff   17934 28 Jun 15:57 print.css
</pre>
</td>
</tr>
</table>
