### PR TITLE
Add a page to rename letter templates

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1494,7 +1494,7 @@ class EmailTemplateForm(BaseTemplateForm):
     subject = TextAreaField("Subject", validators=[DataRequired(message="Cannot be empty")])
 
 
-class LetterTemplateForm(EmailTemplateForm):
+class LetterTemplateForm(StripWhitespaceForm):
     subject = TextAreaField("Main heading", validators=[DataRequired(message="Cannot be empty")])
 
     template_content = TextAreaField(

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1430,6 +1430,10 @@ class ConfirmBroadcastForm(StripWhitespaceForm):
                 return message
 
 
+class RenameTemplateForm(StripWhitespaceForm):
+    name = GovukTextInputField("Template name", validators=[DataRequired(message="Cannot be empty")])
+
+
 class BaseTemplateForm(StripWhitespaceForm):
     name = GovukTextInputField("Template name", validators=[DataRequired(message="Cannot be empty")])
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1430,19 +1430,38 @@ class ConfirmBroadcastForm(StripWhitespaceForm):
                 return message
 
 
-class RenameTemplateForm(StripWhitespaceForm):
+class TemplateNameMixin:
     name = GovukTextInputField("Template name", validators=[DataRequired(message="Cannot be empty")])
+
+
+class RenameTemplateForm(StripWhitespaceForm, TemplateNameMixin):
+    pass
 
 
 class BaseTemplateForm(StripWhitespaceForm):
-    name = GovukTextInputField("Template name", validators=[DataRequired(message="Cannot be empty")])
-
     template_content = TextAreaField(
         "Message", validators=[DataRequired(message="Cannot be empty"), NoCommasInPlaceHolders()]
     )
 
+    def __init__(self, *args, **kwargs):
+        if "content" in kwargs:
+            kwargs["template_content"] = kwargs["content"]
+        super().__init__(*args, **kwargs)
 
-class SMSTemplateForm(BaseTemplateForm):
+    @property
+    def new_template_data(self):
+        new_template_data = {"content": self.template_content.data}
+
+        if hasattr(self, "subject"):
+            new_template_data["subject"] = self.subject.data
+
+        if hasattr(self, "name"):
+            new_template_data["name"] = self.name.data
+
+        return new_template_data
+
+
+class SMSTemplateForm(BaseTemplateForm, TemplateNameMixin):
     def validate_template_content(self, field):
         OnlySMSCharacters(template_type="sms")(None, field)
 
@@ -1490,11 +1509,11 @@ class LetterAddressForm(StripWhitespaceForm):
             )
 
 
-class EmailTemplateForm(BaseTemplateForm):
+class EmailTemplateForm(BaseTemplateForm, TemplateNameMixin):
     subject = TextAreaField("Subject", validators=[DataRequired(message="Cannot be empty")])
 
 
-class LetterTemplateForm(StripWhitespaceForm):
+class LetterTemplateForm(BaseTemplateForm):
     subject = TextAreaField("Main heading", validators=[DataRequired(message="Cannot be empty")])
 
     template_content = TextAreaField(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -616,6 +616,10 @@ def abort_403_if_not_admin_user():
 @user_has_permissions("manage_templates")
 def rename_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
+
+    if template.template_type != "letter":
+        abort(404)
+
     form = RenameTemplateForm(obj=template)
     previous_page = url_for("main.view_template", service_id=current_service.id, template_id=template.id)
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -555,6 +555,9 @@ def delete_template_folder(service_id, template_folder_id):
 )
 @user_has_permissions("manage_templates")
 def add_service_template(service_id, template_type, template_folder_id=None):
+    if template_type == "letter":
+        abort(404)
+
     if template_type not in current_service.available_template_types:
         return redirect(
             url_for(
@@ -584,12 +587,6 @@ def add_service_template(service_id, template_type, template_folder_id=None):
                 and any(["character count greater than" in x for x in e.message["content"]])
             ):
                 form.template_content.errors.extend(e.message["content"])
-            elif (
-                e.status_code == 400
-                and "content" in e.message
-                and any(x == QR_CODE_TOO_LONG for x in e.message["content"])
-            ):
-                form.template_content.errors.append("Cannot create a usable QR code - the link you entered is too long")
             else:
                 raise e
         else:

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -656,6 +656,7 @@ def edit_service_template(service_id, template_id):
     form = form_objects[template.template_type](**template._template)
     if form.validate_on_submit():
         subject = form.subject.data if hasattr(form, "subject") else None
+        name = form.name.data if hasattr(form, "name") else None
 
         current_template_data = {
             "id": template.id,
@@ -663,12 +664,14 @@ def edit_service_template(service_id, template_id):
             "template_type": template.template_type,
         }
         new_template_data = {
-            "name": form.name.data,
             "content": form.template_content.data,
         }
 
         if subject:
             new_template_data["subject"] = subject
+
+        if name:
+            new_template_data["name"] = name
 
         new_template = get_template(
             current_template_data | new_template_data,

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -253,6 +253,7 @@ class MainNavigation(Navigation):
             "approve_broadcast_message",
             "reject_broadcast_message",
             "cancel_broadcast_message",
+            "rename_template",
         },
         "uploads": {
             "upload_contact_list",

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -22,10 +22,6 @@
     {% call form_wrapper() %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-five-sixths">
-          {{ form.name(param_extensions={
-            "classes": "govuk-!-width-full",
-            "hint": {"text": "Your recipients will not see this"}
-          }) }}
           {{ textbox(form.subject, width='1-1', highlight_placeholders=True, rows=2) }}
           {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=8) }}
           {{ sticky_page_footer(

--- a/app/templates/views/rename-template.html
+++ b/app/templates/views/rename-template.html
@@ -1,0 +1,27 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% block service_page_title %}
+  Rename template
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({"href": back_link}) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header('Rename template') }}
+
+  {% call form_wrapper() %}
+    {{ form.name(param_extensions={
+      "classes": "govuk-!-width-full",
+      "hint": {"text": "Your recipients will not see this"}
+    }) }}
+    {{ page_footer('Save') }}
+  {% endcall %}
+
+{% endblock %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -29,7 +29,7 @@
     </div>
   {% else %}
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
+      <div class="{% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %} govuk-grid-column-five-sixths {% else %} govuk-grid-column-full {% endif %}">
         {{ folder_path(
           folders=current_service.get_template_path(template._template),
           service=current_service,
@@ -37,6 +37,11 @@
           current_user=current_user
         ) }}
       </div>
+      {% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %}
+        <div class="govuk-grid-column-one-sixth">
+          <a href="{{ url_for('main.rename_template', service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-manage-link">Rename<span class="govuk-visually-hidden"> this template</span></a>
+        </div>
+      {% endif %}
     </div>
   {% endif %}
 

--- a/tests/app/main/views/test_letters.py
+++ b/tests/app/main/views/test_letters.py
@@ -3,9 +3,26 @@ from functools import partial
 import pytest
 from flask import url_for
 
+from tests import sample_uuid
+
 letters_urls = [
-    partial(url_for, "main.add_service_template", template_type="letter"),
+    partial(url_for, "main.edit_service_template", template_id=sample_uuid()),
 ]
+
+
+@pytest.mark.parametrize("method", ("get", "post"))
+def test_add_template_page_doesnt_work_for_letters(
+    client_request,
+    service_one,
+    method,
+):
+    service_one["permissions"] += ["letter"]
+    getattr(client_request, method)(
+        "main.add_service_template",
+        template_type="letter",
+        service_id=service_one["id"],
+        _expected_status=404,
+    )
 
 
 @pytest.mark.parametrize("url", letters_urls)
@@ -16,7 +33,7 @@ def test_letters_access_restricted(
     mocker,
     permissions,
     response_code,
-    mock_get_service_templates,
+    mock_get_service_letter_template,
     url,
     service_one,
 ):
@@ -36,7 +53,7 @@ def test_letters_lets_in_without_permission(
     mock_login,
     mock_has_permissions,
     api_user_active,
-    mock_get_service_templates,
+    mock_get_service_letter_template,
     url,
     service_one,
 ):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2378,6 +2378,29 @@ def test_name_required_to_rename_template(
     assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Cannot be empty"
 
 
+@pytest.mark.parametrize("template_type", ("email", "sms"))
+def test_only_letters_can_be_renamed_through_rename_page(
+    mocker,
+    client_request,
+    fake_uuid,
+    template_type,
+):
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": create_template(template_type=template_type)},
+    )
+
+    client_request.post(
+        ".rename_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _data={
+            "name": "",
+        },
+        _expected_status=404,
+    )
+
+
 @pytest.mark.parametrize(
     "service_id, template_id",
     (

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -251,6 +251,7 @@ EXCLUDED_ENDPOINTS = set(
             "remove_broadcast_area",
             "remove_user_from_organisation",
             "remove_user_from_service",
+            "rename_template",
             "request_to_go_live",
             "resend_email_link",
             "resend_email_verification",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -973,22 +973,6 @@ def mock_create_service_template_content_too_big(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_create_service_template_qr_code_too_big(mocker):
-    def _create(name, type_, content, service, subject=None, parent_folder_id=None):
-        json_mock = Mock(
-            return_value={
-                "message": {"content": ["qr-code-too-long"]},
-                "result": "error",
-            }
-        )
-        resp_mock = Mock(status_code=400, json=json_mock)
-        http_error = HTTPError(response=resp_mock, message={"content": ["qr-code-too-long"]})
-        raise http_error
-
-    return mocker.patch("app.service_api_client.create_service_template", side_effect=_create)
-
-
-@pytest.fixture(scope="function")
 def mock_update_service_template_400_content_too_big(mocker):
     def _update(*, service_id, template_id, name=None, content=None, subject=None):
         json_mock = Mock(

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -306,6 +306,7 @@
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit-postage",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/redact",
+    "/services/<uuid:service_id>/templates/<uuid:template_id>/rename",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/set-template-sender",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/version/<int:version>",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/version/<int:version>.<filetype>",


### PR DESCRIPTION
A lot of the actions for letter templates (editing the content, adding branding, editing the contact block, etc) are on separate pages. This is because having them all on one page would make the page too complicated.

Renaming the template is still on the same page as editing the template. Although this is consistent with how email and text message templates work, this probably makes it harder to find.

So this pull request adds a new page which just lets you rename a template without changing any other aspects of it.

Also for bilingual letters we will soon have 2 edit pages, one for English content and one for Welsh content. It would be quite confusing to either have:
- the edit button on only one of these pages
- the edit button on both (but changing the same field)

***

There’s a fair bit of refactoring/tidying up in this pull request so it’s best reviewed commit-by-commit.

***

– | Before | After
---|---|---
View | <img width="772" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/dd26d084-9438-42df-97f2-5a5409426b44"> | <img width="771" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/92fc1d18-9c20-468c-8d50-76c7ae75cc72">
Edit | <img width="772" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/8da53d3b-d719-4065-abe8-3170b6140b66"> | <img width="774" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/3afd6ee7-b908-4b56-b306-398ee661d5db">
Rename | Does not exist | <img width="771" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/b041f3c0-b66a-4dad-9f47-af4d15712dd2">
