### PR TITLE
Update radio select to fix accessibility issues

### DIFF
--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -3,212 +3,238 @@
   "use strict";
 
   var Modules = global.GOVUK.NotifyModules;
-  var Hogan = global.Hogan;
 
   // Object holding all the states for the component's HTML
-  let states = {
-    'initial': Hogan.compile(`
-      {{#showNowAsDefault}}
-        <div class="radio-select__column">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" checked="checked" id="{{name}}-0" name="{{name}}" type="radio" value="">
-            <label class="govuk-label govuk-radios__label" for="{{name}}-0">Now</label>
-          </div>
-        </div>
-      {{/showNowAsDefault}}
-      <div class="radio-select__column">
-        {{#categories}}
-          <input type='button' class='govuk-button govuk-button--secondary radio-select__button--category' aria-expanded="false" value='{{.}}' />
-        {{/categories}}
-      </div>
-    `),
-    'choose': Hogan.compile(`
-      {{#showNowAsDefault}}
-        <div class="radio-select__column">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" checked="checked" id="{{name}}-0" name="{{name}}" type="radio" value="">
-            <label class="govuk-label govuk-radios__label" for="{{name}}-0">Now</label>
-          </div>
-        </div>
-      {{/showNowAsDefault}}
-      <div class="radio-select__column">
-        {{#choices}}
-          <div class="govuk-radios__item js-option">
-            <input class="govuk-radios__input" type="radio" value="{{value}}" id="{{id}}" name="{{name}}" />
-            <label class="govuk-label govuk-radios__label" for="{{id}}">{{label}}</label>
-          </div>
-        {{/choices}}
-        <input type='button' class='govuk-button govuk-button--secondary radio-select__button--done' aria-expanded='true' value='Done' />
-      </div>
-    `),
-    'chosen': Hogan.compile(`
-      {{#showNowAsDefault}}
-        <div class="radio-select__column">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="{{name}}-0" name="{{name}}" type="radio" value="">
-            <label class="govuk-label govuk-radios__label" for="{{name}}-0">Now</label>
-          </div>
-        </div>
-      {{/showNowAsDefault}}
-      <div class="radio-select__column">
-        {{#choices}}
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" checked="checked" type="radio" value="{{value}}" id="{{id}}" name="{{name}}" />
-            <label class="govuk-label govuk-radios__label" for="{{id}}">{{label}}</label>
-          </div>
-        {{/choices}}
-      </div>
-      <div class="radio-select__column">
-        <input type='button' class='govuk-button govuk-button--secondary radio-select__button--reset' aria-expanded='false' value='Choose a different time' />
-      </div>
-    `)
-  };
+  function getInitialHTML (params) {
 
-  let shiftFocus = function(elementToFocus, component) {
-    // The first option is always the default
-    if (elementToFocus === 'default') {
-      $('[type=radio]', component).eq(0).focus();
-    }
-    if (elementToFocus === 'option') {
-      $('[type=radio]', component).eq(1).focus();
-    }
-  };
+    return `
+      <label for="radio-select__selected-day-and-time" class="govuk-label radio-select__label">${params.componentLabel}</label>
+      <div class="radio-select__selection-and-button">
+        <input type="text" class="radio-select__selected-day-and-time" id="radio-select__selected-day-and-time" readonly value="${params.selectedTime.label}">
+        <input type="hidden" class="radio-select__selected-value" value="${params.selectedTime.value}" name="${params.componentName}">
+        <div class="radio-select__expander-and-expandee">
+          <button type='button' class='govuk-button govuk-button--secondary radio-select__expander' aria-expanded="false" >Choose another time</button>
+          <div class="radio-select__expandee" hidden>
+            <div class="radio-select__column">
+              <fieldset class="govuk-fieldset radio-select__days">
+                <legend class="govuk-visually-hidden">Day to send these messages</legend>
+                ${params.days.map((day, idx) => `
+                  <button class="govuk-button govuk-button--secondary radio-select__day" type="button" name="${day.value}" value="${day.value}">
+                    ${day.label}
+                  </button>`
+                ).join('')}
+              </fieldset>
+            </div>
+            <div class="radio-select__column" hidden>
+              <a href="" class="govuk-link govuk-back-link radio-select__return-to-days js-header">Back to days</a>
+              ${params.days.map((day, idx) => `
+                <fieldset class="govuk-fieldset radio-select__times" aria-describedby="radio-select__times-description" id="radio-select__times-for-${day.value}" hidden>
+                  <legend class="govuk-visually-hidden">Time to send these messages</legend>
+                  <p class="govuk-visually-hidden" id="radio-select__times-description">Choose a time and press confirm or cancel</p>
+                  ${params.times[day.value].map((time, idx) => `
+                    <div class="govuk-radios__item">
+                      <input class="govuk-radios__input radio-select__time" type="radio" value="${time.value}" id="${time.id}" name="${time.name}"${time.checked ? ' checked' : ''} />
+                      <label class="govuk-label govuk-radios__label" for="${time.id}">${time.label}</label>
+                    </div>`
+                  ).join('')}
+              </fieldset>`
+              ).join('')}
+              <div class="radio-select__confirm js-stick-at-bottom-when-scrolling">
+                <button type="button" class="govuk-button radio-select__confirm__button">Confirm time</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
 
   Modules.RadioSelect = function() {
 
     this.start = function(component) {
 
-      let $component = $(component);
-      let render = (state, data) => {
-        $component.html(states[state].render(data));
-      };
-      // store array of all options in component
-      let choices = $('label', $component).toArray().map(function(element) {
-        let $element = $(element);
+      this.$component = $(component);
+      this.confirmMadeSticky = false;
+
+      function _getTimeFromRadio (radio) {
         return {
-          'id': $element.attr('for'),
-          'label': $.trim($element.text()),
-          'value': $element.prev('input').attr('value')
-        };
-      });
-      let categories = $component.data('categories').split(',');
-      let name = $component.find('input').eq(0).attr('name');
-      let mousedownOption = null;
-      let showNowAsDefault = (
-        $component.data('show-now-as-default').toString() === 'true' ?
-        {'name': name} : false
-      );
-
-      // functions for changing the state of the component's HTML
-      const reset = () => {
-        render('initial', {
-          'categories': categories,
-          'name': name,
-          'showNowAsDefault': showNowAsDefault
-        });
-        shiftFocus('default', component);
-      };
-      const selectOption = (value) => {
-        render('chosen', {
-          'choices': choices.filter(
-            element => element.value == value
-          ),
-          'name': name,
-          'showNowAsDefault': showNowAsDefault
-        });
-        shiftFocus('option', component);
-      };
-
-      // use mousedown + mouseup event sequence to confirm option selection
-      const trackMouseup = (event) => {
-        const parentNode = event.target.parentNode;
-
-        if (parentNode === mousedownOption) {
-          const value = $('input', parentNode).attr('value');
-
-          selectOption(value);
-
-          // clear tracking
-          mousedownOption = null;
-          $(document).off('mouseup', trackMouseup);
+          'value': radio.value,
+          'label': radio.nextElementSibling.textContent.trim()
         }
       };
 
-      // set events
-      $component
-        .on('click', '.radio-select__button--category', function(event) {
+      const timesByDay = {};
 
-          event.preventDefault();
-          let wordsInDay = $(this).attr('value').split(' ');
-          let day = wordsInDay[wordsInDay.length - 1].toLowerCase();
-          render('choose', {
-            'choices': choices.filter(
-              element => element.label.toLowerCase().indexOf(day) > -1
-            ),
-            'name': name,
-            'showNowAsDefault': showNowAsDefault
-          });
-          shiftFocus('option', component);
+      const days = this.$component.data('days').split(',').map(day => {
+        const dayValue = day.toLowerCase();
 
-        })
-        .on('mousedown', '.js-option', function(event) {
-          mousedownOption = this;
+        timesByDay[dayValue] = [];
 
-          // mouseup on the same option completes the click action
-          $(document).on('mouseup', trackMouseup);
-        })
-        // space and enter, clicked on a radio confirm that option was selected
-        .on('keydown', 'input[type=radio]', function(event) {
-
-          // allow keypresses which aren’t enter or space through
-          if (event.which !== 13 && event.which !== 32) {
-            return true;
-          }
-
-          event.preventDefault();
-          let value = $(this).attr('value');
-          selectOption(value);
-
-        })
-        .on('click', '.radio-select__button--done', function(event) {
-
-          event.preventDefault();
-          let $selection = $('input[type=radio]:checked', this.parentNode);
-          if ($selection.length) {
-
-            render('chosen', {
-              'choices': choices.filter(
-                element => element.value == $selection.eq(0).attr('value')
-              ),
-              'name': name,
-              'showNowAsDefault': showNowAsDefault
-            });
-            shiftFocus('option', component);
-
-          } else {
-
-            reset();
-            shiftFocus('default', component);
-
-          }
-
-        })
-        .on('click', '.radio-select__button--reset', function(event) {
-
-          event.preventDefault();
-          reset();
-          shiftFocus('default', component);
-
-        });
-
-      // set HTML to initial state
-      render('initial', {
-        'categories': categories,
-        'name': name,
-        'showNowAsDefault': showNowAsDefault
+        return {
+          'value': dayValue,
+          'label': day
+        }
       });
 
-      $component.css({'height': 'auto'});
+      const componentName = this.$component.find('input[type=radio]').attr('name');
+
+      this.$component.find('label').each(function (idx, label) {
+        const labelText = label.textContent.trim();
+        const relatedRadio = label.previousElementSibling;
+        const timeData = {
+          'id': label.getAttribute('for'),
+          'label': labelText,
+          'value': relatedRadio.value
+        };
+        let day = labelText.split(' ')[0].toLowerCase();
+
+        if (idx === 0) { // Store the first time
+          this.selectedTime = _getTimeFromRadio(relatedRadio);
+
+          // The first time's label doesn't contain its day so use the first day
+          day = days[0].value;
+        }
+
+        timeData.name = `times-for-${day}`;
+        timesByDay[day].push(timeData);
+
+      }.bind(this));
+
+      this.focusContainer = function ($container) {
+        const onBlurContainer = evt => {
+          $container
+            .removeAttr('tabindex')
+            .off('blur', onBlurContainer);
+        };
+
+        $container
+          .attr('tabindex', 0)
+          .focus()
+          .on('blur', onBlurContainer);
+      };
+
+      this.showDaysView = function () {
+        const viewPanes = this.$component.find('.radio-select__expandee .radio-select__column');
+
+        viewPanes.get(0).removeAttribute('hidden');
+        viewPanes.get(1).setAttribute('hidden', '');
+      };
+
+      this.showTimesView = function () {
+        const viewPanes = this.$component.find('.radio-select__expandee .radio-select__column');
+
+        viewPanes.get(0).setAttribute('hidden', '');
+        viewPanes.get(1).removeAttribute('hidden');
+
+        GOVUK.stickAtBottomWhenScrolling.recalculate();
+      };
+
+      this.showTimesForDay = function (day) {
+        this.$component.find('.radio-select__expandee .radio-select__times').each((idx, timesGroup) => {
+          if (timesGroup.id === `radio-select__times-for-${day}`) {
+            timesGroup.removeAttribute('hidden');
+          } else {
+            timesGroup.setAttribute('hidden', '');
+          }
+        });
+      };
+
+      this.expandOrCollapseSection = function (state) {
+        const expander = this.$component.find('.radio-select__expander').get(0);
+        const expandee = this.$component.find('.radio-select__expandee').get(0);
+
+        if (state === 'expand') {
+          expander.setAttribute('aria-expanded', 'true');
+          expandee.removeAttribute('hidden');
+        } else {
+          expander.setAttribute('aria-expanded', 'false');
+          expandee.setAttribute('hidden', '');
+        }
+      };
+
+      this.updateSelection = function () {
+        this.$component.find('.radio-select__selected-day-and-time').val(this.selectedTime.label);
+        this.$component.find('.radio-select__selected-value').val(this.selectedTime.value);
+      };
+
+      this.onConfirmClick = function (event) {
+        this.selectedTime = _getTimeFromRadio(
+          this.$component.find('.radio-select__times:not([hidden]) .radio-select__time:checked').get(0)
+        );
+
+        if (this.selectedTime.length === 0) { return; }
+
+        // reset state of expanding section for selecting a day + time
+        this.showDaysView();
+        this.expandOrCollapseSection('collapse');
+        this.updateSelection();
+        this.$component.find('.radio-select__selected-day-and-time').focus();
+      };
+
+      this.onReturnToDaysClick = function (event) {
+        event.preventDefault();
+
+        this.showDaysView();
+        this.focusContainer(
+          this.$component.find('.radio-select__days').eq(0)
+        );
+      };
+
+      this.onDayClick = function (event) {
+        let scrollTop;
+
+        this.selectedDay = event.target.value.trim();
+
+        this.showTimesForDay(this.selectedDay);
+        this.showTimesView();
+
+        scrollTop = $(window).scrollTop(); // store current scroll position
+
+        this.focusContainer(
+          this.$component.find(`#radio-select__times-for-${this.selectedDay}`).eq(0)
+        );
+
+        $(window).scrollTop(scrollTop); // reset window to previous scroll position
+      };
+
+      this.onExpanderClick = function (event) {
+        const isExpanded = event.target.getAttribute('aria-expanded') === 'true';
+        event.preventDefault();
+
+        this.expandOrCollapseSection(
+          isExpanded ? 'collapse' : 'expand'
+        );
+      };
+
+      // uncheck any radios for other days already checked
+      // radios for different days don't share a name so selecting one doesn't deselect those
+      // selected for other days
+      this.onTimeSelection = function (event) {
+        this.$component.find('.radio-select__time:checked').each((idx, radio) => {
+          if (radio !== event.target) { radio.checked = false}
+        });
+      };
+
+      this.selectedDay = days[0];
+      this.selectedTime = timesByDay[this.selectedDay.value][0];
+
+      this.$component.html(getInitialHTML({
+        'componentLabel': this.$component.prev('legend').text().trim(),
+        'componentName': componentName,
+        'selectedTime': this.selectedTime,
+        'days': days,
+        'times': timesByDay
+      }));
+
+      this.$component.parent('fieldset').replaceWith(this.$component);
+
+      // set events
+      this.$component
+        .on('click', '.radio-select__expander', this.onExpanderClick.bind(this))
+        .on('click', '.radio-select__day', this.onDayClick.bind(this))
+        .on('click', '.radio-select__return-to-days', this.onReturnToDaysClick.bind(this))
+        .on('click', '.radio-select__confirm__button', this.onConfirmClick.bind(this))
+        .on('change', '.radio-select__time', this.onTimeSelection.bind(this));
 
     };
 

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -100,19 +100,6 @@
 
       }.bind(this));
 
-      this.focusContainer = function ($container) {
-        const onBlurContainer = evt => {
-          $container
-            .removeAttr('tabindex')
-            .off('blur', onBlurContainer);
-        };
-
-        $container
-          .attr('tabindex', 0)
-          .focus()
-          .on('blur', onBlurContainer);
-      };
-
       this.showDaysView = function () {
         const viewPanes = this.$component.find('.radio-select__expandee .radio-select__view');
 
@@ -192,9 +179,7 @@
         event.preventDefault();
 
         this.showDaysView();
-        this.focusContainer(
-          this.$component.find('.radio-select__days').eq(0)
-        );
+        this.$component.find(`.radio-select__days button[name=${this.selectedDay}]`).focus();
       };
 
       this.onDayClick = function (event) {
@@ -207,9 +192,7 @@
 
         scrollTop = $(window).scrollTop(); // store current scroll position
 
-        this.focusContainer(
-          this.$component.find(`#radio-select__times-for-${this.selectedDay}`).eq(0)
-        );
+        this.$component.find(`#radio-select__times-for-${this.selectedDay}`).parent().focus();
 
         $(window).scrollTop(scrollTop); // reset window to previous scroll position
       };

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -139,17 +139,34 @@
         });
       };
 
-      this.expandOrCollapseSection = function (state) {
+      this.toggleFormSubmit = function () {
+        const $formSubmitButton = this.$component.closest('form').find('.govuk-button:not([type=button])').eq(0);
+
+        if ($formSubmitButton.attr('hidden') === undefined) {
+          $formSubmitButton
+            .hide() // needed to stop the `display` property overriding `hidden`
+            .attr('hidden', '');
+        } else {
+          $formSubmitButton
+            .show() // needed to stop the `display` property overriding `hidden`
+            .removeAttr('hidden', '');
+        }
+      };
+
+      this.toggleExpandingSection = function () {
         const expander = this.$component.find('.radio-select__expander').get(0);
         const expandee = this.$component.find('.radio-select__expandee').get(0);
+        const isExpanded = expander.getAttribute('aria-expanded') === 'true';
 
-        if (state === 'expand') {
-          expander.setAttribute('aria-expanded', 'true');
-          expandee.removeAttribute('hidden');
-        } else {
+        if (isExpanded) {
           expander.setAttribute('aria-expanded', 'false');
           expandee.setAttribute('hidden', '');
+        } else {
+          expander.setAttribute('aria-expanded', 'true');
+          expandee.removeAttribute('hidden');
         }
+
+        this.toggleFormSubmit();
       };
 
       this.updateSelection = function () {
@@ -166,7 +183,7 @@
 
         // reset state of expanding section for selecting a day + time
         this.showDaysView();
-        this.expandOrCollapseSection('collapse');
+        this.toggleExpandingSection();
         this.updateSelection();
         this.$component.find('.radio-select__selected-day-and-time').focus();
       };
@@ -198,12 +215,9 @@
       };
 
       this.onExpanderClick = function (event) {
-        const isExpanded = event.target.getAttribute('aria-expanded') === 'true';
         event.preventDefault();
 
-        this.expandOrCollapseSection(
-          isExpanded ? 'collapse' : 'expand'
-        );
+        this.toggleExpandingSection();
       };
 
       // uncheck any radios for other days already checked

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -60,8 +60,8 @@
         return {
           'value': radio.value,
           'label': radio.nextElementSibling.textContent.trim()
-        }
-      };
+        };
+      }
 
       const timesByDay = {};
 
@@ -73,7 +73,7 @@
         return {
           'value': dayValue,
           'label': day
-        }
+        };
       });
 
       const componentName = this.$component.find('input[type=radio]').attr('name');
@@ -208,7 +208,7 @@
       // selected for other days
       this.onTimeSelection = function (event) {
         this.$component.find('.radio-select__time:checked').each((idx, radio) => {
-          if (radio !== event.target) { radio.checked = false}
+          if (radio !== event.target) { radio.checked = false; }
         });
       };
 

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -13,9 +13,9 @@
         <input type="text" class="radio-select__selected-day-and-time" id="radio-select__selected-day-and-time" readonly value="${params.selectedTime.label}">
         <input type="hidden" class="radio-select__selected-value" value="${params.selectedTime.value}" name="${params.componentName}">
         <div class="radio-select__expander-and-expandee">
-          <button type='button' class='govuk-button govuk-button--secondary radio-select__expander' aria-expanded="false" >Choose another time</button>
-          <div class="radio-select__expandee" hidden>
-            <div class="radio-select__column">
+          <button type="button" class="govuk-button govuk-button--secondary radio-select__expander" aria-expanded="false" aria-controls="${params.componentName}-expanding-section">Choose another time</button>
+          <div class="radio-select__expandee" id="${params.componentName}-expanding-section" hidden>
+            <div class="radio-select__view">
               <fieldset class="govuk-fieldset radio-select__days">
                 <legend class="govuk-visually-hidden">Day to send these messages</legend>
                 ${params.days.map((day, idx) => `
@@ -25,7 +25,7 @@
                 ).join('')}
               </fieldset>
             </div>
-            <div class="radio-select__column" hidden>
+            <div class="radio-select__view" hidden>
               <a href="" class="govuk-link govuk-back-link radio-select__return-to-days js-header">Back to days</a>
               ${params.days.map((day, idx) => `
                 <fieldset class="govuk-fieldset radio-select__times" aria-describedby="radio-select__times-description" id="radio-select__times-for-${day.value}" hidden>
@@ -114,14 +114,14 @@
       };
 
       this.showDaysView = function () {
-        const viewPanes = this.$component.find('.radio-select__expandee .radio-select__column');
+        const viewPanes = this.$component.find('.radio-select__expandee .radio-select__view');
 
         viewPanes.get(0).removeAttribute('hidden');
         viewPanes.get(1).setAttribute('hidden', '');
       };
 
       this.showTimesView = function () {
-        const viewPanes = this.$component.find('.radio-select__expandee .radio-select__column');
+        const viewPanes = this.$component.find('.radio-select__expandee .radio-select__view');
 
         viewPanes.get(0).setAttribute('hidden', '');
         viewPanes.get(1).removeAttribute('hidden');

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -165,7 +165,7 @@
         this.$component.find('.radio-select__selected-value').val(this.selectedTime.value);
       };
 
-      this.onConfirmClick = function (event) {
+      this.selectDayAndTime = function () {
         this.selectedTime = _getTimeFromRadio(
           this.$component.find('.radio-select__times:not([hidden]) .radio-select__time:checked').get(0)
         );
@@ -177,6 +177,10 @@
         this.toggleExpandingSection();
         this.updateSelection();
         this.$component.find('.radio-select__selected-day-and-time').focus();
+      };
+
+      this.onConfirmClick = function (event) {
+        this.selectDayAndTime();
       };
 
       this.onReturnToDaysClick = function (event) {
@@ -220,6 +224,7 @@
         // block uses of enter key to stop form submitting before selection is confirmed
         if (event.which === ENTER_CODE) {
           event.preventDefault();
+          this.selectDayAndTime();
         }
       };
 
@@ -229,6 +234,7 @@
         // block uses of enter key to stop form submitting when day + time selection is expanded
         if (isExpanded && (event.which === ENTER_CODE)) {
           event.preventDefault();
+          this.toggleExpandingSection();
         }
       };
 

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -14,7 +14,7 @@
         <input type="text" class="radio-select__selected-day-and-time" id="radio-select__selected-day-and-time" readonly value="${params.selectedTime.label}">
         <input type="hidden" class="radio-select__selected-value" value="${params.selectedTime.value}" name="${params.componentName}">
         <div class="radio-select__expander-and-expandee">
-          <button type="button" class="govuk-button govuk-button--secondary radio-select__expander" aria-expanded="false" aria-controls="${params.componentName}-expanding-section">Choose another time</button>
+          <button type="button" class="govuk-button govuk-button--secondary radio-select__expander" aria-expanded="false" aria-controls="${params.componentName}-expanding-section">Choose a different time</button>
           <div class="radio-select__expandee" id="${params.componentName}-expanding-section" hidden>
             <div class="radio-select__view">
               <fieldset class="govuk-fieldset radio-select__days">

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -27,7 +27,7 @@
               </fieldset>
             </div>
             <div class="radio-select__view" hidden>
-              <a href="" class="govuk-link govuk-back-link radio-select__return-to-days js-header">Back to days</a>
+              <a href="" class="govuk-link govuk-back-link radio-select__return-to-days js-header">Change the day</a>
               ${params.days.map((day, idx) => `
                 <fieldset class="govuk-fieldset radio-select__times" id="radio-select__times-for-${day.value}" aria-describedby="radio-select__times-help" hidden>
                   <legend class="govuk-visually-hidden">Time to send these messages</legend>

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -41,7 +41,7 @@
               </fieldset>`
               ).join('')}
               <div class="radio-select__confirm js-stick-at-bottom-when-scrolling">
-                <button type="button" class="govuk-button radio-select__confirm__button">Confirm time</button>
+                <button type="button" class="govuk-button govuk-button--secondary radio-select__confirm__button">Confirm time</button>
               </div>
             </div>
           </div>

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -4,56 +4,84 @@ $border-thickness: 4px;
 $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
 
 .radio-select {
-
   min-height: 39px;
+}
 
-  &__column {
+.radio-select__selection-and-button {
+  display: flex;
+  align-items: baseline;
+}
 
-    display: inline-block;
-    vertical-align: top;
+.radio-select__selected-day-and-time {
+  padding-top: 5px;
+  padding-bottom: 4px;
+}
 
-    .multiple-choice {
-      padding-right: 10px;
-      padding-left: 54px - 10px;
-    }
+.radio-select__expander-and-expandee {
+  display: flex;
+  flex-direction: column;
+}
 
-  }
+.radio-select__selected-day-and-time {
+  @include govuk-responsive-margin(3, "right");
+}
 
-  &__button--category {
+.radio-select__expander::before {
+  transform:translateY(-35%) rotate(45deg) scale(1);
+  border-color: black;
+  border-bottom:2px solid govuk-colour('black');
+  border-right:2px solid govuk-colour('black');
+  content:"";
+  display:inline-block;
+  height:8px;
+  margin:0 10px 0 2px;
+  vertical-align:middle;
+  width:8px;
+  position: static; // override GOV.UK Frontend styling from the Button component
+}
 
-    margin-right: govuk-spacing(3);
-    width: auto;
+.radio-select__expander[aria-expanded=true]::before {
+  transform:translateY(1px) rotate(225deg) scale(1);
+}
 
-  }
+.radio-select__expandee > .radio-select__column {
+  @include govuk-responsive-margin(3, "top");
+}
 
-  &__button--done {
+.radio-select__days,
+.radio-select__times {
+  display: flex;
+  flex-direction: column;
+  @include govuk-responsive-margin(6, "bottom");
+}
 
-    display: block;
-    clear: both;
-    margin: 0 0 govuk-spacing(6) 0;
-    position: relative;
-    top: govuk-spacing(3);
+.radio-select__days:focus-visible,
+.radio-select__times:focus-visible {
+  outline: 3px solid $govuk-focus-colour;
+  outline-offset: 2px;
+}
 
-    &:active {
-      top: govuk-spacing(3) + 2px;
-    }
+.radio-select__times[hidden] {
+  display: none;
+}
 
-  }
+// Gaps for flexbox layouts for IE11 (which doesn't support column|row-gap or gap)
+.radio-select__day {
+  @include govuk-responsive-margin(3, "top");
+}
 
-  .js-enabled & {
+.radio-select__day:first-of-type {
+  margin-top: 0;
+}
 
-    overflow: visible;
+.radio-select__return-to-days {
+  margin-top: 8px; // 10px minus 2px for drop shadow below expander button
+  margin-right: 2px;
+  margin-left: 2px;
+}
 
-    .multiple-choice {
-      display: none;
-    }
-
-    .js-multiple-choice {
-      display: block;
-    }
-
-  }
-
+.radio-select__confirm.js-stick-at-bottom-when-scrolling {
+  margin-top: 0;
 }
 
 .govuk-form-group--nested-radio{

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -55,16 +55,14 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   @include govuk-responsive-margin(3, "top");
 }
 
+.radio-select__expandee > .radio-select__view:nth-of-type(2) {
+  margin: 5px 3px 3px;
+}
+
 .radio-select__days,
 .radio-select__times {
   display: flex;
   flex-direction: column;
-}
-
-.radio-select__days:focus-visible,
-.radio-select__times:focus-visible {
-  outline: 3px solid $govuk-focus-colour;
-  outline-offset: 2px;
 }
 
 .radio-select__times[hidden] {

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -51,7 +51,7 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   transform:translateY(1px) rotate(225deg) scale(1);
 }
 
-.radio-select__expandee > .radio-select__column {
+.radio-select__expandee > .radio-select__view {
   @include govuk-responsive-margin(3, "top");
 }
 

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -5,18 +5,16 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
 
 .radio-select {
   min-height: 39px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
 }
 
 .radio-select__selection-and-button {
   @include govuk-responsive-margin(6, "bottom");
-  display: flex;
-  flex-direction: column;
 }
 
 .radio-select__selected-day-and-time {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
   padding-top: 5px;
   padding: 5px;
   border: solid 2px $govuk-input-border-colour;
@@ -25,15 +23,12 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   z-index: 100;
 }
 
-.radio-select__expander-and-expandee {
-  display: flex;
-  flex-direction: column;
-}
-
 .radio-select__expander {
   border-top-color: rgba(255, 255, 255, 0.2);
   border-left-color: rgba(0, 0, 0, 0.02);
   border-right-color: rgba(0, 0, 0, 0.02);
+  display: block;
+  width: 100%;
 }
 
 .radio-select__expander::before {
@@ -89,6 +84,10 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
 
 .radio-select__confirm.js-stick-at-bottom-when-scrolling {
   margin-top: 0;
+}
+
+.radio-select__confirm__button {
+  width: 100%;
 }
 
 .govuk-form-group--nested-radio{

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -15,12 +15,16 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   display: block;
   width: 100%;
   box-sizing: border-box;
-  padding-top: 5px;
-  padding: 5px;
+  padding: 6px 5px 6px;
   border: solid 2px $govuk-input-border-colour;
   text-align: center;
   position: relative;
   z-index: 100;
+}
+
+.radio-select__selected-day-and-time:focus {
+  padding: 5px 5px 5px;
+  border-width: 3px;
 }
 
 .radio-select__expander {

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -11,6 +11,12 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   @include govuk-responsive-margin(6, "bottom");
 }
 
+// make focus ring appear above button
+.radio-select__selected-day-and-time:focus {
+  position: relative;
+  z-index: 1;
+}
+
 .radio-select__selected-day-and-time {
   display: block;
   width: 100%;
@@ -18,8 +24,6 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   padding: 6px 5px 6px;
   border: solid 2px $govuk-input-border-colour;
   text-align: center;
-  position: relative;
-  z-index: 100;
 }
 
 .radio-select__selected-day-and-time:focus {

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -11,11 +11,11 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
 }
 
 .radio-select__selection-and-button {
+  @include govuk-responsive-margin(6, "bottom");
   display: flex;
   flex-direction: column;
   padding: 3px 3px 4px;
   border: solid 3px $govuk-input-border-colour;
-  @include govuk-responsive-margin(6, "bottom");
 }
 
 .radio-select__selected-day-and-time {

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -14,23 +14,20 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   @include govuk-responsive-margin(6, "bottom");
   display: flex;
   flex-direction: column;
-  padding: 3px 3px 4px;
-  border: solid 2px $govuk-input-border-colour;
 }
 
 .radio-select__selected-day-and-time {
   padding-top: 5px;
-  padding-bottom: 4px;
+  padding: 5px;
+  border: solid 2px $govuk-input-border-colour;
+  text-align: center;
+  position: relative;
+  z-index: 100;
 }
 
 .radio-select__expander-and-expandee {
   display: flex;
   flex-direction: column;
-}
-
-.radio-select__selected-day-and-time {
-  margin: 3px;
-  border: none;
 }
 
 .radio-select__expander::before {

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -58,7 +58,7 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
 }
 
 .radio-select__expandee > .radio-select__view:nth-of-type(2) {
-  margin: 5px 3px 3px;
+  margin: 5px 0 3px;
 }
 
 .radio-select__days,

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -5,11 +5,17 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
 
 .radio-select {
   min-height: 39px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .radio-select__selection-and-button {
   display: flex;
-  align-items: baseline;
+  flex-direction: column;
+  padding: 3px 3px 4px;
+  border: solid 3px $govuk-input-border-colour;
+  @include govuk-responsive-margin(6, "bottom");
 }
 
 .radio-select__selected-day-and-time {
@@ -23,7 +29,8 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
 }
 
 .radio-select__selected-day-and-time {
-  @include govuk-responsive-margin(3, "right");
+  margin: 3px;
+  border: none;
 }
 
 .radio-select__expander::before {
@@ -52,7 +59,6 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
 .radio-select__times {
   display: flex;
   flex-direction: column;
-  @include govuk-responsive-margin(6, "bottom");
 }
 
 .radio-select__days:focus-visible,

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -39,7 +39,7 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   content:"";
   display:inline-block;
   height:8px;
-  margin:0 10px 0 2px;
+  margin: 0 10px 0 -18px; // negative left margin means the element effectively occupies 0 width
   vertical-align:middle;
   width:8px;
   position: static; // override GOV.UK Frontend styling from the Button component

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -30,6 +30,12 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   flex-direction: column;
 }
 
+.radio-select__expander {
+  border-top-color: rgba(255, 255, 255, 0.2);
+  border-left-color: rgba(0, 0, 0, 0.02);
+  border-right-color: rgba(0, 0, 0, 0.02);
+}
+
 .radio-select__expander::before {
   transform:translateY(-35%) rotate(45deg) scale(1);
   border-color: black;

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -15,7 +15,7 @@ $border-indent: ($govuk-radios-size/ 2) - ($border-thickness / 2);
   display: flex;
   flex-direction: column;
   padding: 3px 3px 4px;
-  border: solid 3px $govuk-input-border-colour;
+  border: solid 2px $govuk-input-border-colour;
 }
 
 .radio-select__selected-day-and-time {

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1604,7 +1604,7 @@ class ChooseTimeForm(StripWhitespaceForm):
         self.scheduled_for.days = get_next_days_until(get_furthest_possible_scheduled_time())
 
     scheduled_for = GovukRadiosField(
-        "When should Notify send these messages?",
+        "When to send these messages",
         default="",
     )
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -117,11 +117,11 @@ def get_human_time(time):
     return {"0": "midnight", "12": "midday"}.get(time.strftime("%-H"), time.strftime("%-I%p").lower())
 
 
-def get_human_day(time, prefix_today_with="T"):
+def get_human_day(time):
     #  Add 1 hour to get ‘midnight today’ instead of ‘midnight tomorrow’
     time = (time - timedelta(hours=1)).strftime("%A")
     if time == datetime.utcnow().strftime("%A"):
-        return f"{prefix_today_with}oday"
+        return "Today"
     if time == (datetime.utcnow() + timedelta(days=1)).strftime("%A"):
         return "Tomorrow"
     return time
@@ -143,10 +143,7 @@ def get_next_hours_until(until):
 def get_next_days_until(until):
     now = datetime.utcnow()
     days = int((until - now).total_seconds() / (60 * 60 * 24))
-    return [
-        get_human_day((now + timedelta(days=i)).replace(tzinfo=pytz.utc), prefix_today_with="Later t")
-        for i in range(0, days + 1)
-    ]
+    return [get_human_day((now + timedelta(days=i)).replace(tzinfo=pytz.utc)) for i in range(0, days + 1)]
 
 
 class RadioField(WTFormsRadioField):
@@ -1604,7 +1601,7 @@ class ChooseTimeForm(StripWhitespaceForm):
         self.scheduled_for.choices = [("", "Now")] + [
             get_time_value_and_label(hour) for hour in get_next_hours_until(get_furthest_possible_scheduled_time())
         ]
-        self.scheduled_for.categories = get_next_days_until(get_furthest_possible_scheduled_time())
+        self.scheduled_for.days = get_next_days_until(get_furthest_possible_scheduled_time())
 
     scheduled_for = GovukRadiosField(
         "When should Notify send these messages?",

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -34,7 +34,7 @@
 
   {{ template|string }}
   <div class="bottom-gutter-3-2">
-    <form method="post" enctype="multipart/form-data" action="{{url_for('main.start_job', service_id=current_service.id, upload_id=upload_id)}}" class='page-footer'>
+    <form method="post" enctype="multipart/form-data" action="{{url_for('main.start_job', service_id=current_service.id, upload_id=upload_id)}}" class="govuk-!-margin-bottom-6">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <input type="hidden" name="contact_list_id" value="{{ request.args.get('contact_list_id', '') }}" />
       {% if _choose_time_form and template.template_type != 'letter' %}
@@ -42,8 +42,7 @@
           'formGroup': {'classes': 'bottom-gutter-2-3'},
           'attributes': {
             'data-notify-module': 'radio-select',
-            'data-categories': _choose_time_form.scheduled_for.categories|join(','),
-            'data-show-now-as-default': 'true'
+            'data-days': _choose_time_form.scheduled_for.days|join(','),
           }
         }) }}
       {% endif %}

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -38,14 +38,18 @@
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <input type="hidden" name="contact_list_id" value="{{ request.args.get('contact_list_id', '') }}" />
       {% if _choose_time_form and template.template_type != 'letter' %}
-        {{ _choose_time_form.scheduled_for(param_extensions={
-          'formGroup': {'classes': 'bottom-gutter-2-3'},
-          'classes': 'radio-select',
-          'attributes': {
-            'data-notify-module': 'radio-select',
-            'data-days': _choose_time_form.scheduled_for.days|join(','),
-          }
-        }) }}
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            {{ _choose_time_form.scheduled_for(param_extensions={
+              'formGroup': {'classes': 'bottom-gutter-2-3'},
+              'classes': 'radio-select',
+              'attributes': {
+                'data-notify-module': 'radio-select',
+                'data-days': _choose_time_form.scheduled_for.days|join(','),
+              }
+            }) }}
+          </div>
+        </div>
       {% endif %}
       {% if (template.template_type != 'letter' or not request.args.from_test) and not template.too_many_pages %}
         {% set button_text %}

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -40,6 +40,7 @@
       {% if _choose_time_form and template.template_type != 'letter' %}
         {{ _choose_time_form.scheduled_for(param_extensions={
           'formGroup': {'classes': 'bottom-gutter-2-3'},
+          'classes': 'radio-select',
           'attributes': {
             'data-notify-module': 'radio-select',
             'data-days': _choose_time_form.scheduled_for.days|join(','),

--- a/tests/app/main/forms/test_choose_time_form.py
+++ b/tests/app/main/forms/test_choose_time_form.py
@@ -36,4 +36,4 @@ def test_form_defaults_to_now(notify_admin):
 
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_form_contains_next_three_days(notify_admin):
-    assert ChooseTimeForm().scheduled_for.categories == ["Later today", "Tomorrow", "Sunday", "Monday"]
+    assert ChooseTimeForm().scheduled_for.days == ["Today", "Tomorrow", "Sunday", "Monday"]

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -32,8 +32,8 @@ describe('RadioSelect', () => {
            };
   };
 
-  function getEnterKeyupEvent () {
-    return new window.KeyboardEvent('keyup', {
+  function getEnterKeyEvent (eventType) {
+    return new $.Event(eventType, {
       which: 13,
       charCode: 13,
       keyCode: 13,
@@ -200,17 +200,16 @@ describe('RadioSelect', () => {
 
       const expanderButton = document.querySelector('.radio-select__expander');
       const selectedDayAndTimeField = document.querySelector('.radio-select__selected-day-and-time');
-      const enterKeyupEvent = getEnterKeyupEvent();
+      const enterKeydownEvent = getEnterKeyEvent('keydown');
+      const enterKeyupEvent = getEnterKeyEvent('keyup');
+      const submitEvent = new $.Event('submit');
 
-      // JSDOM doesn't seem to implement forms being submitted by a press of the enter key on a field, like browsers.
-      // Because of that, we instead test that enter key events are prevented at the field level instead.
-      // This is testing an implementation detail so 🤮 but unsure how else to do it
-      jest.spyOn(enterKeyupEvent, 'preventDefault');
+      jest.spyOn(submitEvent, 'preventDefault');
       selectedDayAndTimeField.focus();
 
-      selectedDayAndTimeField.dispatchEvent(enterKeyupEvent);
-      expect(enterKeyupEvent.preventDefault).not.toHaveBeenCalled();
-      expect(expanderButton.getAttribute('aria-expanded')).toEqual('false');
+      $(selectedDayAndTimeField).trigger(enterKeydownEvent);
+      $(selectedDayAndTimeField).trigger(enterKeyupEvent);
+      expect(submitEvent.preventDefault).not.toHaveBeenCalled();
 
     });
 
@@ -260,10 +259,16 @@ describe('RadioSelect', () => {
 
     });
 
-    test("it should hide the submit button", () => {
+    test("it should hide the submit button and prevent the form being submitted", () => {
 
-      // it should hide the submit button
       expect(expanderButton.form.querySelector('button:not([type=button])').hasAttribute('hidden')).toBe(true);
+
+      const submitEvent = new $.Event('submit');
+
+      jest.spyOn(submitEvent, 'preventDefault');
+      $(expanderButton.form).trigger(submitEvent);
+
+      expect(submitEvent.preventDefault).toHaveBeenCalled();
 
     });
 
@@ -291,9 +296,16 @@ describe('RadioSelect', () => {
 
     });
 
-    test("it should show the submit button again", () => {
+    test("it should show the submit button again and allow the form to be submitted again", () => {
 
       expect(expanderButton.form.querySelector('button:not([type=button])').hasAttribute('hidden')).toBe(false);
+
+      const submitEvent = new $.Event('submit');
+
+      jest.spyOn(submitEvent, 'preventDefault');
+      $(expanderButton.form).trigger(submitEvent);
+
+      expect(submitEvent.preventDefault).not.toHaveBeenCalled();
 
     });
 
@@ -474,6 +486,7 @@ describe('RadioSelect', () => {
     let expandingSection;
     let buttonForTomorrow;
     let radioFor3amTomorrow;
+    let enterKeydownEvent;
     let enterKeyupEvent;
 
     beforeEach(() => {
@@ -490,36 +503,17 @@ describe('RadioSelect', () => {
 
     });
 
-    // JSDOM doesn't seem to implement forms being submitted by a press of the enter key on a field, like browsers.
-    // Because of that, we instead test that enter key events are prevented at the field level instead.
-    // This is testing an implementation detail so 🤮 but unsure how else to do it
-    test("if the enter key is pressed when the selected day and time field is focused, the form should not submit", () => {
-
-      const selectedDayAndTimeField = document.querySelector('.radio-select__selected-day-and-time')
-
-      enterKeyupEvent = getEnterKeyupEvent();
-      jest.spyOn(enterKeyupEvent, 'preventDefault');
-
-      selectedDayAndTimeField.focus();
-      selectedDayAndTimeField.dispatchEvent(enterKeyupEvent);
-
-      expect(enterKeyupEvent.preventDefault).toHaveBeenCalled();
-
-    });
-
-    describe("if the enter key is pressed when a radio for a time is checked and focused", () => {
+    describe("if the enter key is pressed on a selected radio", () => {
 
       beforeEach(() => {
 
-        // JSDOM doesn't seem to implement forms being submitted by a press of the enter key on a field, like browsers.
-        // Because of that, we instead test that enter key events are prevented at the field level instead.
-        // This is testing an implementation detail so 🤮 but unsure how else to do it
-        enterKeyupEvent = getEnterKeyupEvent();
-        jest.spyOn(enterKeyupEvent, 'preventDefault');
+        enterKeydownEvent = getEnterKeyEvent('keydown');
+        enterKeyupEvent = getEnterKeyEvent('keyup');
 
         radioFor3amTomorrow.focus();
         radioFor3amTomorrow.setAttribute('checked', 'checked');
-        radioFor3amTomorrow.dispatchEvent(enterKeyupEvent);
+        $(radioFor3amTomorrow).trigger(enterKeydownEvent);
+        $(radioFor3amTomorrow).trigger(enterKeyupEvent);
 
       });
 

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -403,7 +403,7 @@ describe('RadioSelect', () => {
       const backLink = expandingSection.querySelector('.radio-select__times').parentElement.querySelector('.govuk-back-link');
 
       expect(backLink).not.toBeNull();
-      expect(backLink.textContent.trim()).toEqual('Back to days');
+      expect(backLink.textContent.trim()).toEqual('Change the day');
 
     });
 

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -138,9 +138,7 @@ describe('RadioSelect', () => {
 
   afterEach(() => {
     document.body.innerHTML = '';
-
     window.GOVUK.stickAtBottomWhenScrolling.recalculate.mockClear();
-    window.scrollTo.mockClear();
   });
 
   describe("when the page has loaded", () => {
@@ -319,11 +317,12 @@ describe('RadioSelect', () => {
       buttonForTomorrow = daysView.querySelectorAll('button[type=button]')[1];
 
       helpers.triggerEvent(expanderButton, 'click');
-      helpers.triggerEvent(buttonForTomorrow, 'click');
 
     });
 
     test("the days view should be hidden", () => {
+
+      helpers.triggerEvent(buttonForTomorrow, 'click');
 
       expect(daysView.hasAttribute('hidden')).toBe(true);
 
@@ -331,31 +330,38 @@ describe('RadioSelect', () => {
 
     test("the times view and the times for that day should show", () => {
 
+      helpers.triggerEvent(buttonForTomorrow, 'click');
+
       expect(timesView.hasAttribute('hidden')).toBe(false);
 
-    });
-
-    test("the times view should be focused", () => {
-
-      expect(document.activeElement).toBe(timesView);
+      // There should be a radio for each hour of the day still remaining and tomorrow should have them all.
+      expect(timesView.querySelectorAll('input[name=times-for-tomorrow]').length).toEqual(24);
 
     });
 
-    test("it should stop the browser scrolling the page when the times view is focused", () => {
-      // Different browsers scroll to show the currently focused element in different ways, so it isn't out of the viewport.
-      // The times view is often too tall for the viewport so the browser may often scroll to try and accommodate.
-      // In our case, this is more confusing that helpful and retaining the current scroll position is better, to match
-      // that of the days view we came from.
-      // We do that by caching the scroll position before we switch views and reset to that afterwards, all quickly enough
-      // to not be noticable
-      //
-      // Note: we have mocked window.scrollTo so the page will not actually scroll here.
+    test("if no times are selected yet for that day, the first radio should be focused", () => {
 
-      expect(window.scrollTo).toHaveBeenCalled();
-      expect(window.scrollTo.mock.lastCall[1]).toEqual(scrollPosition); // window.scrollTo gets called with x,y params
+      helpers.triggerEvent(buttonForTomorrow, 'click');
+
+      expect(document.activeElement).toBe(timesView.querySelector('#radio-select__times-for-tomorrow .govuk-radios__item:nth-of-type(1) input[type=radio]'));
+
+    });
+
+    test("if a time is already selected for that day, its radio should be focused", () => {
+
+      const radioFor2amTomorrow = timesView.querySelector('#radio-select__times-for-tomorrow .govuk-radios__item:nth-of-type(2) input');
+
+      radioFor2amTomorrow.setAttribute('checked', 'checked');
+
+      helpers.triggerEvent(buttonForTomorrow, 'click');
+
+      expect(document.activeElement).toBe(timesView.querySelector('#radio-select__times-for-tomorrow .govuk-radios__item:nth-of-type(2) input'));
+
     });
 
     test("there should be a link to return to the days view", () => {
+
+      helpers.triggerEvent(buttonForTomorrow, 'click');
 
       const backLink = expandingSection.querySelector('.radio-select__times').parentElement.querySelector('.govuk-back-link');
 
@@ -383,6 +389,8 @@ describe('RadioSelect', () => {
 
     test("the 'confirm' button container should be made sticky", () => {
 
+      helpers.triggerEvent(buttonForTomorrow, 'click');
+
       const container = expandingSection.querySelector('.radio-select__confirm');
 
       expect(container.classList.contains('js-stick-at-bottom-when-scrolling')).toBe(true);
@@ -391,6 +399,8 @@ describe('RadioSelect', () => {
     });
 
     test("if you select a time but don't confirm it and collapse the section, neither the field or form data should be updated", () => {
+
+      helpers.triggerEvent(buttonForTomorrow, 'click');
 
       expandingSection.querySelectorAll('.radio-select__times input[name=times-for-tomorrow]')[2].checked = true;
 

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -410,7 +410,7 @@ describe('RadioSelect', () => {
 
     });
 
-    test("if you select a time but don't confirm it and collapse the section, neither the field or form data should be updated", () => {
+    test("if you select a time but don't confirm it and collapse the section, neither the selected time and day field or form data should be updated", () => {
 
       helpers.triggerEvent(buttonForTomorrow, 'click');
 
@@ -461,7 +461,7 @@ describe('RadioSelect', () => {
 
     });
 
-    test("the time chosen should show in the field and its value be updated in the form data", () => {
+    test("the time chosen should show in the selected day and time field and its value be updated in the form data", () => {
 
       const timeLabel = expandingSection.querySelector(`label[for=${radioFor3amTomorrow.id}]`).textContent.trim();
       const timeValue = radioFor3amTomorrow.value;
@@ -472,7 +472,7 @@ describe('RadioSelect', () => {
 
     });
 
-    test("the part of the field showing the time should be focused", () => {
+    test("the field showing the selected day and time should be focused", () => {
 
       expect(document.activeElement).toBe(document.querySelector('.radio-select__selected-day-and-time'));
 
@@ -517,7 +517,7 @@ describe('RadioSelect', () => {
 
       });
 
-      test("the time chosen should show in the field and its value be updated in the form data", () => {
+      test("the time chosen should show in the field showing the selected day and time and its value be updated in the form data", () => {
 
         const timeLabel = expandingSection.querySelector(`label[for=${radioFor3amTomorrow.id}]`).textContent.trim();
         const timeValue = radioFor3amTomorrow.value;
@@ -528,7 +528,7 @@ describe('RadioSelect', () => {
 
       });
 
-      test("the part of the field showing the time should be focused", () => {
+      test("the field showing the selected day and time should be focused", () => {
 
         expect(document.activeElement).toBe(document.querySelector('.radio-select__selected-day-and-time'));
 

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -198,6 +198,24 @@ describe('RadioSelect', () => {
 
     });
 
+    test("If you press the enter key on the selected day and time field, it should submit", () => {
+
+      const expanderButton = document.querySelector('.radio-select__expander');
+      const selectedDayAndTimeField = document.querySelector('.radio-select__selected-day-and-time');
+      const enterKeyupEvent = getEnterKeyupEvent();
+
+      // JSDOM doesn't seem to implement forms being submitted by a press of the enter key on a field, like browsers.
+      // Because of that, we instead test that enter key events are prevented at the field level instead.
+      // This is testing an implementation detail so 🤮 but unsure how else to do it
+      jest.spyOn(enterKeyupEvent, 'preventDefault');
+      selectedDayAndTimeField.focus();
+
+      selectedDayAndTimeField.dispatchEvent(enterKeyupEvent);
+      expect(enterKeyupEvent.preventDefault).not.toHaveBeenCalled();
+      expect(expanderButton.getAttribute('aria-expanded')).toEqual('false');
+
+    });
+
   });
 
   describe("When you click the button to expand the section for choosing a time", () => {
@@ -440,119 +458,121 @@ describe('RadioSelect', () => {
 
   });
 
-  // JSDOM doesn't seem to implement forms being submitted by a press of the enter key on a field, like browsers.
-  // Because of that, we instead test that enter key events are prevented at the field level instead.
-  // This is testing an implementation detail so 🤮 but unsure how else to do it
-  describe("If you press the enter key to submit the form", () => {
-
-    test("on the selected day and time field, when the section for selecting a time is collapsed, it should submit", () => {
-
-      const selectedDayAndTimeField = document.querySelector('.radio-select__selected-day-and-time');
-      const enterKeyupEvent = getEnterKeyupEvent();
-
-      jest.spyOn(enterKeyupEvent, 'preventDefault');
-      selectedDayAndTimeField.focus();
-
-      selectedDayAndTimeField.dispatchEvent(enterKeyupEvent);
-      expect(enterKeyupEvent.preventDefault).not.toHaveBeenCalled();
-
-    });
-
-    describe("when the section for selecting a time is expanded", () => {
-
-      let expanderButton;
-      let expandingSection;
-      let enterKeyupEvent;
-
-      beforeEach(() => {
-
-        expanderButton = document.querySelector('.radio-select__expander');
-        expandingSection = document.getElementById(expanderButton.getAttribute('aria-controls'));
-
-        helpers.triggerEvent(expanderButton, 'click');
-
-      });
-
-      // JSDOM doesn't seem to implement forms being submitted by a press of the enter key on a field, like browsers.
-      // Because of that, we instead test that enter key events are prevented at the field level instead.
-      // This is testing an implementation detail so 🤮 but unsure how else to do it
-      test("and the selected day and time field is focused, it should not submit", () => {
-
-        const selectedDayAndTimeField = document.querySelector('.radio-select__selected-day-and-time')
-
-        enterKeyupEvent = getEnterKeyupEvent();
-        jest.spyOn(enterKeyupEvent, 'preventDefault');
-
-        selectedDayAndTimeField.focus();
-        selectedDayAndTimeField.dispatchEvent(enterKeyupEvent);
-
-        expect(enterKeyupEvent.preventDefault).toHaveBeenCalled();
-
-      });
-
-      // JSDOM doesn't seem to implement forms being submitted by a press of the enter key on a field, like browsers.
-      // Because of that, we instead test that enter key events are prevented at the field level instead.
-      // This is testing an implementation detail so 🤮 but unsure how else to do it
-      test("and a radio for a time is focused, it should not submit", () => {
-
-        buttonForTomorrow = expandingSection.querySelectorAll('.radio-select__days button[type=button]')[1];
-        radioFor3amTomorrow = expandingSection.querySelectorAll('.radio-select__times input[name=times-for-tomorrow]')[2];
-
-        enterKeyupEvent = getEnterKeyupEvent();
-        jest.spyOn(enterKeyupEvent, 'preventDefault');
-
-        helpers.triggerEvent(buttonForTomorrow, 'click');
-        radioFor3amTomorrow.focus();
-
-        radioFor3amTomorrow.dispatchEvent(enterKeyupEvent);
-
-        expect(enterKeyupEvent.preventDefault).toHaveBeenCalled();
-
-      });
-
-    });
-
-  });
-
-  describe("When you click the a 'Back to days' link", () => {
+  describe("When the section for selecting a time is expanded", () => {
 
     let expanderButton;
     let expandingSection;
-    let daysView;
-    let timesView;
     let buttonForTomorrow;
-    let backLink;
+    let radioFor3amTomorrow;
+    let enterKeyupEvent;
 
     beforeEach(() => {
 
       expanderButton = document.querySelector('.radio-select__expander');
       expandingSection = document.getElementById(expanderButton.getAttribute('aria-controls'));
-      daysView = expandingSection.querySelector('.radio-select__days').parentElement;
-      timesView = expandingSection.querySelector('.radio-select__times').parentElement;
-      buttonForTomorrow = expandingSection.querySelectorAll('.radio-select__days button[type=button]')[1];
-      backLink = expandingSection.querySelector('.govuk-back-link');
 
       helpers.triggerEvent(expanderButton, 'click');
+
+      buttonForTomorrow = expandingSection.querySelectorAll('.radio-select__days button[type=button]')[1];
+      radioFor3amTomorrow = expandingSection.querySelectorAll('.radio-select__times input[name=times-for-tomorrow]')[2];
+
       helpers.triggerEvent(buttonForTomorrow, 'click');
-      helpers.triggerEvent(backLink, 'click');
 
     });
 
-    test("the times view should be hidden", () => {
+    // JSDOM doesn't seem to implement forms being submitted by a press of the enter key on a field, like browsers.
+    // Because of that, we instead test that enter key events are prevented at the field level instead.
+    // This is testing an implementation detail so 🤮 but unsure how else to do it
+    test("if the enter key is pressed when the selected day and time field is focused, the form should not submit", () => {
 
-      expect(timesView.hasAttribute('hidden')).toBe(true);
+      const selectedDayAndTimeField = document.querySelector('.radio-select__selected-day-and-time')
+
+      enterKeyupEvent = getEnterKeyupEvent();
+      jest.spyOn(enterKeyupEvent, 'preventDefault');
+
+      selectedDayAndTimeField.focus();
+      selectedDayAndTimeField.dispatchEvent(enterKeyupEvent);
+
+      expect(enterKeyupEvent.preventDefault).toHaveBeenCalled();
 
     });
 
-    test("the days view should show", () => {
+    describe("if the enter key is pressed when a radio for a time is checked and focused", () => {
 
-      expect(daysView.hasAttribute('hidden')).toBe(false);
+      beforeEach(() => {
+
+        // JSDOM doesn't seem to implement forms being submitted by a press of the enter key on a field, like browsers.
+        // Because of that, we instead test that enter key events are prevented at the field level instead.
+        // This is testing an implementation detail so 🤮 but unsure how else to do it
+        enterKeyupEvent = getEnterKeyupEvent();
+        jest.spyOn(enterKeyupEvent, 'preventDefault');
+
+        radioFor3amTomorrow.focus();
+        radioFor3amTomorrow.setAttribute('checked', 'checked');
+        radioFor3amTomorrow.dispatchEvent(enterKeyupEvent);
+
+      });
+
+      test("the time chosen should show in the field and its value be updated in the form data", () => {
+
+        const timeLabel = expandingSection.querySelector(`label[for=${radioFor3amTomorrow.id}]`).textContent.trim();
+        const timeValue = radioFor3amTomorrow.value;
+        const formData = new FormData(radioFor3amTomorrow.form);
+
+        expect(document.querySelector('.radio-select__selected-day-and-time').value).toEqual(timeLabel);
+        expect(formData.get('scheduled_for')).toEqual(timeValue);
+
+      });
+
+      test("the part of the field showing the time should be focused", () => {
+
+        expect(document.activeElement).toBe(document.querySelector('.radio-select__selected-day-and-time'));
+
+      });
 
     });
 
-    test("the button for the day you clicked before should be focused", () => {
+    describe("When you click the a 'Back to days' link", () => {
 
-      expect(document.activeElement).toBe(buttonForTomorrow);
+      let expanderButton;
+      let expandingSection;
+      let daysView;
+      let timesView;
+      let buttonForTomorrow;
+      let backLink;
+
+      beforeEach(() => {
+
+        expanderButton = document.querySelector('.radio-select__expander');
+        expandingSection = document.getElementById(expanderButton.getAttribute('aria-controls'));
+        daysView = expandingSection.querySelector('.radio-select__days').parentElement;
+        timesView = expandingSection.querySelector('.radio-select__times').parentElement;
+        buttonForTomorrow = expandingSection.querySelectorAll('.radio-select__days button[type=button]')[1];
+        backLink = expandingSection.querySelector('.govuk-back-link');
+
+        helpers.triggerEvent(expanderButton, 'click');
+        helpers.triggerEvent(buttonForTomorrow, 'click');
+        helpers.triggerEvent(backLink, 'click');
+
+      });
+
+      test("the times view should be hidden", () => {
+
+        expect(timesView.hasAttribute('hidden')).toBe(true);
+
+      });
+
+      test("the days view should show", () => {
+
+        expect(daysView.hasAttribute('hidden')).toBe(false);
+
+      });
+
+      test("the button for the day you clicked before should be focused", () => {
+
+        expect(document.activeElement).toBe(buttonForTomorrow);
+
+      });
 
     });
 


### PR DESCRIPTION
An attempt at redesigning the component used to select the day and time to send notifications to solve some accessibility issues raised in a previous accessibility audit:

https://trello.com/c/pbtfNwNt/384-make-choosing-a-day-time-to-send-messages-work-with-screen-readers

|Closed by default|Open (choose day to send)|
|---|---|
|<img width="367" alt="image" src="https://github.com/alphagov/notifications-admin/assets/87140/71582619-8d34-48cb-9880-121ca4b2ac8a">|<img width="385" alt="image" src="https://github.com/alphagov/notifications-admin/assets/87140/98da64f8-7455-4d89-a831-da7a4f1cb3b1">|


|Open (choose time to send)|Closed with day and time chosen|
|---|---|
|<img width="377" alt="image" src="https://github.com/alphagov/notifications-admin/assets/87140/b2c3980d-3c29-4b2a-a5d4-b677a523cff7">|<img width="374" alt="image" src="https://github.com/alphagov/notifications-admin/assets/87140/f3a51c23-12a9-4bac-9235-a195a12491be">|


## How to review

TLDR: Read the latest Python, JS and CSS files involved for code quality. Use the JS tests for a list of things the component is expected to do. Try it with mouse, keyboard and, if you're comfortable using one, a screen reader.

### Some explanation

This a completely different design to the current version so looking at changes to the files involved isn't helpful.

My commits show a process of iteration of features based on testing with both browsers and screen readers. I think this is valuable enough to keep but it doesn't make a good narrative of changes (some revert and some change the same thing multiple times).

### How to run the JS tests

`npx jest --config tests/javascripts/jest.config.js tests/javascripts/radioSelect.test.js`

## Hidden semantics

The component's HTML includes some content to help users of screen readers which doesn't appear visually:
- the legend for the fieldset of day buttons contains the text 'Day to send these messages'
- the legend for the fieldset of radios for times contains the text 'Time to send these messages' and has this help text: 'Choose a time and confirm'

Note: we focus the first button / radio when switching between those views which will announce the legend text + button text or label for the radio and what it is. For example:

"Day to send these messages, grouping Today button" (using NVDA).