### PR TITLE
Make `page` a required argument

### DIFF
--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -607,9 +607,9 @@ def test_should_show_image_of_letter_notification(
     assert mock_api.called is False
     mocked_preview.assert_called_once_with(
         notification["template"],
-        filetype,
-        notification["personalisation"],
+        filetype=filetype,
         page=None,
+        values=notification["personalisation"],
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1727,12 +1727,14 @@ def test_should_show_preview_letter_templates(
     mock_get_service_email_template.assert_called_with(service_id, template_id, extra_view_args.get("version"))
     assert mocked_preview.call_args[0][0]["id"] == template_id
     assert mocked_preview.call_args[0][0]["service"] == service_id
-    assert mocked_preview.call_args[0][1] == filetype
+    assert mocked_preview.call_args[1]["filetype"] == filetype
 
     if "page" in extra_view_args:
         assert mocked_preview.call_args[1]["page"] == extra_view_args["page"]
     else:
         assert mocked_preview.call_args[1]["page"] is None
+
+    assert mocked_preview.call_args[1]["values"] == {}
 
 
 def test_should_show_preview_letter_attachment(


### PR DESCRIPTION
Refactor this method signature slightly to make `page` required, and make `filetype` required via kwarg to make it a bit more readable.