### PR TITLE
Rollback to cflinuxfs3 due to performance issues

### DIFF
--- a/manifest-droplet.yml
+++ b/manifest-droplet.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: ((app_name))
-  stack: cflinuxfs4
+  stack: cflinuxfs3
   processes:
   - type: web
     instances: 0

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -29,7 +29,7 @@ applications:
     health-check-http-endpoint: '/_status?simple=true'
     health-check-invocation-timeout: 10
 
-    stack: cflinuxfs4
+    stack: cflinuxfs3
 
     services:
       - logit-ssl-syslog-drain

--- a/paas-failwhale/manifest.yml
+++ b/paas-failwhale/manifest.yml
@@ -5,4 +5,4 @@ applications:
     no-route: true
     buildpack: staticfile_buildpack
     memory: 256M
-    stack: cflinuxfs4
+    stack: cflinuxfs3


### PR DESCRIPTION
What
----

Rollback to cflinuxfs3

Why
----

Unfortunately we are seeing significant performance issues with cflinuxfs4 in production.