### PR TITLE
Add error summaries to base templates

### DIFF
--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -122,6 +122,7 @@ def platform_admin_update_email_branding(branding_id, logo=None):
             cdn_url=current_app.config["LOGO_CDN_DOMAIN"],
             logo=logo_key,
             back_link=url_for("main.platform_admin_view_email_branding", branding_id=email_branding.id),
+            error_summary_enabled=True,
         ),
         400 if form.errors else 200,
     )
@@ -255,6 +256,7 @@ def platform_admin_create_email_branding(logo=None):
             cdn_url=current_app.config["LOGO_CDN_DOMAIN"],
             logo=temporary_logo_key,
             back_link=back_link,
+            error_summary_enabled=True,
         ),
         400 if form.errors else 200,
     )

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -234,7 +234,11 @@ def invite_org_user(org_id):
         flash(f"Invite sent to {invited_org_user.email_address}", "default_with_tick")
         return redirect(url_for(".manage_org_users", org_id=org_id))
 
-    return render_template("views/organisations/organisation/users/invite-org-user.html", form=form)
+    return render_template(
+        "views/organisations/organisation/users/invite-org-user.html",
+        form=form,
+        error_summary_enabled=True,
+    )
 
 
 @main.route("/organisations/<uuid:org_id>/users/<uuid:user_id>", methods=["GET", "POST"])

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -78,6 +78,7 @@ def platform_admin_search():
         users=users,
         services=services,
         organisations=organisations,
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -488,6 +488,7 @@ def email_branding_choose_banner_colour(service_id):
                 **_email_branding_flow_query_params(request),
             ),
             abandon_flow_link=abandon_flow_link,
+            error_summary_enabled=True,
         ),
         400 if form.errors else 200,
     )

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -260,6 +260,7 @@ def email_branding_choose_logo(service_id):
             "views/service-settings/branding/new/email-branding-choose-logo.html",
             form=form,
             branding_choice=branding_choice,
+            error_summary_enabled=True,
         ),
         400 if form.errors else 200,
     )

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -452,6 +452,7 @@ def email_branding_choose_banner_type(service_id):
                 service_id=current_service.id,
                 **_email_branding_flow_query_params(request),
             ),
+            error_summary_enabled=True,
         ),
         400 if form.errors else 200,
     )

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -213,6 +213,7 @@ def email_branding_enter_government_identity_logo_text(service_id):
         back_link=url_for(
             ".email_branding_request_government_identity_logo", service_id=service_id, branding_choice=branding_choice
         ),
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -686,6 +686,7 @@ def letter_branding_upload_branding(service_id):
         ),
         # TODO: Create branding-specific zendesk flow that creates branding ticket (see .letter_branding_request)
         abandon_flow_link=url_for(".letter_branding_request", service_id=current_service.id),
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -307,6 +307,7 @@ def email_branding_upload_logo(service_id):
             form=form,
             back_link=back_link,
             abandon_flow_link=abandon_flow_link,
+            error_summary_enabled=True,
         ),
         400 if form.errors else 200,
     )

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -752,4 +752,5 @@ def letter_branding_set_name(service_id):
         ),
         temp_filename=letter_filename_for_db_from_logo_key(temporary_logo_key),
         form=form,
+        error_summary_enabled=True,
     )

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -385,6 +385,7 @@ def email_branding_set_alt_text(service_id):
         ),
         email_preview_data=email_branding_data,
         form=form,
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1155,6 +1155,7 @@ def service_set_branding_add_to_branding_pool_step(service_id, notification_type
         back_link=url_for(".service_set_branding", service_id=current_service.id, notification_type=notification_type),
         form=form,
         branding_name=branding_name,
+        error_summary_enabled=True,
     )
 
 

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -1,5 +1,7 @@
 {% extends "admin_template.html" %}
 
+{% from "components/error-summary.html" import errorSummary %}
+
 {% block per_page_title %}
   {% block org_page_title %}{% endblock %} – {{ current_org.name }}
 {% endblock %}
@@ -26,6 +28,11 @@
         <main class="govuk-main-wrapper column-main govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main" >
           {% block content %}
             {% include 'flash_messages.html' %}
+            {% block errorSummary %}
+              {% if error_summary_enabled %}
+                {% if form and form.errors %}{{ errorSummary(form) }}{% endif %}
+              {% endif %}
+            {% endblock %}
             {% block maincolumn_content %}{% endblock %}
           {% endblock %}
         </main>

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -3,22 +3,17 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/error-summary.html" import errorSummary %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   {{ '{} email branding'.format('Update' if email_branding else 'Add')}}
 {% endblock %}
 
-
 {% block backLink %}
   {{ govukBackLink({ "href": back_link }) }}
 {% endblock %}
 
 {% block platform_admin_content %}
-
-  {{ errorSummary(form) }}
-
   {{ page_header('{} email branding'.format('Update' if email_branding else 'Add')) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">

--- a/app/templates/views/organisations/organisation/users/invite-org-user.html
+++ b/app/templates/views/organisations/organisation/users/invite-org-user.html
@@ -4,7 +4,6 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/error-summary.html" import errorSummary %}
 
 {% block org_page_title %}
   Invite a team member
@@ -15,9 +14,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-
-  {{ errorSummary(form) }}
-
   {{ page_header("Invite a team member") }}
 
   {% call form_wrapper() %}

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -1,5 +1,7 @@
 {% extends "withoutnav_template.html" %}
 
+{% from "components/error-summary.html" import errorSummary %}
+
 {% block main %}
 <div class="govuk-width-container {{ mainClasses }}">
     <div class="navigation-service">
@@ -41,6 +43,11 @@
         <main class="govuk-main-wrapper column-main govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main">
           {% block content %}
             {% include 'flash_messages.html' %}
+            {% block errorSummary %}
+              {% if error_summary_enabled %}
+                {% if form and form.errors %}{{ errorSummary(form) }}{% endif %}
+              {% endif %}
+            {% endblock %}
             {% block platform_admin_content %}{% endblock %}
           {% endblock %}
         </main>

--- a/app/templates/views/platform-admin/search.html
+++ b/app/templates/views/platform-admin/search.html
@@ -2,15 +2,12 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/tabs/macro.html" import govukTabs %}
-{% from "components/error-summary.html" import errorSummary %}
 
 {% block per_page_title %}
   Search
 {% endblock %}
 
 {% block platform_admin_content %}
-  {{ errorSummary(form) }}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {% call form_wrapper(class='notify-simple-search-form', action=url_for('main.platform_admin_search')) %}

--- a/app/templates/views/service-settings/branding/new/email-branding-choose-banner-colour.html
+++ b/app/templates/views/service-settings/branding/new/email-branding-choose-banner-colour.html
@@ -2,7 +2,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}
   {{ form.hex_colour.label.text }}
@@ -13,8 +12,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ errorSummary(form) }}
-
   {% call form_wrapper() %}
     {{
       form.hex_colour(

--- a/app/templates/views/service-settings/branding/new/email-branding-choose-banner.html
+++ b/app/templates/views/service-settings/branding/new/email-branding-choose-banner.html
@@ -2,7 +2,6 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}
   {{ form.banner.label.text }}
@@ -13,8 +12,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ errorSummary(form) }}
-
   {% call form_wrapper() %}
     {{ form.banner }}
     {{ page_footer('Continue') }}

--- a/app/templates/views/service-settings/branding/new/email-branding-choose-logo.html
+++ b/app/templates/views/service-settings/branding/new/email-branding-choose-logo.html
@@ -2,7 +2,6 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/error-summary.html" import errorSummary %}
 
 {% set page_title = form.branding_options.label.text %}
 
@@ -25,8 +24,6 @@
 {%- endset %}
 
 {% block maincolumn_content %}
-  {{ errorSummary(form) }}
-
   {% call form_wrapper() %}
     {% if prompt_text %}
       {% set param_extensions = {

--- a/app/templates/views/service-settings/branding/new/email-branding-enter-government-identity-logo-text.html
+++ b/app/templates/views/service-settings/branding/new/email-branding-enter-government-identity-logo-text.html
@@ -2,7 +2,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}
   Enter the text that will appear in your logo
@@ -13,8 +12,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ errorSummary(form) }}
-
   {% call form_wrapper() %}
     {% set html %}
       This is usually the full name of your organisation.

--- a/app/templates/views/service-settings/branding/new/email-branding-set-alt-text.html
+++ b/app/templates/views/service-settings/branding/new/email-branding-set-alt-text.html
@@ -3,7 +3,6 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/branding-preview.html" import custom_email_branding_preview %}
-{% from "components/error-summary.html" import errorSummary %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
@@ -15,10 +14,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-
   {{ page_header('Preview your email branding') }}
-
-  {{ errorSummary(form) }}
 
   <p class="govuk-body">
     This is a preview of what emails from {{ current_service.name }} will look like.

--- a/app/templates/views/service-settings/branding/new/email-branding-upload-logo.html
+++ b/app/templates/views/service-settings/branding/new/email-branding-upload-logo.html
@@ -2,7 +2,6 @@
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}
   {{ form.logo.label.text }}
@@ -13,8 +12,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ errorSummary(form) }}
-
   {{ page_header(form.logo.label.text) }}
 
   <div class="govuk-grid-row">

--- a/app/templates/views/service-settings/branding/new/letter-branding-set-name.html
+++ b/app/templates/views/service-settings/branding/new/letter-branding-set-name.html
@@ -3,7 +3,6 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/branding-preview.html" import custom_letter_branding_preview %}
-{% from "components/error-summary.html" import errorSummary %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
@@ -15,10 +14,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-
   {{ page_header('Preview your letter branding') }}
-
-  {{ errorSummary(form) }}
 
   <p class="govuk-body">
     This is a preview of what letters from {{ current_service.name }} will look like.

--- a/app/templates/views/service-settings/branding/new/letter-branding-upload-branding.html
+++ b/app/templates/views/service-settings/branding/new/letter-branding-upload-branding.html
@@ -2,7 +2,6 @@
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}
   {{ form.branding.label.text }}
@@ -13,8 +12,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ errorSummary(form) }}
-
   {{ page_header(form.branding.label.text) }}
 
   <div class="govuk-grid-row">

--- a/app/templates/views/service-settings/set-branding-add-to-branding-pool-step.html
+++ b/app/templates/views/service-settings/set-branding-add-to-branding-pool-step.html
@@ -2,7 +2,6 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/error-summary.html" import errorSummary %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = "Apply ‘{}’ branding".format(branding_name) %}
@@ -16,7 +15,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-    {{ errorSummary(form) }}
     {{ page_header(page_title) }}
 
     {% call form_wrapper() %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -1,4 +1,5 @@
 {% from "service_navigation.html" import service_navigation %}
+{% from "components/error-summary.html" import errorSummary %}
 
 {% extends "admin_template.html" %}
 
@@ -30,6 +31,11 @@
         <main class="govuk-main-wrapper column-main {{ mainClasses }}" id="main-content" role="main">
         {% block content %}
           {% include 'flash_messages.html' %}
+          {% block errorSummary %}
+            {% if error_summary_enabled %}
+              {% if form and form.errors %}{{ errorSummary(form) }}{% endif %}
+            {% endif %}
+          {% endblock %}
           {% block maincolumn_content %}{% endblock %}
         {% endblock %}
         </main>

--- a/app/templates/withoutnav_template.html
+++ b/app/templates/withoutnav_template.html
@@ -1,5 +1,7 @@
 {% extends "admin_template.html" %}
 
+{% from "components/error-summary.html" import errorSummary %}
+
 {% set mainClasses = "govuk-!-padding-top-0 govuk-!-padding-bottom-12" %}
 
 {% block beforeContent %}
@@ -13,5 +15,10 @@
 
 {% block content %}
     {% include 'flash_messages.html' %}
+    {% block errorSummary %}
+      {% if error_summary_enabled %}
+        {% if form and form.errors %}{{ errorSummary(form) }}{% endif %}
+      {% endif %}
+    {% endblock %}
     {% block maincolumn_content %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
By inserting a new block that populates error summaries automatically, we can make sure we are consistently displaying these without any developer effort (in most cases, ie where there's a single form on the page).

If a page has multiple forms, the developer will need to override the `errorSummary` block (as they do with the errorPrefix block) and build the errorSummary manually using the macro.

Although we're adding this to the base templates, we add an opt-in step so that we can review and enable error summaries on a page-by-page basis, as some error messages are not well suited to the summary display at the moment.