### PR TITLE
Bump core dependencies to latest versions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -293,19 +293,6 @@ def load_user(user_id):
     return User.from_id(user_id)
 
 
-def make_session_permanent():
-    """
-    Make sessions permanent. By permanent, we mean "admin app sets when it expires". Normally the cookie would expire
-    whenever you close the browser. With this, the session expiry is set in `config['PERMANENT_SESSION_LIFETIME']`
-    (20 hours) and is refreshed after every request. IE: you will be logged out after twenty hours of inactivity.
-
-    We don't _need_ to set this every request (it's saved within the cookie itself under the `_permanent` flag), only
-    when you first log in/sign up/get invited/etc, but we do it just to be safe. For more reading, check here:
-    https://stackoverflow.com/questions/34118093/flask-permanent-session-where-to-define-them
-    """
-    session.permanent = True
-
-
 def load_service_before_request():
     g.current_service = None
 
@@ -350,20 +337,6 @@ def load_organisation_before_request():
 
 def load_user_id_before_request():
     g.user_id = get_user_id_from_flask_login_session()
-
-
-def save_service_or_org_after_request(response):
-    # Only save the current session if the request is 200
-    service_id = request.view_args.get("service_id", None) if request.view_args else None
-    organisation_id = request.view_args.get("org_id", None) if request.view_args else None
-    if response.status_code == 200:
-        if service_id:
-            session["service_id"] = service_id
-            session["organisation_id"] = None
-        elif organisation_id:
-            session["service_id"] = None
-            session["organisation_id"] = organisation_id
-    return response
 
 
 #  https://www.owasp.org/index.php/List_of_useful_HTTP_headers
@@ -531,9 +504,6 @@ def setup_blueprints(application):
     from app.main import main as main_blueprint
     from app.main import no_cookie as no_cookie_blueprint
     from app.status import status as status_blueprint
-
-    main_blueprint.before_request(make_session_permanent)
-    main_blueprint.after_request(save_service_or_org_after_request)
 
     application.register_blueprint(main_blueprint)
     application.register_blueprint(json_updates_blueprint)

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, request, session
 
 from app.utils.constants import JSON_UPDATES_BLUEPRINT_NAME
 
@@ -49,3 +49,34 @@ from app.main.views import (  # noqa
 )
 from app.main.views.organisations import branding, index  # noqa
 from app.main.views.service_settings import branding, index  # noqa
+
+
+def make_session_permanent():
+    """
+    Make sessions permanent. By permanent, we mean "admin app sets when it expires". Normally the cookie would expire
+    whenever you close the browser. With this, the session expiry is set in `config['PERMANENT_SESSION_LIFETIME']`
+    (20 hours) and is refreshed after every request. IE: you will be logged out after twenty hours of inactivity.
+
+    We don't _need_ to set this every request (it's saved within the cookie itself under the `_permanent` flag), only
+    when you first log in/sign up/get invited/etc, but we do it just to be safe. For more reading, check here:
+    https://stackoverflow.com/questions/34118093/flask-permanent-session-where-to-define-them
+    """
+    session.permanent = True
+
+
+def save_service_or_org_after_request(response):
+    # Only save the current session if the request is 200
+    service_id = request.view_args.get("service_id", None) if request.view_args else None
+    organisation_id = request.view_args.get("org_id", None) if request.view_args else None
+    if response.status_code == 200:
+        if service_id:
+            session["service_id"] = service_id
+            session["organisation_id"] = None
+        elif organisation_id:
+            session["service_id"] = None
+            session["organisation_id"] = organisation_id
+    return response
+
+
+main.before_request(make_session_permanent)
+main.after_request(save_service_or_org_after_request)

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -854,7 +854,7 @@ class OnOffField(GovukRadiosField):
             # This overrides WTForms default behaviour which is to check
             # self.coerce(value) == self.data
             # where self.coerce returns a string for a boolean input
-            yield (value, label, (self.data in {value, self.coerce(value)}))
+            yield (value, label, (self.data in {value, self.coerce(value)}), {})
 
 
 class OrganisationTypeField(GovukRadiosField):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1139,7 +1139,7 @@ class TwoFactorForm(StripWhitespaceForm):
 
     sms_code = SMSCode("Text message code")
 
-    def validate(self):
+    def validate(self, *args, **kwargs):
 
         if not self.sms_code.validate(self):
             return False
@@ -1723,7 +1723,7 @@ class AdminProviderRatioForm(OrderableFieldsForm):
 
         super().__init__(data={provider["identifier"]: provider["priority"] for provider in providers})
 
-    def validate(self):
+    def validate(self, *args, **kwargs):
         if not super().validate():
             return False
 
@@ -1753,7 +1753,7 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
     # This is a text field because the number provided by the user can also be a short code
     phone_number = GovukTextInputField("Phone number")
 
-    def validate(self):
+    def validate(self, *args, **kwargs):
         if self.contact_details_type.data == "url":
             self.url.validators = [
                 NotifyDataRequired(thing="a URL in the correct format"),
@@ -1928,7 +1928,7 @@ class AdminEditEmailBrandingForm(StripWhitespaceForm):
         if op == "email-branding-details" and not self.name.data:
             raise ValidationError("Enter a name for the branding")
 
-    def validate(self):
+    def validate(self, *args, **kwargs):
         rv = super().validate()
 
         op = request.form.get("operation")
@@ -2193,8 +2193,8 @@ class CallbackForm(StripWhitespaceForm):
         validators=[DataRequired(message="Cannot be empty"), Length(min=10, thing="the bearer token")],
     )
 
-    def validate(self):
-        return super().validate() or self.url.data == ""
+    def validate(self, *args, **kwargs):
+        return super().validate(*args, **kwargs) or self.url.data == ""
 
 
 class SMSPrefixForm(StripWhitespaceForm):
@@ -2527,7 +2527,7 @@ class TemplateAndFoldersSelectionForm(OrderableFieldsForm):
     def is_selected(self, template_folder_id):
         return template_folder_id in (self.templates_and_folders.data or [])
 
-    def validate(self):
+    def validate(self, *args, **kwargs):
         self.op = request.form.get("operation")
 
         self.is_move_op = self.op in {"move-to-existing-folder", "move-to-new-folder"}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1150,7 +1150,7 @@ class TwoFactorForm(StripWhitespaceForm):
             self.sms_code.errors.append(reason)
             return False
 
-        return True
+        return super().validate(*args, **kwargs)
 
 
 class TextNotReceivedForm(StripWhitespaceForm):
@@ -1724,7 +1724,7 @@ class AdminProviderRatioForm(OrderableFieldsForm):
         super().__init__(data={provider["identifier"]: provider["priority"] for provider in providers})
 
     def validate(self, *args, **kwargs):
-        if not super().validate():
+        if not super().validate(*args, **kwargs):
             return False
 
         total = sum(getattr(self, provider["identifier"]).data for provider in self._providers)
@@ -1787,7 +1787,7 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
                 valid_non_emergency_phone_number,
             ]
 
-        return super().validate()
+        return super().validate(*args, **kwargs)
 
 
 class ServiceReplyToEmailForm(StripWhitespaceForm):
@@ -1929,7 +1929,7 @@ class AdminEditEmailBrandingForm(StripWhitespaceForm):
             raise ValidationError("Enter a name for the branding")
 
     def validate(self, *args, **kwargs):
-        rv = super().validate()
+        rv = super().validate(*args, **kwargs)
 
         op = request.form.get("operation")
         if op == "email-branding-details":
@@ -2537,7 +2537,7 @@ class TemplateAndFoldersSelectionForm(OrderableFieldsForm):
         if not (self.is_add_folder_op or self.is_move_op or self.is_add_template_op):
             return False
 
-        return super().validate()
+        return super().validate(*args, **kwargs)
 
     def get_folder_name(self):
         if self.op == "add-new-folder":

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -3,7 +3,6 @@
 from functools import partial
 
 from flask import (
-    Markup,
     Response,
     abort,
     flash,
@@ -14,6 +13,7 @@ from flask import (
     stream_with_context,
     url_for,
 )
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils.template import (
     EmailPreviewTemplate,

--- a/app/main/views/organisations/branding.py
+++ b/app/main/views/organisations/branding.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from flask import (
-    Markup,
     abort,
     current_app,
     flash,
@@ -10,6 +9,7 @@ from flask import (
     request,
     url_for,
 )
+from markupsafe import Markup
 from werkzeug import Response
 
 from app import current_organisation, organisations_client

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -1,7 +1,6 @@
 from http import HTTPStatus
 
 from flask import (
-    Markup,
     abort,
     flash,
     redirect,
@@ -11,6 +10,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
+from markupsafe import Markup
 
 from app import login_manager
 from app.main import main

--- a/requirements.in
+++ b/requirements.in
@@ -4,11 +4,12 @@
 ago==0.0.95
 govuk-bank-holidays==0.11
 humanize==4.4.0
-Flask==2.2.5
-Flask-WTF==1.0.1
-wtforms==3.0.1
-Flask-Login==0.6.2
-Werkzeug==2.2.3
+Flask==3.0.0
+Flask-WTF==1.2.1
+wtforms==3.1.0
+Flask-Login @ git+https://github.com/maxcountryman/flask-login.git@2204b4eee7b215977ba5a1bf85e2061f7fa65e20#egg=flask-login
+
+Werkzeug==3.0.1
 jinja2==3.1.2
 Pillow==10.0.1
 

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,6 @@ Werkzeug==2.2.3
 jinja2==3.1.2
 Pillow==10.0.1
 
-blinker==1.5
 pyexcel==0.7.0
 pyexcel-io==0.6.6
 pyexcel-xls==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ awscli-cwlogs==1.4.6
     # via -r requirements.in
 blinker==1.5
     # via
-    #   -r requirements.in
     #   gds-metrics
     #   sentry-sdk
 boto3==1.28.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,9 @@ awscli==1.29.5
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
-blinker==1.5
+blinker==1.6.3
     # via
+    #   flask
     #   gds-metrics
     #   sentry-sdk
 boto3==1.28.5
@@ -54,7 +55,7 @@ eventlet==0.33.1
     # via gunicorn
 fido2==1.1.0
     # via -r requirements.in
-flask==2.2.5
+flask==3.0.0
     # via
     #   -r requirements.in
     #   flask-login
@@ -63,11 +64,11 @@ flask==2.2.5
     #   gds-metrics
     #   notifications-utils
     #   sentry-sdk
-flask-login==0.6.2
+flask-login @ git+https://github.com/maxcountryman/flask-login.git@2204b4eee7b215977ba5a1bf85e2061f7fa65e20
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
-flask-wtf==1.0.1
+flask-wtf==1.2.1
     # via -r requirements.in
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
@@ -220,12 +221,12 @@ urllib3==1.26.18
     #   botocore
     #   requests
     #   sentry-sdk
-werkzeug==2.2.3
+werkzeug==3.0.1
     # via
     #   -r requirements.in
     #   flask
     #   flask-login
-wtforms==3.0.1
+wtforms==3.1.0
     # via
     #   -r requirements.in
     #   flask-wtf

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -326,7 +326,7 @@ def test_two_factor_sms_should_activate_pending_user(
 
 @pytest.mark.parametrize(
     "extra_args, expected_encoded_next_arg",
-    (({}, ""), ({"next": "https://example.com"}, "?next=https%3A%2F%2Fexample.com")),
+    (({}, ""), ({"next": "https://example.com"}, "?next=https://example.com")),
 )
 def test_valid_two_factor_email_link_shows_interstitial(
     client_request,

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -326,7 +326,11 @@ def test_two_factor_sms_should_activate_pending_user(
 
 @pytest.mark.parametrize(
     "extra_args, expected_encoded_next_arg",
-    (({}, ""), ({"next": "https://example.com"}, "?next=https://example.com")),
+    (
+        ({}, ""),
+        ({"next": "https://example.com"}, "?next=https://example.com"),
+        ({"next": "https://example.com?foo=bar&baz=waz"}, "?next=https://example.com?foo%3Dbar%26baz%3Dwaz"),
+    ),
 )
 def test_valid_two_factor_email_link_shows_interstitial(
     client_request,


### PR DESCRIPTION
Fixes #4869 (security update)

***

These changes work with the previous and new versions of the dependencies:
- Don’t re-import `Markup` from Flask
- Register `before_request` and `after_request` globally
- Remove blinker as explicit dependency

Then we update our core frameworks to the latest versions so they all play nicely with each other, including:
- Flask
- Flask-WTF
- wtforms
- Flask-Login (no release for the newest compatible code here, so we have to go by a commit SHA instead)
- Werkzeug (the package with the vulnerability)

Then these changes are to fix problems in our code caused by the new versions of the dependencies:
- Update method signature of `Form.validate`
- Update return value of `iter_choices`
- Don’t expected encoded URL querystring argument value