### PR TITLE
Add create-droplet/deploy scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ cf-deploy: cf-target ## Deploys the app to Cloud Foundry
 	# generate manifest (including secrets) and write it to CF_MANIFEST_PATH (in /tmp/)
 	make -s CF_APP=${CF_APP} generate-manifest > ${CF_MANIFEST_PATH}
 	# reads manifest from CF_MANIFEST_PATH
-	CF_STARTUP_TIMEOUT=10 cf push ${CF_APP} --strategy=rolling -f ${CF_MANIFEST_PATH}
+	$(if ${USE_DROPLETS},CF_APP=${CF_APP} CF_MANIFEST_PATH=${CF_MANIFEST_PATH} ./scripts/deploy.sh,CF_STARTUP_TIMEOUT=10 cf push ${CF_APP} --strategy=rolling -f ${CF_MANIFEST_PATH})
 	# delete old manifest file
 	rm -f ${CF_MANIFEST_PATH}
 

--- a/manifest-droplet.yml
+++ b/manifest-droplet.yml
@@ -1,0 +1,12 @@
+---
+applications:
+- name: ((app_name))
+  stack: cflinuxfs3
+  processes:
+  - type: web
+    instances: 0
+    memory: 1024M
+    disk_quota: 1024M
+    log-rate-limit-per-second: 1M
+    health-check-type: port
+  buildpack: python_buildpack

--- a/scripts/create-droplet.sh
+++ b/scripts/create-droplet.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eux
+
+CF_SPACE=${CF_SPACE:-monitoring}
+
+[[ ! -f ./.git/short_ref ]] && $(git rev-parse --short HEAD) > ./.git/short_ref
+GIT_REF=$(cat .git/short_ref)
+DROPLET_BUILD_APP="droplet-build-admin-${GIT_REF}"
+
+echo "Creating ${DROPLET_BUILD_APP} in ${CF_SPACE}"
+cf target -s ${CF_SPACE}
+cf create-app ${DROPLET_BUILD_APP}
+
+echo "Creating package..."
+cf create-package ${DROPLET_BUILD_APP} -p .
+PACKAGE_GUID=$(cf packages ${DROPLET_BUILD_APP} | tail -n 1 | cut -d" " -f 1)
+
+echo "Staging package to create droplet..."
+cf stage-package ${DROPLET_BUILD_APP} --package-guid ${PACKAGE_GUID}
+DROPLET_GUID=$(cf droplets ${DROPLET_BUILD_APP} | tail -n 1 | cut -d" " -f 1)
+echo "Created droplet ${DROPLET_GUID}"
+
+CURRENT_TIME=$(date '+%Y-%m-%dT%H-%M-%SZ')
+echo $DROPLET_GUID > admin-droplet-guid-${CURRENT_TIME}-${GIT_REF}.txt

--- a/scripts/create-droplet.sh
+++ b/scripts/create-droplet.sh
@@ -4,21 +4,28 @@ set -eux
 
 CF_SPACE=${CF_SPACE:-monitoring}
 
-[[ ! -f ./.git/short_ref ]] && $(git rev-parse --short HEAD) > ./.git/short_ref
-GIT_REF=$(cat .git/short_ref)
+
+if [[ -f .git/short_ref ]]; then
+  GIT_REF=$(cat .git/short_ref)
+else
+  GIT_REF=$(git rev-parse --short HEAD)
+fi
 DROPLET_BUILD_APP="droplet-build-admin-${GIT_REF}"
 
 echo "Creating ${DROPLET_BUILD_APP} in ${CF_SPACE}"
 cf target -s ${CF_SPACE}
 cf create-app ${DROPLET_BUILD_APP}
 
+echo "Applying droplet build app manifest..."
+cf apply-manifest -f manifest-droplet.yml --var app_name=${DROPLET_BUILD_APP}
+
 echo "Creating package..."
 cf create-package ${DROPLET_BUILD_APP} -p .
-PACKAGE_GUID=$(cf packages ${DROPLET_BUILD_APP} | tail -n 1 | cut -d" " -f 1)
+PACKAGE_GUID=$(cf curl /v3/apps/$(cf app ${DROPLET_BUILD_APP} --guid)/packages | jq -r '[.resources[] | {created_at, guid}] | sort_by(.created_at) | reverse | .[0].guid')
 
 echo "Staging package to create droplet..."
 cf stage-package ${DROPLET_BUILD_APP} --package-guid ${PACKAGE_GUID}
-DROPLET_GUID=$(cf droplets ${DROPLET_BUILD_APP} | tail -n 1 | cut -d" " -f 1)
+DROPLET_GUID=$(cf curl /v3/apps/$(cf app ${DROPLET_BUILD_APP} --guid)/droplets | jq -r '[.resources[] | {created_at, guid}] | sort_by(.created_at) | reverse | .[0].guid')
 echo "Created droplet ${DROPLET_GUID}"
 
 CURRENT_TIME=$(date '+%Y-%m-%dT%H-%M-%SZ')

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# if there's not git dir we're in concourse, because the artifact doesn't include the .git dir
+if [[ ! -d ".git" ]]; then
+
+  if [[ $(ls -l ./admin-droplet-guid-*.txt | wc -l) != 1 ]]; then
+    echo "Error:"
+    echo "Exactly one admin-droplet-guid file is expected"
+    exit 1
+  fi
+  ORIGINAL_DROPLET_GUID=$(cat ./admin-droplet-guid-*.txt)
+
+else
+
+  GIT_REF=$(git rev-parse --short HEAD)
+  if [[ ! $(ls ./admin-droplet-guid-*-${GIT_REF}.txt) ]]; then
+    echo "Error:"
+    echo "Missing admin-droplet-guid file for this commit (${GIT_REF})"
+    echo "Run ./scripts/create-droplet.sh and try again"
+    exit 1
+  fi
+  ORIGINAL_DROPLET_GUID=$(cat ./admin-droplet-guid-*-${GIT_REF}.txt)
+fi
+
+echo "Original droplet guid: ${ORIGINAL_DROPLET_GUID}"
+APP_GUID=$(cf app ${CF_APP} --guid)
+
+#
+# Copy droplet
+#
+echo "Copying droplet..."
+DROPLET_GUID=$(cf curl "/v3/droplets?source_guid=${ORIGINAL_DROPLET_GUID}" \
+  -X POST \
+  -H "Content-type: application/json" \
+  -d @<(cat <<END
+{
+    "relationships": {
+      "app": {
+        "data": {
+          "guid": "${APP_GUID}"
+        }
+      }
+    }
+}
+END
+) | jq -r ".guid")
+
+echo "Copied droplet guid: ${DROPLET_GUID}"
+
+# wait a bit for the droplet to be copied
+sleep 5
+
+#
+# Apply manifest before the deployment
+# docs:
+#   https://v3-apidocs.cloudfoundry.org/version/3.116.0/index.html#apply-a-manifest-to-a-space
+#   https://cli.cloudfoundry.org/en-US/v7/apply-manifest.html
+#
+
+echo "Applying manifest..."
+cf apply-manifest -f ${CF_MANIFEST_PATH}
+
+echo "Set the new droplet for the app"
+cf set-droplet ${CF_APP} ${DROPLET_GUID}
+
+echo "Restart the app to pickup the new droplet"
+CF_STARTUP_TIMEOUT=15 cf restart ${CF_APP} --strategy rolling


### PR DESCRIPTION
At the moment we deploy the API app by building a CloudFoundry droplet and then copying that droplet to preview/staging/prod (broadly equivalent to building a docker image and deploying that). In our other apps, though, we build the droplet in each environment as deployments happen. This is both slower and in theory less reproducible, since each environment could have issues building the app or build things differently.

This copies across the relevant scripts from the API so that we can build the droplet once and promote it through each environment.