### PR TITLE
Edit bilingual letter templates

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1531,6 +1531,30 @@ class LetterTemplateForm(BaseTemplateForm, TemplateNameMixin):
     )
 
 
+class WelshLetterTemplateForm(BaseTemplateForm, TemplateNameMixin):
+    subject = TextAreaField("Main heading in Welsh", validators=[DataRequired(message="Cannot be empty")])
+    template_content = TextAreaField(
+        "Body in Welsh", validators=[DataRequired(message="Cannot be empty"), NoCommasInPlaceHolders()]
+    )
+
+    def __init__(self, *args, subject, content, letter_welsh_subject, letter_welsh_content, **kwargs):
+        # Populate subject and template_content form fields using the Welsh template values; we can discard the English
+        # data for this form.
+        super().__init__(*args, subject=letter_welsh_subject, content=letter_welsh_content, **kwargs)
+
+    @property
+    def new_template_data(self):
+        data = super().new_template_data
+
+        if "subject" in data:
+            data["letter_welsh_subject"] = data.pop("subject")
+
+        if "content" in data:
+            data["letter_welsh_content"] = data.pop("content")
+
+        return data
+
+
 class LetterTemplatePostageForm(StripWhitespaceForm):
     postage = GovukRadiosField(
         "Choose the postage for this letter template",

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1253,7 +1253,7 @@ def letter_template_change_language(template_id, service_id):
     if template.template_type != "letter" or not isinstance(template, TemplatedLetterImageTemplate):
         abort(404)
 
-    current_languages = template._template.get("letter_languages")
+    current_languages = template._template["letter_languages"]
     form = LetterTemplateLanguagesForm(data=dict(languages=current_languages))
     if form.validate_on_submit():
         languages = form.languages.data

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -312,6 +312,9 @@ def template_json(
     postage=None,
     folder=None,
     letter_attachment=None,
+    letter_languages="english",
+    letter_welsh_subject=None,
+    letter_welsh_content=None,
 ):
     template = {
         "id": id_,
@@ -330,6 +333,9 @@ def template_json(
         "folder": folder,
         "postage": postage,
         "letter_attachment": letter_attachment,
+        "letter_languages": letter_languages,
+        "letter_welsh_subject": letter_welsh_subject,
+        "letter_welsh_content": letter_welsh_content,
     }
     if content is None:
         template["content"] = "template content"

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -979,7 +979,7 @@ def test_POST_letter_template_change_to_english_redirects_to_confirmation_page(
     mocker,
     fake_uuid,
     active_user_with_permissions,
-    mock_get_service_letter_template,
+    mock_get_service_letter_template_welsh_language,
 ):
     service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
@@ -991,7 +991,9 @@ def test_POST_letter_template_change_to_english_redirects_to_confirmation_page(
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
         _data={"languages": "english"},
-        _follow_redirects=True,
+        _expected_redirect=url_for(
+            "main.letter_template_confirm_remove_welsh", service_id=SERVICE_ONE_ID, template_id=fake_uuid
+        ),
     )
     assert mock_template_change_language.call_args_list == []
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -525,7 +525,7 @@ def test_editing_letter_template_should_have_hidden_name_field(
     assert name_input["type"] == "hidden"
 
 
-def test_editing_welsh_content_for_letter_template(
+def test_GET_edit_service_template_for_welsh_letter(
     client_request, mock_get_service_letter_template_welsh_language, fake_uuid, service_one
 ):
     service_one["permissions"].append("letter")

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -525,6 +525,23 @@ def test_editing_letter_template_should_have_hidden_name_field(
     assert name_input["type"] == "hidden"
 
 
+def test_editing_welsh_content_for_letter_template(
+    client_request, mock_get_service_letter_template_welsh_language, fake_uuid, service_one
+):
+    service_one["permissions"].append("letter")
+    service_one["permissions"].append("extra_letter_formatting")
+    template_id = fake_uuid
+    page = client_request.get(
+        ".edit_service_template", service_id=SERVICE_ONE_ID, template_id=template_id, language="welsh"
+    )
+
+    subject_label = page.select_one("label[for=subject]")
+    assert subject_label.text.strip() == "Main heading in Welsh"
+
+    content_label = page.select_one("label[for=template_content]")
+    assert content_label.text.strip() == "Body in Welsh"
+
+
 def test_broadcast_template_doesnt_highlight_placeholders_but_does_count_characters(
     client_request,
     service_one,
@@ -2822,6 +2839,164 @@ def test_should_redirect_when_saving_a_template_email(
         name=name,
         content=content,
         subject=subject,
+    )
+
+
+def test_should_redirect_when_saving_a_template_letter(
+    client_request,
+    mock_get_service_letter_template,
+    mock_update_service_template,
+    mock_get_user_by_email,
+    fake_uuid,
+    service_one,
+):
+    service_one["permissions"].append("letter")
+    name = "new template name"
+    content = "new letter content"
+    subject = "new letter subject"
+    client_request.post(
+        ".edit_service_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _data={
+            "name": name,
+            "subject": subject,
+            "template_content": content,
+        },
+        _expected_status=302,
+        _expected_redirect=url_for(
+            "main.view_template",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+        ),
+    )
+    mock_update_service_template.assert_called_with(
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        name=name,
+        content=content,
+        subject=subject,
+    )
+
+
+@pytest.mark.parametrize(
+    "letter_formatting_permission, language, mock_fixturename",
+    (
+        pytest.param(
+            False,
+            "welsh",
+            "mock_get_service_letter_template",
+            marks=pytest.mark.xfail(
+                raises=AssertionError,
+                reason="Cannot edit Welsh language content on template with letter_languages=english",
+            ),
+        ),
+        pytest.param(
+            True,
+            "welsh",
+            "mock_get_service_letter_template",
+            marks=pytest.mark.xfail(
+                raises=AssertionError,
+                reason="Cannot edit Welsh language content on template with letter_languages=english",
+            ),
+        ),
+        pytest.param(
+            False,
+            "welsh",
+            "mock_get_service_letter_template_welsh_language",
+            marks=pytest.mark.xfail(
+                raises=AssertionError,
+                reason="Cannot edit Welsh content as service does not have extra_letter_formatting set",
+            ),
+        ),
+        pytest.param(
+            False,
+            "gaelic",
+            "mock_get_service_letter_template_welsh_language",
+            marks=pytest.mark.xfail(
+                raises=AssertionError,
+                reason="The only accepted explicit language for editing letter templates is Welsh",
+            ),
+        ),
+        (
+            True,
+            "welsh",
+            "mock_get_service_letter_template_welsh_language",
+        ),
+    ),
+)
+def test_update_template_for_welsh_language_content(
+    request,
+    client_request,
+    mock_update_service_template,
+    mock_get_user_by_email,
+    fake_uuid,
+    service_one,
+    letter_formatting_permission,
+    language,
+    mock_fixturename,
+):
+    # Load get_service_letter_template fixture
+    request.getfixturevalue(mock_fixturename)
+
+    service_one["permissions"].append("letter")
+    if letter_formatting_permission:
+        service_one["permissions"].append("extra_letter_formatting")
+    name = "new template name"
+    content = "Welsh letter content"
+    subject = "Welsh letter subject"
+    client_request.post(
+        ".edit_service_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        language=language,
+        _data={
+            "name": name,
+            "subject": subject,
+            "template_content": content,
+        },
+        _expected_status=302,
+        _expected_redirect=url_for(
+            "main.view_template",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+        ),
+    )
+    mock_update_service_template.assert_called_with(
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        name=name,
+        letter_welsh_subject=subject,
+        letter_welsh_content=content,
+    )
+
+
+@pytest.mark.parametrize("mock_fixturename", ["mock_get_service_email_template", "mock_get_service_template"])
+def test_cannot_edit_welsh_content_for_email_or_sms_templates(
+    request,
+    client_request,
+    mock_fixturename,
+    mock_update_service_template,
+    mock_get_user_by_email,
+    fake_uuid,
+):
+    # Load fixture to mock get email/sms template
+    request.getfixturevalue(mock_fixturename)
+
+    name = "new name"
+    content = "new content"
+    subject = "new subject"
+    client_request.post(
+        ".edit_service_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        language="welsh",
+        _data={
+            "name": name,
+            "template_content": content,
+            "subject": subject,
+        },
+        _expected_status=404,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from notifications_python_client.errors import HTTPError
 from notifications_utils.url_safe_token import generate_token
 
 from app import create_app, webauthn_server
+from app.constants import LetterLanguageOptions
 
 from . import (
     NotifyBeautifulSoup,
@@ -875,6 +876,26 @@ def mock_get_service_letter_template(mocker):
 
 
 @pytest.fixture(scope="function")
+def mock_get_service_letter_template_welsh_language(mocker):
+    def _get(service_id, template_id, version=None, postage="second"):
+        template = template_json(
+            service_id=service_id,
+            id_=template_id,
+            name="Two week reminder",
+            type_="letter",
+            content="Template <em>content</em> with & entity",
+            subject="Subject",
+            postage=postage,
+            letter_languages=LetterLanguageOptions.welsh_then_english.value,
+            letter_welsh_subject="Pennawd y llythyr",
+            letter_welsh_content="Corff y llythyr",
+        )
+        return {"data": template}
+
+    return mocker.patch("app.service_api_client.get_service_template", side_effect=_get)
+
+
+@pytest.fixture(scope="function")
 def mock_get_service_letter_template_with_attachment(mocker):
     def _get(service_id, template_id, version=None, postage="second"):
         template = template_json(
@@ -943,8 +964,25 @@ def mock_create_service_template(mocker, fake_uuid):
 
 @pytest.fixture(scope="function")
 def mock_update_service_template(mocker):
-    def _update(*, service_id, template_id, name=None, content=None, subject=None):
-        template = template_json(service_id=service_id, id_=template_id, name=name, content=content, subject=subject)
+    def _update(
+        *,
+        service_id,
+        template_id,
+        name=None,
+        content=None,
+        subject=None,
+        letter_welsh_subject=None,
+        letter_welsh_content=None,
+    ):
+        template = template_json(
+            service_id=service_id,
+            id_=template_id,
+            name=name,
+            content=content,
+            subject=subject,
+            letter_welsh_subject=None,
+            letter_welsh_content=None,
+        )
         return {"data": template}
 
     return mocker.patch("app.service_api_client.update_service_template", side_effect=_update)

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -310,6 +310,7 @@
     "/services/<uuid:service_id>/templates/<uuid:template_id>/delete",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/edit-postage",
+    "/services/<uuid:service_id>/templates/<uuid:template_id>/edit/<language>",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/redact",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/rename",
     "/services/<uuid:service_id>/templates/<uuid:template_id>/set-template-sender",


### PR DESCRIPTION
Add a new endpoint allowing letter templates that are set with
`letter_languages=welsh_then_english` to edit the Welsh subject and
content (body).

This page is not hooked up anywhere yet as Welsh pages of a letter aren't yet rendered on the 'view template' page, so we'll need to follow up with that later. However you can view the page by URL hacking, and it updates the letter in the DB appropriately.

![2023-11-10 14 14 55](https://github.com/alphagov/notifications-admin/assets/2920760/8b393a6a-e805-4b26-9cd2-4116f70dc41e)

