### PR TITLE
Fix attributes missed from day format update

### DIFF
--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -64,10 +64,14 @@
         };
       }
 
+      function _getKeyFromDayLabel (label) {
+        return label.toLowerCase().replace(/\s/g, '-');
+      }
+
       const timesByDay = {};
 
       const days = this.$component.data('days').split(',').map(day => {
-        const dayValue = day.toLowerCase();
+        const dayValue = _getKeyFromDayLabel(day);
 
         timesByDay[dayValue] = [];
 
@@ -87,7 +91,7 @@
           'label': labelText,
           'value': relatedRadio.value
         };
-        let day = labelText.split(' at ')[0].toLowerCase();
+        let day = _getKeyFromDayLabel(labelText.split(' at ')[0]);
 
         if (idx === 0) { // Store the first time
           this.selectedTime = _getTimeFromRadio(relatedRadio);

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -28,8 +28,11 @@ describe('RadioSelect', () => {
   const DAYS = [
     'Today',
     'Tomorrow',
-    'Friday',
-    'Saturday'
+    'Friday 13 October',
+    'Saturday 14 October',
+    'Sunday 15 October',
+    'Monday 16 October',
+    'Tuesday 17 October'
   ];
   const HOURS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24];
   const scrollPosition = 504;
@@ -88,8 +91,11 @@ describe('RadioSelect', () => {
         let dayAsNumber = {
           'Today': 22,
           'Tomorrow': 23,
-          'Friday': 24,
-          'Saturday': 25
+          'Friday 13 October': 24,
+          'Saturday 14 October': 25,
+          'Sunday 15 October': 26,
+          'Monday 16 October': 27,
+          'Tuesday 17 October': 28,
         }[day];
 
         if (start !== undefined) {
@@ -175,13 +181,24 @@ describe('RadioSelect', () => {
 
         const radioWithValue = document.querySelector(`input[value="${option.value}"]`);
         let labelForRadio;
+        let labelText;
+        let dayName;
+        let fieldsetWithDayName;
 
         expect(radioWithValue).not.toBeNull();
 
         labelForRadio = document.querySelector(`label[for=${radioWithValue.getAttribute('id')}]`);
+        labelText = labelForRadio.textContent.trim();
+        dayName = labelText.split(' at ')[0].toLowerCase().replace(/\s/g, '-');
+        fieldsetWithDayName = document.getElementById(`radio-select__times-for-${dayName}`);
 
         expect(labelForRadio).not.toBeNull();
-        expect(labelForRadio.textContent.trim()).toEqual(option.label);
+        expect(labelText).toEqual(option.label);
+
+        // check radios have the right name for their day and their fieldset id matches this
+        expect(radioWithValue.getAttribute('name')).toEqual(`times-for-${dayName}`);
+        expect(fieldsetWithDayName).not.toBeNull();
+        expect(fieldsetWithDayName.contains(radioWithValue)).toBe(true);
 
       });
 


### PR DESCRIPTION
Fixes this issue where the radios aren't focused when you move to the view showing the hours of a day:

|Currently|With this fix|
|---|---|
|![radio-select-bug](https://github.com/alphagov/notifications-admin/assets/87140/b2126a92-d3d1-4fdb-adbe-20981d57dae8)|![radio-select-bug-after](https://github.com/alphagov/notifications-admin/assets/87140/95766673-6818-401e-98bf-39e96b6aa4d9)|

The format of the days we show changed to include the month and day of the month in [this pull request](https://github.com/alphagov/notifications-admin/pull/4849). It updated the human-readable days but didn't change the code that baked the day into these parts of the HTML:
- the names of radios, ie. `times-for-sunday-15-october`
- the id of fieldsets for a day, ie. `radio-select__times-for-sunday-15-october`

It's not surprising these were missed as there weren't any tests checking them. There should have been though, because not updating these parts of the code meant:
- it couldn't find the radios to shift focus to when the times view shows
- fieldsets wrapping the radios for a day had invalid id attributes

This fixes the code mentioned and adds tests to check those parts of the JS.