### PR TITLE
Add error summary to profile pages

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -162,10 +162,15 @@ class RadioField(WTFormsRadioField):
 
 
 def make_email_address_field(label="Email address", *, gov_user: bool, required=True, thing=None):
-
-    validators = [
-        ValidEmail(),
-    ]
+    if thing:
+        validators = [
+            ValidEmail(message=f"Enter {thing} in the correct format, like name@example.gov.uk"),
+        ]
+    else:
+        # FIXME: being deprecated; remove this when all form fields have been transferred across to `thing`.
+        validators = [
+            ValidEmail(),
+        ]
 
     if gov_user:
         validators.append(ValidGovEmail())

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -261,14 +261,18 @@ def international_phone_number(label="Mobile number"):
     return InternationalPhoneNumber(label, validators=[NotifyDataRequired(thing="a mobile number")])
 
 
-def make_password_field(label="Password", thing="a password"):
+def make_password_field(label="Password", thing="a password", validate_length=True):
+    validators = [
+        NotifyDataRequired(thing=thing),
+        CommonlyUsedPassword(message="Choose a password that’s harder to guess"),
+    ]
+
+    if validate_length:
+        validators.insert(1, Length(min=8, max=255, thing=thing))
+
     return GovukPasswordField(
         label,
-        validators=[
-            NotifyDataRequired(thing=thing),
-            Length(min=8, max=255, message="Must be at least 8 characters"),
-            CommonlyUsedPassword(message="Choose a password that’s harder to guess"),
-        ],
+        validators=validators,
     )
 
 
@@ -579,7 +583,7 @@ class RegisterUserForm(StripWhitespaceForm):
     name = GovukTextInputField("Full name", validators=[NotifyDataRequired(thing="your full name")])
     email_address = make_email_address_field(gov_user=True)
     mobile_number = international_phone_number()
-    password = make_password_field()
+    password = make_password_field(thing="your password")
     # always register as sms type
     auth_type = HiddenField("auth_type", default="sms_auth")
 
@@ -624,7 +628,7 @@ class RegisterUserFromOrgInviteForm(StripWhitespaceForm):
     mobile_number = InternationalPhoneNumber(
         "Mobile number", validators=[NotifyDataRequired(thing="your mobile number")]
     )
-    password = make_password_field()
+    password = make_password_field(thing="your password")
     organisation = HiddenField("organisation")
     email_address = HiddenField("email_address")
     auth_type = HiddenField("auth_type", validators=[DataRequired()])
@@ -1527,7 +1531,7 @@ class ForgotPasswordForm(StripWhitespaceForm):
 
 class NewPasswordForm(StripWhitespaceForm):
 
-    new_password = make_password_field(thing="a new password")
+    new_password = make_password_field(thing="your new password")
 
 
 class ChangePasswordForm(StripWhitespaceForm):
@@ -1535,7 +1539,7 @@ class ChangePasswordForm(StripWhitespaceForm):
         self.validate_password_func = validate_password_func
         super(ChangePasswordForm, self).__init__(*args, **kwargs)
 
-    old_password = make_password_field("Current password", thing="your current password")
+    old_password = make_password_field("Current password", thing="your current password", validate_length=False)
     new_password = make_password_field("New password", thing="your new password")
 
     def validate_old_password(self, field):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1537,7 +1537,7 @@ class ChangePasswordForm(StripWhitespaceForm):
 
     def validate_old_password(self, field):
         if not self.validate_password_func(field.data):
-            raise ValidationError("Invalid password")
+            raise ValidationError("Incorrect password")
 
 
 class CsvUploadForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1551,7 +1551,7 @@ class CsvUploadForm(StripWhitespaceForm):
 
 
 class ChangeNameForm(StripWhitespaceForm):
-    new_name = GovukTextInputField("Your name", validators=[DataRequired()])
+    new_name = GovukTextInputField("Your name", validators=[NotifyDataRequired(thing="your name")])
 
 
 class ChangeEmailForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -46,7 +46,6 @@ from wtforms.validators import (
     UUID,
     DataRequired,
     InputRequired,
-    Length,
     NumberRange,
     Optional,
     Regexp,
@@ -68,6 +67,7 @@ from app.main.validators import (
     CsvFileValidator,
     DoesNotStartWithDoubleZero,
     FileIsVirusFree,
+    Length,
     LettersNumbersSingleQuotesFullStopsAndUnderscoresOnly,
     MustContainAlphanumericCharacters,
     NoCommasInPlaceHolders,
@@ -261,7 +261,7 @@ def make_password_field(label="Password", thing="a password"):
         label,
         validators=[
             NotifyDataRequired(thing=thing),
-            Length(8, 255, message="Must be at least 8 characters"),
+            Length(min=8, max=255, message="Must be at least 8 characters"),
             CommonlyUsedPassword(message="Choose a password that’s harder to guess"),
         ],
     )
@@ -311,8 +311,7 @@ class SMSCode(GovukTextInputField):
     validators = [
         NotifyDataRequired(thing="your text message code"),
         Regexp(regex=r"^\d+$", message="Numbers only"),
-        Length(min=5, message="Not enough numbers"),
-        Length(max=5, message="Too many numbers"),
+        Length(min=5, max=5, thing="security code", unit="digits"),
     ]
 
     def process_formdata(self, valuelist):
@@ -1154,7 +1153,7 @@ class RenameServiceForm(StripWhitespaceForm):
         validators=[
             DataRequired(message="Cannot be empty"),
             MustContainAlphanumericCharacters(),
-            Length(max=255, message="Service name must be 255 characters or fewer"),
+            Length(max=255, thing="service name"),
         ],
     )
 
@@ -1165,7 +1164,7 @@ class RenameOrganisationForm(StripWhitespaceForm):
         validators=[
             DataRequired(message="Cannot be empty"),
             MustContainAlphanumericCharacters(),
-            Length(max=255, message="Organisation name must be 255 characters or fewer"),
+            Length(max=255, thing="organisation name"),
         ],
     )
 
@@ -1280,7 +1279,7 @@ class CreateServiceForm(StripWhitespaceForm):
         validators=[
             DataRequired(message="Cannot be empty"),
             MustContainAlphanumericCharacters(),
-            Length(max=255, message="Service name must be 255 characters or fewer"),
+            Length(max=255, thing="service name"),
         ],
     )
     organisation_type = OrganisationTypeField("Who runs this service?")
@@ -1741,7 +1740,11 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
             self.url.validators = [DataRequired(), URL(message="Must be a valid URL")]
 
         elif self.contact_details_type.data == "email_address":
-            self.email_address.validators = [DataRequired(), Length(min=5, max=255), ValidEmail()]
+            self.email_address.validators = [
+                DataRequired(),
+                Length(min=5, max=255, thing="email address"),
+                ValidEmail(),
+            ]
 
         elif self.contact_details_type.data == "phone_number":
             # we can't use the existing phone number validation functions here since we want to allow landlines
@@ -1759,7 +1762,7 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
 
             self.phone_number.validators = [
                 DataRequired(),
-                Length(min=3, max=20),
+                Length(min=3, max=20, thing="phone number"),
                 valid_non_emergency_phone_number,
             ]
 
@@ -1776,8 +1779,8 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
         "Text message sender",
         validators=[
             DataRequired(message="Cannot be empty"),
-            Length(max=11, message="Enter 11 characters or fewer"),
-            Length(min=3, message="Enter 3 characters or more"),
+            Length(min=3, thing="text message sender"),
+            Length(max=11, thing="text message sender"),
             LettersNumbersSingleQuotesFullStopsAndUnderscoresOnly(),
             DoesNotStartWithDoubleZero(),
         ],
@@ -2158,7 +2161,7 @@ class CallbackForm(StripWhitespaceForm):
     )
     bearer_token = GovukPasswordField(
         "Bearer token",
-        validators=[DataRequired(message="Cannot be empty"), Length(min=10, message="Must be at least 10 characters")],
+        validators=[DataRequired(message="Cannot be empty"), Length(min=10, thing="the bearer token")],
     )
 
     def validate(self):
@@ -2744,7 +2747,7 @@ class ChangeSecurityKeyNameForm(StripWhitespaceForm):
         validators=[
             DataRequired(message="Enter a name for this key"),
             MustContainAlphanumericCharacters(thing="the name of the key"),
-            Length(max=255, message="Name of key must be 255 characters or fewer"),
+            Length(max=255, thing="the name of the key"),
         ],
     )
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1358,7 +1358,6 @@ class ConfirmPasswordForm(StripWhitespaceForm):
     password = GovukPasswordField("Enter your password", validators=[NotifyDataRequired(thing="your password")])
 
     def validate_password(self, field):
-        print(self.validate_password_func)
         if not self.validate_password_func(field.data):
             raise ValidationError("Incorrect password")
 
@@ -1560,8 +1559,7 @@ class ChangeEmailForm(StripWhitespaceForm):
         self.validate_email_func = validate_email_func
         super(ChangeEmailForm, self).__init__(*args, **kwargs)
 
-    email_address = make_email_address_field(thing="Enter an email address")
-    email_address = make_email_address_field(gov_user=True)
+    email_address = make_email_address_field(thing="an email address", gov_user=True)
 
     def validate_email_address(self, field):
         # The validate_email_func can be used to call API to check if the email address is already in
@@ -2735,7 +2733,7 @@ class ChangeSecurityKeyNameForm(StripWhitespaceForm):
     security_key_name = GovukTextInputField(
         "Name of key",
         validators=[
-            DataRequired(message="Cannot be empty"),
+            DataRequired(message="Enter a name for this key"),
             MustContainAlphanumericCharacters(),
             Length(max=255, message="Name of key must be 255 characters or fewer"),
         ],

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1551,7 +1551,10 @@ class CsvUploadForm(StripWhitespaceForm):
 
 
 class ChangeNameForm(StripWhitespaceForm):
-    new_name = GovukTextInputField("Your name", validators=[NotifyDataRequired(thing="your name")])
+    new_name = GovukTextInputField(
+        "Change your name",
+        validators=[NotifyDataRequired(thing="your name")],
+    )
 
 
 class ChangeEmailForm(StripWhitespaceForm):
@@ -1559,7 +1562,11 @@ class ChangeEmailForm(StripWhitespaceForm):
         self.validate_email_func = validate_email_func
         super(ChangeEmailForm, self).__init__(*args, **kwargs)
 
-    email_address = make_email_address_field(thing="an email address", gov_user=True)
+    email_address = make_email_address_field(
+        label="Change your email address",
+        thing="an email address",
+        gov_user=True,
+    )
 
     def validate_email_address(self, field):
         # The validate_email_func can be used to call API to check if the email address is already in
@@ -1578,7 +1585,9 @@ class ChangeNonGovEmailForm(ChangeEmailForm):
 
 
 class ChangeMobileNumberForm(StripWhitespaceForm):
-    mobile_number = international_phone_number()
+    mobile_number = international_phone_number(
+        label="Change your mobile number",
+    )
 
 
 class ChooseTimeForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -252,13 +252,8 @@ def uk_mobile_number(label="Mobile number"):
     return UKMobileNumber(label, validators=[DataRequired(message="Cannot be empty")])
 
 
-def international_phone_number(label="Mobile number", thing=None):
-    validators_list = []
-    if thing:
-        validators_list.append(NotifyDataRequired(thing=thing))
-    else:
-        validators_list.append(DataRequired(message="Cannot be empty"))
-    return InternationalPhoneNumber(label, validators=validators_list)
+def international_phone_number(label="Mobile number"):
+    return InternationalPhoneNumber(label, validators=[NotifyDataRequired(thing="a mobile number")])
 
 
 def make_password_field(label="Password", thing="a password"):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1355,11 +1355,12 @@ class ConfirmPasswordForm(StripWhitespaceForm):
         self.validate_password_func = validate_password_func
         super(ConfirmPasswordForm, self).__init__(*args, **kwargs)
 
-    password = GovukPasswordField("Enter password")
+    password = GovukPasswordField("Enter your password", validators=[NotifyDataRequired(thing="your password")])
 
     def validate_password(self, field):
+        print(self.validate_password_func)
         if not self.validate_password_func(field.data):
-            raise ValidationError("Invalid password")
+            raise ValidationError("Incorrect password")
 
 
 class NewBroadcastForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1559,6 +1559,7 @@ class ChangeEmailForm(StripWhitespaceForm):
         self.validate_email_func = validate_email_func
         super(ChangeEmailForm, self).__init__(*args, **kwargs)
 
+    email_address = make_email_address_field(thing="Enter an email address")
     email_address = make_email_address_field(gov_user=True)
 
     def validate_email_address(self, field):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2743,7 +2743,7 @@ class ChangeSecurityKeyNameForm(StripWhitespaceForm):
         "Name of key",
         validators=[
             DataRequired(message="Enter a name for this key"),
-            MustContainAlphanumericCharacters(),
+            MustContainAlphanumericCharacters(thing="the name of the key"),
             Length(max=255, message="Name of key must be 255 characters or fewer"),
         ],
     )

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1839,7 +1839,7 @@ class OnOffSettingForm(StripWhitespaceForm):
 
 class YesNoSettingForm(OnOffSettingForm):
     def __init__(self, name, *args, **kwargs):
-        super().__init__(name, *args, truthy="Yes", falsey="No", **kwargs)
+        super().__init__(name, *args, truthy="Yes", falsey="No", choices_for_error_message="yes or no", **kwargs)
 
 
 class ServiceSwitchChannelForm(OnOffSettingForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1577,7 +1577,7 @@ class ChangeEmailForm(StripWhitespaceForm):
 
         is_valid = self.validate_email_func(field.data)
         if is_valid:
-            raise ValidationError("The email address is already in use")
+            raise ValidationError("This email address is already in use")
 
 
 class ChangeNonGovEmailForm(ChangeEmailForm):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -58,11 +58,10 @@ class ValidGovEmail:
 
 
 class ValidEmail:
-
-    message = "Enter a valid email address"
+    def __init__(self, message="Enter a valid email address"):
+        self.message = message
 
     def __call__(self, form, field):
-
         if not field.data:
             return
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -12,6 +12,7 @@ from wtforms import ValidationError
 from wtforms.validators import DataRequired, StopValidation
 
 from app import antivirus_client
+from app.formatters import sentence_case
 from app.main._commonly_used_passwords import commonly_used_passwords
 from app.models.spreadsheet import Spreadsheet
 from app.utils.user import is_gov_user
@@ -181,8 +182,13 @@ class MustContainAlphanumericCharacters:
 
     regex = re.compile(r".*[a-zA-Z0-9].*[a-zA-Z0-9].*")
 
-    def __init__(self, message="Must include at least two alphanumeric characters"):
-        self.message = message
+    def __init__(self, *, thing=None, message="Must include at least two alphanumeric characters"):
+        if thing:
+            self.message = f"{sentence_case(thing)} must include at least 2 letters or numbers"
+        else:
+            # DEPRECATED - prefer to pass in `thing` instead. When all instances are using `thing,` retire `message`
+            # altogether.
+            self.message = message
 
     def __call__(self, form, field):
         if field.data and not re.match(self.regex, field.data):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -10,6 +10,7 @@ from notifications_utils.template import BroadcastMessageTemplate
 from orderedset import OrderedSet
 from wtforms import ValidationError
 from wtforms.validators import DataRequired, StopValidation
+from wtforms.validators import Length as WTFormsLength
 
 from app import antivirus_client
 from app.formatters import sentence_case
@@ -242,3 +243,24 @@ class FileIsVirusFree:
 class NotifyDataRequired(DataRequired):
     def __init__(self, thing):
         super().__init__(message=f"Enter {thing}")
+
+
+class Length(WTFormsLength):
+    def __init__(self, min=-1, max=-1, message=None, thing=None, unit="characters"):
+        super().__init__(min=min, max=max, message=message)
+        self.thing = thing
+        self.unit = unit
+
+        if not self.message:
+            if not self.thing:
+                raise RuntimeError("Must provide `thing` (preferred) unless `message` is explicitly set.")
+
+            if min >= 0 and max >= 0:
+                if min == max:
+                    self.message = f"{sentence_case(thing)} must be {min} {unit} long"
+                else:
+                    self.message = f"{sentence_case(thing)} must be between {min} and {max} {unit} long"
+            elif min >= 0:
+                self.message = f"{sentence_case(thing)} must be at least {min} {unit} long"
+            else:
+                self.message = f"{sentence_case(thing)} cannot be longer than {max} {unit}"

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -239,7 +239,7 @@ def user_profile_take_part_in_user_research():
         current_user.update(take_part_in_research=form.enabled.data)
         return redirect(url_for(".user_profile"))
 
-    return render_template("views/user-profile/take-part-in-user-research.html", form=form)
+    return render_template("views/user-profile/take-part-in-user-research.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/user-profile/disable-platform-admin-view", methods=["GET", "POST"])
@@ -259,7 +259,7 @@ def user_profile_disable_platform_admin_view():
         session["disable_platform_admin_view"] = not form.enabled.data
         return redirect(url_for(".user_profile"))
 
-    return render_template("views/user-profile/disable-platform-admin-view.html", form=form)
+    return render_template("views/user-profile/disable-platform-admin-view.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/user-profile/security-keys", methods=["GET"])

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -99,6 +99,7 @@ def user_profile_email_authenticate():
         thing="email address",
         form=form,
         back_link=url_for(".user_profile_email"),
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -74,6 +74,7 @@ def user_profile_email():
         "views/user-profile/change.html",
         thing="email address",
         form=form,
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -53,7 +53,11 @@ def user_profile_name():
         current_user.update(name=form.new_name.data)
         return redirect(url_for(".user_profile"))
 
-    return render_template("views/user-profile/change.html", thing="name", form_field=form.new_name)
+    return render_template(
+        "views/user-profile/change.html",
+        thing="name",
+        form=form,
+    )
 
 
 @main.route("/user-profile/email", methods=["GET", "POST"])
@@ -66,7 +70,11 @@ def user_profile_email():
     if form.validate_on_submit():
         session[NEW_EMAIL] = form.email_address.data
         return redirect(url_for(".user_profile_email_authenticate"))
-    return render_template("views/user-profile/change.html", thing="email address", form_field=form.email_address)
+    return render_template(
+        "views/user-profile/change.html",
+        thing="email address",
+        form=form,
+    )
 
 
 @main.route("/user-profile/email/authenticate", methods=["GET", "POST"])
@@ -126,7 +134,11 @@ def user_profile_mobile_number():
         flash("Are you sure you want to delete your mobile number from Notify?", "delete")
 
     return render_template(
-        "views/user-profile/change.html", thing="mobile number", form_field=form.mobile_number, user_auth=user.auth_type
+        "views/user-profile/change.html",
+        thing="mobile number",
+        form=form,
+        user_auth=user.auth_type,
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -219,7 +219,11 @@ def user_profile_password():
         user_api_client.update_password(current_user.id, password=form.new_password.data)
         return redirect(url_for(".user_profile"))
 
-    return render_template("views/user-profile/change-password.html", form=form)
+    return render_template(
+        "views/user-profile/change-password.html",
+        form=form,
+        error_summary_enabled=True,
+    )
 
 
 @main.route("/user-profile/take-part-in-user-research", methods=["GET", "POST"])

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -304,7 +304,12 @@ def user_profile_manage_security_key(key_id):
     if request.endpoint == "main.user_profile_confirm_delete_security_key":
         flash("Are you sure you want to delete this security key?", "delete")
 
-    return render_template("views/user-profile/manage-security-key.html", security_key=security_key, form=form)
+    return render_template(
+        "views/user-profile/manage-security-key.html",
+        security_key=security_key,
+        form=form,
+        error_summary_enabled=True,
+    )
 
 
 @main.route("/user-profile/security-keys/<uuid:key_id>/delete", methods=["POST"])

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -57,6 +57,7 @@ def user_profile_name():
         "views/user-profile/change.html",
         thing="name",
         form=form,
+        error_summary_enabled=True,
     )
 
 

--- a/app/templates/components/error-summary.html
+++ b/app/templates/components/error-summary.html
@@ -8,7 +8,7 @@
         {% do errors.append(
           {
             "href": "#" + (form[field_name].error_summary_id if form[field_name].error_summary_id != undefined else form[field_name].id),
-            "text": error_list[0]
+            "text": error_list[0] | striptags
           }
         ) %}
       {% else %}

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
@@ -14,7 +13,7 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header('Change your password') }}
+  <h1 class="govuk-heading-l">Change your password</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -19,7 +19,13 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper() %}
-        {{ form_field(error_message_with_html=True) }}
+          {%  if thing == "email address" %}
+              {{ form.email_address }}
+          {%  elif thing == "name" %}
+              {{ form.new_name }}
+          {%  elif thing == "mobile number" %}
+              {{ form.mobile_number }}
+           {%  endif %}
         {% if current_user.auth_type == 'email_auth' and (current_user.mobile_number and thing == "mobile number") %}
           {{ page_footer(
             'Save',

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -17,7 +17,7 @@
     <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper() %}
           {%  if thing == "email address" %}
-              {{ form.email_address(param_extensions={"label": {"isPageHeading": True, "classes": "govuk-label--l"}}) }}
+              {{ form.email_address(param_extensions={"label": {"isPageHeading": True, "classes": "govuk-label--l"}}, error_message_with_html=True) }}
           {%  elif thing == "name" %}
               {{ form.new_name(param_extensions={"label": {"isPageHeading": True, "classes": "govuk-label--l"}}) }}
           {%  elif thing == "mobile number" %}

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
@@ -14,17 +13,15 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header('Change your {}'.format(thing)) }}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper() %}
           {%  if thing == "email address" %}
-              {{ form.email_address }}
+              {{ form.email_address(param_extensions={"label": {"isPageHeading": True, "classes": "govuk-label--l"}}) }}
           {%  elif thing == "name" %}
-              {{ form.new_name }}
+              {{ form.new_name(param_extensions={"label": {"isPageHeading": True, "classes": "govuk-label--l"}}) }}
           {%  elif thing == "mobile number" %}
-              {{ form.mobile_number }}
+              {{ form.mobile_number(param_extensions={"label": {"isPageHeading": True, "classes": "govuk-label--l"}}) }}
            {%  endif %}
         {% if current_user.auth_type == 'email_auth' and (current_user.mobile_number and thing == "mobile number") %}
           {{ page_footer(

--- a/app/templates/views/user-profile/manage-security-key.html
+++ b/app/templates/views/user-profile/manage-security-key.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
@@ -15,7 +14,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ page_header(page_title) }}
+  <h1 class="govuk-heading-l">{{ page_title }}</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">

--- a/app/templates/views/user-profile/take-part-in-user-research.html
+++ b/app/templates/views/user-profile/take-part-in-user-research.html
@@ -17,7 +17,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
-        {% call form_wrapper(class="govuk-!-margin-top-3") %}
+        {% call form_wrapper() %}
           {{
             form.enabled(param_extensions={
               "fieldset": {

--- a/tests/app/main/forms/test_service_sms_senders_form.py
+++ b/tests/app/main/forms/test_service_sms_senders_form.py
@@ -7,10 +7,10 @@ from app.main.forms import ServiceSmsSenderForm
     "sms_sender,error_expected,error_message",
     [
         ("", True, "Cannot be empty"),
-        ("22", True, "Enter 3 characters or more"),
+        ("22", True, "Text message sender must be at least 3 characters long"),
         ("333", False, None),
         ("elevenchars", False, None),  # 11 chars
-        ("twelvecharas", True, "Enter 11 characters or fewer"),  # 12 chars
+        ("twelvecharas", True, "Text message sender cannot be longer than 11 characters"),  # 12 chars
         ("###", True, "Use letters and numbers only"),
         ("00111222333", True, "Cannot start with 00"),
         ("UK_GOV", False, None),  # Underscores are allowed

--- a/tests/app/main/forms/test_two_factor_form.py
+++ b/tests/app/main/forms/test_two_factor_form.py
@@ -34,11 +34,11 @@ def test_form_is_valid_returns_no_errors(
     (
         (
             {"sms_code": "1234"},
-            "Not enough numbers",
+            "Security code must be 5 digits long",
         ),
         (
             {"sms_code": "123456"},
-            "Too many numbers",
+            "Security code must be 5 digits long",
         ),
         (
             {},

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -151,7 +151,7 @@ def test_create_new_organisation_validates(
     [
         ("", "Cannot be empty"),
         ("a", "at least two alphanumeric characters"),
-        ("a" * 256, "Organisation name must be 255 characters or fewer"),
+        ("a" * 256, "Organisation name cannot be longer than 255 characters"),
     ],
 )
 def test_create_new_organisation_fails_with_incorrect_input(
@@ -1773,7 +1773,7 @@ def test_update_organisation_name(
     [
         ("", "Cannot be empty"),
         ("a", "at least two alphanumeric characters"),
-        ("a" * 256, "Organisation name must be 255 characters or fewer"),
+        ("a" * 256, "Organisation name cannot be longer than 255 characters"),
     ],
 )
 def test_update_organisation_with_incorrect_input(

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -636,7 +636,7 @@ def test_should_show_service_name_with_no_prefixing(
     [
         ("", "Cannot be empty"),
         (".", "Must include at least two alphanumeric characters"),
-        ("a" * 256, "Service name must be 255 characters or fewer"),
+        ("a" * 256, "Service name cannot be longer than 255 characters"),
     ],
 )
 def test_service_name_change_fails_if_new_name_fails_validation(
@@ -2558,7 +2558,7 @@ def test_incorrect_letter_contact_block_input(
         ("elevenchars", None),
         ("11 chars", None),
         ("", "Cannot be empty"),
-        ("abcdefghijkhgkg", "Enter 11 characters or fewer"),
+        ("abcdefghijkhgkg", "Text message sender cannot be longer than 11 characters"),
         (r" ¯\_(ツ)_/¯ ", "Use letters and numbers only"),
         ("blood.co.uk", None),
         ("00123", "Cannot start with 00"),
@@ -2603,7 +2603,7 @@ def test_incorrect_sms_sender_input_with_multiple_errors_only_shows_the_first(
     error_message = page.select_one(".govuk-error-message")
     count_of_api_calls = len(mock_add_sms_sender.call_args_list)
 
-    assert normalize_spaces(error_message.text) == "Error: Enter 3 characters or more"
+    assert normalize_spaces(error_message.text) == "Error: Text message sender must be at least 3 characters long"
     assert count_of_api_calls == 0
 
 

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -301,7 +301,7 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
     [
         ("", "Cannot be empty"),
         (".", "Must include at least two alphanumeric characters"),
-        ("a" * 256, "Service name must be 255 characters or fewer"),
+        ("a" * 256, "Service name cannot be longer than 255 characters"),
     ],
 )
 def test_add_service_fails_if_service_name_fails_validation(

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -475,7 +475,7 @@ def test_should_validate_guestlist_items(
     [
         ("https://example.com", "", "Cannot be empty"),
         ("http://not_https.com", "1234567890", "Must be a valid https URL"),
-        ("https://test.com", "123456789", "Must be at least 10 characters"),
+        ("https://test.com", "123456789", "The bearer token must be at least 10 characters long"),
     ],
 )
 def test_callback_forms_validation(

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -482,7 +482,7 @@ def test_cannot_register_with_sms_auth_and_missing_mobile_number(
     )
 
     err = page.select_one(".govuk-error-message")
-    assert err.text.strip() == "Error: Cannot be empty"
+    assert err.text.strip() == "Error: Enter a mobile number"
     assert err.attrs["data-error-label"] == "mobile_number"
 
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -136,7 +136,8 @@ def test_should_redirect_after_email_change(
             'Enter a public sector email address or <a class="govuk-link govuk-link--no-visited-state" '
             'href="/features/who-can-use-notify">find out who can use Notify</a>',
         ),
-        ("not_valid", "Enter a valid email address"),  # 2 errors with email address, only first error shown
+        # 2 errors with email address, only first error shown
+        ("not_valid", "Enter an email address in the correct format, like name@example.gov.uk"),
     ],
 )
 def test_should_show_errors_if_new_email_address_does_not_validate(

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -131,7 +131,11 @@ def test_should_redirect_after_email_change(
 @pytest.mark.parametrize(
     "email_address,error_message",
     [
-        ("me@example.com", "Enter a public sector email address or find out who can use Notify"),
+        (
+            "me@example.com",
+            'Enter a public sector email address or <a class="govuk-link govuk-link--no-visited-state" '
+            'href="/features/who-can-use-notify">find out who can use Notify</a>',
+        ),
         ("not_valid", "Enter a valid email address"),  # 2 errors with email address, only first error shown
     ],
 )


### PR DESCRIPTION
This PR enables error summary for profile page forms as directed in [this](https://trello.com/c/IgLu00uK/449-add-error-summaries-to-profile-page-forms) ticket.

I have attached screen shots depicting the updated validation error messages that have been applied.

/user-profile/mobile-number
<img width="1092" alt="mobile-number" src="https://github.com/alphagov/notifications-admin/assets/32799090/0bfcd739-2bca-40fe-bfa0-b17fb42311ff">

/user-profile/email
<img width="1306" alt="empty-email-error" src="https://github.com/alphagov/notifications-admin/assets/32799090/adb497cd-f863-40bc-93b3-3c8b8306690a">

/user-profile/email/authenticate
<img width="1012" alt="email-address-already-in-use" src="https://github.com/alphagov/notifications-admin/assets/32799090/efad2105-a90f-499f-996b-ac8f99b9abb6">

<img width="1091" alt="incorrect-password" src="https://github.com/alphagov/notifications-admin/assets/32799090/3112c02b-b590-487f-88c2-1eee17a874db">

<img width="1128" alt="email-authenticate-empty-password" src="https://github.com/alphagov/notifications-admin/assets/32799090/901ae1d2-c44b-4341-b8f0-352fba26f300">

/user-profile/password

<img width="1140" alt="user-profile-password-errors" src="https://github.com/alphagov/notifications-admin/assets/32799090/1e1a01a0-f6dc-4d86-b36a-ac4f26271508">

/user-profile/security-keys/<key_id>/manage (when entering key name)
<img width="1210" alt="manage-security-keys" src="https://github.com/alphagov/notifications-admin/assets/32799090/ad81fd3c-bbe8-4240-b2a0-b7e8b469b397">

