### PR TITLE
fix copy letter template page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1503,7 +1503,7 @@ class EmailTemplateForm(BaseTemplateForm, TemplateNameMixin):
     subject = TextAreaField("Subject", validators=[DataRequired(message="Cannot be empty")])
 
 
-class LetterTemplateForm(BaseTemplateForm):
+class LetterTemplateForm(BaseTemplateForm, TemplateNameMixin):
     subject = TextAreaField("Main heading", validators=[DataRequired(message="Cannot be empty")])
 
     template_content = TextAreaField(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -552,7 +552,9 @@ def delete_template_folder(service_id, template_folder_id):
 )
 @user_has_permissions("manage_templates")
 def add_service_template(service_id, template_type, template_folder_id=None):
-    if template_type == "letter":
+    # letter templates are created for the user straight from the choose_template page, but this
+    # code path is still accessed if the user has come via the copy an existing template flow
+    if template_type == "letter" and request.endpoint == "main.add_service_template":
         abort(404)
 
     if template_type not in current_service.available_template_types:

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -27,6 +27,10 @@
           {{ sticky_page_footer(
             'Save'
           ) }}
+
+          {# this needs to be passed through if we're showing this from the copy page #}
+          <input type="hidden" name="name" value="{{ form.name.data }}" />
+
         </div>
         <div class="govuk-grid-column-full">
           {% include "partials/templates/guidance-formatting-letters.html" %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -513,6 +513,18 @@ def test_should_show_page_for_one_template(
     mock_get_service_template.assert_called_with(SERVICE_ONE_ID, template_id, None)
 
 
+def test_editing_letter_template_should_have_hidden_name_field(
+    client_request, mock_get_service_letter_template, fake_uuid, service_one
+):
+    service_one["permissions"].append("letter")
+    template_id = fake_uuid
+    page = client_request.get(".edit_service_template", service_id=SERVICE_ONE_ID, template_id=template_id)
+
+    name_input = page.select_one("input[name=name]")
+    assert name_input["value"] == "Two week reminder"
+    assert name_input["type"] == "hidden"
+
+
 def test_broadcast_template_doesnt_highlight_placeholders_but_does_count_characters(
     client_request,
     service_one,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2205,6 +2205,37 @@ def test_post_copy_template(
     ]
 
 
+def test_post_copy_letter_template(
+    mocker,
+    client_request,
+    mock_get_service_letter_template,
+    mock_get_organisations_and_services_for_user,
+    mock_create_service_template,
+    service_one,
+):
+    service_one["permissions"].append("letter")
+
+    client_request.post(
+        "main.copy_template",
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_ONE_ID,
+        template_id=TEMPLATE_ONE_ID,
+        _data={
+            "name": "template (copy)",
+            "subject": "some letter",
+            "template_content": "this is a copy of that other template",
+            "template_type": "letter",
+            "service": SERVICE_ONE_ID,
+        },
+        _expected_status=302,
+    )
+    assert mock_create_service_template.call_args_list == [
+        mocker.call(
+            "template (copy)", "letter", "this is a copy of that other template", SERVICE_ONE_ID, "some letter", None
+        )
+    ]
+
+
 @pytest.mark.parametrize(
     "template_type, expected_page_heading",
     [


### PR DESCRIPTION
we removed the ability to call "add template" for letters in fe7e9a32

however, this inadvertently broke the copy template page, which calls through to add template. change the guard to refer to the endpoint itself to allow copying.

Notably in the commit mentioned above we removed some complexity around validating QR code lengths. This can still be removed since the previous template you're copying will have already passed those checks when edited.

we also need to add the TemplateNameMixin back into the LetterTemplateForm since we need to copy across the name when creating a new copied template. We don't use this form when creating a new template, and when editing an existing template we pre-populate the form with the prev contents of the template, so the name simply gets passed through.

We'll need to be careful about these flows when we get to welsh content to ensure copying still works cleanly.