### PR TITLE
Don’t reimport `Markup` from Flask

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -9,7 +9,8 @@ from numbers import Number
 import ago
 import dateutil
 import humanize
-from flask import Markup, url_for
+from flask import url_for
+from markupsafe import Markup
 from notifications_utils.field import Field
 from notifications_utils.formatters import make_quotes_smart
 from notifications_utils.formatters import nl2br as utils_nl2br

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -7,11 +7,12 @@ from itertools import chain
 from numbers import Number
 
 import pytz
-from flask import Markup, request
+from flask import request
 from flask_login import current_user
 from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileAllowed, FileSize
 from flask_wtf.file import FileField as FileField_wtf
+from markupsafe import Markup
 from notifications_utils.countries.data import Postage
 from notifications_utils.formatters import strip_all_whitespace
 from notifications_utils.insensitive_dict import InsensitiveDict

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -1,5 +1,6 @@
-from flask import Markup, abort, flash, redirect, render_template, request, url_for
+from flask import abort, flash, redirect, render_template, request, url_for
 from flask_login import current_user
+from markupsafe import Markup
 
 from app import (
     api_key_api_client,

--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -1,7 +1,8 @@
 import copy
 from abc import ABC, abstractmethod
 
-from flask import Markup, render_template_string
+from flask import render_template_string
+from markupsafe import Markup
 
 from app.utils import merge_jsonlike
 


### PR DESCRIPTION
This is not supported in the newest versions of Flask. It should be directly imported from `markupsafe` instead.

Was deprecated in https://github.com/pallets/flask/pull/4996

Already did this work in utils in https://github.com/alphagov/notifications-utils/pull/874