### PR TITLE
Remove the ‘Introducing Notify’ video from the product page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -381,7 +381,7 @@ def useful_headers_after_request(response):
             "font-src 'self' {asset_domain} data:;"
             "img-src 'self' {asset_domain} *.tile.openstreetmap.org *.google-analytics.com"
             " *.notifications.service.gov.uk {logo_domain} data:;"
-            "frame-src 'self' www.youtube-nocookie.com;".format(
+            "frame-src 'self';".format(
                 asset_domain=current_app.config["ASSET_DOMAIN"],
                 logo_domain=current_app.config["LOGO_CDN_DOMAIN"],
             )

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -109,16 +109,6 @@
     </div>
   </div>
   <div class="product-page-section">
-    <h2 class="with-keyline">
-      Introducing GOV.UK Notify
-    </h2>
-    <div class="responsive-embed responsive-embed--16by9 responsive-embed--bordered bottom-gutter-2">
-      <div class="responsive-embed__wrapper">
-        <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/_90cv1YgQo4" frameborder="0" allowfullscreen></iframe>
-      </div>
-    </div>
-  </div>
-  <div class="product-page-section">
     <div class="with-keyline bottom-gutter-2" id="whos-using-notify">
       <h2>Who’s using GOV.UK Notify</h2>
       <div class="govuk-grid-row bottom-gutter">

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -18,7 +18,7 @@ def test_owasp_useful_headers_set(
         "img-src "
         "'self' static.example.com *.tile.openstreetmap.org *.google-analytics.com"
         " *.notifications.service.gov.uk static-logos.test.com data:;"
-        "frame-src 'self' www.youtube-nocookie.com;"
+        "frame-src 'self';"
     )
     assert response.headers["Link"] == (
         "<https://static.example.com>; rel=dns-prefetch, " "<https://static.example.com>; rel=preconnect"
@@ -47,5 +47,5 @@ def test_headers_non_ascii_characters_are_replaced(
         "img-src"
         " 'self' static.example.com *.tile.openstreetmap.org *.google-analytics.com"
         " *.notifications.service.gov.uk static-logos??.test.com data:;"
-        "frame-src 'self' www.youtube-nocookie.com;"
+        "frame-src 'self';"
     )

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -405,7 +405,7 @@ def test_sms_price(
 
     expected_rate = "1.97"
     assert (
-        normalize_spaces(home_page.select(".product-page-section")[5].select(".govuk-grid-column-one-half")[1].text)
+        normalize_spaces(home_page.select(".product-page-section")[4].select(".govuk-grid-column-one-half")[1].text)
         == f"Text messages Up to 40,000 free text messages a year, then {expected_rate} pence per message"
     )
 


### PR DESCRIPTION
This PR removes the ‘Introducing Notify’ video from the signed out version of our product page.

The idea is to do a reverse pilot. Remove the video and see if anyone notices.

The video is 6 years old, and does not accurately represent the current user experience, design, content and functionality of GOV.UK Notify.

Since January 2020, we have no data about user engagement with this embedded video.

You can read more about our thinking (and join the discussion) in [this Google document](https://docs.google.com/document/d/1qhbm0jUbDF-F8cHZEKjj1fDWSoj7pA1xVrAky-Eh4fs/edit?usp=sharing).