### PR TITLE
Deprecate `consent_to_research`

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1542,15 +1542,6 @@ class EstimateUsageForm(StripWhitespaceForm):
         "How many letters do you expect to send in the next year?",
         things="number of letters",
     )
-    consent_to_research = GovukRadiosField(
-        "Can we contact you when we’re doing user research?",
-        choices=[
-            ("yes", "Yes"),
-            ("no", "No"),
-        ],
-        thing="yes or no",
-        param_extensions={"hint": {"text": "You do not have to take part and you can unsubscribe at any time"}},
-    )
 
     at_least_one_volume_filled = True
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -135,10 +135,6 @@ def estimate_usage(service_id):
         volume_email=current_service.volume_email,
         volume_sms=current_service.volume_sms,
         volume_letter=current_service.volume_letter,
-        consent_to_research={
-            True: "yes",
-            False: "no",
-        }.get(current_service.consent_to_research),
     )
 
     if form.validate_on_submit():
@@ -146,7 +142,6 @@ def estimate_usage(service_id):
             volume_email=form.volume_email.data,
             volume_sms=form.volume_sms.data,
             volume_letter=form.volume_letter.data,
-            consent_to_research=(form.consent_to_research.data == "yes"),
         )
         return redirect(
             url_for(

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -30,7 +30,6 @@ class Service(JSONModel):
         "billing_contact_names",
         "billing_reference",
         "broadcast_channel",
-        "consent_to_research",
         "contact_link",
         "count_as_live",
         "email_from",
@@ -253,7 +252,7 @@ class Service(JSONModel):
 
     @property
     def has_estimated_usage(self):
-        return self.consent_to_research is not None and any(self.volumes_by_channel.values())
+        return any(self.volumes_by_channel.values())
 
     def has_templates_of_type(self, template_type):
         return any(template for template in self.all_templates if template["template_type"] == template_type)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -79,7 +79,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "billing_contact_email_addresses",
             "billing_contact_names",
             "billing_reference",
-            "consent_to_research",
             "contact_link",
             "created_by",
             "count_as_live",

--- a/app/templates/support-tickets/go-live-request.txt
+++ b/app/templates/support-tickets/go-live-request.txt
@@ -20,7 +20,6 @@ Agreement signed by: {{ organisation.agreement_signed_by.email_address }}
 Agreement signed on behalf of: {{ organisation.agreement_signed_on_behalf_of_email_address }}
 {%- endif %}
 
-Consent to research: {{ service.consent_to_research|format_yes_no }}
 Other live services for that user: {{ user.live_services|format_yes_no }}
 
 ---

--- a/app/templates/views/service-settings/estimate-usage.html
+++ b/app/templates/views/service-settings/estimate-usage.html
@@ -40,7 +40,6 @@
             "hint": {"text": "For example, 50,000"},
           }) }}
         </div>
-        {{ form.consent_to_research }}
         {{ page_footer('Continue') }}
       {% endcall %}
     </div>

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -576,7 +576,6 @@ def test_client_updates_service_with_allowed_attributes(
 
     allowed_attributes = [
         "active",
-        "consent_to_research",
         "contact_link",
         "count_as_live",
         "email_branding",


### PR DESCRIPTION
We want to move to storing this data on an individual user level. So we don’t need to collect it or display it at a service level any more.

Removing this from the admin app will eventually let us remove the column from the services table entirely.

Before | After
---|---
<img width="800" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/04c64463-7f62-4fb7-bd77-3e897832e42b"> | <img width="800" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/c6ff6fc4-d069-4188-9f62-354ad60e1633">
