### PR TITLE
Fix requirements (unable to freeze)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ago==0.0.95
     # via -r requirements.in
 async-timeout==4.0.2
     # via redis
-awscli==1.25.57
+awscli==1.29.5
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
@@ -17,9 +17,9 @@ blinker==1.5
     #   -r requirements.in
     #   gds-metrics
     #   sentry-sdk
-boto3==1.24.56
+boto3==1.28.5
     # via notifications-utils
-botocore==1.27.56
+botocore==1.31.5
     # via
     #   awscli
     #   boto3
@@ -174,7 +174,7 @@ pytz==2022.6
     # via
     #   -r requirements.in
     #   notifications-utils
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   awscli
     #   notifications-utils


### PR DESCRIPTION
For the last few days we've been unable to run `make freeze-requirements`, getting errors like this:

```
...
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
...
pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1

make: *** [freeze-requirements] Error 1
```

From some searches online this seems related to a release of cython3 that just came out, which PyYAML uses.

yaml/pyyaml#724

There is now a new release of PyYAML (6.0.1) that fixes the issue, so let's bump to that. In order to bump to that, we need to bump awscli, which means bumping boto3 and botocore.