### PR TITLE
Allow `REDIS_ENABLED` to be set in the manifest

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -54,6 +54,9 @@ applications:
       {% if REDIS_URL is defined %}
       REDIS_URL: '{{ REDIS_URL }}'
       {% endif %}
+      {% if REDIS_ENABLED is defined %}
+      REDIS_ENABLED: '{{ REDIS_ENABLED }}'
+      {% endif %}
 
       AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID }}'
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'


### PR DESCRIPTION
This allows the new environment variable, `REDIS_ENABLED` to be set on the PaaS apps if it's defined. This will be used to enable / disable Redis.