### PR TITLE
Build assets before local dev server start

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ then
 
 elif [ "$1" == "web-local" ]
 then
+  npm run build
   flask run --host 0.0.0.0 --port $PORT
 
 else


### PR DESCRIPTION
If you're running notify admin via notifications-local (docker-compose) on a clean checkout, you won't have any static assets built yet. We should make sure those are built before trying to start the server.