### PR TITLE
Remove email_from

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -109,7 +109,6 @@ def service_name_change(service_id):
             normalised_service_name = email_safe(form.name.data)
             current_service.update(
                 name=form.name.data,
-                email_from=normalised_service_name,
                 normalised_service_name=normalised_service_name,
             )
         except HTTPError as http_error:

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -33,7 +33,6 @@ class Service(JSONModel):
         "broadcast_channel",
         "contact_link",
         "count_as_live",
-        "email_from",
         "go_live_at",
         "has_active_go_live_request",
         "id",

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -31,7 +31,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "letter_message_limit": letter_message_limit,
             "user_id": user_id,
             "restricted": restricted,
-            "email_from": normalised_service_name,
             "normalised_service_name": normalised_service_name,
         }
         data = _attach_current_user(data)
@@ -84,7 +83,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "created_by",
             "count_as_live",
             "email_branding",
-            "email_from",
             "normalised_service_name",
             "free_sms_fragment_limit",
             "go_live_at",
@@ -504,7 +502,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     @classmethod
     def parse_edit_service_http_error(cls, http_error):
         """Inspect the HTTPError from a create_service/update_service call and return a human-friendly error message"""
-        if http_error.message.get("email_from") or http_error.message.get("normalised_service_name"):
+        if http_error.message.get("normalised_service_name"):
             return "Service name must not include characters from a non-Latin alphabet"
 
         elif http_error.message.get("name"):

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -92,7 +92,6 @@ def get_template(
         return EmailPreviewTemplate(
             template,
             from_name=service.name,
-            from_address=f"{service.email_from}@notifications.service.gov.uk",
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
             reply_to=email_reply_to,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -203,7 +203,6 @@ def service_json(
         "rate_limit": rate_limit,
         "active": active,
         "restricted": restricted,
-        "email_from": normalised_service_name,
         "normalised_service_name": normalised_service_name,
         "reply_to_email_address": reply_to_email_address,
         "sms_sender": sms_sender,

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -930,7 +930,6 @@ def test_should_redirect_after_service_name_change(
     mock_update_service.assert_called_once_with(
         SERVICE_ONE_ID,
         name="New Name",
-        email_from="new.name",
         normalised_service_name="new.name",
     )
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -88,7 +88,6 @@ def test_client_creates_service_with_correct_data(
             letter_message_limit=1,
             restricted=True,
             user_id=fake_uuid,
-            email_from="some.test.name",
             normalised_service_name="some.test.name",
         ),
     )
@@ -578,7 +577,6 @@ def test_client_updates_service_with_allowed_attributes(
         "contact_link",
         "count_as_live",
         "email_branding",
-        "email_from",
         "normalised_service_name",
         "free_sms_fragment_limit",
         "go_live_at",
@@ -611,10 +609,6 @@ def test_client_updates_service_with_allowed_attributes(
     "err_data, expected_message",
     (
         ({"name": "Service name error"}, "This service name is already in use"),
-        (
-            {"email_from": "email_from disallowed characters"},
-            "Service name must not include characters from a non-Latin alphabet",
-        ),
         (
             {"normalised_service_name": "normalised service name has disallowed characters"},
             "Service name must not include characters from a non-Latin alphabet",


### PR DESCRIPTION
1. ~~add new column as nullable~~ (https://github.com/alphagov/notifications-api/pull/3865)
2. ~~write new values to both new and old column~~ (https://github.com/alphagov/notifications-admin/pull/4824)
3. ~~migrate old data. add unique and not null constraints.~~ (https://github.com/alphagov/notifications-api/pull/3881)
4. ~~use new column~~ (https://github.com/alphagov/notifications-api/pull/3868)
5. **delete references to old column in code**
6. drop old column

we won't need to clear cache around this - the cache will have extra values that will jsut be ignored when the json is loaded into the `Service` model