### PR TITLE
Fix viewing letter template version pages

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -313,7 +313,7 @@ def view_template_version(service_id, template_id, version):
 @user_has_permissions(allow_org_user=True)
 def view_template_version_preview(service_id, template_id, version, filetype):
     template = current_service.get_template(template_id, version=version)
-    return TemplatePreview.from_utils_template(template, filetype)
+    return TemplatePreview.from_utils_template(template, filetype, page=request.args.get("page"))
 
 
 def _add_template_by_type(template_type, template_folder_id):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1708,6 +1708,7 @@ def test_should_show_message_with_prefix_hint_if_enabled_for_service(
     [
         ("no_cookie.view_letter_template_preview", {}),
         ("no_cookie.view_template_version_preview", {"version": 1}),
+        ("no_cookie.view_template_version_preview", {"version": 1, "page": "2"}),
     ],
 )
 def test_should_show_preview_letter_templates(
@@ -1726,6 +1727,11 @@ def test_should_show_preview_letter_templates(
     assert mocked_preview.call_args[0][0]["id"] == template_id
     assert mocked_preview.call_args[0][0]["service"] == service_id
     assert mocked_preview.call_args[0][1] == filetype
+
+    if "page" in extra_view_args:
+        assert mocked_preview.call_args[1]["page"] == extra_view_args["page"]
+    else:
+        assert mocked_preview.call_args[1]["page"] is None
 
 
 def test_should_show_preview_letter_attachment(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1707,6 +1707,7 @@ def test_should_show_message_with_prefix_hint_if_enabled_for_service(
     "view, extra_view_args",
     [
         ("no_cookie.view_letter_template_preview", {}),
+        ("no_cookie.view_letter_template_preview", {"page": "2"}),
         ("no_cookie.view_template_version_preview", {"version": 1}),
         ("no_cookie.view_template_version_preview", {"version": 1, "page": "2"}),
     ],


### PR DESCRIPTION
We weren't passing `page` through to template-preview, meaning that each page preview was just showing page 1. Passing this through renders an accurate preview of each page in the template.

Also fixes the 'view paginated template history' views

## Before
![before](https://github.com/alphagov/notifications-admin/assets/2920760/5accc721-ac5d-474c-9591-d14aa8f9f623)


## After
![after](https://github.com/alphagov/notifications-admin/assets/2920760/a1c222ca-5606-4c0a-932c-71301591b7c4)
