### PR TITLE
Enable error summaries for organisation page forms

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1104,7 +1104,7 @@ class BaseInviteUserForm:
         if current_user.platform_admin:
             return
         if field.data.lower() == self.inviter_email_address.lower():
-            raise ValidationError("You cannot send an invitation to yourself")
+            raise ValidationError("Enter an email address that is not your own")
 
 
 class InviteUserForm(BaseInviteUserForm, PermissionsForm):
@@ -1172,7 +1172,7 @@ class RenameOrganisationForm(StripWhitespaceForm):
     name = GovukTextInputField(
         "Organisation name",
         validators=[
-            NotifyDataRequired(thing="an organisation name"),
+            NotifyDataRequired(thing="your organisation name"),
             MustContainAlphanumericCharacters(thing="organisation name"),
             Length(max=255, thing="organisation name"),
         ],
@@ -1312,6 +1312,15 @@ class AdminNewOrganisationForm(
         super().__init__(*args, **kwargs)
         # Don’t offer the ‘not sure’ choice
         self.crown_status.choices = self.crown_status.choices[:-1]
+
+    name = GovukTextInputField(
+        "Organisation name",
+        validators=[
+            NotifyDataRequired(thing="an organisation name"),
+            MustContainAlphanumericCharacters(thing="organisation name"),
+            Length(max=255, thing="organisation name"),
+        ],
+    )
 
 
 class AdminServiceSMSAllowanceForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1202,7 +1202,7 @@ class AddGPOrganisationForm(StripWhitespaceForm):
             (True, "Yes"),
             (False, "No"),
         ],
-        choices_for_error_message="yes to confirm the name of your GP surgery",
+        choices_for_error_message="‘yes‘ to confirm the name of your GP surgery",
     )
 
     name = GovukTextInputField(
@@ -1288,7 +1288,7 @@ class CreateServiceForm(StripWhitespaceForm):
     name = GovukTextInputField(
         "Service name",
         validators=[
-            DataRequired(message="Cannot be empty"),
+            DataRequired(message="Enter a service name"),
             MustContainAlphanumericCharacters(),
             Length(max=255, thing="service name"),
         ],

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1202,6 +1202,7 @@ class AddGPOrganisationForm(StripWhitespaceForm):
             (True, "Yes"),
             (False, "No"),
         ],
+        choices_for_error_message="yes to confirm the name of your GP surgery",
     )
 
     name = GovukTextInputField(
@@ -1211,7 +1212,7 @@ class AddGPOrganisationForm(StripWhitespaceForm):
     def validate_name(self, field):
         if self.same_as_service_name.data is False:
             if not field.data:
-                raise ValidationError("Cannot be empty")
+                raise ValidationError("Enter the name of your GP surgery")
         else:
             field.data = ""
 

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -91,4 +91,5 @@ def _render_add_service_page(form, default_organisation_type):
         "views/add-service.html",
         form=form,
         default_organisation_type=default_organisation_type,
+        error_summary_enabled=True,
     )

--- a/app/main/views/organisations/branding.py
+++ b/app/main/views/organisations/branding.py
@@ -205,6 +205,7 @@ def add_organisation_email_branding_options(org_id):
         "views/organisations/organisation/settings/add-email-branding-options.html",
         form=form,
         _search_form=SearchByNameForm(),
+        error_summary_enabled=True,
     )
 
 

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -98,7 +98,7 @@ def add_organisation_from_gp_service(service_id):
             )
         )
 
-    return render_template("views/organisations/add-gp-organisation.html", form=form)
+    return render_template("views/organisations/add-gp-organisation.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/services/<uuid:service_id>/add-nhs-local-organisation", methods=["GET", "POST"])

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -69,7 +69,7 @@ def add_organisation():
         except HTTPError as e:
             msg = "Organisation name already exists"
             if e.status_code == 400 and msg in e.message:
-                form.name.errors.append("This organisation name is already in use - contact GOV.UK Notify support")
+                form.name.errors.append("This organisation name is already in use.")
             else:
                 raise e
 
@@ -304,15 +304,14 @@ def edit_organisation_name(org_id):
         except HTTPError as http_error:
             error_msg = "Organisation name already exists"
             if http_error.status_code == 400 and error_msg in http_error.message:
-                form.name.errors.append("This organisation name is already in use")
+                form.name.errors.append("This organisation name is already in use.")
             else:
                 raise http_error
         else:
             return redirect(url_for(".organisation_settings", org_id=org_id))
 
     return render_template(
-        "views/organisations/organisation/settings/edit-name.html",
-        form=form,
+        "views/organisations/organisation/settings/edit-name.html", form=form, error_summary_enabled=True
     )
 
 

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -69,7 +69,7 @@ def add_organisation():
         except HTTPError as e:
             msg = "Organisation name already exists"
             if e.status_code == 400 and msg in e.message:
-                form.name.errors.append("This organisation name is already in use")
+                form.name.errors.append("This organisation name is already in use - contact GOV.UK Notify support")
             else:
                 raise e
 

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -304,7 +304,7 @@ def edit_organisation_name(org_id):
         except HTTPError as http_error:
             error_msg = "Organisation name already exists"
             if http_error.status_code == 400 and error_msg in http_error.message:
-                form.name.errors.append("This organisation name is already in use.")
+                form.name.errors.append("This organisation name is already in use")
             else:
                 raise http_error
         else:

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -12,9 +11,9 @@
 {% block maincolumn_content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    {{ page_header(heading) }}
-    <p class="govuk-body">This is the name your emails will come from.</p>
-    <p class="govuk-body">You can also display it at the start of every text message you send.</p>
+      <h1 class="govuk-heading-l"> {{ heading }} </h1>
+      <p class="govuk-body">This is the name your emails will come from.</p>
+      <p class="govuk-body">You can also display it at the start of every text message you send.</p>
 
     {% if default_organisation_type == 'central' or default_organisation_type == 'local'  %}
       <p class="govuk-body">Your service name should tell the recipient what your message is about, as well as who it’s from. For example:</p>

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -112,7 +112,9 @@ def test_invite_org_user_errors_when_same_email_as_inviter(
     )
 
     assert mock_invite_org_user.called is False
-    assert "You cannot send an invitation to yourself" in normalize_spaces(page.select_one(".govuk-error-message").text)
+    assert "Enter an email address that is not your own" in normalize_spaces(
+        page.select_one(".govuk-error-message").text
+    )
 
 
 def test_cancel_invited_org_user_cancels_user_invitations(

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -351,14 +351,14 @@ def test_gps_can_name_their_organisation(
             {
                 "name": "Dr. Example",
             },
-            "Select yes or no",
+            "Select yes to confirm the name of your GP surgery",
         ),
         (
             {
                 "same_as_service_name": False,
                 "name": "",
             },
-            "Cannot be empty",
+            "Enter the name of your GP surgery",
         ),
     ),
 )
@@ -1771,7 +1771,7 @@ def test_update_organisation_name(
 @pytest.mark.parametrize(
     "name, error_message",
     [
-        ("", "Enter an organisation name"),
+        ("", "Enter your organisation name"),
         ("a", "Organisation name must include at least 2 letters or numbers"),
         ("a" * 256, "Organisation name cannot be longer than 255 characters"),
     ],

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -351,7 +351,7 @@ def test_gps_can_name_their_organisation(
             {
                 "name": "Dr. Example",
             },
-            "Select yes to confirm the name of your GP surgery",
+            "Select ‘yes‘ to confirm the name of your GP surgery",
         ),
         (
             {

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -299,7 +299,7 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
 @pytest.mark.parametrize(
     "name, error_message",
     [
-        ("", "Cannot be empty"),
+        ("", "Enter a service name"),
         (".", "Must include at least two alphanumeric characters"),
         ("a" * 256, "Service name cannot be longer than 255 characters"),
     ],

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1523,7 +1523,7 @@ def test_user_cant_invite_themselves(
     )
     assert page.select_one("h1").string.strip() == "Invite a team member"
     form_error = page.select_one(".govuk-error-message").text.strip()
-    assert form_error == "Error: You cannot send an invitation to yourself"
+    assert form_error == "Error: Enter an email address that is not your own"
     assert not mock_create_invite.called
 
 


### PR DESCRIPTION
This PR enables error summaries for the organisation form pages. https://trello.com/c/wZrgot2p/460-add-error-summaries-to-organisation-page-forms

I have shortened the following validation error message: "This organisation name is already in use - contact GOV.UK Notify support"  to "This organisation name is already in use.". This is because the page is only viewed by platform admins.
