### PR TITLE
Update formatting instructions

### DIFF
--- a/app/templates/views/guidance/using-notify/formatting.html
+++ b/app/templates/views/guidance/using-notify/formatting.html
@@ -6,6 +6,22 @@
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Using Notify' %}
+{% set bullets_instructions -%}
+  <p class="govuk-body">Introduce bullet points with a lead-in line ending in a colon:</p>
+  <p class="govuk-body"></p>
+  <p class="govuk-body">* leave one empty line space after the lead-in line<br>
+      * use * (asterisk) or - (dash) followed by a space to add an item<br>
+      * start each item with a lowercase letter, do not end with a full stop<br>
+      * leave one empty line space after the last item<br>
+  </p>
+{%- endset %}
+{% set numbered_list_instructions -%}
+  <p class="govuk-body">1. Leave one empty line space before starting your list.<br>
+      2. Enter a number followed by a full stop and a space to add an item.<br>
+      3. Start each item with a capital letter and end it with a full stop.<br>
+      4. Leave one empty line space after the last item.<br>
+  </p>
+{%- endset %}
 
 {% block per_page_title %}
   Formatting emails and letters
@@ -26,45 +42,43 @@
 <h2 class="heading-medium">Formatting options</h2>
  <p class="govuk-body">Email templates can include:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li><a class="govuk-link" href="#bullets">bullets</a></li>
-    <li><a class="govuk-link" href="#headings-and-subheadings">headings</a></li>
-    <li><a class="govuk-link" href="#horizontal-lines">horizontal lines</a></li>
-    <li><a class="govuk-link" href="#inset-text">inset text</a></li>
-    <li><a class="govuk-link" href="#numbered-steps">numbered steps</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#bullets">bullet points</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#headings-and-subheadings">headings</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#horizontal-lines">horizontal lines</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#inset-text">inset text</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#numbered-steps">numbered steps</a></li>
   </ul>
 
  <p class="govuk-body">Letters can include:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li><a class="govuk-link" href="#bullets">bullets</a></li>
-    <li><a class="govuk-link" href="#headings-and-subheadings">headings</a></li>
-    <li><a class="govuk-link" href="#numbered-steps">numbered steps</a></li>
-    <li><a class="govuk-link" href="#page-breaks">page breaks</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#bullets">bullet points</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#headings-and-subheadings">headings</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#numbered-steps">numbered steps</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#page-breaks">page breaks</a></li>
   </ul>
 
 <p class="govuk-body">You cannot use bold, italics, underlined text, different typefaces or fonts. This is because they can make it harder for people to read what you’ve written.</p>
 
 <h2 class="heading-medium">Guidance</h2>
-<h3 class="heading-small" id="bullets">Bullets</h3>
+<h3 class="heading-small" id="bullets">Bullet points</h3>
 
-<p class="govuk-body">Use bullets to help words or phrases stand out in your emails and letters.</p>
+<p class="govuk-body">Use bullet points to help words or phrases stand out in your emails and letters.</p>
 
-  <p class="govuk-body">Introduce bullet points with a lead-in line ending in a colon. Start each item with a lowercase letter, and do not use a full stop at the end.</p>
-<p class="govuk-body">To create a bulleted list:</p>
-<ul class="govuk-list govuk-list--bullet">
-    <li>leave one empty line space after the lead-in line</li>
-    <li>start each item with * (asterisk) or - (dash)</li>
-    <li>make sure there is one space after the asterisk or dash</li>
-    <li>leave one empty line space after the last item</li>
-  </ul>
+  <p class="govuk-body">Copy this example to add bullet points:</p>
+
+{{ govukInsetText({"html": bullets_instructions,
+  "classes": "govuk-!-margin-top-0"})
+}}
+
 <p class="govuk-body">To create sub-items, add an indent of 2 spaces before the asterisk or dash.</p>
 <p class="govuk-body">There’s more <a class="govuk-link govuk-link--no-visited-state"
-    href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#bullet-points-steps">guidance about bullets on GOV.UK</a>.</p>
+    href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#bullet-points-steps">guidance about bullet points on GOV.UK</a>.</p>
 
 <h3 class="heading-small" id="headings-and-subheadings">Headings</h3>
-<p class="govuk-body">Use headings to break up content in your emails and letters.</p>
-<p class="govuk-body">For letters, use a main heading to tell recipients what your letter is about. Use headings to break up content in a letter template.</p>
-<p class="govuk-body">For emails, use subheadings to break up content. Use as many subheadings as you need to in emails, but the first subheading must come after a heading.</p>
-<p class="govuk-body">Write all headings in sentence case.</p>
+<p class="govuk-body">Use a heading to tell recipients what your email or letter is about.</p>
+<p class="govuk-body">For emails, use subheadings to break up the rest of your content. Your first subheading must come after a heading.</p>
+<p class="govuk-body">For letters, use headings to break up the rest of your content.</p>
+<p class="govuk-body">Write all headings and subheadings in sentence case.</p>
 <p class="govuk-body">Use one hashtag followed by a space for a heading in emails and letters, for example:</p>
 
 {{ govukInsetText({"html": "# This is a heading"}) }}
@@ -78,10 +92,11 @@
 
 <h3 class="heading-small" id="horizontal-lines">Horizontal lines</h3>
 <p class="govuk-body">Use a horizontal line to create separate sections in an email template.</p>
-<p class="govuk-body">To add a horizontal line between 2 paragraphs, use 3 dashes. For example:</p>
+<p class="govuk-body">To add a horizontal line between 2 paragraphs, use 3 dashes. Leave one empty line space after the first paragraph. For example:</p>
 
 {{ govukInsetText({
   "html": '<p class="govuk-body">First paragraph</p>
+            <p class="govuk-body"></p>
             <p class="govuk-body" style="letter-spacing: 1px;">---</p>
             <p class="govuk-body">Second paragraph</p>',
   "classes": "govuk-!-margin-top-0"})
@@ -97,7 +112,7 @@
   </ul>
 <p class="govuk-body">To add inset text, use a ^ (caret). For example:</p>
 
-{{ govukInsetText({"html": "^ You must tell us if your circumstances change"}) }}
+{{ govukInsetText({"html": "^ You must tell us if your circumstances change."}) }}
 
 <p class="govuk-body">Use inset text very sparingly - it’s less effective if it’s overused.</p>
 <p class="govuk-body">There’s more <a class="govuk-link govuk-link--no-visited-state"
@@ -105,14 +120,14 @@
 
 <h3 class="heading-small" id="numbered-steps">Numbered steps</h3>
 <p class="govuk-body">Use numbered steps instead of bullet points to guide a user through a process, or when the order of the items in a list is relevant.</p>
-<p class="govuk-body">You do not need a lead-in line for numbered lists. Items in a numbered list should end in a full stop because each one should be a complete sentence.</p>
-<p class="govuk-body">To create a numbered list:</p>
-   <ol class="govuk-list govuk-list--number">
-    <li>Leave one empty line space.</li>
-    <li>Start each item with ‘1. ’ (leaving one space after the full stop)</li>
-    <li>Leave one empty line space after the last item.</li>
-  </ol>
-<p class="govuk-body">To create sub-items, add an indent of 2 spaces before ‘1. ’.</p>
+<p class="govuk-body">You do not need a lead-in line for numbered lists.</p>
+<p class="govuk-body">Copy this example to add a numbered list:</p>
+
+{{ govukInsetText({"html": numbered_list_instructions,
+  "classes": "govuk-!-margin-top-0"})
+}}
+
+<p class="govuk-body">To create sub-items, add an indent of 2 spaces before the number.</p>
 <p class="govuk-body">There’s more <a class="govuk-link govuk-link--no-visited-state"
     href="https://design-system.service.gov.uk/styles/typography/#numbered-lists">guidance about numbered lists in the GOV.UK Design System</a>.</p>
 


### PR DESCRIPTION
This PR makes a few changes to our formatting instructions.

## 1. Reformat the bullet and numbered list instructions

There’s no reason to treat bullets and numbered lists differently to the other formatting options on this page. Presenting the examples as inset text is consistent and makes it easier for users to copy the correct Markdown.

## 2. Rewrite the headings instructions to make them clearer and less repetitious

Now that we’ve decided not to allow subheadings for letters, I think we can simplify our guidance.

## 3. Correct the horizontal line instructions and example

Explain that you need a line break before the dashes when adding a horizontal line. We’re doing this because David told us about the case of a user who didn’t include a line break and accidentally made their content look like bold.