### PR TITLE
Update the letter price rises notice on Notify pricing page

### DIFF
--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -61,8 +61,8 @@
     <p class="govuk-body">On 1 November 2023:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>second class postage will go up by between 6 and 7 pence</li>
+      <li>first class postage will go up by between 8 and 10 pence</li>
       <li>international postage will go up by between 8 and 21 pence</li>
-      <li>first class postage will go down by between 1 and 2 pence</li>
     </ul>
     <p class="govuk-body">The exact difference will depend on how many sheets of paper you need. The changes listed do not include VAT.</p>
   </div>


### PR DESCRIPTION
Following message from DVLA that they made a mistake in the new prices that they sent us.

The prices for 1st class letter sending have increased, not dicreased.

New content:
![Screenshot 2023-10-25 at 17 25 11](https://github.com/alphagov/notifications-admin/assets/20957548/eadb0d69-becc-4270-8b66-dde8cc93b784)
