### PR TITLE
Fix error summary anchors

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -620,6 +620,14 @@ class GovukCheckboxesField(GovukFrontendWidgetMixin, SelectMultipleField):
     def get_items_from_options(self, field):
         return [self.get_item_from_option(option) for option in field]
 
+    @property
+    def error_summary_id(self):
+        items = self.get_items_from_options(self)
+        if len(items) > 0:
+            return items[0]["id"]
+
+        return self.id
+
     def prepare_params(self, **kwargs):
         # returns either a list or a hierarchy of lists
         # depending on how get_items_from_options is implemented
@@ -714,6 +722,14 @@ class GovukRadiosField(GovukFrontendWidgetMixin, RadioField):
 
     def get_items_from_options(self, field):
         return [self.get_item_from_option(option) for option in field]
+
+    @property
+    def error_summary_id(self):
+        items = self.get_items_from_options(self)
+        if len(items) > 0:
+            return items[0]["id"]
+
+        return self.id
 
     def prepare_params(self, **kwargs):
         # returns either a list or a hierarchy of lists

--- a/app/templates/components/error-summary.html
+++ b/app/templates/components/error-summary.html
@@ -5,7 +5,12 @@
     {% set errors = [] %}
     {% for field_name, error_list in form.errors.items() %}
       {% if field_name %}
-        {% do errors.append({"href": "#" + form[field_name].id, "text": error_list[0]}) %}
+        {% do errors.append(
+          {
+            "href": "#" + form[field_name].error_summary_id if form[field_name].error_summary_id != undefined else form[field_name].id,
+            "text": error_list[0]
+          }
+        ) %}
       {% else %}
         {# field_name is None for form level errors #}
         {% do errors.append({"text": error_list[0]}) %}

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -1679,7 +1679,7 @@ def test_email_branding_choose_banner_type_shows_error_summary_on_invalid_data(c
 
     error_summary = page.select_one(".govuk-error-summary")
     assert normalize_spaces(error_summary.text) == "There is a problem Select an option"
-    assert error_summary.select_one("a").get("href") == "#banner"
+    assert error_summary.select_one("a").get("href") == "#banner-0"
 
     assert "Error: Select an option" in page.select_one("#banner").text
 


### PR DESCRIPTION
When clicking a message in an error summary, it should jump you to the appropriate form field. These anchors were broken for fields with multiple inputs, such as radios and checkboxes. GOV.UK Design System says in these cases, it should take you to the first input:

> For questions that require a user to select one or more options from
> a list using radios or checkboxes, link to the first radio or
> checkbox.

This fixes radio and checkbox fields to provide a custom attribute, `error_summary_id`, which returns the ID of the first input for the field. We update the error summary macro to check for this ID and prefer it, if present.

## Before
![2023-07-31 10 53 15](https://github.com/alphagov/notifications-admin/assets/2920760/9a19ee30-4262-4c33-807e-f1fad0d1fd84)

## After
![2023-07-31 10 53 35](https://github.com/alphagov/notifications-admin/assets/2920760/6c4f544f-e614-44bf-ba49-e9fcbe558f5e)
