### PR TITLE
Make font size smaller when numbers are very big

### DIFF
--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -1,9 +1,12 @@
 {% from "components/big-number.html" import big_number %}
 
+{% set is_high_volume = sms_cost >= 1_000_000 or letter_cost >= 1_000_000 %}
+{% set big_number_kwargs = {"smaller": not is_high_volume, "smallest": is_high_volume} %}
+
 <div class='govuk-grid-row ajax-block-container'>
   <div class='govuk-grid-column-one-third'>
     <div class="keyline-block">
-      {{ big_number("Unlimited", 'free email allowance', smaller=True) }}
+      {{ big_number("Unlimited", 'free email allowance', **big_number_kwargs) }}
     </div>
   </div>
   <div class='govuk-grid-column-one-third'>
@@ -13,10 +16,10 @@
           sms_cost,
           'spent on text messages',
           currency="£",
-          smaller=True
+          **big_number_kwargs
         ) }}
       {% else %}
-        {{ big_number(sms_allowance_remaining, 'free text messages left', smaller=True) }}
+        {{ big_number(sms_allowance_remaining, 'free text messages left', **big_number_kwargs) }}
       {% endif %}
     </div>
   </div>
@@ -26,7 +29,7 @@
         letter_cost,
         'spent on letters',
         currency="£",
-        smaller=True
+        **big_number_kwargs
       ) }}
     </div>
   </div>

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -1,7 +1,7 @@
 {% from "components/big-number.html" import big_number %}
 
-{% set is_high_volume = sms_cost >= 1_000_000 or letter_cost >= 1_000_000 %}
-{% set big_number_kwargs = {"smaller": not is_high_volume, "smallest": is_high_volume} %}
+{% set is_big_spender = sms_cost >= 1_000_000 or letter_cost >= 1_000_000 %}
+{% set big_number_kwargs = {"smaller": not is_big_spender, "smallest": is_big_spender} %}
 
 <div class='govuk-grid-row ajax-block-container'>
   <div class='govuk-grid-column-one-third'>

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -7,6 +7,9 @@
   Usage
 {% endblock %}
 
+{% set is_high_volume = total_emails_sent >= 1_000_000_000 or total_sms_cost >= 1_000_000 or total_letter_cost >= 1_000_000 %}
+{% set big_number_kwargs = {"smaller": not is_high_volume, "smallest": is_high_volume} %}
+
 {% block maincolumn_content %}
 
   <div class="heading-with-aside heading-with-aside--heading-medium">
@@ -27,7 +30,7 @@
         {{ big_number(
           total_emails_sent,
           label='sent',
-          smaller=True
+          **big_number_kwargs
         ) }}
       </div>
     </div>
@@ -38,7 +41,7 @@
           total_sms_cost,
           'spent',
           currency="£",
-          smaller=True
+          **big_number_kwargs
         ) }}
       </div>
     </div>
@@ -49,7 +52,7 @@
           total_letter_cost,
           'spent',
           currency="£",
-          smaller=True
+          **big_number_kwargs
         ) }}
       </div>
     </div>

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -9,6 +9,9 @@
   Usage
 {% endblock %}
 
+{% set is_high_volume = emails_sent >= 1_000_000_000 or sms_cost >= 1_000_000 or letter_cost >= 1_000_000 %}
+{% set big_number_kwargs = {"smaller": not is_high_volume, "smallest": is_high_volume} %}
+
 {% block maincolumn_content %}
 
     {{ page_header('Usage', size='medium') }}
@@ -21,24 +24,24 @@
         <div class='govuk-grid-column-one-third'>
           <h2 class='heading-small'>Emails</h2>
           <div class="keyline-block">
-            {{ big_number(emails_sent, 'sent', smaller=True) }}
+            {{ big_number(emails_sent, 'sent', **big_number_kwargs) }}
             {{ big_number("Unlimited", 'free allowance', smaller=True) }}
           </div>
         </div>
         <div class='govuk-grid-column-one-third'>
           <h2 class='heading-small'>Text messages</h2>
           <div class="keyline-block">
-            {{ big_number(sms_sent, 'sent', smaller=True) }}
-            {{ big_number(sms_free_allowance, 'free allowance', smaller=True) }}
+            {{ big_number(sms_sent, 'sent', **big_number_kwargs) }}
+            {{ big_number(sms_free_allowance, 'free allowance', **big_number_kwargs) }}
             {% if sms_free_allowance > 0 %}
-              {{ big_number(sms_allowance_remaining, 'free allowance remaining', smaller=True) }}
+              {{ big_number(sms_allowance_remaining, 'free allowance remaining', **big_number_kwargs) }}
             {% endif %}
             {% for row in sms_breakdown %}
               {% if row.charged_units > 0 %}
                 {{ big_number(
                   row.charged_units,
                   'at {:.2f} pence per message'.format(row.rate * 100),
-                  smaller=True
+                  **big_number_kwargs
                 ) }}
               {% endif %}
             {% endfor %}
@@ -47,7 +50,7 @@
         <div class='govuk-grid-column-one-third'>
           <h2 class='heading-small'>Letters</h2>
           <div class="keyline-block">
-            {{ big_number(letter_sent, 'sent', smaller=True) }}
+            {{ big_number(letter_sent, 'sent', **big_number_kwargs) }}
           </div>
         </div>
       </div>
@@ -64,7 +67,7 @@
               sms_cost,
               'spent',
               currency="£",
-              smaller=True
+              **big_number_kwargs
             ) }}
           </div>
         </div>
@@ -74,7 +77,7 @@
                 letter_cost,
                 'spent',
                 currency="£",
-                smaller=True
+                **big_number_kwargs
               ) }}
           </div>
         </div>

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -526,6 +526,71 @@ def test_organisation_services_shows_live_services_and_usage_with_count_of_1(
     assert normalize_spaces(usage_rows[5].text) == "£0.00 spent on letters"
 
 
+@pytest.mark.parametrize(
+    "service_usage, expected_css_class",
+    (
+        (
+            {"emails_sent": 999_999_999, "sms_cost": 0, "letter_cost": 0},
+            ".big-number-smaller",
+        ),
+        (
+            {"emails_sent": 1_000_000_000, "sms_cost": 0, "letter_cost": 0},
+            ".big-number-smallest",
+        ),
+        (
+            {"emails_sent": 0, "sms_cost": 999_999, "letter_cost": 0},
+            ".big-number-smaller",
+        ),
+        (
+            {"emails_sent": 0, "sms_cost": 1_000_000, "letter_cost": 0},
+            ".big-number-smallest",
+        ),
+        (
+            {"emails_sent": 0, "sms_cost": 0, "letter_cost": 999_999},
+            ".big-number-smaller",
+        ),
+        (
+            {"emails_sent": 0, "sms_cost": 0, "letter_cost": 1_000_000},
+            ".big-number-smallest",
+        ),
+    ),
+)
+@freeze_time("2020-02-20 20:20")
+def test_organisation_services_shows_usage_in_correct_font_size(
+    client_request,
+    mock_get_organisation,
+    mocker,
+    active_user_with_permissions,
+    fake_uuid,
+    service_usage,
+    expected_css_class,
+):
+    mocker.patch(
+        "app.organisations_client.get_services_and_usage",
+        return_value={
+            "services": [
+                service_usage
+                | {
+                    "service_id": SERVICE_ONE_ID,
+                    "service_name": "1",
+                    "chargeable_billable_sms": 1,
+                    "free_sms_limit": 250000,
+                    "sms_billable_units": 1,
+                    "sms_remainder": None,
+                },
+            ],
+            "updated_at": None,
+        },
+    )
+
+    client_request.login(active_user_with_permissions)
+    page = client_request.get(".organisation_dashboard", org_id=ORGANISATION_ID)
+
+    usage_totals = page.select_one("main .govuk-grid-row").select(expected_css_class)
+
+    assert len(usage_totals) == 3
+
+
 @freeze_time("2020-02-20 20:20")
 @pytest.mark.parametrize(
     "financial_year, expected_selected",


### PR DESCRIPTION
We have a problem where big numbers overflow the width of their columns. This happens when the numbers are bigger than we anticipated (for example when we designed the page we never imagined anyone would spend tens of millions of £ on text messages in a single year).

This commit adds some logic to reduce the font size for all the totals if any of them get so big that they overflow the width of the column. This gives us enough space to display the biggest numbers we currently store in the platform.

This happens in 3 places:

## 1. At the bottom of the service dashboard

Before | After
---|---
<img width="788" alt="Screenshot 2023-08-30 at 11 35 00" src="https://github.com/alphagov/notifications-admin/assets/355079/ff8b234a-dcf8-4f0a-8ef5-06f4cb790390"> | <img width="762" alt="Screenshot 2023-08-30 at 11 35 11" src="https://github.com/alphagov/notifications-admin/assets/355079/94445dab-8de5-4a4f-8f4e-2e510f87a49b">

## 2. The usage page for a service

Before | After
---|---
<img width="793" alt="Screenshot 2023-08-30 at 11 33 52" src="https://github.com/alphagov/notifications-admin/assets/355079/209ab456-6cfd-433d-a07e-ed746eda8a38"> | <img width="793" alt="Screenshot 2023-08-30 at 11 34 07" src="https://github.com/alphagov/notifications-admin/assets/355079/2a3c9e55-7af0-4817-8335-f5b6b39c352a">

## 3. The usage page for an organisation

Before | After
---|---
<img width="788" alt="Screenshot 2023-08-30 at 11 31 51" src="https://github.com/alphagov/notifications-admin/assets/355079/4d24c4c9-afa7-4a07-af78-722b668f77f7"> | <img width="797" alt="Screenshot 2023-08-30 at 11 32 00" src="https://github.com/alphagov/notifications-admin/assets/355079/ae7f26a0-2a3b-4f02-9672-bc0348af978d">

***


Because we use tabular numbers for these elements we don’t need to worry about the width of 1,111,111 versus 9,999,999.

A function which takes 2 arguments, `smaller` and `smallest` isn’t a great piece of API design, but if we want to refactor that it should be as a separate PR. This commit just works within the confines of the existing argument names.

Similarly we can’t wrap this logic up in the `big_number` component because it doesn’t know about:
- the width of the column in which it’s shown
- whether other numbers on the page are too big

