### PR TITLE
Rename ‘hashtag’ to ‘hash symbol’

### DIFF
--- a/app/templates/partials/templates/guidance-formatting-letters.html
+++ b/app/templates/partials/templates/guidance-formatting-letters.html
@@ -1,7 +1,7 @@
 <h2 class="heading-medium">Formatting</h2>
 <h3 class="heading-small">Headings</h3>
 <p class="govuk-body">
-  Use one hash sign followed by a space for a heading, for example:
+  Use one hash symbol followed by a space for a heading, for example:
 </p>
 <pre class="formatting-example"><code class="lang-md"># This is a heading</code></pre>
 <h3 class="heading-small">Bullet points</h3>

--- a/app/templates/partials/templates/guidance-formatting-letters.html
+++ b/app/templates/partials/templates/guidance-formatting-letters.html
@@ -1,7 +1,7 @@
 <h2 class="heading-medium">Formatting</h2>
 <h3 class="heading-small">Headings</h3>
 <p class="govuk-body">
-  Use one hashtag followed by a space for a heading, for example:
+  Use one hash sign followed by a space for a heading, for example:
 </p>
 <pre class="formatting-example"><code class="lang-md"># This is a heading</code></pre>
 <h3 class="heading-small">Bullet points</h3>

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,12 +1,12 @@
 <h2 class="heading-medium">Formatting</h2>
 <h3 class="heading-small">Headings and subheadings</h3>
 <p class="bottom-gutter-1-3">
-  Use one hashtag followed by a space for a heading, for example:
+  Use one hash sign followed by a space for a heading, for example:
 </p>
 <pre class="formatting-example"><code class="lang-md"># This is a heading
 </code></pre>
 <p class="bottom-gutter-1-3">
-  To add a subheading, use 2 hashtags:
+  To add a subheading, use 2 hash signs:
 </p>
 <pre class="formatting-example"><code class="lang-md">## This is a subheading
 </code></pre>

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -6,7 +6,7 @@
 <pre class="formatting-example"><code class="lang-md"># This is a heading
 </code></pre>
 <p class="bottom-gutter-1-3">
-  To add a subheading, use 2 hash signs:
+  To add a subheading, use 2 hash symbols:
 </p>
 <pre class="formatting-example"><code class="lang-md">## This is a subheading
 </code></pre>

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,7 +1,7 @@
 <h2 class="heading-medium">Formatting</h2>
 <h3 class="heading-small">Headings and subheadings</h3>
 <p class="bottom-gutter-1-3">
-  Use one hash sign followed by a space for a heading, for example:
+  Use one hash symbol followed by a space for a heading, for example:
 </p>
 <pre class="formatting-example"><code class="lang-md"># This is a heading
 </code></pre>

--- a/app/templates/views/guidance/using-notify/formatting.html
+++ b/app/templates/views/guidance/using-notify/formatting.html
@@ -65,7 +65,7 @@
 <p class="govuk-body">For emails, use subheadings to break up the rest of your content. Your first subheading must come after a heading.</p>
 <p class="govuk-body">For letters, use headings to break up the rest of your content.</p>
 <p class="govuk-body">Write all headings and subheadings in sentence case.</p>
-<p class="govuk-body">Use one hash sign followed by a space for a heading in emails and letters, for example:</p>
+<p class="govuk-body">Use one hash symbol followed by a space for a heading in emails and letters, for example:</p>
 
 <pre class="formatting-example"><code class="lang-md"># This is a heading
 </code></pre>

--- a/app/templates/views/guidance/using-notify/formatting.html
+++ b/app/templates/views/guidance/using-notify/formatting.html
@@ -65,12 +65,12 @@
 <p class="govuk-body">For emails, use subheadings to break up the rest of your content. Your first subheading must come after a heading.</p>
 <p class="govuk-body">For letters, use headings to break up the rest of your content.</p>
 <p class="govuk-body">Write all headings and subheadings in sentence case.</p>
-<p class="govuk-body">Use one hashtag followed by a space for a heading in emails and letters, for example:</p>
+<p class="govuk-body">Use one hash sign followed by a space for a heading in emails and letters, for example:</p>
 
 <pre class="formatting-example"><code class="lang-md"># This is a heading
 </code></pre>
 
-<p class="govuk-body">Use 2 hashtags followed by a space for a subheading in emails, for example:</p>
+<p class="govuk-body">Use 2 hash signs followed by a space for a subheading in emails, for example:</p>
 
 <pre class="formatting-example"><code class="lang-md">## This is a subheading
 </code></pre>

--- a/app/templates/views/guidance/using-notify/formatting.html
+++ b/app/templates/views/guidance/using-notify/formatting.html
@@ -70,7 +70,7 @@
 <pre class="formatting-example"><code class="lang-md"># This is a heading
 </code></pre>
 
-<p class="govuk-body">Use 2 hash signs followed by a space for a subheading in emails, for example:</p>
+<p class="govuk-body">Use 2 hash symbols followed by a space for a subheading in emails, for example:</p>
 
 <pre class="formatting-example"><code class="lang-md">## This is a subheading
 </code></pre>


### PR DESCRIPTION
After discussion with the team, we think ‘hash symbol’ is a more accurate name for `#` in our formatting guidance.