### PR TITLE
Add error summaries to login registration

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -570,6 +570,15 @@ class RegisterUserForm(StripWhitespaceForm):
 
 
 class RegisterUserFromInviteForm(RegisterUserForm):
+    custom_field_order = (
+        "name",
+        "mobile_number",
+        "password",
+        "service",
+        "email_address",
+        "auth_type",
+    )
+
     def __init__(self, invited_user):
         super().__init__(
             service=invited_user.service,

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -560,7 +560,7 @@ class LoginForm(StripWhitespaceForm):
 
 
 class RegisterUserForm(StripWhitespaceForm):
-    name = GovukTextInputField("Full name", validators=[DataRequired(message="Cannot be empty")])
+    name = GovukTextInputField("Full name", validators=[NotifyDataRequired(thing="your full name")])
     email_address = make_email_address_field()
     mobile_number = international_phone_number()
     password = make_password_field()

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -550,10 +550,8 @@ class VirusScannedFileField(FileField_wtf, RequiredValidatorsMixin):
 
 
 class LoginForm(StripWhitespaceForm):
-    email_address = GovukEmailField(
-        "Email address", validators=[Length(min=5, max=255), DataRequired(message="Cannot be empty"), ValidEmail()]
-    )
-    password = GovukPasswordField("Password", validators=[DataRequired(message="Enter your password")])
+    email_address = make_email_address_field(thing="your email address")
+    password = GovukPasswordField("Password", validators=[NotifyDataRequired(thing="your password")])
 
 
 class RegisterUserForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -253,13 +253,12 @@ def uk_mobile_number(label="Mobile number"):
 
 
 def international_phone_number(label="Mobile number", thing=None):
-    validators = []
+    validators_list = []
     if thing:
-        validators.append(NotifyDataRequired(thing=thing))
+        validators_list.append(NotifyDataRequired(thing=thing))
     else:
-        # FIXME: being deprecated; prefer to pass in `thing`.
-        validators.append(DataRequired(message="Cannot be empty"))
-    return InternationalPhoneNumber(label, validators=validators)
+        validators_list.append(DataRequired(message="Cannot be empty"))
+    return InternationalPhoneNumber(label, validators=validators_list)
 
 
 def make_password_field(label="Password", thing="a password"):
@@ -604,9 +603,11 @@ class RegisterUserFromOrgInviteForm(StripWhitespaceForm):
             email_address=invited_org_user.email_address,
         )
 
-    name = GovukTextInputField("Full name", validators=[DataRequired(message="Cannot be empty")])
+    name = GovukTextInputField("Full name", validators=[NotifyDataRequired(thing="your full name")])
 
-    mobile_number = InternationalPhoneNumber("Mobile number", validators=[DataRequired(message="Cannot be empty")])
+    mobile_number = InternationalPhoneNumber(
+        "Mobile number", validators=[NotifyDataRequired(thing="your mobile number")]
+    )
     password = make_password_field()
     organisation = HiddenField("organisation")
     email_address = HiddenField("email_address")

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -252,8 +252,14 @@ def uk_mobile_number(label="Mobile number"):
     return UKMobileNumber(label, validators=[DataRequired(message="Cannot be empty")])
 
 
-def international_phone_number(label="Mobile number"):
-    return InternationalPhoneNumber(label, validators=[DataRequired(message="Cannot be empty")])
+def international_phone_number(label="Mobile number", thing=None):
+    validators = []
+    if thing:
+        validators.append(NotifyDataRequired(thing=thing))
+    else:
+        # FIXME: being deprecated; prefer to pass in `thing`.
+        validators.append(DataRequired(message="Cannot be empty"))
+    return InternationalPhoneNumber(label, validators=validators)
 
 
 def make_password_field(label="Password", thing="a password"):
@@ -295,7 +301,7 @@ class SMSCode(GovukTextInputField):
     input_type = "tel"
     param_extensions = {"attributes": {"pattern": "[0-9]*"}}
     validators = [
-        DataRequired(message="Cannot be empty"),
+        NotifyDataRequired(thing="your text message code"),
         Regexp(regex=r"^\d+$", message="Numbers only"),
         Length(min=5, message="Not enough numbers"),
         Length(max=5, message="Too many numbers"),
@@ -572,14 +578,14 @@ class RegisterUserFromInviteForm(RegisterUserForm):
             name=guess_name_from_email_address(invited_user.email_address),
         )
 
-    mobile_number = InternationalPhoneNumber("Mobile number", validators=[])
+    mobile_number = InternationalPhoneNumber("Mobile number")
     service = HiddenField("service")
     email_address = HiddenField("email_address")
     auth_type = HiddenField("auth_type", validators=[DataRequired()])
 
     def validate_mobile_number(self, field):
         if self.auth_type.data == "sms_auth" and not field.data:
-            raise ValidationError("Cannot be empty")
+            raise ValidationError("Enter your mobile number")
 
 
 class RegisterUserFromOrgInviteForm(StripWhitespaceForm):

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -48,7 +48,12 @@ def register_from_invite():
             # so just activate them straight away
             return activate_user(session["user_details"]["id"])
 
-    return render_template("views/register-from-invite.html", invited_user=invited_user, form=form)
+    return render_template(
+        "views/register-from-invite.html",
+        invited_user=invited_user,
+        form=form,
+        error_summary_enabled=True,
+    )
 
 
 @main.route("/register-from-org-invite", methods=["GET", "POST"])

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -72,7 +72,12 @@ def register_from_org_invite():
         invited_org_user.accept_invite()
 
         return redirect(url_for("main.verify"))
-    return render_template("views/register-from-org-invite.html", invited_org_user=invited_org_user, form=form)
+    return render_template(
+        "views/register-from-org-invite.html",
+        invited_org_user=invited_org_user,
+        form=form,
+        error_summary_enabled=True,
+    )
 
 
 def _do_registration(form, send_sms=True, send_email=True, organisation_id=None):

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -80,6 +80,7 @@ def sign_in():  # noqa: C901
         again=bool(redirect_url),
         other_device=other_device,
         password_reset_url=password_reset_url,
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -83,7 +83,12 @@ def two_factor_sms():
         else:
             return log_in_user(user_id)
 
-    return render_template("views/two-factor-sms.html", form=form, redirect_url=redirect_url)
+    return render_template(
+        "views/two-factor-sms.html",
+        form=form,
+        redirect_url=redirect_url,
+        error_summary_enabled=True,
+    )
 
 
 @main.route("/two-factor-webauthn", methods=["GET"])

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -10,7 +10,7 @@ Create an account
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="heading-large">Create an account</h1>
+    <h1 class="govuk-heading-l">Create an account</h1>
     <p class="govuk-body">
       Your account will be created with this email address:
       <span class="nowrap">{{invited_user.email_address}}</span>

--- a/app/templates/views/register-from-org-invite.html
+++ b/app/templates/views/register-from-org-invite.html
@@ -10,7 +10,7 @@ Create an account
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="heading-large">Create an account</h1>
+    <h1 class="govuk-heading-l">Create an account</h1>
     <p class="govuk-body">Your account will be created with this email: {{invited_org_user.email_address}}</p>
     {% call form_wrapper() %}
       {{ form.name(param_extensions={"classes": "govuk-!-width-three-quarters"}) }}

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -16,7 +16,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     {% if again %}
-      <h1 class="heading-large">You need to sign in again</h1>
+      <h1 class="govuk-heading-l">You need to sign in again</h1>
       {% if other_device %}
         <p class="govuk-body">
           We signed you out because you logged in to Notify on another device.
@@ -27,7 +27,7 @@
         </p>
       {% endif %}
     {% else %}
-      <h1 class="heading-large">Sign in</h1>
+      <h1 class="govuk-heading-l">Sign in</h1>
       <p class="govuk-body">
         If you do not have an account, you can
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">create one now</a>.

--- a/app/templates/views/two-factor-sms.html
+++ b/app/templates/views/two-factor-sms.html
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="heading-large">Check your phone</h1>
+    <h1 class="govuk-heading-l">Check your phone</h1>
 
     <p class="govuk-body">We’ve sent you a text message with a security code.</p>
 

--- a/tests/app/main/forms/test_two_factor_form.py
+++ b/tests/app/main/forms/test_two_factor_form.py
@@ -42,7 +42,7 @@ def test_form_is_valid_returns_no_errors(
         ),
         (
             {},
-            "Cannot be empty",
+            "Enter your text message code",
         ),
         (
             {"sms_code": "12E45"},


### PR DESCRIPTION
This PR follows on from the work done [here](https://github.com/alphagov/notifications-admin/pull/4793) and enables error summaries for the following:

`register-from-org-invite`, `register-from-invite` , `sign-in` , `two-factor-sms` .
