### PR TITLE
Add QR code guidance

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -270,13 +270,13 @@ def guidance_personalisation():
         navigation_links=using_notify_nav(),
     )
 
+
 @main.route("/using-notify/qr-codes")
 def guidance_qr_codes():
     return render_template(
         "views/guidance/using-notify/qr-codes.html",
         navigation_links=using_notify_nav(),
     )
-
 
 
 @main.route("/using-notify/receive-text-messages")

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -271,7 +271,7 @@ def guidance_personalisation():
     )
 
 @main.route("/using-notify/qr-codes")
-def guidance_personalisation():
+def guidance_qr_codes():
     return render_template(
         "views/guidance/using-notify/qr-codes.html",
         navigation_links=using_notify_nav(),

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -270,6 +270,14 @@ def guidance_personalisation():
         navigation_links=using_notify_nav(),
     )
 
+@main.route("/using-notify/qr-codes")
+def guidance_personalisation():
+    return render_template(
+        "views/guidance/using-notify/qr-codes.html",
+        navigation_links=using_notify_nav(),
+    )
+
+
 
 @main.route("/using-notify/receive-text-messages")
 def guidance_receive_text_messages():

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -127,6 +127,10 @@ def using_notify_nav():
                     "link": "main.guidance_personalisation",
                 },
                 {
+                    "name": "QR codes",
+                    "link": "main.guidance_qr_codes",
+                },                
+                {
                     "name": "Receive text messages",
                     "link": "main.guidance_receive_text_messages",
                 },

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -129,7 +129,7 @@ def using_notify_nav():
                 {
                     "name": "QR codes",
                     "link": "main.guidance_qr_codes",
-                },                
+                },
                 {
                     "name": "Receive text messages",
                     "link": "main.guidance_receive_text_messages",

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -71,6 +71,7 @@ class HeaderNavigation(Navigation):
             "guidance_links_and_URLs",
             "guidance_optional_content",
             "guidance_personalisation",
+            "guidance_qr_codes",
             "guidance_receive_text_messages",
             "guidance_reply_to_email_address",
             "guidance_schedule_messages",

--- a/app/templates/partials/templates/guidance-qr-codes.html
+++ b/app/templates/partials/templates/guidance-qr-codes.html
@@ -7,7 +7,7 @@
 <p class="bottom-gutter-1-3">
   Copy this example if the whole link changes each time you send a letter:
 </p>
-<pre class="formatting-example"><code class="lang-md">QR: ((placeholder))
+<pre class="formatting-example"><code class="lang-md">QR: ((link))
 </code></pre>
 <p class="bottom-gutter-1-3">
   Copy this example if only part of the link changes each time you send a letter:

--- a/app/templates/partials/templates/guidance-qr-codes.html
+++ b/app/templates/partials/templates/guidance-qr-codes.html
@@ -1,0 +1,16 @@
+<h2 class="heading-medium">Add a QR code to a letter template</h2>
+<p class="bottom-gutter-1-3">
+  Copy this example to add the same QR code to every letter you send:
+</p>
+<pre class="formatting-example"><code class="lang-md">QR: https://www.gov.uk/example
+</code></pre>
+<p class="bottom-gutter-1-3">
+  Copy this example if the whole link changes each time you send a letter:
+</p>
+<pre class="formatting-example"><code class="lang-md">QR: ((placeholder))
+</code></pre>
+<p class="bottom-gutter-1-3">
+  Copy this example if only part of the link changes each time you send a letter:
+</p>
+  <pre class="formatting-example"><code class="lang-md">QR: https://www.example.com?reference=((placeholder))
+</code></pre>

--- a/app/templates/partials/templates/guidance-qr-codes.html
+++ b/app/templates/partials/templates/guidance-qr-codes.html
@@ -12,5 +12,5 @@
 <p class="bottom-gutter-1-3">
   Copy this example if only part of the link changes each time you send a letter:
 </p>
-  <pre class="formatting-example"><code class="lang-md">QR: https://www.example.com?reference=((placeholder))
+  <pre class="formatting-example"><code class="lang-md">QR: https://www.example.com?reference=((link reference))
 </code></pre>

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -36,6 +36,7 @@
           {% include "partials/templates/guidance-formatting-letters.html" %}
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-optional-content.html" %}
+          {% include "partials/templates/guidance-qr-codes.html" %}
         </div>
       </div>
     {% endcall %}

--- a/app/templates/views/guidance/using-notify/index.html
+++ b/app/templates/views/guidance/using-notify/index.html
@@ -33,6 +33,7 @@
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_links_and_URLs') }}">Links and URLs</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_optional_content') }}">Optional content</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_personalisation') }}">Personalisation</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_qr_codes') }}">Add a QR code to a letter template</a></li>
    </ul>
 
   <h2 class="heading-medium">Branding</h2>
@@ -48,7 +49,6 @@
   <ul class="govuk-list govuk-list--bullet">
      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_send_files_by_email') }}">Send files by email</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_attach_pages') }}">Attach pages to a letter template</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_qr_codes') }}">Add a QR code to a letter template</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">Upload a letter</a></li>
   </ul>
 

--- a/app/templates/views/guidance/using-notify/index.html
+++ b/app/templates/views/guidance/using-notify/index.html
@@ -48,7 +48,7 @@
   <ul class="govuk-list govuk-list--bullet">
      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_send_files_by_email') }}">Send files by email</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_attach_pages') }}">Attach pages to a letter template</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_qr_codes') }}">Add QR codes to a letter template</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_qr_codes') }}">Add a QR code to a letter template</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">Upload a letter</a></li>
   </ul>
 

--- a/app/templates/views/guidance/using-notify/index.html
+++ b/app/templates/views/guidance/using-notify/index.html
@@ -48,6 +48,7 @@
   <ul class="govuk-list govuk-list--bullet">
      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_send_files_by_email') }}">Send files by email</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_attach_pages') }}">Attach pages to a letter template</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_qr_codes') }}">Add QR codes to a letter template</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">Upload a letter</a></li>
   </ul>
 

--- a/app/templates/views/guidance/using-notify/personalisation.html
+++ b/app/templates/views/guidance/using-notify/personalisation.html
@@ -19,7 +19,7 @@
 
   <pre class="formatting-example"><code class="lang-md">Hello ((first name)), your reference is ((reference number)).</code></pre>
 
-  <p class="govuk-body">Each time you send the message, you can:</p>
+  <p class="govuk-body">Each time you send the message, you can either:</p>
 
   <ul class="govuk-list govuk-list--bullet">
     <li>fill in the placeholders yourself</li>
@@ -27,6 +27,13 @@
   </ul>
 
   <p class="govuk-body">If you upload a list of personal details, the column names in your spreadsheet need to match the placeholders in the template.</p>
+
+  <p class="govuk-body">You can use personalisation to add:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_optional_content') }}">optional content</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_qr_codes') }}">a QR code to a letter template</a></li>
+  </ul>
 
   <h2 class="heading-medium" id="hide-personalised-content">Hide personalised content after sending</h2>
 

--- a/app/templates/views/guidance/using-notify/qr-codes.html
+++ b/app/templates/views/guidance/using-notify/qr-codes.html
@@ -6,7 +6,7 @@
 {% set navigation_label_prefix = 'Using Notify' %}
 
 {% block per_page_title %}
-  QR codes
+  Add a QR code to a letter template
 {% endblock %}
 
 {% block content_column_content %}

--- a/app/templates/views/guidance/using-notify/qr-codes.html
+++ b/app/templates/views/guidance/using-notify/qr-codes.html
@@ -15,11 +15,20 @@
 
   <p class="govuk-body">QR codes let recipients visit your website without having to type in the URL.</p>
 
-  <p class="govuk-body">You must also provide an alternative for people who cannot scan the QR code. For example, a short URL that’s easy to read or written instructions on how to find your website.</p>
+  <p class="govuk-body">You can either:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>add a QR code that will always link to the same website</li>
+    <li>personalise all or part of the link contained in a QR code</li>
+  </ul>
+
+  <h2 class="heading-medium">How to add a QR code</h2>
+
+  <p class="govuk-body">When you add a QR code to your letter, you must provide an alternative for people who cannot scan QR codes. For example, a short URL that’s easy to read or written instructions on how to find your website.</p>
 
   <p class="govuk-body">Do not add more than one QR code per page.</p>
 
-  <h2 class="heading-medium">Add a QR code to a letter template</h2>
+  <h3 class="heading-small">Add a QR code that will always link to the same website</h3>
 
   <p class="govuk-body">Copy this example to add a QR code to your letter template:</p>
 
@@ -27,9 +36,9 @@
 
   <p class="govuk-body">Leave one empty line space before and after the QR code.</p>
 
-  <h2 class="heading-medium">Personalise your QR codes</h2>
+  <h3 class="heading-small">Add a personalised QR code</h3>
 
-  <p class="govuk-body">You can use placeholders to personalise all or part of the link contained in a QR code.</p>
+  <p class="govuk-body">Use placeholders to personalise all or part of the link contained in a QR code.</p>
 
   <p class="govuk-body">Each time you send the letter template, you can either:</p>
 

--- a/app/templates/views/guidance/using-notify/qr-codes.html
+++ b/app/templates/views/guidance/using-notify/qr-codes.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/service-link.html" import service_link %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Using Notify' %}
 

--- a/app/templates/views/guidance/using-notify/qr-codes.html
+++ b/app/templates/views/guidance/using-notify/qr-codes.html
@@ -59,4 +59,6 @@
 
   <p class="govuk-body">Choose a unique name for the placeholder inside the double brackets. When you send the letter, Notify will replace this with the QR code link.</p>
 
+<p class="govuk-body">If you upload a list of personal details, the column names in your spreadsheet need to match the placeholders in the template.</p>
+
 {% endblock %}

--- a/app/templates/views/guidance/using-notify/qr-codes.html
+++ b/app/templates/views/guidance/using-notify/qr-codes.html
@@ -47,7 +47,7 @@
 
   <p class="govuk-body">Copy this example if the whole link changes each time you send a letter:</p>
 
-  <pre class="formatting-example"><code class="lang-md">QR: ((placeholder))</code></pre>
+  <pre class="formatting-example"><code class="lang-md">QR: ((link))</code></pre>
 
   <p class="govuk-body">Copy this example if only part of the link changes each time you send a letter:</p>
 

--- a/app/templates/views/guidance/using-notify/qr-codes.html
+++ b/app/templates/views/guidance/using-notify/qr-codes.html
@@ -1,0 +1,49 @@
+{% extends "content_template.html" %}
+
+{% from "components/service-link.html" import service_link %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
+
+{% block per_page_title %}
+  QR codes
+{% endblock %}
+
+{% block content_column_content %}
+
+  <h1 class="heading-large">Add QR codes to a letter templates</h1>
+
+  <p class="govuk-body">Add a QR code to your letter to let recipients visit your website without having to type in the URL.</p>
+
+  <p class="govuk-body">To personalise a message, use double brackets to add a placeholder to your content. For example:</p>
+
+  <pre class="formatting-example"><code class="lang-md">Hello ((first name)), your reference is ((reference number)).</code></pre>
+
+  <p class="govuk-body">Each time you send the message, you can:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>fill in the placeholders yourself</li>
+    <li>upload a list of personal details and let Notify do it for you</li>
+  </ul>
+
+  <p class="govuk-body">If you upload a list of personal details, the column names in your spreadsheet need to match the placeholders in the template.</p>
+
+  <h2 class="heading-medium" id="hide-personalised-content">Hide personalised content after sending</h2>
+
+  <p class="govuk-body">Some placeholders include sensitive information like security codes or password reset links. To protect your users, you can choose to hide the content of these placeholders after sending.</p>
+
+  <p class="govuk-body">Only the recipient will be able to see the sensitive information you’ve sent them. You and your team will see a redacted version of the message.</p>
+
+  <p class="govuk-body">To hide personalised content after sending:</p>
+
+  <ol class="govuk-list govuk-list--number">
+    <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
+    <li>Add a new template or choose an existing template.</li>
+    <li>Select <b class="govuk-!-font-weight-bold">Hide personalisation after sending</b>.</li>
+  </ol>
+
+  <p class="govuk-body">You cannot undo this change.</p>
+
+  <p class="govuk-body">Read more about <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_security') }}">Notify’s security features</a>.</p>
+
+{% endblock %}

--- a/app/templates/views/guidance/using-notify/qr-codes.html
+++ b/app/templates/views/guidance/using-notify/qr-codes.html
@@ -51,7 +51,7 @@
 
   <p class="govuk-body">Copy this example if only part of the link changes each time you send a letter:</p>
 
-  <pre class="formatting-example"><code class="lang-md">QR: https://www.example.com?reference=((placeholder))</code></pre>
+  <pre class="formatting-example"><code class="lang-md">QR: https://www.example.com?reference=((link reference))</code></pre>
 
   <p class="govuk-body">Leave one empty line space before and after the QR code.</p>
 

--- a/app/templates/views/guidance/using-notify/qr-codes.html
+++ b/app/templates/views/guidance/using-notify/qr-codes.html
@@ -11,39 +11,43 @@
 
 {% block content_column_content %}
 
-  <h1 class="heading-large">Add QR codes to a letter templates</h1>
+  <h1 class="heading-large">Add a QR code to a letter template</h1>
 
-  <p class="govuk-body">Add a QR code to your letter to let recipients visit your website without having to type in the URL.</p>
+  <p class="govuk-body">QR codes let recipients visit your website without having to type in the URL.</p>
 
-  <p class="govuk-body">To personalise a message, use double brackets to add a placeholder to your content. For example:</p>
+  <p class="govuk-body">You must also provide an alternative for people who cannot scan the QR code. For example, a short URL that’s easy to read or written instructions on how to find your website.</p>
 
-  <pre class="formatting-example"><code class="lang-md">Hello ((first name)), your reference is ((reference number)).</code></pre>
+  <p class="govuk-body">Do not add more than one QR code per page.</p>
 
-  <p class="govuk-body">Each time you send the message, you can:</p>
+  <h2 class="heading-medium">Add a QR code to a letter template</h2>
+
+  <p class="govuk-body">Copy this example to add a QR code to your letter template:</p>
+
+  <pre class="formatting-example"><code class="lang-md">QR: https://www.gov.uk/example</code></pre>
+
+  <p class="govuk-body">Leave one empty line space before and after the QR code.</p>
+
+  <h2 class="heading-medium">Personalise your QR codes</h2>
+
+  <p class="govuk-body">You can use placeholders to personalise all or part of the link contained in a QR code.</p>
+
+  <p class="govuk-body">Each time you send the letter template, you can either:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>fill in the placeholders yourself</li>
-    <li>upload a list of personal details and let Notify do it for you</li>
+    <li>fill in the link yourself</li>
+    <li>upload a list of personal details, including links, and let Notify do it for you</li>
   </ul>
 
-  <p class="govuk-body">If you upload a list of personal details, the column names in your spreadsheet need to match the placeholders in the template.</p>
+  <p class="govuk-body">Copy this example if the link changes each time you send a letter:</p>
 
-  <h2 class="heading-medium" id="hide-personalised-content">Hide personalised content after sending</h2>
+  <pre class="formatting-example"><code class="lang-md">QR: ((placeholder))</code></pre>
 
-  <p class="govuk-body">Some placeholders include sensitive information like security codes or password reset links. To protect your users, you can choose to hide the content of these placeholders after sending.</p>
+  <p class="govuk-body">Copy this example if only part of the link changes each time you send a letter:</p>
 
-  <p class="govuk-body">Only the recipient will be able to see the sensitive information you’ve sent them. You and your team will see a redacted version of the message.</p>
+  <pre class="formatting-example"><code class="lang-md">QR: https://www.example.com?reference=((placeholder))</code></pre>
 
-  <p class="govuk-body">To hide personalised content after sending:</p>
+  <p class="govuk-body">Leave one empty line space before and after the QR code.</p>
 
-  <ol class="govuk-list govuk-list--number">
-    <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
-    <li>Add a new template or choose an existing template.</li>
-    <li>Select <b class="govuk-!-font-weight-bold">Hide personalisation after sending</b>.</li>
-  </ol>
-
-  <p class="govuk-body">You cannot undo this change.</p>
-
-  <p class="govuk-body">Read more about <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_security') }}">Notify’s security features</a>.</p>
+  <p class="govuk-body">Choose a unique name for the placeholder inside the double brackets. When you send the letter, Notify will replace this with the QR code link.</p>
 
 {% endblock %}

--- a/app/templates/views/guidance/using-notify/qr-codes.html
+++ b/app/templates/views/guidance/using-notify/qr-codes.html
@@ -13,22 +13,22 @@
 
   <h1 class="heading-large">Add a QR code to a letter template</h1>
 
-  <p class="govuk-body">QR codes let recipients visit your website without having to type in the URL.</p>
+  <p class="govuk-body">A QR code lets the recipient of a letter visit your website without having to type in the URL.</p>
+
+  <p class="govuk-body">When you add a QR code to your letter, you must provide an alternative for people who cannot scan QR codes. For example, a short URL that’s easy to read or written instructions on how to find your website.</p>
+
+  <h2 class="heading-medium">How to add QR codes</h2>
 
   <p class="govuk-body">You can either:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>add a QR code that will always link to the same website</li>
-    <li>personalise all or part of the link contained in a QR code</li>
+    <li>add the same QR code to every letter you send</li>
+    <li>personalise the QR code each time you send a letter</li>
   </ul>
-
-  <h2 class="heading-medium">How to add a QR code</h2>
-
-  <p class="govuk-body">When you add a QR code to your letter, you must provide an alternative for people who cannot scan QR codes. For example, a short URL that’s easy to read or written instructions on how to find your website.</p>
 
   <p class="govuk-body">Do not add more than one QR code per page.</p>
 
-  <h3 class="heading-small">Add a QR code that will always link to the same website</h3>
+  <h3 class="heading-small">Add the same QR code to every letter you send</h3>
 
   <p class="govuk-body">Copy this example to add a QR code to your letter template:</p>
 
@@ -36,18 +36,18 @@
 
   <p class="govuk-body">Leave one empty line space before and after the QR code.</p>
 
-  <h3 class="heading-small">Add a personalised QR code</h3>
+  <h3 class="heading-small">Personalise the QR code each time you send a letter</h3>
 
-  <p class="govuk-body">Use placeholders to personalise all or part of the link contained in a QR code.</p>
+  <p class="govuk-body">Use <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_personalisation') }}">placeholders</a> to personalise all or part of the link contained in a QR code.</p>
 
   <p class="govuk-body">Each time you send the letter template, you can either:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>fill in the link yourself</li>
+    <li>fill in the placeholder with a link yourself</li>
     <li>upload a list of personal details, including links, and let Notify do it for you</li>
   </ul>
 
-  <p class="govuk-body">Copy this example if the link changes each time you send a letter:</p>
+  <p class="govuk-body">Copy this example if the whole link changes each time you send a letter:</p>
 
   <pre class="formatting-example"><code class="lang-md">QR: ((placeholder))</code></pre>
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -152,6 +152,7 @@ EXCLUDED_ENDPOINTS = set(
             "guidance_pricing_letters",
             "guidance_pricing_text_messages",
             "guidance_pricing",
+            "guidance_qr_codes",
             "guidance_receive_text_messages",
             "guidance_reply_to_email_address",
             "guidance_roadmap",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -414,6 +414,7 @@
     "/using-notify/message-status/<template_type:notification_type>",
     "/using-notify/optional-content",
     "/using-notify/personalisation",
+    "/using-notify/qr-codes",
     "/using-notify/receive-text-messages",
     "/using-notify/reply-to-email-address",
     "/using-notify/schedule-messages",


### PR DESCRIPTION
When we release the new QR codes feature, we’ll need to publish guidance for users:

- in the Using Notify section
- on the edit template page

Adding a new page to the Using Notify section means we also need to update our navigation and cross-linking between guidance pages.

The guidance in this PR differs slightly from the version we tested with users at GDS. I’ve updated it to address some potential issues raised during usability testing.

## To do

- [x] finalise guidance for the new Using Notify page
- [x] update navigation
- [x] add in-page guidance to the edit template page
- [x] decide where to group the link to new guidance on the Using Notify landing page