### PR TITLE
Bump utils to 66.0.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.1
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.1
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx
@@ -131,7 +131,7 @@ orderedset==2.0.3
     # via notifications-utils
 packaging==23.1
     # via gunicorn
-phonenumbers==8.12.54
+phonenumbers==8.13.18
     # via notifications-utils
 pillow==9.3.0
     # via -r requirements.in


### PR DESCRIPTION
* Require phonenumbers >= 8.3.18 (changes how some numbers are formatted.
* Render placeholder `((` and `))` as HTML-encoded characters in templates, fixing some display issues for links including placeholders and static text.