### PR TITLE
Fix a bug where our custom unauthorised_handler lost query params

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from urllib.parse import urlparse, urlunparse
 
 from flask import (
     abort,
@@ -89,4 +90,9 @@ def sign_in_again():
     if request.blueprint == JSON_UPDATES_BLUEPRINT_NAME:
         return abort(HTTPStatus.UNAUTHORIZED)
 
-    return redirect(url_for("main.sign_in", next=request.path))
+    return redirect(url_for("main.sign_in", next=_get_next_url(request)))
+
+
+def _get_next_url(request):
+    next_url = urlparse(request.url)
+    return urlunparse(("", "", next_url.path, next_url.params, next_url.query, ""))

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -338,18 +338,7 @@ def test_when_signing_in_as_invited_user_you_cannot_accept_an_invite_for_another
 
 def test_sign_in_again_handler_passes_next_url_with_params(client_request, fake_uuid):
     client_request.logout()
-    client_request.get(
-        "main.service_verify_reply_to_address",
-        service_id=SERVICE_ONE_ID,
-        notification_id=fake_uuid,
-        is_default=True,
-        _expected_redirect=url_for(
-            ".sign_in",
-            next=url_for(
-                ".service_verify_reply_to_address",
-                service_id=SERVICE_ONE_ID,
-                notification_id=fake_uuid,
-                is_default=True,
-            ),
-        ),
+    url = url_for(
+        "main.service_verify_reply_to_address", service_id=SERVICE_ONE_ID, notification_id=fake_uuid, is_default=True
     )
+    client_request.get_url(url, _expected_redirect=url_for(".sign_in", next=url))

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -334,3 +334,22 @@ def test_when_signing_in_as_invited_user_you_cannot_accept_an_invite_for_another
     assert mock_accept_invite.called is False
     assert mock_send_verify_code.called is False
     assert page.select_one(".banner-dangerous").text.strip() == "You cannot accept an invite for another person."
+
+
+def test_sign_in_again_handler_passes_next_url_with_params(client_request, fake_uuid):
+    client_request.logout()
+    client_request.get(
+        "main.service_verify_reply_to_address",
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+        is_default=True,
+        _expected_redirect=url_for(
+            ".sign_in",
+            next=url_for(
+                ".service_verify_reply_to_address",
+                service_id=SERVICE_ONE_ID,
+                notification_id=fake_uuid,
+                is_default=True,
+            ),
+        ),
+    )


### PR DESCRIPTION
from url we want to redirect to after user signs in.

We were using request.path, which doesn't include the query params. Now we instead get the path and the params using urlparse and urlunparse.

Flask login use similar approach to get next_url, too: https://github.com/maxcountryman/flask-login/blob/main/src/flask_login/utils.py#L66