### PR TITLE
Fix static path checking

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -296,7 +296,7 @@ def load_user(user_id):
 def load_service_before_request():
     g.current_service = None
 
-    if "/static/" in request.url:
+    if request.path.startswith("/static/"):
         return
 
     if request.view_args:
@@ -318,7 +318,7 @@ def load_service_before_request():
 def load_organisation_before_request():
     g.current_organisation = None
 
-    if "/static/" in request.url:
+    if request.path.startswith("/static/"):
         return
 
     if request.view_args:


### PR DESCRIPTION
We opt not to load the service or organisation if we're accessing static assets. These are served from `/static/<...>`. To validate this we were doing a naive check on whether the URL contained `/static/`, which works for the most part.

However, this is a loose check. If `/static/` appears _anywhere_ in the URL, then we don't load a service or organisation. There are legitimate cases where we may have that in the URL, but still be accessing non-static assets.

For example, when users use the self-service letter branding flow, we store the letter branding SVG asset in S3 using an object key with the pattern: `letters/static/images/letter-template/<filename>.svg`. This filename is passed through the journey as a URL query parameter.

So why has this only just hit us?

We've just upgraded to Flask 3.0.1 (and Werkzeug 3.0.0). Previously we were on 2.2.5 of Flask and 2.2.3 of Werkzeug.

https://github.com/pallets/werkzeug/blob/main/CHANGES.rst#version-230

In 2.3.0 of Werkzeug, the changelog says "Update which characters are considered safe when using percent encoding in URLs, based on the WhatWG URL Standard. :issue:`2601`". Previously, `/` characters were %-encoded to %2F, leading to our SVG temp filename being
`letters%2Fstatic%2Fimages%2Fletter-template%2f<filename>.svg`. This didn't contain our `/static/` fragment, and so we would load the service/org as needed.

After bumping the dependencies, `/` characters stopped being %-encoded, and our naive `/static/` detection kicked in, which meant `g.current_service` wasn't populated, which caused our templates to break in `main_nav`, as we expect access to a service.