### PR TITLE
Template version history tweaks

### DIFF
--- a/app/templates/views/templates/_template_history.html
+++ b/app/templates/views/templates/_template_history.html
@@ -1,5 +1,11 @@
 <div class="govuk-grid-column-full">
-  <h2 class="message-name">{{ template.name }}</h2>
+  {% if version_heading %}
+  <h2 class="message-name">
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=template.id, version=template._template.version) }}">
+      Version {{ template._template.version }}: {{ template.name }}
+    </a>
+  </h2>
+  {% endif %}
   <p class="hint">
     {% if template.get_raw('version', 1) > 1 %}
       Edit made {% if template.get_raw('updated_at', None) %}{{ template.get_raw('updated_at')|format_datetime_normal }}{% endif %}

--- a/app/templates/views/templates/choose_history.html
+++ b/app/templates/views/templates/choose_history.html
@@ -8,7 +8,7 @@
   <h1 class="heading-large">Previous versions</h1>
   <div class="govuk-grid-row">
     {% for template in versions %}
-      {% with show_title=True %}
+      {% with version_heading=True %}
         {% include 'views/templates/_template_history.html' %}
       {% endwith %}
     {% endfor %}

--- a/app/templates/views/templates/choose_history.html
+++ b/app/templates/views/templates/choose_history.html
@@ -1,7 +1,14 @@
 {% extends "withnav_template.html" %}
 
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "components/previous-next-navigation.html" import previous_next_navigation %}
+
 {% block service_page_title %}
   Previous versions
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({ "href": url_for('main.view_template', service_id=current_service.id, template_id=template_id) }) }}
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -13,7 +20,6 @@
       {% endwith %}
     {% endfor %}
   </div>
-  <p class="govuk-body">
-    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".choose_template", service_id=current_service.id) }}">Back to current templates</a>
-  </p>
+
+  {{ previous_next_navigation(previous_page, next_page) }}
 {% endblock %}

--- a/app/templates/views/templates/template_history.html
+++ b/app/templates/views/templates/template_history.html
@@ -1,17 +1,22 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = "Version " + template._template.version|string + " : " + template.name %}
 
 {% block service_page_title %}
-  {{ template.name }}
+  {{ page_title }}
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({ "href": url_for('main.view_template_versions', service_id=current_service.id, template_id=template.id) }) }}
 {% endblock %}
 
 {% block maincolumn_content %}
-
-
-  <h1 class="heading-large">{{ template.name }}</h1>
+  <h1 class="heading-large">{{ page_title }}</h1>
 
   <div class="govuk-grid-row">
-    {% with show_title=False %}
+    {% with version_heading=False %}
       {% include 'views/templates/_template_history.html' %}
     {% endwith %}
   </div>

--- a/app/utils/pagination.py
+++ b/app/utils/pagination.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from flask import request, url_for
 
 
@@ -25,3 +27,16 @@ def generate_previous_next_dict(view, service_id, page, title, url_args):
         "title": title,
         "label": f"page {page}",
     }
+
+
+def generate_optional_previous_and_next_dicts(
+    view: str, service_id, page: int, num_pages: int, url_args=None
+) -> tuple[Optional[dict], Optional[dict]]:
+    previous_page = (
+        generate_previous_dict(view, service_id=service_id, page=page, url_args=url_args) if page > 1 else None
+    )
+    next_page = (
+        generate_next_dict(view, service_id=service_id, page=page, url_args=url_args) if page < num_pages else None
+    )
+
+    return previous_page, next_page

--- a/tests/app/main/views/test_template_history.py
+++ b/tests/app/main/views/test_template_history.py
@@ -1,5 +1,7 @@
 from flask import url_for
 
+from tests import template_version_json
+
 
 def test_view_template_version(
     client_request,
@@ -54,3 +56,62 @@ def test_view_template_versions(
     assert api_user_active["name"] in page.text
     assert versions["data"][0]["content"] in page.text
     mock_get_template_versions.assert_called_with(service_id, template_id)
+
+
+def test_view_template_versions_pages(
+    client_request,
+    api_user_active,
+    mocker,
+    mock_login,
+    mock_get_service,
+    mock_get_service_template,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_has_permissions,
+    fake_uuid,
+):
+    service_id = fake_uuid
+    template_id = fake_uuid
+
+    versions = [template_version_json(service_id, template_id, api_user_active, version=v + 1) for v in range(51)][::-1]
+    mocker.patch(
+        "app.service_api_client.get_service_template_versions", side_effect=lambda sid, tid: {"data": versions}
+    )
+
+    page = client_request.get(".view_template_versions", service_id=service_id, template_id=template_id)
+    assert api_user_active["name"] in page.text
+    next_page = page.select_one("a[rel=next]")
+    previous_page = page.select_one("a[rel=previous]")
+    assert next_page
+    assert not previous_page
+    assert "Version 51: " in page.text
+    assert "Version 26: " not in page.text
+    assert "Version 1: " not in page.text
+    assert "Next page" in page.text
+    assert "Previous page" not in page.text
+
+    page = client_request.get_url(next_page.get("href"))
+    assert api_user_active["name"] in page.text
+    assert versions[0]["content"] in page.text
+    next_page = page.select_one("a[rel=next]")
+    previous_page = page.select_one("a[rel=previous]")
+    assert next_page
+    assert previous_page
+    assert "Version 51: " not in page.text
+    assert "Version 26: " in page.text
+    assert "Version 1: " not in page.text
+    assert "Next page" in page.text
+    assert "Previous page" in page.text
+
+    page = client_request.get_url(next_page.get("href"))
+    assert api_user_active["name"] in page.text
+    assert versions[0]["content"] in page.text
+    next_page = page.select_one("a[rel=next]")
+    previous_page = page.select_one("a[rel=previous]")
+    assert not next_page
+    assert previous_page
+    assert "Version 51: " not in page.text
+    assert "Version 26: " not in page.text
+    assert "Version 1: " in page.text
+    assert "Next page" not in page.text
+    assert "Previous page" in page.text

--- a/tests/app/utils/test_pagination.py
+++ b/tests/app/utils/test_pagination.py
@@ -1,4 +1,6 @@
-from app.utils.pagination import generate_next_dict, generate_previous_dict
+import pytest
+
+from app.utils.pagination import generate_next_dict, generate_optional_previous_and_next_dicts, generate_previous_dict
 
 
 def test_generate_previous_dict(client_request):
@@ -18,3 +20,27 @@ def test_generate_next_dict(client_request):
 def test_generate_previous_next_dict_adds_other_url_args(client_request):
     result = generate_next_dict("main.view_notifications", "foo", 2, {"message_type": "blah"})
     assert "notifications/blah" in result["url"]
+
+
+@pytest.mark.parametrize(
+    "page, num_pages, expect_previous_page, expect_next_page",
+    (
+        (1, 1, None, None),
+        (1, 2, None, {"url": "/services/s/templates/t/versions?page=2", "title": "Next page", "label": "page 2"}),
+        (2, 2, {"url": "/services/s/templates/t/versions?page=1", "title": "Previous page", "label": "page 1"}, None),
+        (
+            2,
+            3,
+            {"url": "/services/s/templates/t/versions?page=1", "title": "Previous page", "label": "page 1"},
+            {"url": "/services/s/templates/t/versions?page=3", "title": "Next page", "label": "page 3"},
+        ),
+    ),
+)
+def test_generate_optional_previous_and_next_dicts(
+    client_request, page, num_pages, expect_previous_page, expect_next_page
+):
+    previous_page, next_page = generate_optional_previous_and_next_dicts(
+        "main.view_template_versions", service_id="s", page=page, num_pages=num_pages, url_args={"template_id": "t"}
+    )
+    assert previous_page == expect_previous_page
+    assert next_page == expect_next_page


### PR DESCRIPTION
## commit 1: Add links from template history to each version

<img width="1002" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/1d2b03bd-b8a6-4d9c-8623-8924f6843445">


## commit 2: Paginate template history

We know some services have huge numbers of template versions, and this
page effectively breaks for those users.

Let's put pagination on this to reduce the HTML size for those services,
and keep the page a bit more responsive.

Note that this is a quick win rather than a full fix, as the API doesn't
support pagination on this endpoint and so still sends the entire
template history across. We paginate on the admin side only.

We should add pagination to the API to fix this properly, but it's more
complex since we're working across two apps and have to tweak our
template version caching as well.

### Pictures (page size reduced to 3 for screenshot purposes)

![image](https://github.com/alphagov/notifications-admin/assets/2920760/8c57f222-04d1-4d7c-a46b-845566d02651)

![image](https://github.com/alphagov/notifications-admin/assets/2920760/0ede8337-854b-482f-aece-eb2758b6e7a6)
