### PR TITLE
Remove link and update content

### DIFF
--- a/app/templates/views/guidance/features/roadmap.html
+++ b/app/templates/views/guidance/features/roadmap.html
@@ -29,7 +29,7 @@
 
   <ul class="govuk-list govuk-list--bullet">
     
-    <li>Launch a regular email about new features and improvements to GOV.UK Notify</a></li>
+    <li>Launch a regular email about new features and improvements to GOV.UK Notify</li>
     <li>Let services add QR codes to letter templates</li>   
     <li>Let services create letter templates that comply with the <a class="govuk-link govuk-link--no-visited-state" href="https://law.gov.wales/culture/welsh-language/welsh-language-act-1993">Welsh Language Act 1993</a></li>
     <li>Integrate with our letter provider’s API to improve the letter sending process</li>

--- a/app/templates/views/guidance/features/roadmap.html
+++ b/app/templates/views/guidance/features/roadmap.html
@@ -29,7 +29,7 @@
 
   <ul class="govuk-list govuk-list--bullet">
     
-    <li>Create a <a class="govuk-link govuk-link--no-visited-state" href="https://docs.google.com/forms/d/1Fp9krEODWMnMW6mG_UfWa7zzXTKTHLuTUCyBR2QoxZ0/edit">newsletter you can subscribe to</a></li>
+    <li>Launch a regular email about new features and improvements to GOV.UK Notify</a></li>
     <li>Let services add QR codes to letter templates</li>   
     <li>Let services create letter templates that comply with the <a class="govuk-link govuk-link--no-visited-state" href="https://law.gov.wales/culture/welsh-language/welsh-language-act-1993">Welsh Language Act 1993</a></li>
     <li>Integrate with our letter provider’s API to improve the letter sending process</li>


### PR DESCRIPTION
We need to remove the link to ‘a newsletter you can subscribe to’.

We’re not handling subscriptions to the new features and improvements email through that form, so we don’t want anyone to use it.

We also need to rephrase this item in our roadmap, as it’s a bit misleading. We’re not calling the email a ‘newsletter’.