### PR TITLE
Redesign organisation permissions form to work with a single permission

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -947,7 +947,9 @@ class OrganisationUserPermissionsForm(StripWhitespaceForm):
     permissions_field = GovukCheckboxesField(
         "Permissions",
         filters=[partial(filter_by_permissions, permissions=organisation_user_permission_options)],
-        choices=[(value, label) for value, label in organisation_user_permission_options],
+        choices=[
+            (value, f"This team member can {label.lower()}") for value, label in organisation_user_permission_options
+        ],
     )
 
     def __init__(self, *args, **kwargs):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -948,17 +948,6 @@ class OrganisationUserPermissionsForm(StripWhitespaceForm):
         "Permissions",
         filters=[partial(filter_by_permissions, permissions=organisation_user_permission_options)],
         choices=[(value, label) for value, label in organisation_user_permission_options],
-        param_extensions={
-            "hint": {
-                "html": (
-                    '<p class="govuk-hint">All team members can:</p>'
-                    '<ul class="govuk-list govuk-list--bullet govuk-hint">'
-                    "<li>see usage, templates, and team members</li>"
-                    "<li>invite other team members</li>"
-                    "</ul>"
-                )
-            }
-        },
     )
 
     def __init__(self, *args, **kwargs):

--- a/app/templates/views/organisations/organisation/users/invite-org-user.html
+++ b/app/templates/views/organisations/organisation/users/invite-org-user.html
@@ -29,7 +29,9 @@
       error_message_with_html=True
     ) }}
 
-    {{ form.permissions_field }}
+    {{ form.permissions_field(param_extensions={
+      "fieldset": false
+    }) }}
 
     <p class="govuk-body govuk-!-margin-bottom-2">All team members can:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">

--- a/app/templates/views/organisations/organisation/users/invite-org-user.html
+++ b/app/templates/views/organisations/organisation/users/invite-org-user.html
@@ -29,15 +29,7 @@
       error_message_with_html=True
     ) }}
 
-    {{ form.permissions_field(param_extensions={
-      "fieldset": false
-    }) }}
-
-    <p class="govuk-body govuk-!-margin-bottom-2">All team members can:</p>
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-      <li>see usage, templates, and team members</li>
-      <li>invite other team members</li>
-    </ul>
+    {% include 'views/organisations/organisation/users/permissions.html' %}
 
     {{ page_footer('Send invitation email') }}
   {% endcall %}

--- a/app/templates/views/organisations/organisation/users/invite-org-user.html
+++ b/app/templates/views/organisations/organisation/users/invite-org-user.html
@@ -31,6 +31,12 @@
 
     {{ form.permissions_field }}
 
+    <p class="govuk-body govuk-!-margin-bottom-2">All team members can:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+      <li>see usage, templates, and team members</li>
+      <li>invite other team members</li>
+    </ul>
+
     {{ page_footer('Send invitation email') }}
   {% endcall %}
 

--- a/app/templates/views/organisations/organisation/users/permissions.html
+++ b/app/templates/views/organisations/organisation/users/permissions.html
@@ -1,10 +1,3 @@
-{% import "components/svgs.html" as svgs %}
-
-{# this may be called from invite page (where no user exists) #}
-{% if user is not defined %}
-  {% set user = {'platform_admin': False, 'webauthn_auth': False, 'mobile_number': 'truthy so we give auth option'} %}
-{% endif %}
-
 {{ form.permissions_field(param_extensions={
   "fieldset": false
 }) }}

--- a/app/templates/views/organisations/organisation/users/permissions.html
+++ b/app/templates/views/organisations/organisation/users/permissions.html
@@ -5,4 +5,6 @@
   {% set user = {'platform_admin': False, 'webauthn_auth': False, 'mobile_number': 'truthy so we give auth option'} %}
 {% endif %}
 
-{{ form.permissions_field }}
+{{ form.permissions_field(param_extensions={
+  "fieldset": false
+}) }}

--- a/app/templates/views/organisations/organisation/users/permissions.html
+++ b/app/templates/views/organisations/organisation/users/permissions.html
@@ -8,3 +8,9 @@
 {{ form.permissions_field(param_extensions={
   "fieldset": false
 }) }}
+
+<p class="govuk-body govuk-!-margin-bottom-2">All team members can:</p>
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+  <li>see usage, templates, and team members</li>
+  <li>invite other team members</li>
+</ul>

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -12,6 +12,37 @@ from tests.conftest import ORGANISATION_ID, create_active_user_with_permissions,
 
 
 @pytest.mark.parametrize(
+    "can_approve_own_go_live_requests, expected_radios",
+    (
+        (False, []),
+        (True, [("can_make_services_live", "This team member can make new services live")]),
+    ),
+)
+def test_invite_org_user_page(client_request, mocker, can_approve_own_go_live_requests, expected_radios):
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_json(
+            ORGANISATION_ID,
+            "Test organisation",
+            can_approve_own_go_live_requests=can_approve_own_go_live_requests,
+        ),
+    )
+
+    page = client_request.get(
+        ".invite_org_user",
+        org_id=ORGANISATION_ID,
+    )
+
+    assert [
+        (
+            checkbox.select_one("input")["value"],
+            normalize_spaces(checkbox.select_one("label").text),
+        )
+        for checkbox in page.select(".govuk-checkboxes__item")
+    ] == expected_radios
+
+
+@pytest.mark.parametrize(
     "can_approve_own_go_live_requests, extra_form_data, expected_status",
     (
         (False, {}, 302),


### PR DESCRIPTION
Before | After
---|---
<img width="767" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/f413b386-bfaa-48e0-b7f0-d8f1d89b8951"> | <img width="766" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/4e40e375-281b-4211-b857-d3512b7d65d5">
<img width="766" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/f1c22b77-926b-4f36-874d-d27ec8236031"> | <img width="766" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/571b4073-6bdc-4c56-97a2-000d53826014">






