### PR TITLE
Viewing an attachment on the manage-attachment page

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -54,6 +54,7 @@ from app.s3_client.s3_letter_upload_client import (
     upload_letter_to_s3,
 )
 from app.template_previews import (
+    LetterAttachmentPreview,
     TemplatePreview,
     sanitise_letter,
 )
@@ -946,8 +947,20 @@ def letter_template_attach_pages(service_id, template_id):
         form=form,
         template=template,
         service_id=service_id,
+        letter_attachment_image_url=url_for(
+            "no_cookie.view_letter_attachment_preview",
+            service_id=service_id,
+            attachment_id=template.attachment.id,
+        ),
+        page_numbers=list(range(1, template.attachment.page_count + 1)),
         error=error,
     )
+
+
+@no_cookie.route("/services/<uuid:service_id>/attachment/<uuid:attachment_id>.png")
+@user_has_permissions(allow_org_user=True)
+def view_letter_attachment_preview(service_id, attachment_id):
+    return LetterAttachmentPreview.from_attachment_data(attachment_id, page=request.args.get("page"))
 
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/attach-pages/edit", methods=["GET", "POST"])
@@ -990,6 +1003,12 @@ def letter_template_edit_pages(template_id, service_id):
         form=form,
         template=template,
         service_id=service_id,
+        letter_attachment_image_url=url_for(
+            "no_cookie.view_letter_attachment_preview",
+            service_id=service_id,
+            attachment_id=template.attachment.id,
+        ),
+        page_numbers=list(range(1, template.attachment.page_count + 1)),
         error=error,
     )
 

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -8,13 +8,33 @@ from notifications_utils.pdf import extract_page_from_pdf
 from app import current_service
 
 
-class TemplatePreview:
+class AuthPreview:
     @staticmethod
     def get_allowed_headers(headers):
         header_allowlist = {"content-type", "cache-control"}
         allowed_headers = {header: value for header, value in headers.items() if header.lower() in header_allowlist}
         return allowed_headers.items()
 
+
+class LetterAttachmentPreview(AuthPreview):
+    @classmethod
+    def from_attachment_data(cls, attachment_id, page=None):
+        data = {
+            "letter_attachment_id": attachment_id,
+            "service_id": current_service.id,
+        }
+        resp = requests.post(
+            "{}/letter_attachment_preview.png{}".format(
+                current_app.config["TEMPLATE_PREVIEW_API_HOST"],
+                "?page={}".format(page) if page else "",
+            ),
+            json=data,
+            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
+        )
+        return resp.content, resp.status_code, cls.get_allowed_headers(resp.headers)
+
+
+class TemplatePreview(AuthPreview):
     @classmethod
     def from_database_object(cls, template, filetype, values=None, page=None):
         data = {

--- a/app/templates/views/templates/manage-attachment.html
+++ b/app/templates/views/templates/manage-attachment.html
@@ -40,8 +40,13 @@
     )}}
     </div>
     <div class="template-container">
-        <div class="letter page--odd">
-        </div>
+
+        {% for page_number in page_numbers %}
+          <div class="letter page--{{ loop.cycle('odd', 'even') }}{% if loop.first %} page--first{% endif %}{% if loop.last %} page--last{% endif %}">
+            <img src="{{ letter_attachment_image_url }}?page={{ page_number }}" alt="" loading="{{ 'eager' if (page_number==1) else 'lazy' }}">
+          </div>
+        {% endfor %}
+
     </div>
     <div class="govuk-!-margin-bottom-2">
       <div class="js-stick-at-bottom-when-scrolling">

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1099,6 +1099,8 @@ def test_attach_pages_with_letter_attachment_id_in_template_shows_manage_page(
         _expected_status=200,
     )
     assert page.select_one("h1").text.strip() == "original file.pdf"
+    assert len(page.select(".letter")) == 1
+    assert page.select_one(".letter img")["src"] == f"/services/{SERVICE_ONE_ID}/attachment/{sample_uuid()}.png?page=1"
 
 
 def test_post_delete_letter_attachment_calls_archive_letter_attachment(
@@ -1511,6 +1513,25 @@ def test_should_show_preview_letter_templates(
     assert mocked_preview.call_args[0][0]["id"] == template_id
     assert mocked_preview.call_args[0][0]["service"] == service_id
     assert mocked_preview.call_args[0][1] == filetype
+
+
+def test_should_show_preview_letter_attachment(
+    client_request, mock_get_service_email_template, service_one, fake_uuid, mocker
+):
+    mocked_preview = mocker.patch(
+        "app.main.views.templates.LetterAttachmentPreview.from_attachment_data", return_value="foo"
+    )
+
+    service_id, attachment_id = service_one["id"], fake_uuid
+
+    response = client_request.get_response(
+        "no_cookie.view_letter_attachment_preview",
+        service_id=service_id,
+        attachment_id=attachment_id,
+    )
+
+    assert response.get_data(as_text=True) == "foo"
+    assert mocked_preview.call_args[0][0] == attachment_id
 
 
 def test_dont_show_preview_letter_templates_for_bad_filetype(

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -203,6 +203,7 @@ EXCLUDED_ENDPOINTS = set(
             "no_cookie.check_notification_preview",
             "no_cookie.letter_branding_preview_image",
             "no_cookie.send_test_preview",
+            "no_cookie.view_letter_attachment_preview",
             "no_cookie.view_letter_template_preview",
             "no_cookie.view_template_version_preview",
             "notifications_sent_by_service",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -890,6 +890,7 @@ def mock_get_service_letter_template_with_attachment(mocker):
             letter_attachment={
                 "id": sample_uuid(),
                 "original_filename": "original file.pdf",
+                "page_count": 1,
             },
         )
         return {"data": template}

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -149,6 +149,7 @@
     "/services/<uuid:service_id>/api/keys/create",
     "/services/<uuid:service_id>/api/keys/revoke/<uuid:key_id>",
     "/services/<uuid:service_id>/api/whitelist",
+    "/services/<uuid:service_id>/attachment/<uuid:attachment_id>.png",
     "/services/<uuid:service_id>/broadcast-dashboard.json",
     "/services/<uuid:service_id>/broadcast-tour/<int:step_index>",
     "/services/<uuid:service_id>/broadcast-tour/live/<int:step_index>",


### PR DESCRIPTION
This simply adds the looping logic to the manage-attachment page

We may want to pull it out to it's own template so it can be reused for the validation failure page.

Added a simple test for the endpoint

goes with https://github.com/alphagov/notifications-template-preview/pull/739