### PR TITLE
Preview invalid attachment upload

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -944,7 +944,7 @@ def letter_template_attach_pages(service_id, template_id):
                 template=template,
                 error=error,
                 letter_attachment_image_url=letter_attachment_image_url,
-                page_numbers=[*range(1, attachment_page_count + 1)],
+                page_numbers=_get_page_numbers(attachment_page_count),
             ),
             400 if error else 200,
         )
@@ -963,7 +963,7 @@ def letter_template_attach_pages(service_id, template_id):
         template=template,
         service_id=service_id,
         letter_attachment_image_url=letter_attachment_image_url,
-        page_numbers=list(range(1, attachment_page_count + 1)),
+        page_numbers=_get_page_numbers(attachment_page_count),
         error=error,
     )
 
@@ -1019,7 +1019,7 @@ def letter_template_edit_pages(template_id, service_id):
             service_id=service_id,
             attachment_id=template.attachment.id,
         ),
-        page_numbers=list(range(1, template.attachment.page_count + 1)),
+        page_numbers=_get_page_numbers(template.attachment.page_count),
         error=error,
     )
 
@@ -1151,3 +1151,7 @@ def view_invalid_letter_attachment_as_preview(service_id, file_id):
         return TemplatePreview.from_invalid_pdf_file(pdf_file, page, is_an_attachment=True)
     else:
         return TemplatePreview.from_valid_pdf_file(pdf_file, page)
+
+
+def _get_page_numbers(page_count):
+    return [*range(1, page_count + 1)]

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -919,7 +919,7 @@ def letter_template_attach_pages(service_id, template_id):
     form = PDFUploadForm()
     error = {}
     letter_attachment_image_url = None
-    attachment_page_count = None
+    attachment_page_count = 0
     if form.validate_on_submit():
         upload_id = uuid.uuid4()
         try:
@@ -937,7 +937,6 @@ def letter_template_attach_pages(service_id, template_id):
         error = get_error_from_upload_form(form.file.errors[0])
 
     if not template.attachment:
-        attachment_page_count = attachment_page_count or 0
         return (
             render_template(
                 "views/templates/attach-pages.html",

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1151,6 +1151,6 @@ def view_invalid_letter_attachment_as_preview(service_id, file_id):
     invalid_pages = json.loads(metadata.get("invalid_pages", "[]"))
 
     if metadata.get("message") == "content-outside-printable-area" and page in invalid_pages:
-        return TemplatePreview.from_invalid_pdf_file(pdf_file, page)
+        return TemplatePreview.from_invalid_pdf_file(pdf_file, page, is_an_attachment=True)
     else:
         return TemplatePreview.from_valid_pdf_file(pdf_file, page)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -927,13 +927,11 @@ def letter_template_attach_pages(service_id, template_id):
         except LetterAttachmentFormError as e:
             error = e.as_error_dict()
             attachment_page_count = error.get("attachment_page_count", 0)
-            letter_attachment_image_url = (
-                url_for(
-                    "no_cookie.view_invalid_letter_attachment_as_preview",
-                    service_id=service_id,
-                    file_id=upload_id,
-                ),
-            )[0]
+            letter_attachment_image_url = url_for(
+                "no_cookie.view_invalid_letter_attachment_as_preview",
+                service_id=service_id,
+                file_id=upload_id,
+            )
 
     if form.file.errors:
         error = get_error_from_upload_form(form.file.errors[0])

--- a/app/s3_client/s3_letter_upload_client.py
+++ b/app/s3_client/s3_letter_upload_client.py
@@ -66,11 +66,11 @@ class LetterMetadata:
         return value
 
 
-def get_letter_s3_object(service_id, file_id, bucket_name="S3_BUCKET_TRANSIENT_UPLOADED_LETTERS"):
+def get_letter_s3_object(service_id, file_id):
     try:
         file_location = get_transient_letter_file_location(service_id, file_id)
         s3 = resource("s3")
-        return s3.Object(current_app.config[bucket_name], file_location).get()
+        return s3.Object(current_app.config["S3_BUCKET_TRANSIENT_UPLOADED_LETTERS"], file_location).get()
     except botocore.exceptions.ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchKey":
             raise LetterNotFoundError(f"Letter not found for service {service_id} and file {file_id}") from e
@@ -90,7 +90,7 @@ def get_letter_metadata(service_id, file_id):
 
 
 def get_attachment_pdf_and_metadata(service_id, file_id):
-    s3_object = get_letter_s3_object(service_id, file_id, bucket_name="S3_BUCKET_TRANSIENT_UPLOADED_LETTERS")
+    s3_object = get_letter_s3_object(service_id, file_id)
     pdf = s3_object["Body"].read()
     return pdf, s3_object["Metadata"]
 

--- a/app/s3_client/s3_letter_upload_client.py
+++ b/app/s3_client/s3_letter_upload_client.py
@@ -66,15 +66,6 @@ class LetterMetadata:
         return value
 
 
-class LetterAttachmentMetadata:
-    def __init__(self, metadata):
-        self._metadata = metadata
-
-    def get(self, key, default=None):
-        value = self._metadata.get(key, default)
-        return value
-
-
 def get_letter_s3_object(service_id, file_id, bucket_name="S3_BUCKET_TRANSIENT_UPLOADED_LETTERS"):
     try:
         file_location = get_transient_letter_file_location(service_id, file_id)
@@ -101,7 +92,7 @@ def get_letter_metadata(service_id, file_id):
 def get_attachment_pdf_and_metadata(service_id, file_id):
     s3_object = get_letter_s3_object(service_id, file_id, bucket_name="S3_BUCKET_TRANSIENT_UPLOADED_LETTERS")
     pdf = s3_object["Body"].read()
-    return pdf, LetterAttachmentMetadata(s3_object["Metadata"])
+    return pdf, s3_object["Metadata"]
 
 
 def upload_letter_attachment_to_s3(data, *, file_location, page_count, original_filename):

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -68,12 +68,13 @@ class TemplatePreview(AuthPreview):
         return resp.content, resp.status_code, cls.get_allowed_headers(resp.headers)
 
     @classmethod
-    def from_invalid_pdf_file(cls, pdf_file, page):
+    def from_invalid_pdf_file(cls, pdf_file, page, is_an_attachment=False):
         pdf_page = extract_page_from_pdf(BytesIO(pdf_file), int(page) - 1)
 
         resp = requests.post(
             "{}/precompiled/overlay.png{}".format(
-                current_app.config["TEMPLATE_PREVIEW_API_HOST"], "?page_number={}".format(page)
+                current_app.config["TEMPLATE_PREVIEW_API_HOST"],
+                f"?page_number={page}&is_an_attachment={is_an_attachment}",
             ),
             data=pdf_page,
             headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -52,7 +52,7 @@
         {% for page_number in page_numbers %}
         <div
             class="letter page--{{ loop.cycle('odd', 'even') }}{% if loop.first %} page--first{% endif %}{% if loop.last %} page--last{% endif %}">
-            <img src="{{ letter_attachment_image_url[0] }}?page={{ page_number }}" alt=""
+            <img src="{{ letter_attachment_image_url }}?page={{ page_number }}" alt=""
                 loading="{{ 'eager' if (page_number==1) else 'lazy' }}">
         </div>
         {% endfor %}

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -46,4 +46,16 @@
         show_errors=False
         )}}
     </div>
+
+    <div class="template-container">
+
+        {% for page_number in page_numbers %}
+        <div
+            class="letter page--{{ loop.cycle('odd', 'even') }}{% if loop.first %} page--first{% endif %}{% if loop.last %} page--last{% endif %}">
+            <img src="{{ letter_attachment_image_url[0] }}?page={{ page_number }}" alt=""
+                loading="{{ 'eager' if (page_number==1) else 'lazy' }}">
+        </div>
+        {% endfor %}
+
+    </div>
 {% endblock %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -861,6 +861,9 @@ def test_post_attach_pages_errors_when_content_outside_printable_area(
     service_one["permissions"] = ["extra_letter_formatting"]
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
+    # page count for the attachment
+    mocker.patch("app.main.views.templates.pdf_page_count", return_value=1)
+
     mock_s3_upload = mocker.patch("app.main.views.templates.upload_letter_to_s3")
 
     mock_sanitise_response = Mock()
@@ -899,6 +902,12 @@ def test_post_attach_pages_errors_when_content_outside_printable_area(
         "main.letter_template_attach_pages", service_id=SERVICE_ONE_ID, template_id=sample_uuid()
     )
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
+
+    letter_images = page.select("main img")
+    assert len(letter_images) == 1
+    assert letter_images[0]["src"] == url_for(
+        "no_cookie.view_invalid_letter_attachment_as_preview", service_id=SERVICE_ONE_ID, file_id=fake_uuid, page=1
+    )
 
 
 def test_post_attach_pages_errors_when_base_template_plus_attachment_too_long(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -4,7 +4,7 @@ from functools import partial
 from unittest.mock import ANY, Mock
 
 import pytest
-from flask import g, url_for
+from flask import g, make_response, url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 from requests import RequestException
@@ -3270,3 +3270,53 @@ def test_content_count_json_endpoint_for_unsupported_template_types(
         content="foo",
         _expected_status=404,
     )
+
+
+@pytest.mark.parametrize(
+    "invalid_pages, page_requested, overlay_expected",
+    (
+        ("[1, 2]", 1, True),
+        ("[1, 2]", 2, True),
+        ("[1, 2]", 3, False),
+        ("[]", 1, False),
+    ),
+)
+def test_letter_attachment_preview_image_shows_overlay_when_content_outside_printable_area_on_a_page(
+    mocker,
+    client_request,
+    mock_get_service,
+    fake_uuid,
+    invalid_pages,
+    page_requested,
+    overlay_expected,
+):
+    mocker.patch(
+        "app.main.views.templates.get_attachment_pdf_and_metadata",
+        return_value=(
+            "pdf_file",
+            {
+                "message": "content-outside-printable-area",
+                "invalid_pages": invalid_pages,
+            },
+        ),
+    )
+    template_preview_mock_valid = mocker.patch(
+        "app.main.views.templates.TemplatePreview.from_valid_pdf_file", return_value=make_response("page.html", 200)
+    )
+    template_preview_mock_invalid = mocker.patch(
+        "app.main.views.templates.TemplatePreview.from_invalid_pdf_file", return_value=make_response("page.html", 200)
+    )
+
+    client_request.get_response(
+        "no_cookie.view_invalid_letter_attachment_as_preview",
+        file_id=fake_uuid,
+        service_id=SERVICE_ONE_ID,
+        page=page_requested,
+    )
+
+    if overlay_expected:
+        template_preview_mock_invalid.assert_called_once_with("pdf_file", page_requested)
+        assert template_preview_mock_valid.called is False
+    else:
+        template_preview_mock_valid.assert_called_once_with("pdf_file", page_requested)
+        assert template_preview_mock_invalid.called is False

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -3281,7 +3281,7 @@ def test_content_count_json_endpoint_for_unsupported_template_types(
         ("[]", 1, False),
     ),
 )
-def test_letter_attachment_preview_image_shows_overlay_when_content_outside_printable_area_on_a_page(
+def test_letter_attachment_preview_image_shows_overlay_when_content_outside_printable_area(
     mocker,
     client_request,
     mock_get_service,
@@ -3315,7 +3315,7 @@ def test_letter_attachment_preview_image_shows_overlay_when_content_outside_prin
     )
 
     if overlay_expected:
-        template_preview_mock_invalid.assert_called_once_with("pdf_file", page_requested)
+        template_preview_mock_invalid.assert_called_once_with("pdf_file", page_requested, is_an_attachment=True)
         assert template_preview_mock_valid.called is False
     else:
         template_preview_mock_valid.assert_called_once_with("pdf_file", page_requested)

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1067,6 +1067,7 @@ def test_post_attach_pages_doesnt_replace_existing_attachment_if_new_attachment_
 ):
     service_one["permissions"] = ["extra_letter_formatting"]
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
+    mocker.patch("uuid.uuid4", return_value=fake_uuid)
 
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
@@ -1096,6 +1097,13 @@ def test_post_attach_pages_doesnt_replace_existing_attachment_if_new_attachment_
     )
     # Should not have a ‘Remove attachment’ link
     assert not page.select(".js-stick-at-bottom-when-scrolling .govuk-link--destructive")
+
+    # should show preview of invalid attachment
+    letter_images = page.select("main img")
+    assert len(letter_images) == 1
+    assert letter_images[0]["src"] == url_for(
+        "no_cookie.view_invalid_letter_attachment_as_preview", service_id=SERVICE_ONE_ID, file_id=fake_uuid, page=1
+    )
 
 
 def test_save_letter_attachment_saves_to_s3_and_db_and_redirects(notify_admin, service_one, mocker):

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -203,6 +203,7 @@ EXCLUDED_ENDPOINTS = set(
             "no_cookie.check_notification_preview",
             "no_cookie.letter_branding_preview_image",
             "no_cookie.send_test_preview",
+            "no_cookie.view_invalid_letter_attachment_as_preview",
             "no_cookie.view_letter_attachment_preview",
             "no_cookie.view_letter_template_preview",
             "no_cookie.view_template_version_preview",

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -173,7 +173,7 @@ def test_from_invalid_pdf_file_makes_request(mocker, client_request):
 
     assert response == ("a", "b", {"content-type": "image/png"}.items())
     request_mock.assert_called_once_with(
-        "http://localhost:9999/precompiled/overlay.png?page_number=1",
+        "http://localhost:9999/precompiled/overlay.png?page_number=1&is_an_attachment=False",
         data=b"pdf page",
         headers={"Authorization": "Token my-secret-key"},
     )

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -204,6 +204,7 @@
     "/services/<uuid:service_id>/notifications/<template_type:message_type>",
     "/services/<uuid:service_id>/notifications/<template_type:message_type>.json",
     "/services/<uuid:service_id>/past-alerts",
+    "/services/<uuid:service_id>/preview-invalid-attachment-image/<uuid:file_id>",
     "/services/<uuid:service_id>/preview-letter-image/<uuid:file_id>",
     "/services/<uuid:service_id>/preview-letter/<uuid:file_id>",
     "/services/<uuid:service_id>/previous-alerts/<uuid:broadcast_message_id>",


### PR DESCRIPTION
Both when there is a pre-existing attachment for that template, and if there is not.

Needs https://github.com/alphagov/notifications-template-preview/pull/747 to be merged in first

Screenshots:

### no pre-existing attachment, content outside printable area 
![Screenshot 2023-07-21 at 15 03 15](https://github.com/alphagov/notifications-admin/assets/20957548/0e48e0b4-1ae5-4fa2-bb57-616c9ad3f238)


### no pre-existing attachment, different error that doesnt need overlay
![Screenshot 2023-07-20 at 16 28 55](https://github.com/alphagov/notifications-admin/assets/20957548/e9aed4de-88c5-4fb9-9512-984f0a293402)

### with pre-existing attachment, content outside printable area 
![Screenshot 2023-07-21 at 15 04 32](https://github.com/alphagov/notifications-admin/assets/20957548/5c4c240b-007f-49d3-aa5c-a6dc88b93362)



Story ticket: https://trello.com/c/eisYQprO/373-show-preview-of-new-attachment-when-validation-fails
