### PR TITLE
Always treat UUIDs in URLs as lowercase

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -273,7 +273,7 @@ def init_app(application):
             "font_paths": font_paths,
         }
 
-    application.url_map.converters["uuid"].to_python = lambda self, value: value
+    application.url_map.converters["uuid"].to_python = lambda self, value: value.lower()
     application.url_map.converters["template_type"] = TemplateTypeConverter
     application.url_map.converters["ticket_type"] = TicketTypeConverter
     application.url_map.converters["letter_file_extension"] = LetterFileExtensionConverter

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.5
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.5
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2115,35 +2115,51 @@ def test_should_redirect_to_one_off_if_template_type_is_letter(
     )
 
 
+@pytest.mark.parametrize(
+    "service_id, template_id",
+    (
+        (
+            SERVICE_ONE_ID,
+            sample_uuid(),
+        ),
+        (
+            SERVICE_ONE_ID.upper(),
+            sample_uuid().upper(),
+        ),
+    ),
+)
 def test_should_redirect_when_saving_a_template(
     client_request,
     mock_get_service_template,
     mock_get_api_keys,
     mock_update_service_template,
-    fake_uuid,
+    service_id,
+    template_id,
 ):
     name = "new name"
     content = "template <em>content</em> with & entity"
     client_request.post(
         ".edit_service_template",
-        service_id=SERVICE_ONE_ID,
-        template_id=fake_uuid,
+        service_id=service_id,
+        template_id=template_id,
         _data={
-            "id": fake_uuid,
+            "id": template_id,
             "name": name,
             "template_content": content,
             "template_type": "sms",
-            "service": SERVICE_ONE_ID,
+            "service": service_id,
         },
         _expected_status=302,
         _expected_redirect=url_for(
             "main.view_template",
+            # UUIDs are always lowercase here
             service_id=SERVICE_ONE_ID,
-            template_id=fake_uuid,
+            template_id=sample_uuid(),
         ),
     )
     mock_update_service_template.assert_called_with(
-        template_id=fake_uuid,
+        # UUIDs are always lowercase here
+        template_id=sample_uuid(),
         service_id=SERVICE_ONE_ID,
         name=name,
         content=content,


### PR DESCRIPTION
In https://github.com/alphagov/notifications-admin/commit/554a852e2d2d1e5c0315af6ea1feaf179e5d42d2 we overrode the `to_python` method of Flask’s UUID URL convertor to return strings, not `UUID` instances.

This is because it’s easier for us to deal with strings in our test assertions.

However one advantage of dealing with `UUID` instances is that when they are cast to `str` they are always lowercase. This is behaviour that we didn’t match in our overridden method.

Flask’s UUID URL convertor matches on lowercase, uppercase or mixed case UUIDs (which is technically correct because they should be treated as hexadecimal values).

This means that when we passed UUIDs to other parts of the codebase it was possible for them to be strings with uppercase characters in.

This caused a particular problem with our cache keys, which were expecting consistent casing.

While we are fixing this in the caching code (see https://github.com/alphagov/notifications-utils/pull/1064) I think it’s also a good idea to still be consistent with Flask’s default UUID URL convertor, to prevent unexpected bugs like this in the future.

# Utils changes brought in by this PR

## 70.0.5

* Ensure UUIDs in Redis cache keys are always lowercase

 ## 70.0.4

* Update the commit message auto-generated by `make bump-utils` (in app repos) to be copy/pastable via eg vim commit message editing.

 ## 70.0.3

* Remove empty table cell from 'branding only' branding HTML to fix bug with JAWS screen reader

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/70.0.2...70.0.5