### PR TITLE
Redis

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -4,4 +4,6 @@ import os
 
 def extract_cloudfoundry_config():
     vcap_services = json.loads(os.environ["VCAP_SERVICES"])
-    os.environ["REDIS_URL"] = vcap_services["redis"][0]["credentials"]["uri"]
+    # redis config
+    if "REDIS_URL" not in os.environ:
+        os.environ["REDIS_URL"] = vcap_services["redis"][0]["credentials"]["uri"]

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -49,6 +49,9 @@ applications:
       ROUTE_SECRET_KEY_1: '{{ ROUTE_SECRET_KEY_1 }}'
       ROUTE_SECRET_KEY_2: '{{ ROUTE_SECRET_KEY_2 }}'
       METRICS_BASIC_AUTH_TOKEN: {{ METRICS_BASIC_AUTH_TOKEN }}
+      {% if REDIS_URL is defined %}
+      REDIS_URL: '{{ REDIS_URL }}'
+      {% endif %}
 
       AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID }}'
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'


### PR DESCRIPTION
Started configuring the NOTIFY_REDIS_URL to be made available to PaaS apps to use the redis endpoint in the notify-preview environment.
I have not done any work on credentials yet
Please see my comments regarding the overwriting of VCAP_SERVICES by hardcoding the value for the url for redis on notify-preview