### PR TITLE
Fix missing `url_for`

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -89,7 +89,7 @@ def user_profile_email_authenticate():
     form = ConfirmPasswordForm(_check_password)
 
     if NEW_EMAIL not in session:
-        return redirect("main.user_profile_email")
+        return redirect(url_for("main.user_profile_email"))
 
     if form.validate_on_submit():
         user_api_client.send_change_email_verification(current_user.id, session[NEW_EMAIL])

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -185,6 +185,15 @@ def test_should_show_authenticate_after_email_change(
     assert "Confirm" in page.text
 
 
+def test_should_redirect_from_authenticate_if_new_email_not_in_session(
+    client_request,
+):
+    client_request.get(
+        "main.user_profile_email_authenticate",
+        _expected_redirect=url_for("main.user_profile_email"),
+    )
+
+
 def test_should_render_change_email_continue_after_authenticate_email(
     client_request,
     mock_verify_password,


### PR DESCRIPTION
This was redirecting to `/user-profile/email/main.user_profile_email` (the name of the endpoint in Python) rather than `/user-profile/email` (the URL specified in the Flask decorator) because the call to `url_for` was missing.

There was also no test for this so that’s why it slipped through.

[A good example](https://github.com/alphagov/notifications-admin/pull/117) of why breaking up changes into smaller commits and pull requests is a nice thing 😅
