### PR TITLE
Make size of ‘Unlimted emails’ vary with count

### DIFF
--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -25,7 +25,7 @@
           <h2 class='heading-small'>Emails</h2>
           <div class="keyline-block">
             {{ big_number(emails_sent, 'sent', **big_number_kwargs) }}
-            {{ big_number("Unlimited", 'free allowance', smaller=True) }}
+            {{ big_number("Unlimited", 'free allowance', **big_number_kwargs) }}
           </div>
         </div>
         <div class='govuk-grid-column-one-third'>

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1034,7 +1034,7 @@ def test_usage_page_no_sms_spend(
         (
             [{"notification_type": "sms", "chargeable_units": 1, "charged_units": 1, "rate": 1, "cost": 1_000_000}],
             ".big-number-smallest",
-            8,
+            9,
         ),
         (
             [{"notification_type": "email", "notifications_sent": 999_999_999}],
@@ -1044,7 +1044,7 @@ def test_usage_page_no_sms_spend(
         (
             [{"notification_type": "email", "notifications_sent": 1_000_000_000}],
             ".big-number-smallest",
-            7,
+            8,
         ),
         (
             [{"notification_type": "letter", "notifications_sent": 1, "cost": 999_999}],
@@ -1054,7 +1054,7 @@ def test_usage_page_no_sms_spend(
         (
             [{"notification_type": "letter", "notifications_sent": 1, "cost": 1_000_000}],
             ".big-number-smallest",
-            7,
+            8,
         ),
     ),
 )


### PR DESCRIPTION
We change the font size of the count of sent emails based on the service’s volumes, to stop the big numbers overflowing their container.

When we did this we missed that the allowance (unlimted) for emails also needs to change so the font sizes match.

Before | After
---|---
<img width="351" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/fb6bda90-5bf1-4eb4-936b-68ee9e6f2b22"> | <img width="350" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/7108915c-9b26-4c51-89aa-bfc3b14ea3ed">
