### PR TITLE
Restrict negative values for rate limits

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -47,8 +47,10 @@ from wtforms.validators import (
     DataRequired,
     InputRequired,
     Length,
+    NumberRange,
     Optional,
     Regexp,
+    StopValidation,
 )
 
 from app import asset_fingerprinter, current_organisation
@@ -329,7 +331,7 @@ class GovukIntegerField(GovukTextInputField):
         if self.data:
 
             if not isinstance(self.data, int):
-                raise ValidationError(f"{sentence_case(self.things)} must be a whole number")
+                raise StopValidation(f"{sentence_case(self.things)} must be a whole number")
 
             if self.data > self.POSTGRES_MAX_INT:
                 raise ValidationError(
@@ -1222,7 +1224,7 @@ class AdminServiceSMSAllowanceForm(StripWhitespaceForm):
     free_sms_allowance = GovukIntegerField(
         "Numbers of text message fragments per year",
         things="text message fragments",
-        validators=[InputRequired(message="Cannot be empty")],
+        validators=[InputRequired(message="Cannot be empty"), NumberRange(min=0)],
     )
 
 
@@ -1230,7 +1232,7 @@ class AdminServiceMessageLimitForm(StripWhitespaceForm):
     message_limit = GovukIntegerField(
         "",
         things="number of messages",
-        validators=[DataRequired(message="Cannot be empty")],
+        validators=[DataRequired(message="Cannot be empty"), NumberRange(min=0)],
     )
 
     def __init__(self, notification_type, *args, **kwargs):
@@ -1251,7 +1253,7 @@ class AdminServiceRateLimitForm(StripWhitespaceForm):
     rate_limit = GovukIntegerField(
         "Number of messages the service can send in a rolling 60 second window",
         things="number of messages",
-        validators=[DataRequired(message="Cannot be empty")],
+        validators=[DataRequired(message="Cannot be empty"), NumberRange(min=0)],
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1224,7 +1224,10 @@ class AdminServiceSMSAllowanceForm(StripWhitespaceForm):
     free_sms_allowance = GovukIntegerField(
         "Numbers of text message fragments per year",
         things="text message fragments",
-        validators=[InputRequired(message="Cannot be empty"), NumberRange(min=0)],
+        validators=[
+            InputRequired(message="Cannot be empty"),
+            NumberRange(min=0, message="Number must be greater than or equal to 0"),
+        ],
     )
 
 
@@ -1232,7 +1235,10 @@ class AdminServiceMessageLimitForm(StripWhitespaceForm):
     message_limit = GovukIntegerField(
         "",
         things="number of messages",
-        validators=[DataRequired(message="Cannot be empty"), NumberRange(min=0)],
+        validators=[
+            DataRequired(message="Cannot be empty"),
+            NumberRange(min=0, message="Number must be greater than or equal to 0"),
+        ],
     )
 
     def __init__(self, notification_type, *args, **kwargs):
@@ -1253,7 +1259,10 @@ class AdminServiceRateLimitForm(StripWhitespaceForm):
     rate_limit = GovukIntegerField(
         "Number of messages the service can send in a rolling 60 second window",
         things="number of messages",
-        validators=[DataRequired(message="Cannot be empty"), NumberRange(min=0)],
+        validators=[
+            DataRequired(message="Cannot be empty"),
+            NumberRange(min=0, message="Number must be greater than or equal to 0"),
+        ],
     )
 
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1014,7 +1014,6 @@ def service_delete_sms_sender(service_id, sms_sender_id):
 @main.route("/services/<uuid:service_id>/service-settings/set-free-sms-allowance", methods=["GET", "POST"])
 @user_is_platform_admin
 def set_free_sms_allowance(service_id):
-
     form = AdminServiceSMSAllowanceForm(free_sms_allowance=current_service.free_sms_fragment_limit)
 
     if form.validate_on_submit():

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3988,7 +3988,7 @@ def test_should_set_per_minute_rate_limit(
             "main.set_per_minute_rate_limit",
             {},
             {"rate_limit": "-1"},
-            "Error: Number must be at least 0.",
+            "Error: Number must be greater than or equal to 0",
             {},
         ),
         (
@@ -4009,7 +4009,7 @@ def test_should_set_per_minute_rate_limit(
             "main.set_per_day_message_limit",
             {"notification_type": "email"},
             {"message_limit": "-1"},
-            "Error: Number must be at least 0.",
+            "Error: Number must be greater than or equal to 0",
             {},
         ),
         (
@@ -4030,7 +4030,7 @@ def test_should_set_per_minute_rate_limit(
             "main.set_free_sms_allowance",
             {},
             {"free_sms_allowance": "-1"},
-            "Error: Number must be at least 0.",
+            "Error: Number must be greater than or equal to 0",
             {"app.billing_api_client.get_free_sms_fragment_limit_for_year": 0},
         ),
     ),


### PR DESCRIPTION
Not too fussed about the error text (but we can customise it as needed) because it's just a platform admin form. But feels like we should at least stop people being able to enter negative numbers.

<img width="971" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/ce824f81-383e-4257-bbb4-f59ca4592fc3">
