### PR TITLE
Change language UI

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -64,6 +64,10 @@
   }
 }
 
+.change-language {
+  float: right;
+}
+
 .edit-template-link-get-ready-to-send {
   @extend %edit-template-link;
   top: 232px; // covers MDI barcode and aligns to bottom of contact block

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,5 +1,13 @@
 # Organisation user permission codes
+import enum
+
 PERMISSION_CAN_MAKE_SERVICES_LIVE = "can_make_services_live"
 
 # Error codes from the API
 QR_CODE_TOO_LONG = "qr-code-too-long"
+
+
+# Language options supported for bilingual letter templates
+class LetterLanguageOptions(str, enum.Enum):
+    english = "english"
+    welsh_then_english = "welsh_then_english"

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -53,6 +53,7 @@ from wtforms.validators import (
 )
 
 from app import asset_fingerprinter, current_organisation
+from app.constants import LetterLanguageOptions
 from app.formatters import (
     format_auth_type,
     format_thousands,
@@ -1506,8 +1507,8 @@ class LetterTemplateLanguagesForm(StripWhitespaceForm):
     languages = GovukRadiosField(
         "This will change the language used for the date and page numbers of your letter template.",
         choices=[
-            ("english", "English only"),
-            ("welsh_then_english", "Welsh followed by English"),
+            (LetterLanguageOptions.english.value, "English only"),
+            (LetterLanguageOptions.welsh_then_english.value, "Welsh followed by English"),
         ],
         validators=[InputRequired()],
     )

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1509,7 +1509,7 @@ class LetterTemplateLanguagesForm(StripWhitespaceForm):
             ("english", "English only"),
             ("welsh_then_english", "Welsh followed by English"),
         ],
-        validators=[DataRequired()],
+        validators=[InputRequired()],
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1502,6 +1502,17 @@ class LetterTemplatePostageForm(StripWhitespaceForm):
     )
 
 
+class LetterTemplateLanguagesForm(StripWhitespaceForm):
+    languages = GovukRadiosField(
+        "This will change the language used for the date and page numbers of your letter template.",
+        choices=[
+            ("english", "English only"),
+            ("welsh_then_english", "Welsh followed by English"),
+        ],
+        validators=[DataRequired()],
+    )
+
+
 class LetterUploadPostageForm(StripWhitespaceForm):
     def __init__(self, *args, postage_zone, **kwargs):
         super().__init__(*args, **kwargs)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1178,6 +1178,12 @@ def letter_template_change_language(template_id, service_id):
 
     form = LetterTemplateLanguagesForm(**template._template)
 
+    if form.validate_on_submit():
+        languages = form.languages.data
+        service_api_client.update_service_template(service_id, template_id, languages=languages)
+
+        return redirect(url_for("main.view_template", service_id=service_id, template_id=template_id))
+
     return render_template(
         "views/templates/change-language.html",
         form=form,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -38,6 +38,7 @@ from app.main.forms import (
     BroadcastTemplateForm,
     EmailTemplateForm,
     LetterTemplateForm,
+    LetterTemplateLanguagesForm,
     LetterTemplatePostageForm,
     PDFUploadForm,
     SearchTemplatesForm,
@@ -63,6 +64,7 @@ from app.template_previews import (
 )
 from app.utils import (
     NOTIFICATION_TYPES,
+    service_has_permission,
     should_skip_template_page,
 )
 from app.utils.letters import (
@@ -1163,3 +1165,21 @@ def view_invalid_letter_attachment_as_preview(service_id, file_id):
 
 def _get_page_numbers(page_count):
     return [*range(1, page_count + 1)]
+
+
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/change-language", methods=["GET", "POST"])
+@user_has_permissions("manage_templates")
+@service_has_permission("extra_letter_formatting")
+def letter_template_change_language(template_id, service_id):
+    template = current_service.get_template(template_id)
+
+    if template.template_type != "letter":
+        abort(404)
+
+    form = LetterTemplateLanguagesForm(**template._template)
+
+    return render_template(
+        "views/templates/change-language.html",
+        form=form,
+        template=template,
+    )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -71,7 +71,7 @@ from app.utils.letters import (
     get_error_from_upload_form,
     get_letter_validation_error,
 )
-from app.utils.templates import get_template
+from app.utils.templates import TemplatedLetterImageTemplate, get_template
 from app.utils.user import user_has_permissions
 
 form_objects = {
@@ -1175,11 +1175,10 @@ def _get_page_numbers(page_count):
 def letter_template_change_language(template_id, service_id):
     template = current_service.get_template(template_id)
 
-    if template.template_type != "letter":
+    if template.template_type != "letter" or not isinstance(template, TemplatedLetterImageTemplate):
         abort(404)
 
-    form = LetterTemplateLanguagesForm(**template._template)
-
+    form = LetterTemplateLanguagesForm(languages=template._template.get("letter_languages"))
     if form.validate_on_submit():
         languages = form.languages.data
         if languages == "welsh_then_english":

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1182,11 +1182,15 @@ def letter_template_change_language(template_id, service_id):
 
     if form.validate_on_submit():
         languages = form.languages.data
-        welsh_subject = ""
-        welsh_content = ""
         if languages == "welsh_then_english":
             welsh_subject = "Welsh subject line goes here"
             welsh_content = "Welsh content goes here"
+        elif languages == "english":
+            welsh_subject = None
+            welsh_content = None
+        else:
+            # no other radio options
+            abort(404)
         service_api_client.update_service_template(
             service_id,
             template_id,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1180,7 +1180,14 @@ def letter_template_change_language(template_id, service_id):
 
     if form.validate_on_submit():
         languages = form.languages.data
-        service_api_client.update_service_template(service_id, template_id, languages=languages)
+        welsh_subject = ""
+        welsh_content = ""
+        if languages == "welsh_then_english":
+            welsh_subject = "Welsh subject line goes here"
+            welsh_content = "Welsh content goes here"
+        service_api_client.update_service_template(
+            service_id, template_id, languages=languages, welsh_subject=welsh_subject, welsh_content=welsh_content
+        )
 
         return redirect(url_for("main.view_template", service_id=service_id, template_id=template_id))
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1178,11 +1178,11 @@ def letter_template_change_language(template_id, service_id):
     if template.template_type != "letter" or not isinstance(template, TemplatedLetterImageTemplate):
         abort(404)
 
-    current_language = template._template.get("letter_languages")
-    form = LetterTemplateLanguagesForm(data=dict(languages=current_language))
+    current_languages = template._template.get("letter_languages")
+    form = LetterTemplateLanguagesForm(data=dict(languages=current_languages))
     if form.validate_on_submit():
         languages = form.languages.data
-        if languages != current_language:
+        if languages != current_languages:
             if languages == LetterLanguageOptions.welsh_then_english:
                 welsh_subject = "Welsh subject line goes here"
                 welsh_content = "Welsh content goes here"

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1178,7 +1178,8 @@ def letter_template_change_language(template_id, service_id):
     if template.template_type != "letter" or not isinstance(template, TemplatedLetterImageTemplate):
         abort(404)
 
-    form = LetterTemplateLanguagesForm(languages=template._template.get("letter_languages"))
+    current_language = template._template.get("letter_languages")
+    form = LetterTemplateLanguagesForm(data=dict(languages=current_language))
     if form.validate_on_submit():
         languages = form.languages.data
         if languages != current_language:
@@ -1205,4 +1206,5 @@ def letter_template_change_language(template_id, service_id):
         "views/templates/change-language.html",
         form=form,
         template=template,
+        error_summary_enabled=True,
     )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -629,11 +629,13 @@ def edit_service_template(service_id, template_id):
         new_template_data = {
             "name": form.name.data,
             "content": form.template_content.data,
-            "subject": subject,
             "template_type": template.template_type,
             "id": template.id,
             "reply_to_text": template.get_raw("reply_to_text"),
         }
+
+        if subject:
+            new_template_data["subject"] = subject
 
         new_template = get_template(new_template_data, current_service)
         template_change = template.compare_to(new_template)
@@ -1186,7 +1188,11 @@ def letter_template_change_language(template_id, service_id):
             welsh_subject = "Welsh subject line goes here"
             welsh_content = "Welsh content goes here"
         service_api_client.update_service_template(
-            service_id, template_id, languages=languages, welsh_subject=welsh_subject, welsh_content=welsh_content
+            service_id,
+            template_id,
+            letter_languages=languages,
+            letter_welsh_subject=welsh_subject,
+            letter_welsh_content=welsh_content,
         )
 
         return redirect(url_for("main.view_template", service_id=service_id, template_id=template_id))

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -887,7 +887,7 @@ def edit_template_postage(service_id, template_id):
     form = LetterTemplatePostageForm(**template._template)
     if form.validate_on_submit():
         postage = form.postage.data
-        service_api_client.update_service_template_postage(service_id, template_id, postage)
+        service_api_client.update_service_template(service_id, template_id, postage=postage)
 
         return redirect(url_for("main.view_template", service_id=service_id, template_id=template_id))
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -31,7 +31,7 @@ from app import (
     template_folder_api_client,
     template_statistics_client,
 )
-from app.constants import QR_CODE_TOO_LONG
+from app.constants import QR_CODE_TOO_LONG, LetterLanguageOptions
 from app.formatters import character_count, message_count
 from app.main import main, no_cookie
 from app.main.forms import (
@@ -1180,15 +1180,46 @@ def letter_template_change_language(template_id, service_id):
 
     current_language = template._template.get("letter_languages")
     form = LetterTemplateLanguagesForm(data=dict(languages=current_language))
-    if form.validate_on_submit():
+    if "confirm" in request.args:
+        if "languages" not in request.args:
+            return redirect(url_for(".change_letter_template_language", service_id=service_id, template_id=template_id))
+
+        if request.method == "POST":
+            service_api_client.update_service_template(
+                service_id,
+                template_id,
+                letter_languages=LetterLanguageOptions.english.value,
+                letter_welsh_subject=None,
+                letter_welsh_content=None,
+            )
+            return redirect(url_for("main.view_template", service_id=service_id, template_id=template_id))
+
+        form.languages.data = request.args["languages"]
+        return render_template(
+            "views/templates/change-language.html",
+            form=form,
+            template=template,
+            error_summary_enabled=True,
+            confirmation_banner=True,
+            languages=request.args["languages"],
+        )
+
+    elif form.validate_on_submit():
         languages = form.languages.data
         if languages != current_language:
-            if languages == "welsh_then_english":
+            if languages == LetterLanguageOptions.welsh_then_english:
                 welsh_subject = "Welsh subject line goes here"
                 welsh_content = "Welsh content goes here"
-            elif languages == "english":
-                welsh_subject = None
-                welsh_content = None
+            elif languages == LetterLanguageOptions.english:
+                return redirect(
+                    url_for(
+                        ".letter_template_change_language",
+                        service_id=service_id,
+                        template_id=template_id,
+                        confirm="",
+                        languages=languages,
+                    )
+                )
             else:
                 abort(500, f"Unknown/unhandled form option: {languages}")
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1181,22 +1181,23 @@ def letter_template_change_language(template_id, service_id):
     form = LetterTemplateLanguagesForm(languages=template._template.get("letter_languages"))
     if form.validate_on_submit():
         languages = form.languages.data
-        if languages == "welsh_then_english":
-            welsh_subject = "Welsh subject line goes here"
-            welsh_content = "Welsh content goes here"
-        elif languages == "english":
-            welsh_subject = None
-            welsh_content = None
-        else:
-            # no other radio options
-            abort(404)
-        service_api_client.update_service_template(
-            service_id,
-            template_id,
-            letter_languages=languages,
-            letter_welsh_subject=welsh_subject,
-            letter_welsh_content=welsh_content,
-        )
+        if languages != current_language:
+            if languages == "welsh_then_english":
+                welsh_subject = "Welsh subject line goes here"
+                welsh_content = "Welsh content goes here"
+            elif languages == "english":
+                welsh_subject = None
+                welsh_content = None
+            else:
+                abort(500, f"Unknown/unhandled form option: {languages}")
+
+            service_api_client.update_service_template(
+                service_id,
+                template_id,
+                letter_languages=languages,
+                letter_welsh_subject=welsh_subject,
+                letter_welsh_content=welsh_content,
+            )
 
         return redirect(url_for("main.view_template", service_id=service_id, template_id=template_id))
 

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -229,6 +229,7 @@ class MainNavigation(Navigation):
             "edit_template_postage",
             "letter_template_attach_pages",
             "letter_template_change_language",
+            "letter_template_confirm_remove_welsh",
             "manage_template_folder",
             "send_messages",
             "send_one_off",

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -228,6 +228,7 @@ class MainNavigation(Navigation):
             "edit_service_template",
             "edit_template_postage",
             "letter_template_attach_pages",
+            "letter_template_change_language",
             "manage_template_folder",
             "send_messages",
             "send_one_off",

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -5,13 +5,7 @@ from notifications_utils.clients.redis import daily_limit_cache_key
 from app.extensions import redis_client
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 
-ALLOWED_TEMPLATE_ATTRIBUTES = {
-    "content",
-    "languages",
-    "name",
-    "postage",
-    "subject",
-}
+ALLOWED_TEMPLATE_ATTRIBUTES = {"content", "languages", "name", "postage", "subject", "welsh_subject", "welsh_content"}
 
 
 class ServiceAPIClient(NotifyAdminAPIClient):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -9,6 +9,7 @@ ALLOWED_TEMPLATE_ATTRIBUTES = {
     "content",
     "languages",
     "name",
+    "postage",
     "subject",
 }
 
@@ -217,11 +218,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         }
         data = _attach_current_user(data)
         return self.post(f"/service/{service_id}/template/{template_id}", data)
-
-    @cache.delete("service-{service_id}-templates")
-    @cache.delete_by_pattern("service-{service_id}-template-{template_id}*")
-    def update_service_template_postage(self, service_id, template_id, postage):
-        return self.post(f"/service/{service_id}/template/{template_id}", _attach_current_user({"postage": postage}))
 
     @cache.set("service-{service_id}-template-{template_id}-version-{version}")
     def get_service_template(self, service_id, template_id, version=None):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -5,7 +5,15 @@ from notifications_utils.clients.redis import daily_limit_cache_key
 from app.extensions import redis_client
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 
-ALLOWED_TEMPLATE_ATTRIBUTES = {"content", "languages", "name", "postage", "subject", "welsh_subject", "welsh_content"}
+ALLOWED_TEMPLATE_ATTRIBUTES = {
+    "content",
+    "letter_languages",
+    "name",
+    "postage",
+    "subject",
+    "letter_welsh_subject",
+    "letter_welsh_content",
+}
 
 
 class ServiceAPIClient(NotifyAdminAPIClient):
@@ -188,11 +196,10 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         Update a service template.
         """
-        data = dict(kwargs)
-        disallowed_attributes = set(data.keys()) - ALLOWED_TEMPLATE_ATTRIBUTES
+        disallowed_attributes = set(kwargs.keys()) - ALLOWED_TEMPLATE_ATTRIBUTES
         if disallowed_attributes:
             raise TypeError(f"Not allowed to update template attributes: {', '.join(disallowed_attributes)}")
-        data = _attach_current_user(data)
+        data = _attach_current_user(kwargs)
         endpoint = f"/service/{service_id}/template/{template_id}"
         return self.post(endpoint, data)
 

--- a/app/templates/views/templates/_letter_template.html
+++ b/app/templates/views/templates/_letter_template.html
@@ -41,5 +41,18 @@
       ),
     "classes": "govuk-button--secondary edit-template-link-attachment"
     }) }}
+
+    {% if 'extra_letter_formatting' in current_service.permissions %}
+      {{ govukButton({
+      "element": "a",
+      "text": "Change language",
+      "href": url_for(
+      '.view_template',
+      service_id=current_service.id,
+      template_id=template.id
+      ),
+      "classes": "govuk-button--secondary change-language"
+      }) }}
+    {% endif %}
   </div>
 </div>

--- a/app/templates/views/templates/_letter_template.html
+++ b/app/templates/views/templates/_letter_template.html
@@ -47,7 +47,7 @@
       "element": "a",
       "text": "Change language",
       "href": url_for(
-      '.view_template',
+      '.letter_template_change_language',
       service_id=current_service.id,
       template_id=template.id
       ),

--- a/app/templates/views/templates/change-language.html
+++ b/app/templates/views/templates/change-language.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/banner.html" import banner %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
@@ -13,6 +14,15 @@
 {% endblock %}
 
 {% block maincolumn_content %}
+  {% if confirmation_banner %}
+    {{ banner(
+      'Are you sure you want to change the language to English only?<br><br>This will delete the English pages of your letter template.<br><br>You cannot undo this.'|safe,
+      type='dangerous',
+      delete_button='Yes, change the language',
+      action=url_for('main.letter_template_change_language', service_id=current_service.id, template_id=template.id, confirm="yes", languages=languages)
+    ) }}
+  {% endif %}
+
 
   {{ page_header(title) }}
   {% call form_wrapper(class="govuk-!-margin-bottom-7") %}

--- a/app/templates/views/templates/change-language.html
+++ b/app/templates/views/templates/change-language.html
@@ -1,0 +1,31 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% set title = 'Change language' %}
+{% block service_page_title %}
+  {{ title }}
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({ "href": url_for('main.view_template', service_id=current_service.id, template_id=template_id) }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(title) }}
+  {% call form_wrapper(class="govuk-!-margin-bottom-7") %}
+    {{ form.languages(param_extensions={
+      "fieldset": {
+          "legend": {
+              "classes": "",
+          },
+      }
+    }) }}
+    {{ page_footer('Save') }}
+  {% endcall %}
+
+
+
+{% endblock %}

--- a/app/templates/views/templates/change-language.html
+++ b/app/templates/views/templates/change-language.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
@@ -14,16 +13,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {% if confirmation_banner %}
-    {{ banner(
-      'Are you sure you want to change the language to English only?<br><br>This will delete the English pages of your letter template.<br><br>You cannot undo this.'|safe,
-      type='dangerous',
-      delete_button='Yes, change the language',
-      action=url_for('main.letter_template_change_language', service_id=current_service.id, template_id=template.id, confirm="yes", languages=languages)
-    ) }}
-  {% endif %}
-
-
   {{ page_header(title) }}
   {% call form_wrapper(class="govuk-!-margin-bottom-7") %}
     {{ form.languages(param_extensions={
@@ -35,7 +24,4 @@
     }) }}
     {{ page_footer('Save') }}
   {% endcall %}
-
-
-
 {% endblock %}

--- a/app/templates/views/templates/change-language.html
+++ b/app/templates/views/templates/change-language.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('main.view_template', service_id=current_service.id, template_id=template_id) }) }}
+  {{ govukBackLink({ "href": url_for('main.view_template', service_id=current_service.id, template_id=template.id) }) }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/templates/remove-welsh-language-from-letter.html
+++ b/app/templates/views/templates/remove-welsh-language-from-letter.html
@@ -21,7 +21,7 @@
 
   {% call form_wrapper() %}
     <input type="hidden" name="confirm" value="true" />
-    {{ page_footer('Remove Welsh pages', destructive=True) }}
+    {{ page_footer('Remove Welsh pages') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/templates/remove-welsh-language-from-letter.html
+++ b/app/templates/views/templates/remove-welsh-language-from-letter.html
@@ -1,0 +1,29 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% set title = 'Remove Welsh pages' %}
+{% block service_page_title %}
+  {{ title }}
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({ "href": url_for('main.letter_template_change_language', service_id=current_service.id, template_id=template.id) }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+  {{ page_header(title) }}
+
+  <p class="govuk-body">Are you sure you want to change the language to English only?</p>
+
+  <p class="govuk-body">This will delete the Welsh pages of your letter template.</p>
+
+  <p class="govuk-body">You cannot undo this.</p>
+
+  {% call form_wrapper() %}
+    <input type="hidden" name="confirm" value="true" />
+    {{ page_footer('Remove Welsh pages', destructive=True) }}
+  {% endcall %}
+
+{% endblock %}

--- a/app/templates/views/templates/remove-welsh-language-from-letter.html
+++ b/app/templates/views/templates/remove-welsh-language-from-letter.html
@@ -19,8 +19,6 @@
 
   <p class="govuk-body">This will delete the Welsh pages of your letter template.</p>
 
-  <p class="govuk-body">You cannot undo this.</p>
-
   {% call form_wrapper() %}
     <input type="hidden" name="confirm" value="true" />
     {{ page_footer('Remove Welsh pages', destructive=True) }}

--- a/app/templates/views/templates/remove-welsh-language-from-letter.html
+++ b/app/templates/views/templates/remove-welsh-language-from-letter.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% set title = 'Remove Welsh pages' %}
+{% set title = 'Are you sure you want to change the language to English only?' %}
 {% block service_page_title %}
   {{ title }}
 {% endblock %}
@@ -15,13 +15,11 @@
 {% block maincolumn_content %}
   {{ page_header(title) }}
 
-  <p class="govuk-body">Are you sure you want to change the language to English only?</p>
-
-  <p class="govuk-body">This will delete the Welsh pages of your letter template.</p>
+  <p class="govuk-body">This will remove the Welsh pages of your letter template.</p>
 
   {% call form_wrapper() %}
     <input type="hidden" name="confirm" value="true" />
-    {{ page_footer('Remove Welsh pages') }}
+    {{ page_footer('Yes, change the language') }}
   {% endcall %}
 
 {% endblock %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -869,6 +869,23 @@ def test_POST_letter_template_change_language_updates_language(
     mock_template_change_language.assert_called_with(SERVICE_ONE_ID, fake_uuid, languages="welsh_then_english")
 
 
+def test_letter_template_change_language_404s_if_template_is_not_a_letter(
+    client_request,
+    service_one,
+    mock_get_service_template,
+    active_user_with_permissions,
+    mocker,
+    fake_uuid,
+):
+    service_one["permissions"].append("extra_letter_formatting")
+    client_request.login(active_user_with_permissions)
+    page = client_request.get(
+        "main.letter_template_change_language", service_id=SERVICE_ONE_ID, template_id=fake_uuid, _expected_status=404
+    )
+
+    assert page.select_one("h1").text.strip() != "Change language"
+
+
 def test_GET_letter_template_attach_pages(
     client_request, service_one, fake_uuid, mocker, mock_get_service_letter_template
 ):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -870,8 +870,8 @@ def test_letter_template_change_language_to_welsh_then_english_populates_default
         SERVICE_ONE_ID,
         fake_uuid,
         languages="welsh_then_english",
-        welsh_subject="Templed llythyr di-deitl",
-        welsh_content="Cynnwys templed",
+        welsh_subject="Welsh subject line goes here",
+        welsh_content="Welsh content goes here",
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -795,30 +795,31 @@ def test_view_letter_template_displays_change_language_button(
     service_one["permissions"].append("extra_letter_formatting")
     mocker.patch("app.template_previews.get_page_count_for_letter", return_value=1)
     client_request.login(active_user_with_permissions)
+    template_id = fake_uuid
     mocker.patch(
         "app.service_api_client.get_service_template",
-        return_value={"data": create_template(template_type="letter")},
+        return_value={"data": create_template(template_type="letter", template_id=template_id)},
     )
-
     page = client_request.get(
         "main.view_template",
         service_id=SERVICE_ONE_ID,
-        template_id=fake_uuid,
+        template_id=template_id,
         _test_page_title=False,
     )
 
     change_language_button = page.select_one(".change-language")
 
     assert normalize_spaces(change_language_button.text) == "Change language"
-
     assert change_language_button["href"] == url_for(
-        "main.letter_template_change_language", service_id=SERVICE_ONE_ID, template_id=sample_uuid()
+        "main.letter_template_change_language", service_id=SERVICE_ONE_ID, template_id=template_id
     )
 
 
 def test_GET_letter_template_change_language(
-    client_request, service_one, fake_uuid, mocker, mock_get_service_letter_template
+    client_request, service_one, fake_uuid, mocker, mock_get_service_letter_template, active_user_with_permissions
 ):
+    service_one["permissions"].append("extra_letter_formatting")
+    client_request.login(active_user_with_permissions)
     page = client_request.get(
         "main.letter_template_change_language",
         service_id=SERVICE_ONE_ID,
@@ -828,8 +829,8 @@ def test_GET_letter_template_change_language(
     assert page.select_one("h1").text.strip() == "Change language"
 
     assert [label.text.strip() for label in page.select(".govuk-radios__item label")] == [
-        "English",
-        "Welsh, then English",
+        "English only",
+        "Welsh followed by English",
     ]
     assert [radio["value"] for radio in page.select(".govuk-radios__item input")] == [
         "english",

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -842,7 +842,24 @@ def test_GET_letter_template_change_language(
     mock_get_service_letter_template.assert_called_once_with(SERVICE_ONE_ID, fake_uuid, None)
 
 
-def test_letter_template_change_language_to_welsh_then_english_populates_default_welsh_content_and_subject(
+def test_GET_letter_template_change_language_404s_if_template_is_not_a_letter(
+    client_request,
+    service_one,
+    mock_get_service_template,
+    active_user_with_permissions,
+    mocker,
+    fake_uuid,
+):
+    service_one["permissions"].append("extra_letter_formatting")
+    client_request.login(active_user_with_permissions)
+    page = client_request.get(
+        "main.letter_template_change_language", service_id=SERVICE_ONE_ID, template_id=fake_uuid, _expected_status=404
+    )
+
+    assert page.select_one("h1").text.strip() != "Change language"
+
+
+def test_POST_letter_template_change_language_to_welsh_then_english_populates_default_welsh_content_and_subject(
     client_request,
     service_one,
     mocker,
@@ -873,23 +890,6 @@ def test_letter_template_change_language_to_welsh_then_english_populates_default
         letter_welsh_subject="Welsh subject line goes here",
         letter_welsh_content="Welsh content goes here",
     )
-
-
-def test_letter_template_change_language_404s_if_template_is_not_a_letter(
-    client_request,
-    service_one,
-    mock_get_service_template,
-    active_user_with_permissions,
-    mocker,
-    fake_uuid,
-):
-    service_one["permissions"].append("extra_letter_formatting")
-    client_request.login(active_user_with_permissions)
-    page = client_request.get(
-        "main.letter_template_change_language", service_id=SERVICE_ONE_ID, template_id=fake_uuid, _expected_status=404
-    )
-
-    assert page.select_one("h1").text.strip() != "Change language"
 
 
 def test_GET_letter_template_attach_pages(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -842,16 +842,18 @@ def test_GET_letter_template_change_language(
     mock_get_service_letter_template.assert_called_once_with(SERVICE_ONE_ID, fake_uuid, None)
 
 
-def test_letter_template_change_language_updates_language(
+def test_POST_letter_template_change_language_updates_language(
     client_request,
     service_one,
     mocker,
     fake_uuid,
+    active_user_with_permissions,
     mock_get_service_letter_template,
 ):
-    mock_template_change_language = mocker.patch(
-        "app.main.views.templates.service_api_client.update_service_template_language"
-    )
+    service_one["permissions"].append("extra_letter_formatting")
+    client_request.login(active_user_with_permissions)
+
+    mock_template_change_language = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
 
     client_request.post(
         "main.letter_template_change_language",
@@ -864,7 +866,7 @@ def test_letter_template_change_language_updates_language(
             template_id=fake_uuid,
         ),
     )
-    mock_template_change_language.assert_called_with(SERVICE_ONE_ID, fake_uuid, "welsh_then_english")
+    mock_template_change_language.assert_called_with(SERVICE_ONE_ID, fake_uuid, languages="welsh_then_english")
 
 
 def test_GET_letter_template_attach_pages(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -842,6 +842,31 @@ def test_GET_letter_template_change_language(
     mock_get_service_letter_template.assert_called_once_with(SERVICE_ONE_ID, fake_uuid, None)
 
 
+def test_letter_template_change_language_updates_language(
+    client_request,
+    service_one,
+    mocker,
+    fake_uuid,
+    mock_get_service_letter_template,
+):
+    mock_template_change_language = mocker.patch(
+        "app.main.views.templates.service_api_client.update_service_template_language"
+    )
+
+    client_request.post(
+        "main.letter_template_change_language",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _data={"languages": "welsh_then_english"},
+        _expected_redirect=url_for(
+            "main.view_template",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+        ),
+    )
+    mock_template_change_language.assert_called_with(SERVICE_ONE_ID, fake_uuid, "welsh_then_english")
+
+
 def test_GET_letter_template_attach_pages(
     client_request, service_one, fake_uuid, mocker, mock_get_service_letter_template
 ):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -859,13 +859,20 @@ def test_GET_letter_template_change_language_404s_if_template_is_not_a_letter(
     assert page.select_one("h1").text.strip() != "Change language"
 
 
-def test_POST_letter_template_change_language_to_welsh_then_english_populates_default_welsh_content_and_subject(
+@pytest.mark.parametrize(
+    "languages, expected_welsh_subject, expected_welsh_content",
+    [("welsh_then_english", "Welsh subject line goes here", "Welsh content goes here"), ("english", None, None)],
+)
+def test_POST_letter_template_change_language_also_changes_welsh_subject_and_content(
     client_request,
     service_one,
     mocker,
     fake_uuid,
     active_user_with_permissions,
     mock_get_service_letter_template,
+    languages,
+    expected_welsh_subject,
+    expected_welsh_content,
 ):
     service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
@@ -876,7 +883,7 @@ def test_POST_letter_template_change_language_to_welsh_then_english_populates_de
         "main.letter_template_change_language",
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
-        _data={"languages": "welsh_then_english"},
+        _data={"languages": languages},
         _expected_redirect=url_for(
             "main.view_template",
             service_id=SERVICE_ONE_ID,
@@ -886,9 +893,9 @@ def test_POST_letter_template_change_language_to_welsh_then_english_populates_de
     mock_template_change_language.assert_called_with(
         SERVICE_ONE_ID,
         fake_uuid,
-        letter_languages="welsh_then_english",
-        letter_welsh_subject="Welsh subject line goes here",
-        letter_welsh_content="Welsh content goes here",
+        letter_languages=languages,
+        letter_welsh_subject=expected_welsh_subject,
+        letter_welsh_content=expected_welsh_content,
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -807,7 +807,7 @@ def test_view_letter_template_displays_change_language_button(
         _test_page_title=False,
     )
 
-    assert normalize_spaces(page.select_one(".change_language").text) == "Change Language"
+    assert normalize_spaces(page.select_one(".change-language").text) == "Change language"
 
 
 def test_GET_letter_template_attach_pages(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -807,7 +807,38 @@ def test_view_letter_template_displays_change_language_button(
         _test_page_title=False,
     )
 
-    assert normalize_spaces(page.select_one(".change-language").text) == "Change language"
+    change_language_button = page.select_one(".change-language")
+
+    assert normalize_spaces(change_language_button.text) == "Change language"
+
+    assert change_language_button["href"] == url_for(
+        "main.letter_template_change_language", service_id=SERVICE_ONE_ID, template_id=sample_uuid()
+    )
+
+
+def test_GET_letter_template_change_language(
+    client_request, service_one, fake_uuid, mocker, mock_get_service_letter_template
+):
+    page = client_request.get(
+        "main.letter_template_change_language",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+    )
+
+    assert page.select_one("h1").text.strip() == "Change language"
+
+    assert [label.text.strip() for label in page.select(".govuk-radios__item label")] == [
+        "English",
+        "Welsh, then English",
+    ]
+    assert [radio["value"] for radio in page.select(".govuk-radios__item input")] == [
+        "english",
+        "welsh_then_english",
+    ]
+
+    assert page.select("form button")
+
+    mock_get_service_letter_template.assert_called_once_with(SERVICE_ONE_ID, fake_uuid, None)
 
 
 def test_GET_letter_template_attach_pages(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1294,9 +1294,7 @@ def test_edit_letter_templates_postage_updates_postage(
     fake_uuid,
     mock_get_service_letter_template,
 ):
-    mock_update_template_postage = mocker.patch(
-        "app.main.views.templates.service_api_client.update_service_template_postage"
-    )
+    mock_update_template_postage = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
 
     client_request.post(
         "main.edit_template_postage",
@@ -1304,7 +1302,7 @@ def test_edit_letter_templates_postage_updates_postage(
         template_id=fake_uuid,
         _data={"postage": "first"},
     )
-    mock_update_template_postage.assert_called_with(SERVICE_ONE_ID, fake_uuid, "first")
+    mock_update_template_postage.assert_called_with(SERVICE_ONE_ID, fake_uuid, postage="first")
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -842,7 +842,7 @@ def test_GET_letter_template_change_language(
     mock_get_service_letter_template.assert_called_once_with(SERVICE_ONE_ID, fake_uuid, None)
 
 
-def test_POST_letter_template_change_language_updates_language(
+def test_letter_template_change_language_to_welsh_then_english_populates_default_welsh_content_and_subject(
     client_request,
     service_one,
     mocker,
@@ -866,7 +866,13 @@ def test_POST_letter_template_change_language_updates_language(
             template_id=fake_uuid,
         ),
     )
-    mock_template_change_language.assert_called_with(SERVICE_ONE_ID, fake_uuid, languages="welsh_then_english")
+    mock_template_change_language.assert_called_with(
+        SERVICE_ONE_ID,
+        fake_uuid,
+        languages="welsh_then_english",
+        welsh_subject="Templed llythyr di-deitl",
+        welsh_content="Cynnwys templed",
+    )
 
 
 def test_letter_template_change_language_404s_if_template_is_not_a_letter(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -781,6 +781,35 @@ def test_view_letter_template_does_not_display_send_button_if_template_over_10_p
     assert page.select_one("h1", {"data-error-type": "letter-too-long"})
 
 
+def test_view_letter_template_displays_change_language_button(
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    single_letter_contact_block,
+    mock_has_jobs,
+    active_user_with_permissions,
+    mocker,
+    fake_uuid,
+):
+    service_one["permissions"].append("extra_letter_formatting")
+    mocker.patch("app.template_previews.get_page_count_for_letter", return_value=1)
+    client_request.login(active_user_with_permissions)
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": create_template(template_type="letter")},
+    )
+
+    page = client_request.get(
+        "main.view_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+
+    assert normalize_spaces(page.select_one(".change_language").text) == "Change Language"
+
+
 def test_GET_letter_template_attach_pages(
     client_request, service_one, fake_uuid, mocker, mock_get_service_letter_template
 ):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -841,6 +841,10 @@ def test_GET_letter_template_change_language(
 
     mock_get_service_letter_template.assert_called_once_with(SERVICE_ONE_ID, fake_uuid, None)
 
+    assert (
+        page.select_one("a[class='govuk-back-link']").get("href") == f"/services/{SERVICE_ONE_ID}/templates/{fake_uuid}"
+    )
+
 
 def test_GET_letter_template_change_language_404s_if_template_is_not_a_letter(
     client_request,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -869,9 +869,9 @@ def test_letter_template_change_language_to_welsh_then_english_populates_default
     mock_template_change_language.assert_called_with(
         SERVICE_ONE_ID,
         fake_uuid,
-        languages="welsh_then_english",
-        welsh_subject="Welsh subject line goes here",
-        welsh_content="Welsh content goes here",
+        letter_languages="welsh_then_english",
+        letter_welsh_subject="Welsh subject line goes here",
+        letter_welsh_content="Welsh content goes here",
     )
 
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -440,13 +440,6 @@ def test_deletes_service_cache(
             [f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*"],
         ),
         (
-            "update_service_template_postage",
-            [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, "first"],
-            {},
-            [f"service-{SERVICE_ONE_ID}-templates"],
-            [f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}*"],
-        ),
-        (
             "delete_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             {},

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -189,6 +189,7 @@ EXCLUDED_ENDPOINTS = set(
             "letter_template",
             "letter_template_attach_pages",
             "letter_template_change_language",
+            "letter_template_confirm_remove_welsh",
             "letter_template_edit_pages",
             "link_service_to_organisation",
             "live_services_csv",

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -188,6 +188,7 @@ EXCLUDED_ENDPOINTS = set(
             "letter_spec",
             "letter_template",
             "letter_template_attach_pages",
+            "letter_template_change_language",
             "letter_template_edit_pages",
             "link_service_to_organisation",
             "live_services_csv",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -301,6 +301,7 @@
     "/services/<uuid:service_id>/templates/<uuid:template_id>/attach-pages",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/attach-pages/edit",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/change-language",
+    "/services/<uuid:service_id>/templates/<uuid:template_id>/change-language/confirm",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/delete",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit-postage",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -300,6 +300,7 @@
     "/services/<uuid:service_id>/templates/<uuid:template_id>.<filetype>",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/attach-pages",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/attach-pages/edit",
+    "/services/<uuid:service_id>/templates/<uuid:template_id>/change-language",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/delete",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit-postage",


### PR DESCRIPTION
Add a flow for changing the language(s) for a letter template between just English (the default), and Welsh & English.

Note: this PR allows us to change the setting, but nothing actually changes visibly on the template preview page, and I suspect that letters set to `welsh_then_english` will either by unprintable or only print as if `english` for now. The only services that can use this flow, as of now, are the Notify service and some developer test services, so this is OK.

Update: @quis suggested a separate confirmation page rather than a banner confirmation. The code for this is cleaner and it looks like a nicer flow as well, so have updated to work that way. Words are placeholder and mostly copied from the confirmation banner - probably need updating @karlchillmaid / @saimaghafoor  

## Page previews
![image](https://github.com/alphagov/notifications-admin/assets/2920760/f6545e3d-ff98-4e0d-883a-2420fed8628a)

![image](https://github.com/alphagov/notifications-admin/assets/2920760/498eafec-d269-4f85-ae47-573fd1653dcc)

<img width="1008" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/315b66c7-df9d-42ef-8a47-52405ae59c7a">
