### PR TITLE
Defer loading of crests and insignia

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -79,7 +79,7 @@ from app.main.validators import (
 )
 from app.models.branding import (
     GOVERNMENT_IDENTITY_SYSTEM_COLOURS,
-    GOVERNMENT_IDENTITY_SYSTEM_CRESTS_OR_INSIGNIA,
+    get_government_identity_system_crests_or_insignia,
 )
 from app.models.feedback import PROBLEM_TICKET_TYPE, QUESTION_TICKET_TYPE
 from app.models.organisation import Organisation
@@ -2606,13 +2606,15 @@ def markup_for_coloured_stripe(colour):
 
 
 class GovernmentIdentityCoatOfArmsOrInsignia(StripWhitespaceForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.coat_of_arms_or_insignia.choices = [
+            (name, markup_for_crest_or_insignia(f"{name}.png") + name)
+            for name in sorted(get_government_identity_system_crests_or_insignia())
+        ]
 
     coat_of_arms_or_insignia = GovukRadiosField(
         "Coat of arms or insignia",
-        choices=[
-            (name, markup_for_crest_or_insignia(f"{name}.png") + name)
-            for name in sorted(GOVERNMENT_IDENTITY_SYSTEM_CRESTS_OR_INSIGNIA)
-        ],
         thing="a coat of arms or insignia",
     )
 

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -15,10 +15,10 @@ from app.main.forms import (
     SearchByNameForm,
 )
 from app.models.branding import (
-    GOVERNMENT_IDENTITY_SYSTEM_CRESTS_OR_INSIGNIA,
-    INSIGNIA_ASSETS_PATH,
     AllEmailBranding,
     EmailBranding,
+    get_government_identity_system_crests_or_insignia,
+    get_insignia_asset_path,
 )
 from app.s3_client.logo_client import logo_client
 from app.utils.user import user_is_platform_admin
@@ -160,14 +160,14 @@ def create_email_branding_government_identity_logo():
 def create_email_branding_government_identity_colour():
 
     filename = request.args.get("filename")
-    if filename not in GOVERNMENT_IDENTITY_SYSTEM_CRESTS_OR_INSIGNIA:
+    if filename not in get_government_identity_system_crests_or_insignia():
         abort(400)
 
     filename = f"{filename}.png"
     form = GovernmentIdentityColour(crest_or_insignia_image_filename=filename)
 
     if form.validate_on_submit():
-        image_file_path = INSIGNIA_ASSETS_PATH / filename
+        image_file_path = get_insignia_asset_path() / filename
         logo_data = FileStorage(
             BytesIO(image_file_path.resolve().read_bytes()), filename=filename, content_type="image/png"
         )

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -267,8 +267,10 @@ GOVERNMENT_IDENTITY_SYSTEM_COLOURS = {
     "Wales Office": "#a33038",
 }
 
-INSIGNIA_ASSETS_PATH = Path(asset_fingerprinter._filesystem_path) / "images/branding/insignia/"
 
-GOVERNMENT_IDENTITY_SYSTEM_CRESTS_OR_INSIGNIA = tuple(
-    item.stem for item in INSIGNIA_ASSETS_PATH.resolve().iterdir() if item.is_file()
-)
+def get_insignia_asset_path():
+    return Path(asset_fingerprinter._filesystem_path) / "images/branding/insignia/"
+
+
+def get_government_identity_system_crests_or_insignia():
+    return tuple(item.stem for item in get_insignia_asset_path().resolve().iterdir() if item.is_file())

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -6,7 +6,7 @@ import pytest
 from flask import url_for
 from notifications_python_client.errors import HTTPError
 
-from app.models.branding import INSIGNIA_ASSETS_PATH
+from app.models.branding import get_insignia_asset_path
 from tests.conftest import create_email_branding, normalize_spaces
 
 
@@ -979,4 +979,4 @@ def test_post_create_email_branding_government_identity_form_colour(mocker, clie
 
     assert mock_save_temporary.call_args_list == [mocker.call(mocker.ANY, logo_type="email")]
     logo_bytes_io = mock_save_temporary.call_args_list[0][0][0]
-    assert logo_bytes_io.read() == (INSIGNIA_ASSETS_PATH / "HM Government.png").resolve().read_bytes()
+    assert logo_bytes_io.read() == (get_insignia_asset_path() / "HM Government.png").resolve().read_bytes()


### PR DESCRIPTION
Currently this app tries to load the images for government crests and insignia at startup time.

This means that if the files cannot be found then the app will crash on startup. This typically happens when the app is restarting because it’s noticed some changes (for example by checking out a different branch).

The files may be missing because the Gulp task to copy them into the static folder has not run yet.

Previously this wasn’t a problem because we didn’t delete the old files before copying the new ones. But as of https://github.com/alphagov/notifications-admin/pull/4710 we clean the whole directory before re-copying the assets.

This commit changes the app to not look for the images until it needs them. By this time the Gulp task should have had a chance to finish cleaning the folder and copying the images into place.