### PR TITLE
Bump utils to 70.0.6

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.5
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.6
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.5
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.6
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
 ## 70.0.6

* Fix QR code rendering for old-style syntax `[QR]()`

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/70.0.5...70.0.6