### PR TITLE
Fix spacing under new date picker

### DIFF
--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -34,7 +34,7 @@
 
   {{ template|string }}
   <div class="bottom-gutter-3-2">
-    <form method="post" enctype="multipart/form-data" action="{{url_for('main.start_job', service_id=current_service.id, upload_id=upload_id)}}" class="govuk-!-margin-bottom-6">
+    <form method="post" enctype="multipart/form-data" action="{{url_for('main.start_job', service_id=current_service.id, upload_id=upload_id)}}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <input type="hidden" name="contact_list_id" value="{{ request.args.get('contact_list_id', '') }}" />
       {% if _choose_time_form and template.template_type != 'letter' %}


### PR DESCRIPTION
As part of the work<sup>1</sup> to build the new date and time picker one of our old spacing classes, `page-footer`, was replaced with one of the new spacing classes from GOV.UK Frontend, `govuk-!-margin-bottom-6`.

`page-footer` and `govuk-!-margin-bottom-6` both add 30px of bottom margin.

Both are inside a `<div>` with the class `bottom-gutter-3-2` which adds `45px` of bottom margin.

Before the new date picker the bottom margin of `page-footer` combines the bottom margin of `bottom-gutter-3-2` for a total of `45px` of (the larger of the 2 values).

With the new date picker the bottom margin of `page-footer` adds on to the bottom margin of `bottom-gutter-3-2` for a total of `75px` of (the 2 values summed together).

Not 100% sure why this has changed. On the page without the date picker (for example when you’re about to send a letter job) the appearance is the same with and without the `page-footer` class. So it’s something to do with the new date picker ‘activating’ the bottom margin on `page-footer` 🤔

Before before | Before | After
---|---|---
<img width="420" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/5bf3b171-8d21-49c3-9e7a-8e59c50b2491"> | <img width="420" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/a2c77cad-c645-4974-b713-5a9b15ac4d2f"> | <img width="420" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/c29d142e-57d2-4993-99c7-165e0de54933">
<img width="420" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/33bc1db1-a958-436e-aa3e-b1816f199047"> | <img width="420" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/33bc1db1-a958-436e-aa3e-b1816f199047"> | <img width="420" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/33bc1db1-a958-436e-aa3e-b1816f199047">



1. https://github.com/alphagov/notifications-admin/commit/afdf04148ba30726cdf4db61b882d628032d0747#diff-f10085db71986399c42e16e82dd64862f2a262b03e08491c304d758fc427f337L37