### PR TITLE
Create attach-pages

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -182,6 +182,14 @@ def guidance_api_documentation():
     )
 
 
+@main.route("/using-notify/attach-pages")
+def guidance_attach_pages():
+    return render_template(
+        "views/guidance/using-notify/attach-pages.html",
+        navigation_links=using_notify_nav(),
+    )
+
+
 @main.route("/using-notify/bulk-sending")
 def guidance_bulk_sending():
     return render_template(

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -91,6 +91,10 @@ def using_notify_nav():
                     "link": "main.guidance_api_documentation",
                 },
                 {
+                    "name": "Attach pages",
+                    "link": "main.guidance_attach_pages",
+                },
+                {
                     "name": "Bulk sending",
                     "link": "main.guidance_bulk_sending",
                 },

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -61,6 +61,7 @@ class HeaderNavigation(Navigation):
         "using-notify": {
             "guidance_using_notify",
             "guidance_api_documentation",
+            "guidance_attach_pages",
             "guidance_bulk_sending",
             "guidance_message_status",
             "guidance_delivery_times",

--- a/app/templates/views/guidance/using-notify/attach-pages
+++ b/app/templates/views/guidance/using-notify/attach-pages
@@ -1,0 +1,46 @@
+{% extends "content_template.html" %}
+
+{% from "components/service-link.html" import service_link %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
+
+{% block per_page_title %}
+  Attach pages
+{% endblock %}
+
+{% block content_column_content %}
+
+  <h1 class="heading-large">Attach pages</h1>
+
+  <p class="govuk-body">Add attachments to your letters such as documents, tables and direct debit mandates.</p>
+  <p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
+
+
+  <p class="govuk-body">To add an attachment to your letter:</p>
+
+  <ol class="govuk-list govuk-list--number">
+    <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
+    <li>Add a new template or choose an existing template</li>
+    <li>Select <b class="govuk-!-font-weight-bold">Attach pages</b> and <b class="govuk-!-font-weight-bold">choose a file</b>.</li>
+  </ol>
+
+  <p class="govuk-body">Your PDF must meet our attachment specification.</p>
+
+  <h2 class="heading-medium">Attachment specification</h2>
+
+  <p class="govuk-body">Page size and layout: A4 portrait (210 × 297 mm)</p>
+  <p class="govuk-body">Maximum file size: 2 MB</p>
+  <p class="govuk-body">Your letter must be 10 pages or less (5 double-sided sheets of paper).</p>
+  <p class="govuk-body">The content of your letter must appear inside the printable area.</p>
+  <p class=govuk-body">The printable area is:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Left margin 15mm</li>
+    <li>Right margin 15mm</li>
+    <li>Top margin 5mm</li>
+    <li>Bottom margin 5mm</li>
+<ul>
+
+{% endblock %}

--- a/app/templates/views/guidance/using-notify/attach-pages.html
+++ b/app/templates/views/guidance/using-notify/attach-pages.html
@@ -14,7 +14,7 @@
   <h1 class="heading-large">Attach pages to a letter template</h1>
 
     <p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
-    <p class="govuk-body">You can attach pages with complex layouts. For example, forms, tables or direct debit mandates.</p>
+    <p class="govuk-body">You can attach pages with complex layouts. For example, forms, tables or Direct Debit mandates.</p>
 
 
 

--- a/app/templates/views/guidance/using-notify/attach-pages.html
+++ b/app/templates/views/guidance/using-notify/attach-pages.html
@@ -1,7 +1,6 @@
 {% extends "content_template.html" %}
 
 {% from "components/service-link.html" import service_link %}
-{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Using Notify' %}

--- a/app/templates/views/guidance/using-notify/attach-pages.html
+++ b/app/templates/views/guidance/using-notify/attach-pages.html
@@ -22,7 +22,7 @@
 
   <ol class="govuk-list govuk-list--number">
     <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
-    <li>Add a new template or choose an existing template</li>
+    <li>Add a new letter template or choose an existing template</li>
     <li>Select <b class="govuk-!-font-weight-bold">Attach pages</b> and <b class="govuk-!-font-weight-bold">choose a file</b>.</li>
   </ol>
 

--- a/app/templates/views/guidance/using-notify/attach-pages.html
+++ b/app/templates/views/guidance/using-notify/attach-pages.html
@@ -33,8 +33,7 @@
   <p class="govuk-body">Page size and layout: A4 portrait (210 × 297 mm)</p>
   <p class="govuk-body">Maximum file size: 2 MB</p>
   <p class="govuk-body">Your letter must be 10 pages or less (5 double-sided sheets of paper).</p>
-  <p class="govuk-body">The content of your letter must appear inside the printable area.</p>
-  <p class=govuk-body">The printable area is:</p>
+  <p class="govuk-body">The content of your letter must appear inside the printable area:</p>
 
   <ul class="govuk-list govuk-list--bullet">
     <li>Left margin 15mm</li>

--- a/app/templates/views/guidance/using-notify/attach-pages.html
+++ b/app/templates/views/guidance/using-notify/attach-pages.html
@@ -11,7 +11,7 @@
 
 {% block content_column_content %}
 
-  <h1 class="heading-large">Attach pages</h1>
+  <h1 class="heading-large">Attach pages to a letter template</h1>
 
   <p class="govuk-body">Add attachments to your letters such as documents, tables and direct debit mandates.</p>
   <p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>

--- a/app/templates/views/guidance/using-notify/attach-pages.html
+++ b/app/templates/views/guidance/using-notify/attach-pages.html
@@ -6,7 +6,7 @@
 {% set navigation_label_prefix = 'Using Notify' %}
 
 {% block per_page_title %}
-  Attach pages
+  Attach pages to a letter template
 {% endblock %}
 
 {% block content_column_content %}

--- a/app/templates/views/guidance/using-notify/attach-pages.html
+++ b/app/templates/views/guidance/using-notify/attach-pages.html
@@ -13,8 +13,9 @@
 
   <h1 class="heading-large">Attach pages to a letter template</h1>
 
-  <p class="govuk-body">Add attachments to your letters such as documents, tables and direct debit mandates.</p>
-  <p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
+    <p class="govuk-body">Upload a PDF and we’ll print it as part of your letter.</p>
+    <p class="govuk-body">You can attach pages with complex layouts. For example, forms, tables or direct debit mandates.</p>
+
 
 
   <p class="govuk-body">To add an attachment to your letter:</p>

--- a/app/templates/views/guidance/using-notify/index.html
+++ b/app/templates/views/guidance/using-notify/index.html
@@ -17,6 +17,7 @@
 
   <ul class="govuk-list govuk-list--bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_attach_pages') }}">Attach pages</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_bulk_sending') }}">Bulk sending</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_delivery_times') }}">Delivery times</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_email_branding') }}">Email branding</a></li>

--- a/app/templates/views/guidance/using-notify/index.html
+++ b/app/templates/views/guidance/using-notify/index.html
@@ -17,7 +17,7 @@
 
   <ul class="govuk-list govuk-list--bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_attach_pages') }}">Attach pages</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_attach_pages') }}">Attach pages to a letter template</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_bulk_sending') }}">Bulk sending</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_delivery_times') }}">Delivery times</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_email_branding') }}">Email branding</a></li>

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -136,6 +136,7 @@ EXCLUDED_ENDPOINTS = set(
             "go_to_dashboard_after_tour",
             "guest_list",
             "guidance_api_documentation",
+            "guidance_attach_pages",
             "guidance_billing_details",
             "guidance_bulk_sending",
             "guidance_delivery_times",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -379,6 +379,7 @@
     "/users/<uuid:user_id>/change_auth",
     "/using-notify",
     "/using-notify/api-documentation",
+    "/using-notify/attach-pages",
     "/using-notify/bulk-sending",
     "/using-notify/delivery-status",
     "/using-notify/delivery-times",


### PR DESCRIPTION
Creating new guidance for attaching pages to letters as the spec for pdf attachments differs slightly from letter uploads.

This PR also needs to:

- [ ] have a link added to the [Using Notify](url) page
- [ ] be added to the side nav of Using Notify