### PR TITLE
Don't explicitly list every SASS file in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -149,11 +149,7 @@ const javascripts = () => {
 
 
 const sass = () => {
-  return src([
-      paths.src + '/stylesheets/main*.scss',
-      paths.src + '/stylesheets/map.scss',
-      paths.src + '/stylesheets/print.scss'
-    ])
+  return src(paths.src + '/stylesheets/*.scss')
     .pipe(plugins.prettyerror())
     .pipe(plugins.sass.sync({
       includePaths: [


### PR DESCRIPTION
Instead, use globs to just grab everything.

Note that we don't need `/**/*.scss` since main.scss imports everything (and we get errors if we glob all the smaller components).

***

This implements https://github.com/alphagov/notifications-admin/pull/4764 but without the changes to the Javascript build.