### PR TITLE
Make organisation add page consistent with other platform admin pages

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -863,7 +863,7 @@ class OrganisationTypeField(GovukRadiosField):
                 for value, label in Organisation.TYPE_LABELS.items()
                 if not include_only or value in include_only
             ],
-            thing="the type of organisation",
+            thing="a type of organisation",
             validators=validators or [],
             **kwargs,
         )
@@ -1169,8 +1169,8 @@ class RenameOrganisationForm(StripWhitespaceForm):
     name = GovukTextInputField(
         "Organisation name",
         validators=[
-            DataRequired(message="Cannot be empty"),
-            MustContainAlphanumericCharacters(),
+            NotifyDataRequired(thing="an organisation name"),
+            MustContainAlphanumericCharacters(thing="organisation name"),
             Length(max=255, thing="organisation name"),
         ],
     )
@@ -1236,7 +1236,7 @@ class OrganisationCrownStatusForm(StripWhitespaceForm):
             ("non-crown", "No"),
             ("unknown", "Not sure"),
         ],
-        thing="whether this organisation is a crown body",
+        thing="yes if the organisation is a Crown body",
     )
 
 

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -73,7 +73,7 @@ def add_organisation():
             else:
                 raise e
 
-    return render_template("views/organisations/add-organisation.html", form=form)
+    return render_template("views/organisations/add-organisation.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/services/<uuid:service_id>/add-gp-organisation", methods=["GET", "POST"])

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -1,38 +1,23 @@
-{% extends "withoutnav_template.html" %}
+{% extends "views/platform-admin/_base_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   New organisation
 {% endblock %}
 
-{% block main %}
-  <div class="govuk-width-container">
-    <div class="navigation-service">
-      <a href="{{ url_for('main.organisations') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-back-to">All organisations</a>
-      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-switch">Switch service</a>
-    </div>
+{% block backLink %}
+{{ govukBackLink({ "href": url_for('main.organisations')  }) }}
+{% endblock %}
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        &nbsp;
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <main class="govuk-main-wrapper column-main govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main" >
-          {% block beforeContent %}{% endblock %}
-          {% block content %}
-            {{ page_header('New organisation') }}
-            {% call form_wrapper() %}
-              {{ form.name }}
-              {{ form.organisation_type }}
-              {{ form.crown_status }}
-              {{ page_footer('Save') }}
-            {% endcall %}
-          {% endblock %}
-        </main>
-      </div>
-    </div>
-  </div>
-
+{% block platform_admin_content %}
+    {{ page_header('New organisation') }}
+    {% call form_wrapper() %}
+        {{ form.name }}
+        {{ form.organisation_type }}
+        {{ form.crown_status }}
+        {{ page_footer('Save') }}
+    {% endcall %}
 {% endblock %}

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -139,9 +139,9 @@ def test_create_new_organisation_validates(
     assert [
         (error["data-error-label"], normalize_spaces(error.text)) for error in page.select(".govuk-error-message")
     ] == [
-        ("name", "Error: Cannot be empty"),
-        ("organisation_type", "Error: Select the type of organisation"),
-        ("crown_status", "Error: Select whether this organisation is a crown body"),
+        ("name", "Error: Enter an organisation name"),
+        ("organisation_type", "Error: Select a type of organisation"),
+        ("crown_status", "Error: Select yes if the organisation is a Crown body"),
     ]
     assert mock_create_organisation.called is False
 
@@ -149,8 +149,8 @@ def test_create_new_organisation_validates(
 @pytest.mark.parametrize(
     "name, error_message",
     [
-        ("", "Cannot be empty"),
-        ("a", "at least two alphanumeric characters"),
+        ("", "Enter an organisation name"),
+        ("a", "Organisation name must include at least 2 letters or numbers"),
         ("a" * 256, "Organisation name cannot be longer than 255 characters"),
     ],
 )
@@ -1771,8 +1771,8 @@ def test_update_organisation_name(
 @pytest.mark.parametrize(
     "name, error_message",
     [
-        ("", "Cannot be empty"),
-        ("a", "at least two alphanumeric characters"),
+        ("", "Enter an organisation name"),
+        ("a", "Organisation name must include at least 2 letters or numbers"),
         ("a" * 256, "Organisation name cannot be longer than 255 characters"),
     ],
 )

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -201,7 +201,7 @@ def test_add_service_has_to_choose_org_type(
         },
         _expected_status=200,
     )
-    assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Select the type of organisation"
+    assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Select a type of organisation"
     assert mock_create_service.called is False
     assert mock_create_service_template.called is False
 


### PR DESCRIPTION
Currently the organisations/add page has a layout that is not consistent with other platform admin pages and especially not consistent with the organisations page that links to it. 
Enabling error summaries introduced aesthetic issues that are resolved by making the page consistent with the patterns established in the other platform admin pages.

This PR updates `add-organisation.html` and enables error summaries for `/organisations/add` page form.

Before:

<img width="1015" alt="before-1" src="https://github.com/alphagov/notifications-admin/assets/32799090/754b9808-a532-4323-ad2e-16e6bd17dbe2">

After:

<img width="1047" alt="after-1" src="https://github.com/alphagov/notifications-admin/assets/32799090/caf7ee8f-9c47-4352-94ca-4b8bec158ddb">

The `back` link replaces the `organisations` link.

