### PR TITLE
Clarify the maximum batch size for messages

### DIFF
--- a/app/templates/views/guidance/using-notify/bulk-sending.html
+++ b/app/templates/views/guidance/using-notify/bulk-sending.html
@@ -13,7 +13,7 @@
 
   <h1 class="heading-large">Bulk sending</h1>
 
-  <p class="govuk-body">You can send a batch of up to {{ max_spreadsheet_rows|format_thousands }} personalised messages at once.</p>
+  <p class="govuk-body">You can send a batch of up to {{ max_spreadsheet_rows|format_thousands }} messages at once.</p>
 
   <p class="govuk-body">There’s a maximum daily limit of {{ rate_limits|formatted_list(before_each="", after_each="") }}. If you need to discuss these limits, <a class="govuk-link govuk-link--no-visited-state" href={{ url_for("main.support") }}>contact us</a>.</p>
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -420,9 +420,7 @@ def test_bulk_sending_limits(client_request):
     page = client_request.get("main.guidance_bulk_sending")
     paragraphs = page.select("main p")
 
-    assert normalize_spaces(paragraphs[0].text) == (
-        "You can send a batch of up to 100,000" " personalised messages at once."
-    )
+    assert normalize_spaces(paragraphs[0].text) == "You can send a batch of up to 100,000 messages at once."
     assert normalize_spaces(paragraphs[1].text) == (
         "There’s a maximum daily limit of 250,000 emails, 250,000 text messages and 20,000 letters. "
         "If you need to discuss these limits, contact us."


### PR DESCRIPTION
We had an enquiry from a user asking if there was a different limit for the number of messages you could send in bulk if the content was not personalised.

Even though this is only 1 enquiry, looking at our content I agree that it could be misleading.

This PR removes the word ‘personalised’ to avoid any possible confusion.