### PR TITLE
Show recipients for scheduled jobs

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -89,7 +89,7 @@
 
       this.$scrollableTable
         .css({
-            'width': this.$component.parent('main').width() - indexColumnWidth,
+            'width': this.$component.parent().width() - indexColumnWidth,
             'margin-left': indexColumnWidth
         });
 

--- a/app/assets/javascripts/removeInPresenceOf.js
+++ b/app/assets/javascripts/removeInPresenceOf.js
@@ -1,0 +1,23 @@
+(function (Modules) {
+
+  'use strict';
+
+  Modules.RemoveInPresenceOf = function () {
+
+    let elementToRemove;
+    let observer = new MutationObserver(function () {
+      if (document.getElementById(elementToRemove.dataset.targetElementId)) {
+        elementToRemove.parentNode.removeChild(elementToRemove);
+        observer.disconnect();
+      }
+    });
+
+    this.start = function ($elementToRemove) {
+
+      elementToRemove = $elementToRemove[0];
+      observer.observe(document.getElementById('main-content'), { childList: true, subtree: true });
+
+    };
+
+  };
+})(window.GOVUK.NotifyModules);

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from pathlib import Path
 
 import pytz
 from notifications_utils.letter_timings import (
@@ -210,6 +211,10 @@ class Job(JSONModel):
             return job_api_client.cancel_letter_job(self.service, self.id)
         else:
             return job_api_client.cancel_job(self.service, self.id)
+
+    @property
+    def original_file_name_without_extention(self):
+        return Path(self.original_file_name).stem
 
 
 class ImmediateJobs(ModelList):

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -22,7 +22,7 @@
   {% else %}
 
     {% if notifications %}
-      <div class="dashboard-table bottom-gutter-3-2">
+      <div class="dashboard-table bottom-gutter-3-2" id="job-notifications">
     {% endif %}
 
       {% if job.template_type == 'letter' %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -3,6 +3,7 @@
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 
 {% block service_page_title %}
   {{ job.original_file_name }}
@@ -25,6 +26,46 @@
     {% endif %}
     {{ ajax_block(partials, updates_url, 'counts', finished=job.processing_finished) }}
     {{ ajax_block(partials, updates_url, 'notifications', finished=job.processing_finished) }}
+
+    {% if scheduled_recipients %}
+
+        <div class="fullscreen-content" data-notify-module="fullscreen-table">
+          {% call(item, row_number) list_table(
+            scheduled_recipients.displayed_rows,
+            caption=job.original_file_name,
+            caption_visible=False,
+            field_headings=[
+              '<span class="govuk-visually-hidden">Row in file</span><span aria-hidden="true">1</span>'|safe
+            ] + scheduled_recipients.column_headers
+          ) %}
+            {% call index_field() %}
+              <span>
+                {{ item.index + 2 }}
+              </span>
+            {% endcall %}
+            {% for column in scheduled_recipients.column_headers %}
+              {% if item[column].ignore %}
+                {{ text_field(item[column].data or '', status='default') }}
+              {% else %}
+                {{ text_field(item[column].data or '') }}
+              {% endif %}
+            {% endfor %}
+            {% if item[None].data %}
+              {% for column in item[None].data %}
+                {{ text_field(column, status='default') }}
+              {% endfor %}
+            {% endif %}
+          {% endcall %}
+        </div>
+
+        <div class="table-show-more-link">
+          {% if scheduled_recipients|length > scheduled_recipients.displayed_rows|list|length %}
+            <p class="govuk-!-margin-bottom-1">Only showing the first {{ scheduled_recipients.displayed_rows|list|length }} rows</p>
+          {% endif %}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.view_job_original_file_csv', service_id=current_service.id, job_id=job.id) }}" download>Download this file (CSV)</a>
+        </div>
+
+    {% endif %}
 
     {% if job.letter_job_can_be_cancelled %}
       <div class="js-stick-at-bottom-when-scrolling">

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -28,7 +28,7 @@
     {{ ajax_block(partials, updates_url, 'notifications', finished=job.processing_finished) }}
 
     {% if scheduled_recipients %}
-
+      <div data-notify-module="remove-in-presence-of" data-target-element-id="job-notifications">
         <div class="fullscreen-content" data-notify-module="fullscreen-table">
           {% call(item, row_number) list_table(
             scheduled_recipients.displayed_rows,
@@ -64,7 +64,7 @@
           {% endif %}
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.view_job_original_file_csv', service_id=current_service.id, job_id=job.id) }}" download>Download this file (CSV)</a>
         </div>
-
+      </div>
     {% endif %}
 
     {% if job.letter_job_can_be_cancelled %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,6 +132,7 @@ const javascripts = () => {
     paths.src + 'javascripts/updateStatus.js',
     paths.src + 'javascripts/errorBanner.js',
     paths.src + 'javascripts/homepage.js',
+    paths.src + 'javascripts/removeInPresenceOf.js',
     paths.src + 'javascripts/main.js',
   ])
   .pipe(plugins.prettyerror())

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -111,7 +111,7 @@ def test_should_show_page_for_one_job(
     )
     assert csv_link.text == "Download this report (CSV)"
     assert page.select_one("span#time-left").text == "Data available for 7 days"
-
+    assert page.select_one("#job-notifications")
     assert normalize_spaces(page.select_one("tbody tr").text) == normalize_spaces(
         "07123456789 template content Delivered 1 January at 11:10am"
     )
@@ -478,7 +478,10 @@ def test_should_show_scheduled_job(
     assert page.select_one("form button").text.strip() == "Cancel sending"
     assert not page.select_one(".govuk-back-link")
 
-    recipients_table = page.select_one('.fullscreen-content[data-notify-module="fullscreen-table"] table')
+    recipients_table = page.select_one(
+        "[data-notify-module=remove-in-presence-of][data-target-element-id=job-notifications] "
+        '.fullscreen-content[data-notify-module="fullscreen-table"] table'
+    )
     assert [normalize_spaces(column_heading.text) for column_heading in recipients_table.select("thead tr th")] == [
         "Row in file1",
         "phone number",

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -445,6 +445,7 @@ def test_should_show_letter_job_with_banner_after_sending_after_1730(
 
 @freeze_time("2016-01-01T00:00:00.061258")
 def test_should_show_scheduled_job(
+    mocker,
     client_request,
     mock_get_service_template,
     mock_get_scheduled_job,
@@ -452,6 +453,14 @@ def test_should_show_scheduled_job(
     mock_get_notifications,
     fake_uuid,
 ):
+    mocker.patch(
+        "app.main.views.jobs.s3download",
+        return_value="""
+            phone number,name
+            +447700900986,John
+            +447700900986,Smith
+        """,
+    )
     page = client_request.get(
         "main.view_job",
         service_id=SERVICE_ONE_ID,
@@ -468,6 +477,63 @@ def test_should_show_scheduled_job(
     )
     assert page.select_one("form button").text.strip() == "Cancel sending"
     assert not page.select_one(".govuk-back-link")
+
+    recipients_table = page.select_one('.fullscreen-content[data-notify-module="fullscreen-table"] table')
+    assert [normalize_spaces(column_heading.text) for column_heading in recipients_table.select("thead tr th")] == [
+        "Row in file1",
+        "phone number",
+        "name",
+    ]
+    assert [
+        [normalize_spaces(column.text) for column in row.select("td")] for row in recipients_table.select("tbody tr")
+    ] == [
+        ["2", "+447700900986", "John"],
+        ["3", "+447700900986", "Smith"],
+    ]
+
+    download_link = page.select_one(".table-show-more-link a")
+    assert normalize_spaces(download_link.text) == "Download this file (CSV)"
+    assert download_link["href"] == url_for(
+        "main.view_job_original_file_csv",
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+    )
+
+
+def test_should_download_scheduled_job(
+    mocker,
+    client_request,
+    mock_get_scheduled_job,
+    fake_uuid,
+):
+    original_file_contents = "phone number,name\n" "+447700900986,John\n" "+447700900986,Smith\n"
+    mocker.patch(
+        "app.main.views.jobs.s3download",
+        return_value=original_file_contents,
+    )
+    response = client_request.get_response(
+        "main.view_job_original_file_csv",
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+    )
+    assert response.data.decode("utf-8") == original_file_contents
+    assert response.headers["Content-Disposition"] == 'inline; filename="thisisatest.csv"'
+
+
+def test_should_not_download_unscheduled_job(
+    mocker,
+    client_request,
+    mock_get_job,
+    mock_get_service_data_retention,
+    mock_get_notifications,
+    fake_uuid,
+):
+    client_request.get(
+        "main.view_job_original_file_csv",
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+        _expected_status=404,
+    )
 
 
 def test_should_cancel_job(

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -372,6 +372,7 @@ EXCLUDED_ENDPOINTS = set(
             "view_current_broadcast",
             "view_job_csv",
             "view_job",
+            "view_job_original_file_csv",
             "view_jobs",
             "view_letter_notification_as_preview",
             "view_letter_upload_as_preview",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -190,6 +190,7 @@
     "/services/<uuid:service_id>/jobs/<uuid:job_id>.csv",
     "/services/<uuid:service_id>/jobs/<uuid:job_id>.json",
     "/services/<uuid:service_id>/jobs/<uuid:job_id>/cancel",
+    "/services/<uuid:service_id>/jobs/<uuid:job_id>/original.csv",
     "/services/<uuid:service_id>/make-service-live",
     "/services/<uuid:service_id>/monthly",
     "/services/<uuid:service_id>/new-broadcast",


### PR DESCRIPTION
This is useful so that:
- you can go back and check you uploaded the right thing
- someone else can see who a job is going to
- someone else who spots a mistake can correct it by downloading and re-uploading the original file

![preview](https://github.com/alphagov/notifications-admin/assets/355079/5379ec12-1974-4839-8084-e9ba3dac2f80)
