### PR TITLE
Add some more error summaries

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -256,11 +256,11 @@ def international_phone_number(label="Mobile number"):
     return InternationalPhoneNumber(label, validators=[DataRequired(message="Cannot be empty")])
 
 
-def make_password_field(label="Password", no_input_error="Enter a password"):
+def make_password_field(label="Password", thing="a password"):
     return GovukPasswordField(
         label,
         validators=[
-            DataRequired(message=no_input_error),
+            NotifyDataRequired(thing=thing),
             Length(8, 255, message="Must be at least 8 characters"),
             CommonlyUsedPassword(message="Choose a password that’s harder to guess"),
         ],
@@ -964,7 +964,7 @@ class BasePermissionsForm(StripWhitespaceForm):
             ("sms_auth", "Text message code"),
             ("email_auth", "Email link"),
         ],
-        thing="how this team member should sign in",
+        thing="a sign-in method",
         param_extensions={"fieldset": {"legend": {"classes": "govuk-fieldset__legend--s"}}},
     )
 
@@ -1059,7 +1059,7 @@ class OrganisationUserPermissionsForm(StripWhitespaceForm):
 
 
 class BaseInviteUserForm:
-    email_address = make_email_address_field(gov_user=False)
+    email_address = make_email_address_field(gov_user=False, thing="an email address")
 
     def __init__(self, inviter_email_address, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1492,11 +1492,12 @@ class LetterUploadPostageForm(StripWhitespaceForm):
 
 
 class ForgotPasswordForm(StripWhitespaceForm):
-    email_address = make_email_address_field(gov_user=False)
+    email_address = make_email_address_field(gov_user=False, thing="your email address")
 
 
 class NewPasswordForm(StripWhitespaceForm):
-    new_password = make_password_field()
+
+    new_password = make_password_field(thing="a new password")
 
 
 class ChangePasswordForm(StripWhitespaceForm):
@@ -1504,8 +1505,8 @@ class ChangePasswordForm(StripWhitespaceForm):
         self.validate_password_func = validate_password_func
         super(ChangePasswordForm, self).__init__(*args, **kwargs)
 
-    old_password = make_password_field("Current password", no_input_error="Enter your current password")
-    new_password = make_password_field("New password", no_input_error="Enter your new password")
+    old_password = make_password_field("Current password", thing="your current password")
+    new_password = make_password_field("New password", thing="your new password")
 
     def validate_old_password(self, field):
         if not self.validate_password_func(field.data):
@@ -1574,12 +1575,12 @@ class CreateKeyForm(StripWhitespaceForm):
         super().__init__(*args, **kwargs)
 
     key_name = GovukTextInputField(
-        "Name for this key", validators=[DataRequired(message="You need to give the key a name")]
+        "Name for this key", validators=[NotifyDataRequired(thing="a name for this API key")]
     )
 
     key_type = GovukRadiosField(
         "Type of key",
-        thing="the type of key",
+        thing="a type of API key",
     )
 
     def validate_key_name(self, key_name):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -251,11 +251,11 @@ def international_phone_number(label="Mobile number"):
     return InternationalPhoneNumber(label, validators=[DataRequired(message="Cannot be empty")])
 
 
-def password(label="Password"):
+def make_password_field(label="Password", no_input_error="Enter a password"):
     return GovukPasswordField(
         label,
         validators=[
-            DataRequired(message="Cannot be empty"),
+            DataRequired(message=no_input_error),
             Length(8, 255, message="Must be at least 8 characters"),
             CommonlyUsedPassword(message="Choose a password that’s harder to guess"),
         ],
@@ -522,7 +522,7 @@ class RegisterUserForm(StripWhitespaceForm):
     name = GovukTextInputField("Full name", validators=[DataRequired(message="Cannot be empty")])
     email_address = email_address()
     mobile_number = international_phone_number()
-    password = password()
+    password = make_password_field()
     # always register as sms type
     auth_type = HiddenField("auth_type", default="sms_auth")
 
@@ -556,7 +556,7 @@ class RegisterUserFromOrgInviteForm(StripWhitespaceForm):
     name = GovukTextInputField("Full name", validators=[DataRequired(message="Cannot be empty")])
 
     mobile_number = InternationalPhoneNumber("Mobile number", validators=[DataRequired(message="Cannot be empty")])
-    password = password()
+    password = make_password_field()
     organisation = HiddenField("organisation")
     email_address = HiddenField("email_address")
     auth_type = HiddenField("auth_type", validators=[DataRequired()])
@@ -1454,7 +1454,7 @@ class ForgotPasswordForm(StripWhitespaceForm):
 
 
 class NewPasswordForm(StripWhitespaceForm):
-    new_password = password()
+    new_password = make_password_field()
 
 
 class ChangePasswordForm(StripWhitespaceForm):
@@ -1462,8 +1462,8 @@ class ChangePasswordForm(StripWhitespaceForm):
         self.validate_password_func = validate_password_func
         super(ChangePasswordForm, self).__init__(*args, **kwargs)
 
-    old_password = password("Current password")
-    new_password = password("New password")
+    old_password = make_password_field("Current password", no_input_error="Enter your current password")
+    new_password = make_password_field("New password", no_input_error="Enter your new password")
 
     def validate_old_password(self, field):
         if not self.validate_password_func(field.data):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1531,13 +1531,13 @@ class CreateKeyForm(StripWhitespaceForm):
         self.existing_key_names = [key["name"].lower() for key in existing_keys if not key["expiry_date"]]
         super().__init__(*args, **kwargs)
 
+    key_name = GovukTextInputField(
+        "Name for this key", validators=[DataRequired(message="You need to give the key a name")]
+    )
+
     key_type = GovukRadiosField(
         "Type of key",
         thing="the type of key",
-    )
-
-    key_name = GovukTextInputField(
-        "Name for this key", validators=[DataRequired(message="You need to give the key a name")]
     )
 
     def validate_key_name(self, key_name):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -9,7 +9,7 @@ from notifications_utils.sanitise_text import SanitiseSMS
 from notifications_utils.template import BroadcastMessageTemplate
 from orderedset import OrderedSet
 from wtforms import ValidationError
-from wtforms.validators import StopValidation
+from wtforms.validators import DataRequired, StopValidation
 
 from app import antivirus_client
 from app.main._commonly_used_passwords import commonly_used_passwords
@@ -231,3 +231,8 @@ class FileIsVirusFree:
                         raise StopValidation("Your file contains a virus")
                 finally:
                     field.data.seek(0)
+
+
+class NotifyDataRequired(DataRequired):
+    def __init__(self, thing):
+        super().__init__(message=f"Enter {thing}")

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -100,7 +100,7 @@ def create_api_key(service_id):
             service_id=service_id,
             key_name=email_safe(form.key_name.data, whitespace="_"),
         )
-    return render_template("views/api/keys/create.html", form=form)
+    return render_template("views/api/keys/create.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/services/<uuid:service_id>/api/keys/revoke/<uuid:key_id>", methods=["GET", "POST"])

--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -19,4 +19,4 @@ def forgot_password():
                 raise e
         return render_template("views/password-reset-sent.html")
 
-    return render_template("views/forgot-password.html", form=form)
+    return render_template("views/forgot-password.html", form=form, error_summary_enabled=True)

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -97,6 +97,7 @@ def invite_user(service_id, user_id=None):
         form=form,
         mobile_number=True,
         user_to_invite=user_to_invite,
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -55,4 +55,4 @@ def new_password(token):
             user.send_verify_code()
             return redirect(url_for("main.two_factor_sms", next=request.args.get("next")))
     else:
-        return render_template("views/new-password.html", token=token, form=form, user=user)
+        return render_template("views/new-password.html", token=token, form=form, user=user, error_summary_enabled=True)

--- a/app/templates/views/forgot-password.html
+++ b/app/templates/views/forgot-password.html
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="heading-large">Forgotten your password?</h1>
+    <h1 class="govuk-heading-l">Forgotten your password?</h1>
 
     <p class="govuk-body">We’ll send you an email to create a new password.</p>
 

--- a/app/templates/views/new-password.html
+++ b/app/templates/views/new-password.html
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     {% if user %}
-      <h1 class="heading-large">
+      <h1 class="govuk-heading-l">
         Create a new password
       </h1>
       <p class="govuk-body">

--- a/app/templates/withoutnav_template.html
+++ b/app/templates/withoutnav_template.html
@@ -2,7 +2,7 @@
 
 {% from "components/error-summary.html" import errorSummary %}
 
-{% set mainClasses = "govuk-!-padding-top-0 govuk-!-padding-bottom-12" %}
+{% set mainClasses = "govuk-!-padding-top-0 govuk-!-padding-bottom-12" if not error_summary_enabled else "" %}
 
 {% block beforeContent %}
     {% if current_service and current_service.active and current_user.is_authenticated and current_user.belongs_to_service(current_service.id) %}

--- a/tests/app/main/forms/test_create_key_form.py
+++ b/tests/app/main/forms/test_create_key_form.py
@@ -35,7 +35,7 @@ def test_return_validation_error_when_key_name_exists(
 
 
 @pytest.mark.parametrize(
-    "key_type, expected_error", [("", "Select the type of key"), ("invalid", "Select the type of key")]
+    "key_type, expected_error", [("", "Select a type of API key"), ("invalid", "Select a type of API key")]
 )
 def test_return_validation_error_when_key_type_not_chosen(client_request, key_type, expected_error):
 

--- a/tests/app/main/test_forms.py
+++ b/tests/app/main/test_forms.py
@@ -1,0 +1,43 @@
+import pytest
+
+from app.main.forms import OrderableFieldsForm, StripWhitespaceStringField
+from tests.conftest import set_config_values
+
+
+class TestOrderableFieldsForm:
+    def test_can_reorder_fields(self):
+        class TestForm(OrderableFieldsForm):
+            field1 = StripWhitespaceStringField()
+            field2 = StripWhitespaceStringField()
+
+            custom_field_order = ("field2", "field1")
+
+        form = TestForm()
+        assert [field.name for field in form] == ["field2", "field1"]
+
+    def test_all_fields_must_be_listed(self):
+        class TestForm(OrderableFieldsForm):
+            field1 = StripWhitespaceStringField()
+            field2 = StripWhitespaceStringField()
+            field3 = StripWhitespaceStringField()
+
+            custom_field_order = ("field2", "field1")
+
+        with pytest.raises(RuntimeError) as e:
+            TestForm()
+
+        assert str(e.value) == (
+            "When setting `OrderableFieldsForm.custom_field_order`, all fields must be listed exhaustively. "
+            "The following fields are missing: {'field3'}."
+        )
+
+    def test_auto_injects_csrf_token_field(self, notify_admin, client_request):
+        class TestForm(OrderableFieldsForm):
+            field1 = StripWhitespaceStringField()
+            field2 = StripWhitespaceStringField()
+
+            custom_field_order = ("field2", "field1")
+
+        with set_config_values(notify_admin, dict(WTF_CSRF_ENABLED=True)):
+            form = TestForm()
+            assert [field.name for field in form] == ["csrf_token", "field2", "field1"]


### PR DESCRIPTION
This patch enables error summaries on 4 more pages, and tweaks some of the error messages as appropriate.

It also adds a new base form `OrderableFieldsForm` in 60f614170f99beed8f343002d225cf1128aa5c92 that allows us to override the order that fields are iterated through on a form. WTForms normally orders them according to when they are created in the code, but with our form inheritance structure sometimes the creation order differs from the display order and is not easy to correct. This gives us a way to explicitly set the field iteration order in line with the display order. We use this because errors are iterated through in field order, and the error summary should show errors in the same order as the fields appear on the page. "Invite a team member" was the page that required the fix in this PR.

---

<img width="664" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/faa56756-50cd-4ae5-a1e1-295715b5d2dd">

<img width="674" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/2400640b-c7d5-466f-8373-d9b9cbf0b1d9">

<img width="653" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/329915c8-dd09-4883-87be-eccaba50ddea">

<img width="659" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/a4cc3a46-eb9f-4881-881a-1f51a1efb4bd">
