### PR TITLE
Add a letter specification for attached pages

### DIFF
--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -32,10 +32,23 @@
     <p class="govuk-body">
         In total, your letter must be 10 pages or less (5 double-sided sheets of paper).
     </p>
-    <p class="govuk-body">
-        Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">letter
-            specification</a>.
-    </p>
+
+{% set letter_spec %}
+    <p class="govuk-body">Page size and layout: A4 portrait (210 × 297 mm)</p>
+    <p class="govuk-body">Maximum file size: 2 MB</p>
+    <p class="govuk-body">The content of your letter must appear inside the printable area:</p>
+
+    <p class="govuk-body">Left margin 15mm</p>
+    <p class="govuk-body">Right margin 15mm</p>
+    <p class="govuk-body">Top margin 5mm</p>
+    <p class="govuk-body">Bottom margin 5mm</p>
+  {% endset %}
+
+  {{ govukDetails({
+    "summaryText": "Your PDF must meet our letter specification",
+    "html": letter_spec
+  }) }}
+
 
     <div class="govuk-body">
         {{ file_upload(


### PR DESCRIPTION
This PR updates the content on the Attach pages screen to include letter specifications for the PDF a user uploads.

Previously the page linked to the letter spec on the ‘Upload a letter’ guidance page. This page is about the ‘Upload a letter’ feature, which is different to ‘Attach pages‘. This could be confusing - especially because the spec is slightly different for uploaded letters (which have a first page with address blocks etc) and attaching pages to templates (which have much simpler layout requirements).

We’re adding a separate spec for the ‘Attach pages’ feature. We’re working on a page of guidance that will be published in the ‘Using Notify’ section of the website. However, we may not need to link users out to this. The ‘Attach pages’ spec is short enough that we can probably incorporate it into the UI, using the Details component.