### PR TITLE
Fix leaky path style in folder SVG

### DIFF
--- a/app/templates/components/svgs.html
+++ b/app/templates/components/svgs.html
@@ -34,15 +34,15 @@
   <svg xmlns="http://www.w3.org/2000/svg" width="26" height="20" viewBox="0 0 26 20"
     {%- if alt %} aria-labeledby="{{ id }}" role="img"
     {%- else %} aria-hidden="true" focusable="false"{% endif %}
-    {%- if classes %} class="{{ classes }}"{% endif -%}
+    class="svg-folder-icon{%- if classes %} {{ classes }}{% endif -%}"
   >
     <style><![CDATA[
-      path {
+      .svg-folder-icon > path {
         fill: #dee0e2;
       }
 
       @media (forced-colors: active) {
-        path {
+        .svg-folder-icon > path {
           fill: none;
         }
       }


### PR DESCRIPTION
Makes the selector targeting the `<path>` element in the folder icon SVG use a unique class so it doesn't apply to all `<path>`s in the document.

This was causing the GOV.UK crown to be coloured the same grey as the folder icon.

## Current

<img width="244" alt="grey_govuk_crown" src="https://github.com/alphagov/notifications-admin/assets/87140/67540831-399b-4e30-a9a5-4f0623eb33e9">

## Proposed

<img width="244" alt="white_govuk_crown" src="https://github.com/alphagov/notifications-admin/assets/87140/a4bd963d-599d-4b50-8b58-2018cd3c8a63">
