### PR TITLE
Update error handling for reply-to email address

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -451,34 +451,43 @@ def service_add_email_reply_to(service_id):
     form = ServiceReplyToEmailForm()
     first_email_address = current_service.count_email_reply_to_addresses == 0
     is_default = first_email_address if first_email_address else form.is_default.data
+
     if form.validate_on_submit():
         if current_user.platform_admin:
-            service_api_client.add_reply_to_email_address(
-                service_id, email_address=form.email_address.data, is_default=is_default
-            )
-            return redirect(url_for(".service_email_reply_to", service_id=service_id))
+            try:
+                service_api_client.add_reply_to_email_address(
+                    service_id, email_address=form.email_address.data, is_default=is_default
+                )
+
+            except HTTPError as e:
+                handle_reply_to_email_address_http_error(e, form)
+
+            else:
+                return redirect(url_for(".service_email_reply_to", service_id=service_id))
+
         else:
             try:
                 notification_id = service_api_client.verify_reply_to_email_address(service_id, form.email_address.data)[
                     "data"
                 ]["id"]
             except HTTPError as e:
-                if e.status_code == 409:
-                    flash(e.message, "error")
-                    return redirect(url_for(".service_email_reply_to", service_id=service_id))
-                else:
-                    raise e
-            return redirect(
-                url_for(
-                    ".service_verify_reply_to_address",
-                    service_id=service_id,
-                    notification_id=notification_id,
-                    is_default=is_default,
+                handle_reply_to_email_address_http_error(e, form)
+
+            else:
+                return redirect(
+                    url_for(
+                        ".service_verify_reply_to_address",
+                        service_id=service_id,
+                        notification_id=notification_id,
+                        is_default=is_default,
+                    )
                 )
-            )
 
     return render_template(
-        "views/service-settings/email-reply-to/add.html", form=form, first_email_address=first_email_address
+        "views/service-settings/email-reply-to/add.html",
+        form=form,
+        first_email_address=first_email_address,
+        error_summary_enabled=True,
     )
 
 
@@ -571,7 +580,7 @@ def get_service_verify_reply_to_address_partials(service_id, notification_id):
 def service_edit_email_reply_to(service_id, reply_to_email_id):
     form = ServiceReplyToEmailForm()
     reply_to_email_address = current_service.get_email_reply_to_address(reply_to_email_id)
-
+    print(reply_to_email_address)
     if request.method == "GET":
         form.email_address.data = reply_to_email_address["email_address"]
         form.is_default.data = reply_to_email_address["is_default"]
@@ -588,9 +597,11 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
             )
             return redirect(url_for(".service_email_reply_to", service_id=service_id))
         try:
+
             notification_id = service_api_client.verify_reply_to_email_address(service_id, form.email_address.data)[
                 "data"
             ]["id"]
+
         except HTTPError as e:
             if e.status_code == 409:
                 flash(e.message, "error")
@@ -1350,3 +1361,12 @@ def check_contact_details_type(contact_details):
         return "email_address"
     else:
         return "phone_number"
+
+
+def handle_reply_to_email_address_http_error(raised_exception, form):
+    if raised_exception.status_code == 409:
+        error_message = raised_exception.message
+        form.email_address.errors.append(error_message)
+
+    else:
+        raise raised_exception

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3120,19 +3120,19 @@ def test_edit_reply_to_email_address_goes_straight_to_update_if_address_not_chan
 
 
 @pytest.mark.parametrize(
-    "url",
+    "url, header_text",
     [
-        "main.service_edit_email_reply_to",
-        "main.service_add_email_reply_to",
+        ("main.service_edit_email_reply_to", "Reply-to email addresses"),
+        ("main.service_add_email_reply_to", "Add reply-to email address"),
     ],
 )
 def test_add_edit_reply_to_email_address_goes_straight_to_update_if_address_not_changed(
-    mocker, fake_uuid, client_request, mock_update_reply_to_email_address, url
+    mocker, fake_uuid, client_request, mock_update_reply_to_email_address, url, header_text
 ):
     reply_to_email_address = create_reply_to_email_address()
     mocker.patch("app.service_api_client.get_reply_to_email_addresses", return_value=[reply_to_email_address])
     mocker.patch("app.service_api_client.get_reply_to_email_address", return_value=reply_to_email_address)
-    error_message = "Your service already uses ‘reply_to@example.com’ as an email reply-to address."
+    error_message = "‘reply_to@example.com’ is already a reply-to email address for this service."
     mocker.patch(
         "app.service_api_client.verify_reply_to_email_address",
         side_effect=[
@@ -3147,8 +3147,12 @@ def test_add_edit_reply_to_email_address_goes_straight_to_update_if_address_not_
         url, service_id=SERVICE_ONE_ID, reply_to_email_id=fake_uuid, _data=data, _follow_redirects=True
     )
 
-    assert page.select_one("h1").text == "Reply-to email addresses"
-    assert error_message in page.select_one("div.banner-dangerous").text
+    assert page.select_one("h1").text == header_text
+
+    if url == "main.service_edit_email_reply_to":
+        assert error_message in page.select_one("div.banner-dangerous").text
+    else:
+        assert error_message in page.select_one(".govuk-error-message").text
 
     assert mock_update_reply_to_email_address.called is False
 


### PR DESCRIPTION
This PR updates our error handling for when a user tires to add a reply-to email address that is already in use.
Instead of redirecting the user to service-settings/email-reply-to where a message is flashed, the error will now be displayed inline and as part of the error summary displayed at eh top of the page.

Before:
<img width="937" alt="reply-to-address-already-in-use-before" src="https://github.com/alphagov/notifications-admin/assets/32799090/c5f96462-92dc-49bf-9868-09192ab05ffd">

After:
<img width="951" alt="reply-to-address-already-in-use-after" src="https://github.com/alphagov/notifications-admin/assets/32799090/76a077eb-ca90-40fd-a73a-f1c35246088b">
