### PR TITLE
Fix editing text message templates

### DIFF
--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2353,7 +2353,6 @@ def test_should_redirect_when_saving_a_template(
         service_id=SERVICE_ONE_ID,
         name=name,
         content=content,
-        subject=None,
     )
 
 


### PR DESCRIPTION
When editing a template, we should only send through `subject` to the update template API call if it's part of the thing we're editing. For text message templates, there is no subject, and sending subject=None throws a validation error.