### PR TITLE
give zendesk tickets different subjects

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import pytz
-from flask import redirect, render_template, request, session, url_for
+from flask import current_app, redirect, render_template, request, session, url_for
 from flask_login import current_user
 from notifications_utils.bank_holidays import BankHolidays
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket
@@ -118,8 +118,15 @@ def feedback(ticket_type):
             out_of_hours_emergency=out_of_hours_emergency,
         )
 
+        prefix = (
+            ""
+            if current_app.config["NOTIFY_ENVIRONMENT"] == "production"
+            else f"[env: {current_app.config['NOTIFY_ENVIRONMENT']}] "
+        )
+        subject = prefix + ticket_type_names[ticket_type]["ticket_subject"]
+
         ticket = NotifySupportTicket(
-            subject=ticket_type_names[ticket_type]["ticket_subject"],
+            subject=subject,
             message=feedback_msg,
             ticket_type=get_zendesk_ticket_type(ticket_type),
             notify_ticket_type=None,  # don't set technical/non-technical, we'll do this as part of triage on support

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -121,14 +121,16 @@ def test_get_feedback_page(client_request, ticket_type, expected_status_code):
 
 @freeze_time("2016-12-12 12:00:00.000000")
 @pytest.mark.parametrize(
-    "ticket_type, zendesk_ticket_type",
+    "ticket_type, zendesk_ticket_type, expected_subject",
     [
-        (PROBLEM_TICKET_TYPE, "incident"),
-        (QUESTION_TICKET_TYPE, "question"),
-        (GENERAL_TICKET_TYPE, "question"),
+        (PROBLEM_TICKET_TYPE, "incident", "Reported Problem"),
+        (QUESTION_TICKET_TYPE, "question", "Question/Feedback"),
+        (GENERAL_TICKET_TYPE, "question", "General Notify Support"),
     ],
 )
-def test_passed_non_logged_in_user_details_through_flow(client_request, mocker, ticket_type, zendesk_ticket_type):
+def test_passed_non_logged_in_user_details_through_flow(
+    client_request, mocker, ticket_type, zendesk_ticket_type, expected_subject
+):
     client_request.logout()
     mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
     mock_send_ticket_to_zendesk = mocker.patch(
@@ -151,7 +153,7 @@ def test_passed_non_logged_in_user_details_through_flow(client_request, mocker, 
 
     mock_create_ticket.assert_called_once_with(
         ANY,
-        subject="Notify feedback",
+        subject=expected_subject,
         message="blah\n",
         ticket_type=zendesk_ticket_type,
         p1=False,
@@ -170,11 +172,11 @@ def test_passed_non_logged_in_user_details_through_flow(client_request, mocker, 
     "data", [{"feedback": "blah"}, {"feedback": "blah", "name": "Ignored", "email_address": "ignored@email.com"}]
 )
 @pytest.mark.parametrize(
-    "ticket_type, zendesk_ticket_type",
+    "ticket_type, zendesk_ticket_type, expected_subject",
     [
-        (PROBLEM_TICKET_TYPE, "incident"),
-        (QUESTION_TICKET_TYPE, "question"),
-        (GENERAL_TICKET_TYPE, "question"),
+        (PROBLEM_TICKET_TYPE, "incident", "Reported Problem"),
+        (QUESTION_TICKET_TYPE, "question", "Question/Feedback"),
+        (GENERAL_TICKET_TYPE, "question", "General Notify Support"),
     ],
 )
 def test_passes_user_details_through_flow(
@@ -183,6 +185,7 @@ def test_passes_user_details_through_flow(
     mocker,
     ticket_type,
     zendesk_ticket_type,
+    expected_subject,
     data,
 ):
     mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
@@ -204,7 +207,7 @@ def test_passes_user_details_through_flow(
     )
     mock_create_ticket.assert_called_once_with(
         ANY,
-        subject="Notify feedback",
+        subject=expected_subject,
         message=ANY,
         ticket_type=zendesk_ticket_type,
         p1=False,
@@ -421,7 +424,6 @@ def test_doesnt_lose_message_if_post_across_closing(
     client_request,
     mocker,
 ):
-
     mocker.patch("app.models.user.User.live_services", return_value=True)
     mocker.patch("app.main.views.feedback.in_business_hours", return_value=False)
 
@@ -584,7 +586,6 @@ def test_should_be_shown_the_bat_email(
     expected_status_code_when_logged_in,
     expected_redirect_when_logged_in,
 ):
-
     mocker.patch("app.main.views.feedback.in_business_hours", return_value=is_in_business_hours)
 
     feedback_page = url_for("main.feedback", ticket_type=PROBLEM_TICKET_TYPE, severe=severe)
@@ -642,7 +643,6 @@ def test_should_be_shown_the_bat_email_for_general_questions(
     expected_status_code_when_logged_in,
     expected_redirect_when_logged_in,
 ):
-
     mocker.patch("app.main.views.feedback.in_business_hours", return_value=False)
 
     feedback_page = url_for("main.feedback", ticket_type=GENERAL_TICKET_TYPE, severe=severe)

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -12,7 +12,7 @@ from app.models.feedback import (
     PROBLEM_TICKET_TYPE,
     QUESTION_TICKET_TYPE,
 )
-from tests.conftest import SERVICE_ONE_ID, normalize_spaces
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces, set_config
 
 
 def no_redirect():
@@ -120,17 +120,7 @@ def test_get_feedback_page(client_request, ticket_type, expected_status_code):
 
 
 @freeze_time("2016-12-12 12:00:00.000000")
-@pytest.mark.parametrize(
-    "ticket_type, zendesk_ticket_type, expected_subject",
-    [
-        (PROBLEM_TICKET_TYPE, "incident", "Reported Problem"),
-        (QUESTION_TICKET_TYPE, "question", "Question/Feedback"),
-        (GENERAL_TICKET_TYPE, "question", "General Notify Support"),
-    ],
-)
-def test_passed_non_logged_in_user_details_through_flow(
-    client_request, mocker, ticket_type, zendesk_ticket_type, expected_subject
-):
+def test_passed_non_logged_in_user_details_through_flow(client_request, mocker):
     client_request.logout()
     mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
     mock_send_ticket_to_zendesk = mocker.patch(
@@ -142,7 +132,7 @@ def test_passed_non_logged_in_user_details_through_flow(
 
     client_request.post(
         "main.feedback",
-        ticket_type=ticket_type,
+        ticket_type=GENERAL_TICKET_TYPE,
         _data=data,
         _expected_redirect=url_for(
             "main.thanks",
@@ -153,9 +143,9 @@ def test_passed_non_logged_in_user_details_through_flow(
 
     mock_create_ticket.assert_called_once_with(
         ANY,
-        subject=expected_subject,
+        subject="[env: test] General Notify Support",
         message="blah\n",
-        ticket_type=zendesk_ticket_type,
+        ticket_type="question",
         p1=False,
         user_name="Anne Example",
         user_email="anne@example.com",
@@ -174,9 +164,8 @@ def test_passed_non_logged_in_user_details_through_flow(
 @pytest.mark.parametrize(
     "ticket_type, zendesk_ticket_type, expected_subject",
     [
-        (PROBLEM_TICKET_TYPE, "incident", "Reported Problem"),
-        (QUESTION_TICKET_TYPE, "question", "Question/Feedback"),
-        (GENERAL_TICKET_TYPE, "question", "General Notify Support"),
+        (PROBLEM_TICKET_TYPE, "incident", "[env: test] Reported Problem"),
+        (QUESTION_TICKET_TYPE, "question", "[env: test] Question/Feedback"),
     ],
 )
 def test_passes_user_details_through_flow(
@@ -232,6 +221,47 @@ def test_passes_user_details_through_flow(
         ]
     )
     mock_send_ticket_to_zendesk.assert_called_once()
+
+
+@pytest.mark.freeze_time("2016-12-12 12:00:00.000000")
+def test_zendesk_subject_doesnt_show_env_flag_on_prod(
+    notify_admin,
+    client_request,
+    mock_get_non_empty_organisations_and_services_for_user,
+    mocker,
+):
+    mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
+    mocker.patch(
+        "app.main.views.feedback.zendesk_client.send_ticket_to_zendesk",
+        autospec=True,
+    )
+
+    with set_config(notify_admin, "NOTIFY_ENVIRONMENT", "production"):
+        client_request.post(
+            "main.feedback",
+            ticket_type=GENERAL_TICKET_TYPE,
+            _data={"feedback": "blah"},
+            _expected_status=302,
+            _expected_redirect=url_for(
+                "main.thanks",
+                email_address_provided=True,
+                out_of_hours_emergency=False,
+            ),
+        )
+
+    mock_create_ticket.assert_called_once_with(
+        ANY,
+        subject="General Notify Support",
+        message=ANY,
+        ticket_type="question",
+        p1=False,
+        user_name="Test User",
+        user_email="test@user.gov.uk",
+        notify_ticket_type=None,
+        org_id=None,
+        org_type="central",
+        service_id=SERVICE_ONE_ID,
+    )
 
 
 @freeze_time("2016-12-12 12:00:00.000000")


### PR DESCRIPTION
we often struggle to distinguish tickets as they come in, and appropriately identify them.

We can do a low-impact change here to make our lives simpler - by setting the subject based on what flow the user took through the triage process.

If they're not signed in, they get GENERAL
If they're signed in, they get PROBLEM or QUESTION depending on which radio they press

these new subjects will be seen by the user when we reply to their tickets

![image](https://github.com/alphagov/notifications-admin/assets/5020841/2bc9b586-10e2-4b24-88f5-63b47c19690b)