### PR TITLE
cf manifest: remove `notify-splunk` service binding

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -33,7 +33,6 @@ applications:
 
     services:
       - logit-ssl-syslog-drain
-      - notify-splunk
 
     env:
       NOTIFY_APP_NAME: admin


### PR DESCRIPTION
https://trello.com/c/IXguDClO/467-stop-trying-to-send-logs-from-our-apps-into-splunk

We no longer need to log to splunk.