### PR TITLE
Enable error summaries for service settings pages

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1755,11 +1755,14 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
 
     def validate(self):
         if self.contact_details_type.data == "url":
-            self.url.validators = [DataRequired(), URL(message="Must be a valid URL")]
+            self.url.validators = [
+                NotifyDataRequired(thing="a URL in the correct format"),
+                URL(message="Enter a URL in the correct format"),
+            ]
 
         elif self.contact_details_type.data == "email_address":
             self.email_address.validators = [
-                DataRequired(),
+                NotifyDataRequired(thing="an email address"),
                 Length(min=5, max=255, thing="email address"),
                 ValidEmail(),
             ]
@@ -1771,15 +1774,15 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
                 try:
                     normalised_number = normalise_phone_number(num.data)
                 except InvalidPhoneError as e:
-                    raise ValidationError("Must be a valid phone number") from e
+                    raise ValidationError("Enter a phone number in the correct format") from e
 
                 if normalised_number in {"999", "112"}:
-                    raise ValidationError("Must not be an emergency number")
+                    raise ValidationError("Phone number cannot be an emergency number")
 
                 return True
 
             self.phone_number.validators = [
-                DataRequired(),
+                NotifyDataRequired(thing="a phone number"),
                 Length(min=3, max=20, thing="phone number"),
                 valid_non_emergency_phone_number,
             ]
@@ -1788,7 +1791,7 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
 
 
 class ServiceReplyToEmailForm(StripWhitespaceForm):
-    email_address = make_email_address_field(label="Reply-to email address", gov_user=False)
+    email_address = make_email_address_field(label="Reply-to email address", thing="an email address", gov_user=False)
     is_default = GovukCheckboxField("Make this email address the default")
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2690,7 +2690,10 @@ class AcceptAgreementForm(StripWhitespaceForm):
             on_behalf_of_email=org.agreement_signed_on_behalf_of_email_address,
         )
 
-    version = GovukTextInputField("Which version of the agreement do you want to accept?")
+    version = GovukTextInputField(
+        "Which version of the agreement do you want to accept?",
+        validators=[NotifyDataRequired(thing="a version number")],
+    )
 
     who = GovukRadiosField(
         "Who are you accepting the agreement for?",
@@ -2715,9 +2718,16 @@ class AcceptAgreementForm(StripWhitespaceForm):
     )
 
     def __validate_if_nominating(self, field):
+
+        error_messages = {
+            "on_behalf_of_name": "Enter the name of the person accepting the agreement",
+            "on_behalf_of_email": "Enter the email address of the person accepting the agreement",
+        }
+
         if self.who.data == "someone-else":
             if not field.data:
-                raise ValidationError("Cannot be empty")
+                error_message = error_messages[field.name]
+                raise ValidationError(error_message)
         else:
             field.data = ""
 
@@ -2728,7 +2738,7 @@ class AcceptAgreementForm(StripWhitespaceForm):
         try:
             float(field.data)
         except (TypeError, ValueError) as e:
-            raise ValidationError("Must be a number") from e
+            raise ValidationError("Enter a version number in digits, like 3.1") from e
 
 
 class BroadcastAreaForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1158,8 +1158,8 @@ class RenameServiceForm(StripWhitespaceForm):
     name = GovukTextInputField(
         "Service name",
         validators=[
-            DataRequired(message="Cannot be empty"),
-            MustContainAlphanumericCharacters(),
+            NotifyDataRequired(thing="a service name"),
+            MustContainAlphanumericCharacters(thing="Service name"),
             Length(max=255, thing="service name"),
         ],
     )
@@ -1313,9 +1313,9 @@ class AdminNewOrganisationForm(
 class AdminServiceSMSAllowanceForm(StripWhitespaceForm):
     free_sms_allowance = GovukIntegerField(
         "Numbers of text message fragments per year",
-        things="text message fragments",
+        things="the number of text message fragments",
         validators=[
-            InputRequired(message="Cannot be empty"),
+            InputRequired(message="Enter a number of text messages"),
             NumberRange(min=0, message="Number must be greater than or equal to 0"),
         ],
     )
@@ -1709,7 +1709,7 @@ class AdminProviderRatioForm(OrderableFieldsForm):
                 provider["identifier"],
                 GovukIntegerField(
                     f"{provider['display_name']} (%)",
-                    things="percentage",
+                    things="a percentage",
                     validators=[validators.NumberRange(min=0, max=100, message="Must be between 0 and 100")],
                     param_extensions={
                         "classes": "govuk-input--width-3",

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1322,14 +1322,7 @@ class AdminServiceSMSAllowanceForm(StripWhitespaceForm):
 
 
 class AdminServiceMessageLimitForm(StripWhitespaceForm):
-    message_limit = GovukIntegerField(
-        "",
-        things="the number of messages",
-        validators=[
-            DataRequired(message="Cannot be empty"),
-            NumberRange(min=0, message="Number must be greater than or equal to 0"),
-        ],
-    )
+    message_limit = GovukIntegerField("", things="the number of messages", validators=[])
 
     def __init__(self, notification_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1343,6 +1336,11 @@ class AdminServiceMessageLimitForm(StripWhitespaceForm):
                 )
             }
         }
+        self.type_of_message = {"email": "emails", "sms": "text messages", "letter": "letters"}
+        self.message_limit.validators = [
+            InputRequired(message=f"Enter a number of {self.type_of_message[notification_type]}"),
+            NumberRange(min=0, message="Number must be greater than or equal to 0"),
+        ]
 
 
 class AdminServiceRateLimitForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1737,13 +1737,13 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
     contact_details_type = GovukRadiosField(
         "Type of contact details",
         choices=[
-            ("url", "Link"),
+            ("url", "Link to a website"),
             ("email_address", "Email address"),
             ("phone_number", "Phone number"),
         ],
     )
 
-    url = GovukTextInputField("URL")
+    url = GovukTextInputField("URL", param_extensions={"hint": {"text": "For example, https://www.example.gov.uk"}})
     email_address = GovukEmailField("Email address")
     # This is a text field because the number provided by the user can also be a short code
     phone_number = GovukTextInputField("Phone number")
@@ -2388,11 +2388,11 @@ class AdminServiceAddDataRetentionForm(StripWhitespaceForm):
             ("sms", "SMS"),
             ("letter", "Letter"),
         ],
-        thing="notification type",
+        thing="a type of notification",
     )
     days_of_retention = GovukIntegerField(
         label="Days of retention",
-        things="days of retention",
+        things="a number of days",
         validators=[validators.NumberRange(min=3, max=90, message="The number of days must be between 3 and 90")],
     )
 
@@ -2400,8 +2400,8 @@ class AdminServiceAddDataRetentionForm(StripWhitespaceForm):
 class AdminServiceEditDataRetentionForm(StripWhitespaceForm):
     days_of_retention = GovukIntegerField(
         label="Days of retention",
-        things="days of retention",
-        validators=[validators.NumberRange(min=3, max=90, message="Must be between 3 and 90")],
+        things="a number of days",
+        validators=[validators.NumberRange(min=3, max=90, message="The number of days must be between 3 and 90")],
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -359,7 +359,7 @@ class GovukIntegerField(GovukTextInputField):
                 raise StopValidation(f"Enter {self.things} in digits")
 
             if not isinstance(self.data, int):
-                raise StopValidation(f"{sentence_case(self.things)} must be a whole number")
+                raise StopValidation(f"Enter {self.things} in digits")
 
             if self.data > self.POSTGRES_MAX_INT:
                 raise ValidationError(
@@ -1350,7 +1350,7 @@ class AdminServiceRateLimitForm(StripWhitespaceForm):
         "Number of messages the service can send in a rolling 60 second window",
         things="the number of messages",
         validators=[
-            DataRequired(message="Cannot be empty"),
+            NotifyDataRequired(thing="a number of messages"),
             NumberRange(min=0, message="Number must be greater than or equal to 0"),
         ],
     )

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -42,10 +42,8 @@ from wtforms import (
 )
 from wtforms import RadioField as WTFormsRadioField
 from wtforms.validators import (
-    URL,
     UUID,
     DataRequired,
-    InputRequired,
     NumberRange,
     Optional,
     Regexp,
@@ -76,6 +74,8 @@ from app.main.validators import (
     NoPlaceholders,
     NoTextInSVG,
     NotifyDataRequired,
+    NotifyInputRequired,
+    NotifyUrlValidator,
     OnlySMSCharacters,
     StringsNotAllowed,
     ValidEmail,
@@ -354,9 +354,6 @@ class GovukIntegerField(GovukTextInputField):
     def pre_validate(self, form):
 
         if self.data:
-
-            if isinstance(self.data, str):
-                raise StopValidation(f"Enter {self.things} in digits")
 
             if not isinstance(self.data, int):
                 raise StopValidation(f"Enter {self.things} in digits")
@@ -1159,7 +1156,7 @@ class RenameServiceForm(StripWhitespaceForm):
         "Service name",
         validators=[
             NotifyDataRequired(thing="a service name"),
-            MustContainAlphanumericCharacters(thing="Service name"),
+            MustContainAlphanumericCharacters(thing="service name"),
             Length(max=255, thing="service name"),
         ],
     )
@@ -1315,7 +1312,7 @@ class AdminServiceSMSAllowanceForm(StripWhitespaceForm):
         "Numbers of text message fragments per year",
         things="the number of text message fragments",
         validators=[
-            InputRequired(message="Enter a number of text messages"),
+            NotifyInputRequired(thing="a number of text messages"),
             NumberRange(min=0, message="Number must be greater than or equal to 0"),
         ],
     )
@@ -1336,9 +1333,8 @@ class AdminServiceMessageLimitForm(StripWhitespaceForm):
                 )
             }
         }
-        self.type_of_message = {"email": "emails", "sms": "text messages", "letter": "letters"}
         self.message_limit.validators = [
-            InputRequired(message=f"Enter a number of {self.type_of_message[notification_type]}"),
+            NotifyInputRequired(thing=f"a number of {message_count_noun(2, notification_type)}"),
             NumberRange(min=0, message="Number must be greater than or equal to 0"),
         ]
 
@@ -1755,7 +1751,7 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
         if self.contact_details_type.data == "url":
             self.url.validators = [
                 NotifyDataRequired(thing="a URL in the correct format"),
-                URL(message="Enter a URL in the correct format"),
+                NotifyUrlValidator(),
             ]
 
         elif self.contact_details_type.data == "email_address":

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1796,7 +1796,7 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
     sms_sender = GovukTextInputField(
         "Text message sender",
         validators=[
-            DataRequired(message="Cannot be empty"),
+            NotifyDataRequired(thing="a text message sender"),
             Length(min=3, thing="text message sender"),
             Length(max=11, thing="text message sender"),
             LettersNumbersSingleQuotesFullStopsAndUnderscoresOnly(),

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1823,13 +1823,15 @@ class AdminBillingDetailsForm(StripWhitespaceForm):
 
 
 class ServiceLetterContactBlockForm(StripWhitespaceForm):
-    letter_contact_block = TextAreaField(validators=[DataRequired(message="Cannot be empty"), NoCommasInPlaceHolders()])
+    letter_contact_block = TextAreaField(
+        validators=[NotifyDataRequired(thing="a sender address"), NoCommasInPlaceHolders()]
+    )
     is_default = GovukCheckboxField("Set as your default address")
 
     def validate_letter_contact_block(self, field):
         line_count = field.data.strip().count("\n")
         if line_count >= 10:
-            raise ValidationError(f"Contains {line_count + 1} lines, maximum is 10")
+            raise ValidationError(f"This address is {line_count + 1} lines long - the most you can have is 10 lines")
 
 
 class OnOffSettingForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -44,6 +44,7 @@ from wtforms import RadioField as WTFormsRadioField
 from wtforms.validators import (
     UUID,
     DataRequired,
+    InputRequired,
     NumberRange,
     Optional,
     Regexp,
@@ -2392,7 +2393,7 @@ class AdminServiceAddDataRetentionForm(StripWhitespaceForm):
     days_of_retention = GovukIntegerField(
         label="Days of retention",
         things="days of retention",
-        validators=[validators.NumberRange(min=3, max=90, message="Must be between 3 and 90")],
+        validators=[validators.NumberRange(min=3, max=90, message="The number of days must be between 3 and 90")],
     )
 
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -58,7 +58,7 @@ class ValidGovEmail:
 
 
 class ValidEmail:
-    def __init__(self, message="Enter a valid email address"):
+    def __init__(self, message="Enter an email address in the correct format, like name@example.gov.uk"):
         self.message = message
 
     def __call__(self, form, field):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -9,7 +9,7 @@ from notifications_utils.sanitise_text import SanitiseSMS
 from notifications_utils.template import BroadcastMessageTemplate
 from orderedset import OrderedSet
 from wtforms import ValidationError
-from wtforms.validators import DataRequired, StopValidation
+from wtforms.validators import URL, DataRequired, InputRequired, StopValidation
 from wtforms.validators import Length as WTFormsLength
 
 from app import antivirus_client
@@ -241,6 +241,16 @@ class FileIsVirusFree:
 
 class NotifyDataRequired(DataRequired):
     def __init__(self, thing):
+        super().__init__(message=f"Enter {thing}")
+
+
+class NotifyInputRequired(InputRequired):
+    def __init__(self, thing):
+        super().__init__(message=f"Enter {thing}")
+
+
+class NotifyUrlValidator(URL):
+    def __init__(self, thing="a URL in the correct format"):
         super().__init__(message=f"Enter {thing}")
 
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -161,7 +161,7 @@ class LettersNumbersSingleQuotesFullStopsAndUnderscoresOnly:
 
     regex = re.compile(r"^[a-zA-Z0-9\s\._']+$")
 
-    def __init__(self, message="Use letters and numbers only"):
+    def __init__(self, message="Text message sender can only include letters and numbers"):
         self.message = message
 
     def __call__(self, form, field):
@@ -170,7 +170,7 @@ class LettersNumbersSingleQuotesFullStopsAndUnderscoresOnly:
 
 
 class DoesNotStartWithDoubleZero:
-    def __init__(self, message="Cannot start with 00"):
+    def __init__(self, message="Text message sender cannot start with 00"):
         self.message = message
 
     def __call__(self, form, field):

--- a/app/main/views/agreement.py
+++ b/app/main/views/agreement.py
@@ -50,10 +50,7 @@ def service_accept_agreement(service_id):
         )
         return redirect(url_for("main.service_confirm_agreement", service_id=current_service.id))
 
-    return render_template(
-        "views/agreement/agreement-accept.html",
-        form=form,
-    )
+    return render_template("views/agreement/agreement-accept.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/services/<uuid:service_id>/agreement/confirm", methods=["GET", "POST"])

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -172,7 +172,13 @@ def edit_user_email(service_id, user_id):
 
         return redirect(url_for(".confirm_edit_user_email", user_id=user.id, service_id=service_id))
 
-    return render_template("views/manage-users/edit-user-email.html", user=user, form=form, service_id=service_id)
+    return render_template(
+        "views/manage-users/edit-user-email.html",
+        user=user,
+        form=form,
+        service_id=service_id,
+        error_summary_enabled=True,
+    )
 
 
 @main.route("/services/<uuid:service_id>/users/<uuid:user_id>/edit-email/confirm", methods=["GET", "POST"])
@@ -218,7 +224,13 @@ def edit_user_mobile_number(service_id, user_id):
         session["team_member_mobile_change"] = form.mobile_number.data
 
         return redirect(url_for(".confirm_edit_user_mobile_number", user_id=user.id, service_id=service_id))
-    return render_template("views/manage-users/edit-user-mobile.html", user=user, form=form, service_id=service_id)
+    return render_template(
+        "views/manage-users/edit-user-mobile.html",
+        user=user,
+        form=form,
+        service_id=service_id,
+        error_summary_enabled=True,
+    )
 
 
 @main.route("/services/<uuid:service_id>/users/<uuid:user_id>/edit-mobile-number/confirm", methods=["GET", "POST"])

--- a/app/main/views/organisations/branding.py
+++ b/app/main/views/organisations/branding.py
@@ -367,4 +367,5 @@ def add_organisation_letter_branding_options(org_id):
         "views/organisations/organisation/settings/add-letter-branding-options.html",
         form=form,
         _search_form=SearchByNameForm(),
+        error_summary_enabled=True,
     )

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -102,8 +102,7 @@ def email_branding_options(service_id):
         )
 
     return render_template(
-        "views/service-settings/branding/email-branding-options.html",
-        form=form,
+        "views/service-settings/branding/email-branding-options.html", form=form, error_summary_enabled=True
     )
 
 

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -604,6 +604,7 @@ def letter_branding_options(service_id):
         "views/service-settings/branding/letter-branding-options.html",
         form=form,
         from_template=from_template,
+        error_summary_enabled=True,
     )
 
 
@@ -648,6 +649,7 @@ def letter_branding_request(service_id):
             service_id=current_service.id,
             **_letter_branding_flow_query_params(),
         ),
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -582,7 +582,6 @@ def get_service_verify_reply_to_address_partials(service_id, notification_id):
 def service_edit_email_reply_to(service_id, reply_to_email_id):
     form = ServiceReplyToEmailForm()
     reply_to_email_address = current_service.get_email_reply_to_address(reply_to_email_id)
-    print(reply_to_email_address)
     if request.method == "GET":
         form.email_address.data = reply_to_email_address["email_address"]
         form.is_default.data = reply_to_email_address["is_default"]
@@ -605,20 +604,18 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
             ]["id"]
 
         except HTTPError as e:
-            if e.status_code == 409:
-                flash(e.message, "error")
-                return redirect(url_for(".service_email_reply_to", service_id=service_id))
-            else:
-                raise e
-        return redirect(
-            url_for(
-                ".service_verify_reply_to_address",
-                service_id=service_id,
-                notification_id=notification_id,
-                is_default=True if reply_to_email_address["is_default"] else form.is_default.data,
-                replace=reply_to_email_id,
+            handle_reply_to_email_address_http_error(e, form)
+
+        else:
+            return redirect(
+                url_for(
+                    ".service_verify_reply_to_address",
+                    service_id=service_id,
+                    notification_id=notification_id,
+                    is_default=True if reply_to_email_address["is_default"] else form.is_default.data,
+                    replace=reply_to_email_id,
+                )
             )
-        )
 
     if request.endpoint == "main.service_confirm_delete_email_reply_to":
         flash("Are you sure you want to delete this reply-to email address?", "delete")
@@ -627,6 +624,7 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
         form=form,
         reply_to_email_address_id=reply_to_email_id,
         show_choice_of_default_checkbox=show_choice_of_default_checkbox,
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -915,6 +915,7 @@ def service_add_letter_contact(service_id):
             if from_template
             else url_for(".service_letter_contact_details", service_id=current_service.id)
         ),
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1086,10 +1086,7 @@ def set_per_day_message_limit(service_id, notification_type):
 
         return redirect(url_for(".service_settings", service_id=service_id))
 
-    return render_template(
-        "views/service-settings/set-message-limit.html",
-        form=form,
-    )
+    return render_template("views/service-settings/set-message-limit.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/services/<uuid:service_id>/service-settings/set-rate-limit", methods=["GET", "POST"])

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -990,7 +990,12 @@ def service_add_sms_sender(service_id):
             is_default=first_sms_sender if first_sms_sender else form.is_default.data,
         )
         return redirect(url_for(".service_sms_senders", service_id=service_id))
-    return render_template("views/service-settings/sms-sender/add.html", form=form, first_sms_sender=first_sms_sender)
+    return render_template(
+        "views/service-settings/sms-sender/add.html",
+        form=form,
+        first_sms_sender=first_sms_sender,
+        error_summary_enabled=True,
+    )
 
 
 @main.route(

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -427,7 +427,10 @@ def send_files_by_email_contact_details(service_id):
         return redirect(url_for(".service_settings", service_id=current_service.id))
 
     return render_template(
-        "views/service-settings/send-files-by-email.html", form=form, contact_details=contact_details
+        "views/service-settings/send-files-by-email.html",
+        form=form,
+        contact_details=contact_details,
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1298,6 +1298,7 @@ def edit_data_retention(service_id, data_retention_id):
         form=form,
         data_retention_id=data_retention_id,
         notification_type=data_retention_item["notification_type"],
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1282,7 +1282,11 @@ def add_data_retention(service_id):
             service_id, form.notification_type.data, form.days_of_retention.data
         )
         return redirect(url_for(".data_retention", service_id=service_id))
-    return render_template("views/service-settings/data-retention/add.html", form=form)
+    return render_template(
+        "views/service-settings/data-retention/add.html",
+        form=form,
+        error_summary_enabled=True,
+    )
 
 
 @main.route("/services/<uuid:service_id>/data-retention/<uuid:data_retention_id>/edit", methods=["GET", "POST"])

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -126,6 +126,7 @@ def service_name_change(service_id):
         "views/service-settings/name.html",
         form=form,
         organisation_type=current_service.organisation_type,
+        error_summary_enabled=True,
     )
 
 
@@ -1064,10 +1065,7 @@ def set_free_sms_allowance(service_id):
 
         return redirect(url_for(".service_settings", service_id=service_id))
 
-    return render_template(
-        "views/service-settings/set-free-sms-allowance.html",
-        form=form,
-    )
+    return render_template("views/service-settings/set-free-sms-allowance.html", form=form, error_summary_enabled=True)
 
 
 @main.route(

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1102,10 +1102,7 @@ def set_per_minute_rate_limit(service_id):
 
         return redirect(url_for(".service_settings", service_id=service_id))
 
-    return render_template(
-        "views/service-settings/set-rate-limit.html",
-        form=form,
-    )
+    return render_template("views/service-settings/set-rate-limit.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/services/<uuid:service_id>/service-settings/set-<notification_type>-branding", methods=["GET", "POST"])

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1037,6 +1037,7 @@ def service_edit_sms_sender(service_id, sms_sender_id):
         sms_sender=sms_sender,
         inbound_number=is_inbound_number,
         sms_sender_id=sms_sender_id,
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -948,7 +948,10 @@ def service_edit_letter_contact(service_id, letter_contact_id):
     if request.endpoint == "main.service_confirm_delete_letter_contact":
         flash("Are you sure you want to delete this contact block?", "delete")
     return render_template(
-        "views/service-settings/letter-contact/edit.html", form=form, letter_contact_id=letter_contact_block["id"]
+        "views/service-settings/letter-contact/edit.html",
+        form=form,
+        letter_contact_id=letter_contact_block["id"],
+        error_summary_enabled=True,
     )
 
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -503,11 +503,11 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     @classmethod
     def parse_edit_service_http_error(cls, http_error):
         """Inspect the HTTPError from a create_service/update_service call and return a human-friendly error message"""
-        if http_error.message.get("normalised_service_name"):
-            return "Service name must not include characters from a non-Latin alphabet"
+        if http_error.message.get("email_from"):
+            return "Service name cannot include characters from a non-Latin alphabet"
 
         elif http_error.message.get("name"):
-            return "This service name is already in use"
+            return "This service name is already in use - enter a unique name"
 
         return None
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -503,7 +503,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     @classmethod
     def parse_edit_service_http_error(cls, http_error):
         """Inspect the HTTPError from a create_service/update_service call and return a human-friendly error message"""
-        if http_error.message.get("email_from"):
+        if http_error.message.get("email_from") or http_error.message.get("normalised_service_name"):
             return "Service name cannot include characters from a non-Latin alphabet"
 
         elif http_error.message.get("name"):

--- a/app/templates/views/service-settings/data-retention/edit.html
+++ b/app/templates/views/service-settings/data-retention/edit.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('main.edit_data_retention', service_id=current_service.id, data_retention_id=data_retention_id) }) }}
+  {{ govukBackLink({ "href": url_for('main.data_retention', service_id=current_service.id) }) }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/tests/app/main/forms/test_placeholder_form.py
+++ b/tests/app/main/forms/test_placeholder_form.py
@@ -20,8 +20,20 @@ def test_form_class_not_mutated(notify_admin):
     "service_can_send_international_sms, placeholder_name, template_type, value, expected_error",
     [
         (False, "email address", "email", "", "Cannot be empty"),
-        (False, "email address", "email", "12345", "Enter a valid email address"),
-        (False, "email address", "email", "“bad”@email-address.com", "Enter a valid email address"),
+        (
+            False,
+            "email address",
+            "email",
+            "12345",
+            "Enter an email address in the correct format, like name@example.gov.uk",
+        ),
+        (
+            False,
+            "email address",
+            "email",
+            "“bad”@email-address.com",
+            "Enter an email address in the correct format, like name@example.gov.uk",
+        ),
         (False, "email address", "email", "test@example.com", None),
         (False, "email address", "email", "test@example.gov.uk", None),
         (False, "phone number", "sms", "", "Cannot be empty"),

--- a/tests/app/main/forms/test_service_contact_details_form.py
+++ b/tests/app/main/forms/test_service_contact_details_form.py
@@ -13,18 +13,18 @@ def test_form_fails_validation_with_no_radio_buttons_selected(notify_admin):
 
 
 @pytest.mark.parametrize(
-    "selected_radio_button, selected_text_box, text_box_data",
+    "selected_radio_button, selected_text_box, text_box_data, error_message",
     [
-        ("email_address", "url", "http://www.example.com"),
-        ("phone_number", "url", "http://www.example.com"),
-        ("url", "email_address", "user@example.com"),
-        ("phone_number", "email_address", "user@example.com"),
-        ("url", "phone_number", "0207 123 4567"),
-        ("email_address", "phone_number", "0207 123 4567"),
+        ("email_address", "url", "http://www.example.com", "Enter an email address"),
+        ("phone_number", "url", "http://www.example.com", "Enter a phone number"),
+        ("url", "email_address", "user@example.com", "Enter a URL in the correct format"),
+        ("phone_number", "email_address", "user@example.com", "Enter a phone number"),
+        ("url", "phone_number", "0207 123 4567", "Enter a URL in the correct format"),
+        ("email_address", "phone_number", "0207 123 4567", "Enter an email address"),
     ],
 )
 def test_form_fails_validation_when_radio_button_selected_and_text_box_filled_in_do_not_match(
-    notify_admin, selected_radio_button, selected_text_box, text_box_data
+    notify_admin, selected_radio_button, selected_text_box, text_box_data, error_message
 ):
     data = {"contact_details_type": selected_radio_button, selected_text_box: text_box_data}
 
@@ -33,7 +33,7 @@ def test_form_fails_validation_when_radio_button_selected_and_text_box_filled_in
 
         assert not form.validate_on_submit()
         assert len(form.errors) == 1
-        assert form.errors[selected_radio_button] == ["This field is required."]
+        assert form.errors[selected_radio_button] == [error_message]
 
 
 @pytest.mark.parametrize(
@@ -94,7 +94,7 @@ def test_form_phone_number_validation_fails_with_invalid_phone_number_field(noti
 
         assert not form.validate_on_submit()
         assert len(form.errors) == 1
-        assert "Must be a valid phone number" in form.errors["phone_number"]
+        assert "Enter a phone number in the correct format" in form.errors["phone_number"]
 
 
 @pytest.mark.parametrize(
@@ -121,4 +121,4 @@ def test_form_phone_number_allows_non_emergency_3_digit_numbers(notify_admin, sh
         else:
             assert not form.validate_on_submit()
             assert len(form.errors) == 1
-            assert form.errors["phone_number"] == ["Must not be an emergency number"]
+            assert form.errors["phone_number"] == ["Phone number cannot be an emergency number"]

--- a/tests/app/main/forms/test_service_sms_senders_form.py
+++ b/tests/app/main/forms/test_service_sms_senders_form.py
@@ -6,13 +6,13 @@ from app.main.forms import ServiceSmsSenderForm
 @pytest.mark.parametrize(
     "sms_sender,error_expected,error_message",
     [
-        ("", True, "Cannot be empty"),
+        ("", True, "Enter a text message sender"),
         ("22", True, "Text message sender must be at least 3 characters long"),
         ("333", False, None),
         ("elevenchars", False, None),  # 11 chars
         ("twelvecharas", True, "Text message sender cannot be longer than 11 characters"),  # 12 chars
-        ("###", True, "Use letters and numbers only"),
-        ("00111222333", True, "Cannot start with 00"),
+        ("###", True, "Text message sender can only include letters and numbers"),
+        ("00111222333", True, "Text message sender cannot start with 00"),
         ("UK_GOV", False, None),  # Underscores are allowed
         ("UK.GOV", False, None),  # Full stops are allowed
         ("'UC'", False, None),  # Straight single quotes are allowed

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4444,7 +4444,7 @@ def test_should_set_per_minute_rate_limit(
             "main.set_per_minute_rate_limit",
             {},
             {"rate_limit": ""},
-            "Error: Cannot be empty",
+            "Error: Enter a number of messages",
             {},
         ),
         (
@@ -4486,7 +4486,7 @@ def test_should_set_per_minute_rate_limit(
             "main.set_per_day_message_limit",
             {"notification_type": "letter"},
             {"message_limit": "12.34"},
-            "Error: The number of letters must be a whole number",
+            "Error: Enter the number of letters in digits",
             {},
         ),
         (

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4465,7 +4465,7 @@ def test_should_set_per_minute_rate_limit(
             "main.set_per_day_message_limit",
             {"notification_type": "sms"},
             {"message_limit": ""},
-            "Error: Cannot be empty",
+            "Error: Enter a number of text messages",
             {},
         ),
         (

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2712,8 +2712,11 @@ def test_incorrect_reply_to_email_address_input(
 @pytest.mark.parametrize(
     "contact_block_input, expected_error",
     [
-        ("", "Cannot be empty"),
-        ("1 \n 2 \n 3 \n 4 \n 5 \n 6 \n 7 \n 8 \n 9 \n 0 \n a", "Contains 11 lines, maximum is 10"),
+        ("", "Enter a sender address"),
+        (
+            "1 \n 2 \n 3 \n 4 \n 5 \n 6 \n 7 \n 8 \n 9 \n 0 \n a",
+            "This address is 11 lines long - the most you can have is 10 lines",
+        ),
     ],
 )
 def test_incorrect_letter_contact_block_input(
@@ -2754,7 +2757,6 @@ def test_incorrect_sms_sender_input(
         _data={"sms_sender": sms_sender_input},
         _expected_status=(200 if expected_error else 302),
     )
-
     error_message = page.select_one(".govuk-error-message")
     count_of_api_calls = len(mock_add_sms_sender.call_args_list)
 
@@ -2762,6 +2764,7 @@ def test_incorrect_sms_sender_input(
         assert not error_message
         assert count_of_api_calls == 1
     else:
+
         assert expected_error in error_message.text
         assert count_of_api_calls == 0
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3129,11 +3129,11 @@ def test_edit_reply_to_email_address_goes_straight_to_update_if_address_not_chan
 @pytest.mark.parametrize(
     "url, header_text",
     [
-        ("main.service_edit_email_reply_to", "Reply-to email addresses"),
+        ("main.service_edit_email_reply_to", "Change reply-to email address"),
         ("main.service_add_email_reply_to", "Add reply-to email address"),
     ],
 )
-def test_add_edit_reply_to_email_address_goes_straight_to_update_if_address_not_changed(
+def test_add_and_edit_reply_to_email_address(
     mocker, fake_uuid, client_request, mock_update_reply_to_email_address, url, header_text
 ):
     reply_to_email_address = create_reply_to_email_address()
@@ -3155,12 +3155,7 @@ def test_add_edit_reply_to_email_address_goes_straight_to_update_if_address_not_
     )
 
     assert page.select_one("h1").text == header_text
-
-    if url == "main.service_edit_email_reply_to":
-        assert error_message in page.select_one("div.banner-dangerous").text
-    else:
-        assert error_message in page.select_one(".govuk-error-message").text
-
+    assert error_message in page.select_one(".govuk-error-message").text
     assert mock_update_reply_to_email_address.called is False
 
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -639,8 +639,8 @@ def test_should_show_service_name_with_no_prefixing(
 @pytest.mark.parametrize(
     "name, error_message",
     [
-        ("", "Cannot be empty"),
-        (".", "Must include at least two alphanumeric characters"),
+        ("", "Error: Enter a service name"),
+        (".", "Service name must include at least 2 letters or numbers"),
         ("a" * 256, "Service name cannot be longer than 255 characters"),
     ],
 )
@@ -4976,7 +4976,7 @@ def test_send_files_by_email_contact_details_displays_error_message_when_no_radi
 @pytest.mark.parametrize(
     "contact_details_type, invalid_value, error",
     [
-        ("url", "invalid.com/", "Enter a URL in the correct"),
+        ("url", "invalid.com/", "Enter a URL in the correct format"),
         ("email_address", "me@co", "Enter an email address in the correct format, like name@example.gov.uk"),
         ("phone_number", "abcde", "Enter a phone number in the correct format"),
     ],

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -5812,7 +5812,7 @@ def test_update_service_data_retention_return_validation_error_for_negative_days
         _data={"days_of_retention": -5},
         _expected_status=200,
     )
-    assert "Must be between 3 and 90" in page.select_one(".govuk-error-message").text
+    assert "The number of days must be between 3 and 90" in page.select_one(".govuk-error-message").text
     assert mock_get_service_data_retention.called
     assert not mock_update_service_data_retention.called
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2737,11 +2737,11 @@ def test_incorrect_letter_contact_block_input(
     [
         ("elevenchars", None),
         ("11 chars", None),
-        ("", "Cannot be empty"),
+        ("", "Enter a text message sender"),
         ("abcdefghijkhgkg", "Text message sender cannot be longer than 11 characters"),
-        (r" ¯\_(ツ)_/¯ ", "Use letters and numbers only"),
+        (r" ¯\_(ツ)_/¯ ", "Text message sender can only include letters and numbers"),
         ("blood.co.uk", None),
-        ("00123", "Cannot start with 00"),
+        ("00123", "Text message sender cannot start with 00"),
     ],
 )
 def test_incorrect_sms_sender_input(

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2692,8 +2692,8 @@ def test_no_senders_message_shows(client_request, sender_list_page, endpoint_to_
 @pytest.mark.parametrize(
     "reply_to_input, expected_error",
     [
-        ("", "Cannot be empty"),
-        ("testtest", "Enter a valid email address"),
+        ("", "Enter an email address"),
+        ("testtest", "Enter an email address in the correct format, like name@example.gov.uk"),
     ],
 )
 def test_incorrect_reply_to_email_address_input(
@@ -3232,7 +3232,7 @@ def test_shows_delete_link_for_error_on_post_request_for_edit_email_reply_to_add
 ):
     mocker.patch("app.service_api_client.get_reply_to_email_address", return_value=reply_to_address)
 
-    data = {"email_address": "not a valid email address"}
+    data = {"email_address": "Enter an email address"}
     if default_checkbox_checked:
         data["is_default"] = "y"
 
@@ -3249,8 +3249,11 @@ def test_shows_delete_link_for_error_on_post_request_for_edit_email_reply_to_add
         ".service_email_reply_to",
         service_id=SERVICE_ONE_ID,
     )
-    assert page.select_one(".govuk-error-message").text.strip() == "Error: Enter a valid email address"
-    assert page.select_one("input#email_address").get("value") == "not a valid email address"
+    assert (
+        page.select_one(".govuk-error-message").text.strip()
+        == "Error: Enter an email address in the correct format, like name@example.gov.uk"
+    )
+    assert page.select_one("input#email_address").get("value") == "Enter an email address"
 
     if default_choice_and_delete_link_expected:
         link = page.select_one(".page-footer a")
@@ -4973,9 +4976,9 @@ def test_send_files_by_email_contact_details_displays_error_message_when_no_radi
 @pytest.mark.parametrize(
     "contact_details_type, invalid_value, error",
     [
-        ("url", "invalid.com/", "Must be a valid URL"),
-        ("email_address", "me@co", "Enter a valid email address"),
-        ("phone_number", "abcde", "Must be a valid phone number"),
+        ("url", "invalid.com/", "Enter a URL in the correct"),
+        ("email_address", "me@co", "Enter an email address in the correct format, like name@example.gov.uk"),
+        ("phone_number", "abcde", "Enter a phone number in the correct format"),
     ],
 )
 def test_send_files_by_email_contact_details_does_not_update_invalid_contact_details(

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -259,7 +259,7 @@ def test_accept_agreement_page_populates(
             },
             [
                 "Error: Select an option",
-                "Error: Must be a number",
+                "Error: Enter a version number",
             ],
         ),
         (
@@ -270,7 +270,7 @@ def test_accept_agreement_page_populates(
                 "on_behalf_of_email": "",
             },
             [
-                "Error: Must be a number",
+                "Error: Enter a version number in digits, like 3.1",
             ],
         ),
         (
@@ -281,8 +281,8 @@ def test_accept_agreement_page_populates(
                 "on_behalf_of_email": "",
             },
             [
-                "Error: Cannot be empty",
-                "Error: Cannot be empty",
+                "Error: Enter the name of the person accepting the agreement",
+                "Error: Enter the email address of the person accepting the agreement",
             ],
         ),
         (
@@ -293,7 +293,7 @@ def test_accept_agreement_page_populates(
                 "on_behalf_of_email": "",
             },
             [
-                "Error: Cannot be empty",
+                "Error: Enter the email address of the person accepting the agreement",
             ],
         ),
         (
@@ -304,7 +304,7 @@ def test_accept_agreement_page_populates(
                 "on_behalf_of_email": "test@example.com",
             },
             [
-                "Error: Cannot be empty",
+                "Error: Enter the name of the person accepting the agreement",
             ],
         ),
     ),

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -276,7 +276,10 @@ def test_email_address_must_be_valid_if_provided_to_support_form(
         _expected_status=200,
     )
 
-    assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Enter a valid email address"
+    assert (
+        normalize_spaces(page.select_one(".govuk-error-message").text)
+        == "Error: Enter an email address in the correct format, like name@example.gov.uk"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -385,7 +385,7 @@ def test_edit_sms_provider_ratio_submit(
     [
         ({"sms_provider_1": 90, "sms_provider_2": 20}, "The total must add up to 100%"),
         ({"sms_provider_1": 101, "sms_provider_2": 20}, "Must be between 0 and 100"),
-        ({"sms_provider_1": 99.9, "sms_provider_2": 0.1}, "Enter percentage in digits"),
+        ({"sms_provider_1": 99.9, "sms_provider_2": 0.1}, "Enter a percentage in digits"),
     ],
 )
 def test_edit_sms_provider_submit_invalid_percentages(

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -385,7 +385,7 @@ def test_edit_sms_provider_ratio_submit(
     [
         ({"sms_provider_1": 90, "sms_provider_2": 20}, "The total must add up to 100%"),
         ({"sms_provider_1": 101, "sms_provider_2": 20}, "Must be between 0 and 100"),
-        ({"sms_provider_1": 99.9, "sms_provider_2": 0.1}, "Percentage must be a whole number"),
+        ({"sms_provider_1": 99.9, "sms_provider_2": 0.1}, "Enter percentage in digits"),
     ],
 )
 def test_edit_sms_provider_submit_invalid_percentages(

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -604,7 +604,7 @@ def test_client_updates_service_with_allowed_attributes(
         ({"name": "Service name error"}, "This service name is already in use - enter a unique name"),
         (
             {"normalised_service_name": "normalised service name has disallowed characters"},
-            "Service name must not include characters from a non-Latin alphabet",
+            "Service name cannot include characters from a non-Latin alphabet",
         ),
         ({"other": "blah"}, None),
     ),

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -601,7 +601,7 @@ def test_client_updates_service_with_allowed_attributes(
 @pytest.mark.parametrize(
     "err_data, expected_message",
     (
-        ({"name": "Service name error"}, "This service name is already in use"),
+        ({"name": "Service name error"}, "This service name is already in use - enter a unique name"),
         (
             {"normalised_service_name": "normalised service name has disallowed characters"},
             "Service name must not include characters from a non-Latin alphabet",


### PR DESCRIPTION
This PR enables error summaries for the admin app service settings pages as specified in [this](https://trello.com/c/8JBMz4Nu/459-add-error-summaries-to-service-settings-page-forms) ticket.

After a discussion with @karlchillmaid and @tombye, `/services/<service_id>/service-settings/request-to-go-live/estimate-usage` is not being dealt with as a rethink of the pages content is being considered. It will be handled in a separate PR.
