### PR TITLE
Fix sign in to allow non-gov email addresses

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -555,7 +555,7 @@ class VirusScannedFileField(FileField_wtf, RequiredValidatorsMixin):
 
 
 class LoginForm(StripWhitespaceForm):
-    email_address = make_email_address_field(thing="your email address")
+    email_address = make_email_address_field(gov_user=False, thing="your email address")
     password = GovukPasswordField("Password", validators=[NotifyDataRequired(thing="your password")])
 
 


### PR DESCRIPTION
We switched this over to use `make_email_address_field`, but didn't catch that it applies a default validator for gov-only email addresses. We need to rmeove that.