### PR TITLE
Enable error summaries for support pages

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1704,8 +1704,10 @@ class SupportRedirect(StripWhitespaceForm):
 
 class FeedbackOrProblem(StripWhitespaceForm):
     name = GovukTextInputField("Name (optional)")
-    email_address = make_email_address_field(label="Email address", gov_user=False, required=True)
-    feedback = TextAreaField("Your message", validators=[DataRequired(message="Cannot be empty")])
+    email_address = make_email_address_field(
+        label="Email address", gov_user=False, required=True, thing="your email address"
+    )
+    feedback = TextAreaField("Your message", validators=[NotifyDataRequired(thing="your message")])
 
 
 class Triage(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1715,7 +1715,7 @@ class Triage(StripWhitespaceForm):
             ("yes", "Yes"),
             ("no", "No"),
         ],
-        thing="yes or no",
+        thing="‘yes’ if you want us to contact you when we’re doing user research",
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1703,11 +1703,11 @@ class SupportRedirect(StripWhitespaceForm):
 
 
 class FeedbackOrProblem(StripWhitespaceForm):
+    feedback = TextAreaField("Your message", validators=[NotifyDataRequired(thing="your message")])
     name = GovukTextInputField("Name (optional)")
     email_address = make_email_address_field(
         label="Email address", gov_user=False, required=True, thing="your email address"
     )
-    feedback = TextAreaField("Your message", validators=[NotifyDataRequired(thing="your message")])
 
 
 class Triage(StripWhitespaceForm):
@@ -1717,7 +1717,7 @@ class Triage(StripWhitespaceForm):
             ("yes", "Yes"),
             ("no", "No"),
         ],
-        thing="‘yes’ if you want us to contact you when we’re doing user research",
+        thing="‘yes’ if it is an emergency",
     )
 
 

--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -61,10 +61,7 @@ def triage(ticket_type=PROBLEM_TICKET_TYPE):
     form = Triage()
     if form.validate_on_submit():
         return redirect(url_for(".feedback", ticket_type=ticket_type, severe=form.severe.data))
-    return render_template(
-        "views/support/triage.html",
-        form=form,
-    )
+    return render_template("views/support/triage.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/support/<ticket_type:ticket_type>", methods=["GET", "POST"])

--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -45,7 +45,7 @@ def support():
                     )
                 )
 
-    return render_template("views/support/index.html", form=form)
+    return render_template("views/support/index.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/support/public")
@@ -155,6 +155,7 @@ def feedback(ticket_type):
         back_link=(url_for(".support") if severe is None else url_for(".triage", ticket_type=ticket_type)),
         show_status_page_banner=(ticket_type == PROBLEM_TICKET_TYPE),
         page_title=page_title,
+        error_summary_enabled=True,
     )
 
 

--- a/app/templates/views/support/form.html
+++ b/app/templates/views/support/form.html
@@ -1,7 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import sticky_page_footer %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
@@ -16,7 +15,7 @@
 
 {% block maincolumn_content %}
 
-    {{ page_header(page_title) }}
+<h1 class="govuk-heading-l" id="page-header">{{ page_title }}</h1>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {% if show_status_page_banner %}

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -8,7 +8,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Support</h1>
+  <h1 class="govuk-heading-l">Support</h1>
   <p class="govuk-body">GOV.UK Notify provides 24-hour online support.</p>
   <p class="govuk-body">If it’s an emergency, we’ll reply within 30 minutes and update you every hour until we fix the problem.</p>
 <p class="govuk-body">If it’s not an emergency, we’ll reply within 1 working day.</p>

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -288,7 +288,7 @@ def test_email_address_required_for_problems_and_questions(
     mocker.patch("app.main.views.feedback.zendesk_client")
     client_request.logout()
     page = client_request.post("main.feedback", ticket_type=ticket_type, _data=data, _expected_status=200)
-    assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Cannot be empty"
+    assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Enter your email address"
 
 
 @freeze_time("2016-12-12 12:00:00.000000")
@@ -311,7 +311,7 @@ def test_email_address_must_be_valid_if_provided_to_support_form(
 
     assert (
         normalize_spaces(page.select_one(".govuk-error-message").text)
-        == "Error: Enter an email address in the correct format, like name@example.gov.uk"
+        == "Error: Enter your email address in the correct format, like name@example.gov.uk"
     )
 
 


### PR DESCRIPTION
This PR enables error summaries for support page forms.
https://trello.com/c/hh1xh8il/458-add-error-summaries-to-support-page-forms