### PR TITLE
disable redis for staging class

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -197,6 +197,7 @@ class Staging(Config):
     CHECK_PROXY_HEADER = False
     ASSET_DOMAIN = "static.staging-notify.works"
     ASSET_PATH = "https://static.staging-notify.works/"
+    REDIS_ENABLED = False
 
 
 class Production(Config):


### PR DESCRIPTION
THIS PR IS PART OF STEP 2
This PR is part of a set of PRs to be merged during the proposed migration of PaaS apps to start using redis from notify-staging
The steps agreed on the document are:
1. **Change Credentials REPO** - This PR adds the redis_url to the credentials repo
2. **Disable redis** (by setting REDIS_ENABLED to false on API, ADMIN and DOCUMENT_DOWNLOAD_API)
3. **Enable redis** (by removing REDIS_ENABLED line on staging class on API, ADMIN and DOCUMENT_DOWNLOAD_API