### PR TITLE
Switch over to use cflinuxfs4

### DIFF
--- a/manifest-droplet.yml
+++ b/manifest-droplet.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: ((app_name))
-  stack: cflinuxfs3
+  stack: cflinuxfs4
   processes:
   - type: web
     instances: 0

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -29,6 +29,8 @@ applications:
     health-check-http-endpoint: '/_status?simple=true'
     health-check-invocation-timeout: 10
 
+    stack: cflinuxfs4
+
     services:
       - logit-ssl-syslog-drain
       - notify-splunk

--- a/paas-failwhale/manifest.yml
+++ b/paas-failwhale/manifest.yml
@@ -5,3 +5,4 @@ applications:
     no-route: true
     buildpack: staticfile_buildpack
     memory: 256M
+    stack: cflinuxfs4


### PR DESCRIPTION
What
----

Switch over to use the PaaS cflinuxfs4 stack.

Why
----

cflinuxfs3 is currently the default on the PaaS. This is based off ubuntu 18.04. This stopped receiving updates after Apr 2023.

cflinuxfs4 will become the default on the PaaS after 27 Nov 2023.

The intention is to migrate all applications to cflinuxfs4 eventually.