### PR TITLE
Bump utils to 65.2.0

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -17,7 +17,7 @@ Text message pricing
 
     {{ content_metadata(
       data={
-        "Last updated": "1 April 2023"
+        "Last updated": "11 July 2023"
       }
     ) }}
 

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.2.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.2.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
 ## 65.2.0

* Update international billing rates for new text message costs from MMG.

 ## 65.1.0

* Add a few more mappings to the list of countries for postage

---

~We discussed updating content on the pricing page to highlight that these changed as of 1 April 2023 but that may have to wait for a bit until Karl is back.~ The only change Karl wants is to update the last-updated snippet :)