### PR TITLE
fix email_from being uneditable

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -84,6 +84,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "created_by",
             "count_as_live",
             "email_branding",
+            "email_from",
             "normalised_service_name",
             "free_sms_fragment_limit",
             "go_live_at",

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -578,6 +578,7 @@ def test_client_updates_service_with_allowed_attributes(
         "contact_link",
         "count_as_live",
         "email_branding",
+        "email_from",
         "normalised_service_name",
         "free_sms_fragment_limit",
         "go_live_at",


### PR DESCRIPTION
admin, for now, is passing both old and new values back to the api. we inadvertently removed email_from from the supported values list