### PR TITLE
Add archive_service_confirmation_message.html

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -11,6 +11,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket, NotifyTicketType
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
@@ -394,9 +395,16 @@ def archive_service(service_id):
         return redirect(url_for(".choose_account"))
     else:
         flash(
-            f"Are you sure you want to delete ‘{current_service.name}’? There’s no way to undo this.",
+            Markup(
+                render_template(
+                    "partials/flash_messages/archive_service_confirmation_message.html",
+                    service_name=current_service.name,
+                    platform_admin=current_user.platform_admin,
+                )
+            ),
             "delete",
         )
+
         return service_settings(service_id)
 
 

--- a/app/templates/partials/flash_messages/archive_service_confirmation_message.html
+++ b/app/templates/partials/flash_messages/archive_service_confirmation_message.html
@@ -1,15 +1,14 @@
 {% if platform_admin %}
-      <h3 class="govuk-body govuk-!-font-weight-bold">Before you delete ‘{{service_name}}’: </h3>
-           <ol class="govuk-list govuk-list--number">
-             <li>Confirm the exact name of the service the user wants to delete.</li>
-             <li>Check the user has the ‘Manage settings, team and usage’ permission for this service.</li>
-             <li>Confirm the request with another team member who has the ‘Manage settings, team and usage’ permission.</li> 
-             <li>Check if we need to raise an invoice.</li>           
-           </ol>
-           
-       <p class="govuk-body">If the service can receive text messages, tell the user that their phone number will stop working.</p>
-
       <h2 class="banner-title">Are you sure you want to delete ‘{{service_name}}’?</h2>
+      <br>
+      <p class="govuk-body">Before you delete ‘{{service_name}}’: </p>
+           <ul class="govuk-list govuk-list--bullet">
+             <li>confirm the exact name of the service the user wants to delete</li>
+             <li>check the user has the ‘Manage settings, team and usage’ permission for this service</li>
+             <li>confirm the request with another team member who has the ‘Manage settings, team and usage’ permission</li>
+             <li>check if we need to raise an invoice</li>
+           </ul>
+       <p class="govuk-body">If the service can receive text messages, tell the user that the phone number for this service will stop working.</p>
 {% else %}
       <h2 class="govuk-body govuk-!-font-weight-bold">
           Are you sure you want to delete ‘{{current_service.name}}’? There’s no way to undo this.

--- a/app/templates/partials/flash_messages/archive_service_confirmation_message.html
+++ b/app/templates/partials/flash_messages/archive_service_confirmation_message.html
@@ -1,7 +1,7 @@
 {% if platform_admin %}
       <h3 class="govuk-body govuk-!-font-weight-bold">Before you delete ‘{{service_name}}’, confirm the user: </h3>
            <ul class="govuk-list govuk-list--bullet">
-             <li>has given the exact name of the service they want to delete</li>
+             <li>the exact name of the service the user wants to delete</li>
              <li>is aware they will no longer be able to use the inbound number to receive replies if there is one</li>
            </ul>
 

--- a/app/templates/partials/flash_messages/archive_service_confirmation_message.html
+++ b/app/templates/partials/flash_messages/archive_service_confirmation_message.html
@@ -2,7 +2,7 @@
       <h3 class="govuk-body govuk-!-font-weight-bold">Before you delete ‘{{service_name}}’, confirm the user: </h3>
            <ul class="govuk-list govuk-list--bullet">
              <li>the exact name of the service the user wants to delete</li>
-             <li>is aware they will no longer be able to use the inbound number to receive replies if there is one</li>
+             <li>the user understands they can no longer receive text messages (if they use this feature)</li>
            </ul>
 
       <h3 class="govuk-body govuk-!-font-weight-bold">You will need to:</h3>

--- a/app/templates/partials/flash_messages/archive_service_confirmation_message.html
+++ b/app/templates/partials/flash_messages/archive_service_confirmation_message.html
@@ -1,0 +1,23 @@
+{% if platform_admin %}
+      <h3 class="govuk-body govuk-!-font-weight-bold">Before you delete ‘{{service_name}}’, confirm the user: </h3>
+           <ul class="govuk-list govuk-list--bullet">
+             <li>has given the exact name of the service they want to delete</li>
+             <li>is aware they will no longer be able to use the inbound number to receive replies if there is one</li>
+           </ul>
+
+      <h3 class="govuk-body govuk-!-font-weight-bold">You will need to:</h3>
+           <ul class="govuk-list govuk-list--bullet">
+              <li>check the user is a member of the service</li>
+              <li>check the user has the ‘Manage settings, team and usage’ permissions’</li>
+              <li>contact another team member if there is one with the ‘Manage setting,
+                  team and usage’ permissions for a second approval </li>
+              <li>check the service has not sent any messages over their allowance that we may need an
+                  to raise an invoice for </li>
+           </ul>
+
+      <h2 class="banner-title">Are you sure you want to delete ‘{{service_name}}’?</h2>
+{% else %}
+      <h2 class="govuk-body govuk-!-font-weight-bold">
+          Are you sure you want to delete ‘{{current_service.name}}’? There’s no way to undo this.
+      </h2>
+{% endif %}

--- a/app/templates/partials/flash_messages/archive_service_confirmation_message.html
+++ b/app/templates/partials/flash_messages/archive_service_confirmation_message.html
@@ -1,16 +1,13 @@
 {% if platform_admin %}
-      <h3 class="govuk-body govuk-!-font-weight-bold">Before you delete ‘{{service_name}}’, confirm the user: </h3>
-           <ul class="govuk-list govuk-list--bullet">
-             <li>has given the exact name of the service they want to delete</li>
-             <li>understands they can no longer receive text messages (if they use this feature)</li>
-           </ul>
-
-      <h3 class="govuk-body govuk-!-font-weight-bold">You also need to:</h3>
-           <ul class="govuk-list govuk-list--bullet">
-              <li>check the user has the ‘Manage settings, team and usage’ permission for this service</li>
-              <li>ask a team member with the ‘Manage settings, team and usage’ permission to confirm the request</li>
-              <li>check if the service has exceeded its annual allowance, in case we need to raise an invoice</li>
-           </ul>
+      <h3 class="govuk-body govuk-!-font-weight-bold">Before you delete ‘{{service_name}}’: </h3>
+           <ol class="govuk-list govuk-list--number">
+             <li>Confirm the exact name of the service the user wants to delete.</li>
+             <li>Check the user has the ‘Manage settings, team and usage’ permission for this service.</li>
+             <li>Confirm the request with another team member who has the ‘Manage settings, team and usage’ permission.</li> 
+             <li>Check if we need to raise an invoice.</li>           
+           </ol>
+           
+       <p class="govuk-body">If the service can receive text messages, tell the user that their phone number will stop working.</p>
 
       <h2 class="banner-title">Are you sure you want to delete ‘{{service_name}}’?</h2>
 {% else %}

--- a/app/templates/partials/flash_messages/archive_service_confirmation_message.html
+++ b/app/templates/partials/flash_messages/archive_service_confirmation_message.html
@@ -1,8 +1,8 @@
 {% if platform_admin %}
       <h3 class="govuk-body govuk-!-font-weight-bold">Before you delete ‘{{service_name}}’, confirm the user: </h3>
            <ul class="govuk-list govuk-list--bullet">
-             <li>the exact name of the service the user wants to delete</li>
-             <li>the user understands they can no longer receive text messages (if they use this feature)</li>
+             <li>has given the exact name of the service they want to delete</li>
+             <li>understands they can no longer receive text messages (if they use this feature)</li>
            </ul>
 
       <h3 class="govuk-body govuk-!-font-weight-bold">You also need to:</h3>

--- a/app/templates/partials/flash_messages/archive_service_confirmation_message.html
+++ b/app/templates/partials/flash_messages/archive_service_confirmation_message.html
@@ -5,14 +5,11 @@
              <li>the user understands they can no longer receive text messages (if they use this feature)</li>
            </ul>
 
-      <h3 class="govuk-body govuk-!-font-weight-bold">You will need to:</h3>
+      <h3 class="govuk-body govuk-!-font-weight-bold">You also need to:</h3>
            <ul class="govuk-list govuk-list--bullet">
-              <li>check the user is a member of the service</li>
-              <li>check the user has the ‘Manage settings, team and usage’ permissions’</li>
-              <li>contact another team member if there is one with the ‘Manage setting,
-                  team and usage’ permissions for a second approval </li>
-              <li>check the service has not sent any messages over their allowance that we may need an
-                  to raise an invoice for </li>
+              <li>check the user has the ‘Manage settings, team and usage’ permission for this service</li>
+              <li>ask a team member with the ‘Manage settings, team and usage’ permission to confirm the request</li>
+              <li>check if the service has exceeded its annual allowance, in case we need to raise an invoice</li>
            </ul>
 
       <h2 class="banner-title">Are you sure you want to delete ‘{{service_name}}’?</h2>

--- a/app/templates/partials/flash_messages/archive_service_confirmation_message.html
+++ b/app/templates/partials/flash_messages/archive_service_confirmation_message.html
@@ -1,7 +1,7 @@
 {% if platform_admin %}
       <h2 class="banner-title">Are you sure you want to delete ‘{{service_name}}’?</h2>
       <br>
-      <p class="govuk-body">Before you delete ‘{{service_name}}’: </p>
+      <p class="govuk-body">Before you delete this service: </p>
            <ul class="govuk-list govuk-list--bullet">
              <li>confirm the exact name of the service the user wants to delete</li>
              <li>check the user has the ‘Manage settings, team and usage’ permission for this service</li>

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4795,14 +4795,37 @@ def test_archive_service_after_confirm(
     assert call(f"user-{sample_uuid()}") in redis_delete_mock.call_args_list
 
 
+platform_admin_archive_service_confirmation_message = """
+Before you delete ‘service one’, confirm the user: has given the exact name of the service they want to delete is aware
+they will no longer be able to use the inbound number to receive replies if there is one You will need to: check the
+user is a member of the service check the user has the ‘Manage settings, team and usage’ permissions’ contact another
+team member if there is one with the ‘Manage setting, team and usage’ permissions for a second approval check the
+service has not sent any messages over their allowance that we may need an to raise an invoice for Are you sure
+you want to delete ‘service one’? Yes, delete
+"""
+user_archive_service_confirmation_message = (
+    "Are you sure you want to delete ‘service one’? There’s no way to undo this. Yes, delete"
+)
+
+
 @pytest.mark.parametrize(
-    "user, is_trial_service",
+    "user, is_trial_service, confirmation_message",
     (
-        [create_platform_admin_user(), True],
-        [create_platform_admin_user(), False],
-        [create_active_user_with_permissions(), True],
-        pytest.param(create_active_user_with_permissions(), False, marks=pytest.mark.xfail),
-        pytest.param(create_active_user_no_settings_permission(), True, marks=pytest.mark.xfail),
+        [create_platform_admin_user(), True, platform_admin_archive_service_confirmation_message],
+        [create_platform_admin_user(), False, platform_admin_archive_service_confirmation_message],
+        [create_active_user_with_permissions(), True, user_archive_service_confirmation_message],
+        pytest.param(
+            create_active_user_with_permissions(),
+            False,
+            user_archive_service_confirmation_message,
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            create_active_user_no_settings_permission(),
+            True,
+            user_archive_service_confirmation_message,
+            marks=pytest.mark.xfail,
+        ),
     ),
 )
 def test_archive_service_prompts_user(
@@ -4815,6 +4838,7 @@ def test_archive_service_prompts_user(
     mock_get_service_settings_page_common,
     user,
     is_trial_service,
+    confirmation_message,
 ):
     mock_api = mocker.patch("app.service_api_client.post")
     service_one["restricted"] = is_trial_service
@@ -4832,9 +4856,7 @@ def test_archive_service_prompts_user(
         "main.archive_service",
         service_id=SERVICE_ONE_ID,
     )
-    assert normalize_spaces(delete_page.select_one(".banner-dangerous").text) == (
-        "Are you sure you want to delete ‘service one’? There’s no way to undo this. Yes, delete"
-    )
+    assert normalize_spaces(delete_page.select_one(".banner-dangerous").text) == normalize_spaces(confirmation_message)
     assert mock_api.called is False
 
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4795,35 +4795,20 @@ def test_archive_service_after_confirm(
     assert call(f"user-{sample_uuid()}") in redis_delete_mock.call_args_list
 
 
-platform_admin_archive_service_confirmation_message = """
-Before you delete ‘service one’, confirm the user: has given the exact name of the service they want to delete is aware
-they will no longer be able to use the inbound number to receive replies if there is one You will need to: check the
-user is a member of the service check the user has the ‘Manage settings, team and usage’ permissions’ contact another
-team member if there is one with the ‘Manage setting, team and usage’ permissions for a second approval check the
-service has not sent any messages over their allowance that we may need an to raise an invoice for Are you sure
-you want to delete ‘service one’? Yes, delete
-"""
-user_archive_service_confirmation_message = (
-    "Are you sure you want to delete ‘service one’? There’s no way to undo this. Yes, delete"
-)
-
-
 @pytest.mark.parametrize(
-    "user, is_trial_service, confirmation_message",
+    "user, is_trial_service",
     (
-        [create_platform_admin_user(), True, platform_admin_archive_service_confirmation_message],
-        [create_platform_admin_user(), False, platform_admin_archive_service_confirmation_message],
-        [create_active_user_with_permissions(), True, user_archive_service_confirmation_message],
+        [create_platform_admin_user(), True],
+        [create_platform_admin_user(), False],
+        [create_active_user_with_permissions(), True],
         pytest.param(
             create_active_user_with_permissions(),
             False,
-            user_archive_service_confirmation_message,
             marks=pytest.mark.xfail,
         ),
         pytest.param(
             create_active_user_no_settings_permission(),
             True,
-            user_archive_service_confirmation_message,
             marks=pytest.mark.xfail,
         ),
     ),
@@ -4838,7 +4823,6 @@ def test_archive_service_prompts_user(
     mock_get_service_settings_page_common,
     user,
     is_trial_service,
-    confirmation_message,
 ):
     mock_api = mocker.patch("app.service_api_client.post")
     service_one["restricted"] = is_trial_service
@@ -4856,7 +4840,7 @@ def test_archive_service_prompts_user(
         "main.archive_service",
         service_id=SERVICE_ONE_ID,
     )
-    assert normalize_spaces(delete_page.select_one(".banner-dangerous").text) == normalize_spaces(confirmation_message)
+    assert "Are you sure you want to delete" in normalize_spaces(delete_page.select_one(".banner-dangerous").text)
     assert mock_api.called is False
 
 


### PR DESCRIPTION
 This PR updates `archive_service` to add guidance to the confirmation message shown to  platform_admins while archiving a service. The details are described [here](https://trello.com/c/KHKQOYfT/462-add-guidance-to-the-confirmation-message-shown-when-you-archive-a-service).

platform_admin confirmation message:
![Screenshot 2023-11-14 at 13 08 46](https://github.com/alphagov/notifications-admin/assets/32799090/df578217-3be4-42b6-8df4-026d0633ea9d)

user confirmation message
![Screenshot 2023-11-14 at 13 07 58](https://github.com/alphagov/notifications-admin/assets/32799090/b49c3df6-4560-4cb4-b688-2d5c1431d136)
