### PR TITLE
Add a line about how long to keep files

### DIFF
--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -24,7 +24,12 @@
 
   <h2 class="heading-medium">Protect personal information about your users</h2>
   <p class="govuk-body">When the recipient clicks the link in the email, they will need to enter their email address. Only someone who knows the recipient’s email address can download the file. This security feature is optional.</p>
-  <p class="govuk-body">You can also choose the length of time that a file is available to download. To reduce the risk to your recipients, you should keep this as short as possible.</p>
+  <p class="govuk-body">You can also choose the length of time that a file is available to download. When doing this, you should consider:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>the risk to the recipient if the file contains personal information</li>
+    <li>whether they’ll need to download the file again later</li>
+  </ul>
 
   <h2 class="heading-medium">How to send files by email</h2>
   <p class="govuk-body">This is currently an API-only feature. You’ll need a developer on your team to set it up for you.</p>

--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -28,7 +28,7 @@
 
   <ul class="govuk-list govuk-list--bullet">
     <li>the need to protect the recipient’s personal information</li>
-    <li>whether they’ll need to download the file again later</li>
+    <li>whether the recipient will need to download the file again later</li>
   </ul>
 
   <h2 class="heading-medium">How to send files by email</h2>

--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -24,7 +24,7 @@
 
   <h2 class="heading-medium">Protect personal information about your users</h2>
   <p class="govuk-body">When the recipient clicks the link in the email, they will need to enter their email address. Only someone who knows the recipient’s email address can download the file. This security feature is optional.</p>
-  <p class="govuk-body">You can also choose the length of time that a file is available to download. When doing this, you should consider:</p>
+  <p class="govuk-body">You can also choose the length of time that a file is available to download. When deciding this, you should consider:</p>
 
   <ul class="govuk-list govuk-list--bullet">
     <li>the risk to the recipient if the file contains personal information</li>

--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -27,7 +27,7 @@
   <p class="govuk-body">You can also choose the length of time that a file is available to download. When deciding this, you should consider:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>the risk to the recipient if the file contains personal information</li>
+    <li>the need to protect the recipient’s personal information</li>
     <li>whether they’ll need to download the file again later</li>
   </ul>
 

--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -24,7 +24,7 @@
 
   <h2 class="heading-medium">Protect personal information about your users</h2>
   <p class="govuk-body">When the recipient clicks the link in the email, they will need to enter their email address. Only someone who knows the recipient’s email address can download the file. This security feature is optional.</p>
-  <p class="govuk-body">You can also choose the length of time that a file is available to download.</p>
+  <p class="govuk-body">You can also choose the length of time that a file is available to download. To reduce the risk to your recipients, you should keep this as short as possible.</p>
 
   <h2 class="heading-medium">How to send files by email</h2>
   <p class="govuk-body">This is currently an API-only feature. You’ll need a developer on your team to set it up for you.</p>


### PR DESCRIPTION
Information Assurance asked us to recommend that services keep files available for as short a period as practically possible.

We were asked to include this in Notify’s terms and conditions, but agreed it would be more relevant and useful in the:

* Using Notify guidance
* API documentation