### PR TITLE
Extend maximum time for scheduled jobs to 7 days

### DIFF
--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -87,7 +87,7 @@
           'label': labelText,
           'value': relatedRadio.value
         };
-        let day = labelText.split(' ')[0].toLowerCase();
+        let day = labelText.split(' at ')[0].toLowerCase();
 
         if (idx === 0) { // Store the first time
           this.selectedTime = _getTimeFromRadio(relatedRadio);

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -105,11 +105,12 @@ from app.utils.user_permissions import (
 
 
 def get_time_value_and_label(future_time):
+    timestamp = future_time.astimezone(pytz.timezone("Europe/London"))
     return (
         future_time.replace(tzinfo=None).isoformat(),
         "{} at {}".format(
-            get_human_day(future_time.astimezone(pytz.timezone("Europe/London"))),
-            get_human_time(future_time.astimezone(pytz.timezone("Europe/London"))),
+            get_human_day(timestamp),
+            get_human_time(timestamp),
         ),
     )
 
@@ -119,12 +120,15 @@ def get_human_time(time):
 
 
 def get_human_day(time):
+    date_format = "%A %-d %B"  # for example "Monday 4 January"
+
     #  Add 1 hour to get ‘midnight today’ instead of ‘midnight tomorrow’
-    time = (time - timedelta(hours=1)).strftime("%A")
-    if time == datetime.utcnow().strftime("%A"):
+    time = (time - timedelta(hours=1)).strftime(date_format)
+    if time == datetime.utcnow().strftime(date_format):
         return "Today"
-    if time == (datetime.utcnow() + timedelta(days=1)).strftime("%A"):
+    if time == (datetime.utcnow() + timedelta(days=1)).strftime(date_format):
         return "Tomorrow"
+
     return time
 
 
@@ -144,6 +148,7 @@ def get_next_hours_until(until):
 def get_next_days_until(until):
     now = datetime.utcnow()
     days = int((until - now).total_seconds() / (60 * 60 * 24))
+
     return [get_human_day((now + timedelta(days=i)).replace(tzinfo=pytz.utc)) for i in range(0, days + 1)]
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -129,7 +129,7 @@ def get_human_day(time):
 
 
 def get_furthest_possible_scheduled_time():
-    return (datetime.utcnow() + timedelta(days=4)).replace(hour=0)
+    return (datetime.utcnow() + timedelta(days=7)).replace(hour=0)
 
 
 def get_next_hours_until(until):

--- a/tests/app/main/forms/test_choose_time_form.py
+++ b/tests/app/main/forms/test_choose_time_form.py
@@ -25,8 +25,18 @@ def test_form_contains_next_24h(notify_admin):
     assert choices[84] == ("2016-01-04T23:00:00", "Monday at 11pm")
     assert choices[85] == ("2016-01-05T00:00:00", "Monday at midnight")
 
+    # Tuesday
+    assert choices[86] == ("2016-01-05T01:00:00", "Tuesday at 1am")
+
+    # Wednesday
+    assert choices[110] == ("2016-01-06T01:00:00", "Wednesday at 1am")
+
+    # Thursday
+    assert choices[134] == ("2016-01-07T01:00:00", "Thursday at 1am")
+    assert choices[-1] == ("2016-01-08T00:00:00", "Thursday at midnight")
+
     with pytest.raises(IndexError):
-        assert choices[12 + (3 * 24) + 2]  # hours left in the day  # 3 days  # magic number
+        assert choices[12 + (6 * 24) + 2]  # hours left in the day  # 3 days  # magic number
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
@@ -36,4 +46,12 @@ def test_form_defaults_to_now(notify_admin):
 
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_form_contains_next_three_days(notify_admin):
-    assert ChooseTimeForm().scheduled_for.days == ["Today", "Tomorrow", "Sunday", "Monday"]
+    assert ChooseTimeForm().scheduled_for.days == [
+        "Today",
+        "Tomorrow",
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+    ]

--- a/tests/app/main/forms/test_choose_time_form.py
+++ b/tests/app/main/forms/test_choose_time_form.py
@@ -5,7 +5,7 @@ from app.main.forms import ChooseTimeForm
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_form_contains_next_24h(notify_admin):
+def test_form_contains_next_7_days_in_hour_intervals(notify_admin):
 
     choices = ChooseTimeForm().scheduled_for.choices
 
@@ -19,21 +19,21 @@ def test_form_contains_next_24h(notify_admin):
     assert choices[37] == ("2016-01-03T00:00:00", "Tomorrow at midnight")
 
     # Sunday
-    assert choices[38] == ("2016-01-03T01:00:00", "Sunday at 1am")
+    assert choices[38] == ("2016-01-03T01:00:00", "Sunday 3 January at 1am")
 
     # Monday
-    assert choices[84] == ("2016-01-04T23:00:00", "Monday at 11pm")
-    assert choices[85] == ("2016-01-05T00:00:00", "Monday at midnight")
+    assert choices[84] == ("2016-01-04T23:00:00", "Monday 4 January at 11pm")
+    assert choices[85] == ("2016-01-05T00:00:00", "Monday 4 January at midnight")
 
     # Tuesday
-    assert choices[86] == ("2016-01-05T01:00:00", "Tuesday at 1am")
+    assert choices[86] == ("2016-01-05T01:00:00", "Tuesday 5 January at 1am")
 
     # Wednesday
-    assert choices[110] == ("2016-01-06T01:00:00", "Wednesday at 1am")
+    assert choices[110] == ("2016-01-06T01:00:00", "Wednesday 6 January at 1am")
 
     # Thursday
-    assert choices[134] == ("2016-01-07T01:00:00", "Thursday at 1am")
-    assert choices[-1] == ("2016-01-08T00:00:00", "Thursday at midnight")
+    assert choices[134] == ("2016-01-07T01:00:00", "Thursday 7 January at 1am")
+    assert choices[-1] == ("2016-01-08T00:00:00", "Thursday 7 January at midnight")
 
     with pytest.raises(IndexError):
         assert choices[12 + (6 * 24) + 2]  # hours left in the day  # 3 days  # magic number
@@ -45,13 +45,13 @@ def test_form_defaults_to_now(notify_admin):
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_form_contains_next_three_days(notify_admin):
+def test_form_contains_next_7_days(notify_admin):
     assert ChooseTimeForm().scheduled_for.days == [
         "Today",
         "Tomorrow",
-        "Sunday",
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
+        "Sunday 3 January",
+        "Monday 4 January",
+        "Tuesday 5 January",
+        "Wednesday 6 January",
+        "Thursday 7 January",
     ]


### PR DESCRIPTION
4 days is sometimes not enough if there is a weekend with a bank holiday before and after it.

7 days is a sensible new limit because it:
- accounts for these longer weekends or holiday periods like Christmas
- without introducing any ambiguity about which ‘Thursday’ is meant (because only one of each weekday will ever be shown at once)

Before | After
---|---
<img width="390" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/02f43c5d-fc6e-4655-b609-636221442bad"> | <img width="390" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/120be993-5fd7-422b-97f9-bdfabc54c986">

***

Depends on:
- [ ] https://github.com/alphagov/notifications-api/pull/3911
