### PR TITLE
Fix spacing issue on `/verify` page

### DIFF
--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -27,7 +27,7 @@ def verify():
         session.pop("user_details", None)
         return activate_user(user_id)
 
-    return render_template("views/two-factor-sms.html", form=form)
+    return render_template("views/two-factor-sms.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/verify-email/<token>")


### PR DESCRIPTION
Fix for this spacing issue:

<img width="806" alt="image" src="https://github.com/alphagov/notifications-admin/assets/87140/52185aa3-9a5c-4753-a17e-7c292065a163">

...which these changes make look like:

![image](https://github.com/alphagov/notifications-admin/assets/87140/ef18d3dc-052c-4293-8c5a-98067d687e4f)

This came about by an unlucky combination of things:
- the `/two-factor-sms` and `/verify` routes share the `app/templates/views/two-factor-sms.html` template
- both have the `app/templates/withoutnav_template.html` page as a parent
- `/two-factor-sms` was changed to set the `error_summary_enabled` flag when rendering but `/verify` wasn't
- having the `error_summary_enabled` flag set removed classes on the `<main>` block which set `padding-top: 0` on the main content area (which the h1 is in)
- we replaced the `heading-large` class on the h1 with `govuk-heading-l` in the `app/templates/views/two-factor-sms.html` page for very good reasons (see https://github.com/alphagov/notifications-admin/commit/219a10c1cdbb8bd8512288e3e502a6b979ef69ac) but this meant `/verify` had no `margin-top` on the h1 or `padding-top` on `<main>`, because it didn't have the `error_summary_enabled` flag set, so there is nothing creating space above the h1 when no error summaries are present

This just adds the flag, making `/verify` like `/two-factor-sms`, and so giving it the spacing originally intended.
