### PR TITLE
Validate correct combination of CSS classes on `<h1>` and `<main>` elements

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -179,6 +179,7 @@ def user_profile_mobile_number_authenticate():
         thing="mobile number",
         form=form,
         back_link=url_for(".user_profile_mobile_number_confirm"),
+        error_summary_enabled=True,
     )
 
 

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -16,7 +16,7 @@
 {%  endblock %}
 
 {% block maincolumn_content %}
-    <h1 class="govuk-heading-l">{{ page_title }}</h1>
+    <h1 class="heading-large">{{ page_title }}</h1>
 
     <!-- display default branding and it's preview -->
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">

--- a/app/templates/views/platform-admin/clear-cache.html
+++ b/app/templates/views/platform-admin/clear-cache.html
@@ -8,7 +8,7 @@
 
 {% block platform_admin_content %}
 
-  <h1 class="govuk-heading-l">
+  <h1 class="heading-medium">
     Clear cache
   </h1>
 

--- a/app/templates/views/service-settings/service-data-retention.html
+++ b/app/templates/views/service-settings/service-data-retention.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="govuk-heading-l">Data retention period</h1>
+  <h1 class="heading-large">Data retention period</h1>
 
   {% if single_retention_period %}
     <p class="govuk-body">Your current data retention period is {{ single_retention_period }} days.</p>

--- a/app/templates/views/user-profile/authenticate.html
+++ b/app/templates/views/user-profile/authenticate.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
@@ -14,7 +13,7 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header('Change your {}'.format(thing)) }}
+  <h1 class="govuk-heading-l">Change your {{ thing }}</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2981,10 +2981,14 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
                             f'(you probably want to add class="{hint}")'
                         )
 
-                assert not page.select(r"main.govuk-\!-padding-top-0 h1.govuk-heading-l")
+                assert not page.select(
+                    r"main.govuk-\!-padding-top-0 h1.govuk-heading-l"
+                ), "Use heading-large or set error_summary_enabled=True"
 
                 if page.select("h1.heading-large"):
-                    assert "govuk-!-padding-top-0" in page.select_one("main")["class"]
+                    assert (
+                        "govuk-!-padding-top-0" in page.select_one("main")["class"]
+                    ), "Use govuk-heading-l or set error_summary_enabled=False"
 
             return page
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2980,6 +2980,12 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
                             f"\n"
                             f'(you probably want to add class="{hint}")'
                         )
+
+                assert not page.select(r"main.govuk-\!-padding-top-0 h1.govuk-heading-l")
+
+                if page.select("h1.heading-large"):
+                    assert "govuk-!-padding-top-0" in page.select_one("main")["class"]
+
             return page
 
         @staticmethod


### PR DESCRIPTION
Either we should have `govuk-heading-l`<sup>1</sup> with the default padding on the `<main>` element or `heading-large`<sup>2</sup> with 0 padding on the main element.

This commit adds some automatic checks for this, then fixes the places where it’s wrong.

***

1. Newer class from GOV.UK Frontend which does not have any top margin
2. Old class from GOV.UK Elements which has some built-in top margin