### PR TITLE
Enable custom data retention for all

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -130,7 +130,7 @@ def service_name_change(service_id):
 
 
 @main.route("/services/<uuid:service_id>/service-settings/set-data-retention", methods=["GET", "POST"])
-@user_is_platform_admin
+@user_has_permissions("manage_service")
 def service_data_retention(service_id):
     high_volume_service = service_has_or_is_expected_to_send_x_or_more_notifications(
         current_service, num_notifications=1_000_000

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -47,8 +47,7 @@
           }}
         {% endcall %}
 
-        {# TODO: Remove platform admin restriction when we want to release this #}
-        {% if not current_service.has_permission('broadcast') and current_user.platform_admin %}
+        {% if not current_service.has_permission('broadcast') %}
           {% call row() %}
             {{ text_field('Data retention period') }}
             {% if current_service.get_consistent_data_retention_period() %}

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -510,6 +510,7 @@ def test_email_branding_option_preview_changes_email_branding_when_user_confirms
     single_sms_sender,
     mock_get_email_branding_pool,
     mock_update_service,
+    mock_get_service_data_retention,
 ):
     organisation_one["organisation_type"] = "central"
     service_one["organisation"] = organisation_one
@@ -599,6 +600,7 @@ def test_email_branding_govuk_submit(
     mock_get_email_branding,
     single_sms_sender,
     mock_update_service,
+    mock_get_service_data_retention,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -635,6 +637,7 @@ def test_email_branding_nhs_submit(
     mock_get_email_branding,
     single_sms_sender,
     mock_update_service,
+    mock_get_service_data_retention,
 ):
     service_one["email_branding"] = sample_uuid()
     service_one["organisation_type"] = "nhs_local"
@@ -736,6 +739,7 @@ def test_email_branding_request_submit(
     mock_get_empty_email_branding_pool,
     mock_get_email_branding,
     single_sms_sender,
+    mock_get_service_data_retention,
 ):
     service_one["email_branding"] = sample_uuid()
     service_one["organisation_type"] = "nhs_local"

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -735,6 +735,7 @@ def test_letter_branding_option_preview_changes_letter_branding_when_user_confir
     single_sms_sender,
     mock_get_letter_branding_pool,
     mock_update_service,
+    mock_get_service_data_retention,
 ):
     organisation_one["organisation_type"] = "central"
     service_one["organisation"] = organisation_one

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -67,6 +67,7 @@ def mock_get_service_settings_page_common(
                 "Label Value Action",
                 "Service name Test Service Change service name",
                 "Sign-in method Text message code Change sign-in method",
+                "Data retention period 7 days Change data retention",
                 "Label Value Action",
                 "Send emails On Change your settings for sending emails",
                 "Reply-to email addresses Not set Manage reply-to email addresses",
@@ -89,6 +90,7 @@ def mock_get_service_settings_page_common(
                 "Label Value Action",
                 "Service name Test Service Change service name",
                 "Sign-in method Text message code Change sign-in method",
+                "Data retention period 7 days Change data retention",
                 "Label Value Action",
                 "Send emails Off Change your settings for sending emails",
                 "Label Value Action",
@@ -425,6 +427,7 @@ def test_send_files_by_email_row_on_settings_page(
             [
                 "Service name service one Change service name",
                 "Sign-in method Text message code Change sign-in method",
+                "Data retention period 7 days Change data retention",
                 "Label Value Action",
                 "Send emails On Change your settings for sending emails",
                 "Reply-to email addresses test@example.com Manage reply-to email addresses",
@@ -445,6 +448,7 @@ def test_send_files_by_email_row_on_settings_page(
             [
                 "Service name service one Change service name",
                 "Sign-in method Email link or text message code Change sign-in method",
+                "Data retention period 7 days Change data retention",
                 "Label Value Action",
                 "Send emails On Change your settings for sending emails",
                 "Reply-to email addresses test@example.com Manage reply-to email addresses",
@@ -465,6 +469,7 @@ def test_send_files_by_email_row_on_settings_page(
             [
                 "Service name service one Change service name",
                 "Sign-in method Text message code Change sign-in method",
+                "Data retention period 7 days Change data retention",
                 "Label Value Action",
                 "Send emails Off Change your settings for sending emails",
                 "Label Value Action",
@@ -532,7 +537,7 @@ def test_letter_contact_block_shows_none_if_not_set(
         service_id=SERVICE_ONE_ID,
     )
 
-    div = page.select("tr")[10].select("td")[1].div
+    div = page.select("tr")[11].select("td")[1].div
     assert div.text.strip() == "Not set"
     assert "default" in div.attrs["class"][0]
 
@@ -552,7 +557,7 @@ def test_escapes_letter_contact_block(
         service_id=SERVICE_ONE_ID,
     )
 
-    div = str(page.select("tr")[10].select("td")[1].div)
+    div = str(page.select("tr")[11].select("td")[1].div)
     assert "foo<br/>bar" in div
     assert "<script>" not in div
 
@@ -5412,6 +5417,7 @@ def test_service_settings_page_loads_when_inbound_number_is_not_set(
     single_reply_to_email_address,
     single_sms_sender,
     mock_no_inbound_number_for_service,
+    mock_get_service_data_retention,
 ):
     client_request.get(
         "main.service_settings",
@@ -5688,6 +5694,7 @@ def test_service_settings_links_to_branding_request_page_for_emails(
     client_request,
     no_reply_to_email_addresses,
     single_sms_sender,
+    mock_get_service_data_retention,
 ):
     # expect to have a "NHS" option as well as the
     # fallback one, so ask user to choose
@@ -5704,6 +5711,7 @@ def test_service_settings_links_to_branding_options_page_for_letters(
     no_reply_to_email_addresses,
     no_letter_contact_blocks,
     single_sms_sender,
+    mock_get_service_data_retention,
 ):
     service_one["permissions"].append("letter")
     page = client_request.get(".service_settings", service_id=SERVICE_ONE_ID)


### PR DESCRIPTION
Remove the platform admin check on this service setting entry, so that all users with the `manage_service` permission can read/set it.