### PR TITLE
Fix link between error summary and file upload

### DIFF
--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -27,8 +27,11 @@
     this.addFakeButton = function () {
 
       var buttonText = this.$field.data('buttonText');
+      var fieldId = this.$field.attr('id'); // copy the id across so error links work
+      var oldFieldId = `hidden-${fieldId}`;
+      var oldLabel = this.$field.parent().find(`label[for=${fieldId}]`);
       var buttonHTMLStr = `
-        <button type="button" class="file-upload-button govuk-button govuk-!-margin-right-1" id="file-upload-button">
+        <button type="button" class="file-upload-button govuk-button govuk-!-margin-right-1" id="${fieldId}">
           ${buttonText}
         </button>`; // Styled as a submit button to raise prominence. The type shouldn't change.
 
@@ -37,12 +40,16 @@
       // errors need to be added to that.
       if (this.$fieldErrors.length > 0) {
         buttonHTMLStr = `
-          <label class="file-upload-button-label error-message" for="file-upload-button">
+          <label class="file-upload-button-label error-message" for="${fieldId}">
             <span class="govuk-visually-hidden">${buttonText} </span>
             ${this.$fieldErrors.eq(0).text()}
           </label>
           ${buttonHTMLStr}`;
       }
+
+      // Change id of field now we're using it for the button
+      this.$field.attr('id', oldFieldId);
+      this.$field.parent().find(`label[for=${fieldId}]`).attr('for', oldFieldId);
 
       $(buttonHTMLStr)
       .on('click', e => this.$field.click())

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -62,14 +62,41 @@ describe('File upload', () => {
 
   });
 
-  test("An 'upload' button should be added", () => {
+  describe("An 'upload' button should visually replace the file field", () => {
 
-    // start module
-    window.GOVUK.notifyModules.start();
+    var uploadButton;
+    var uploadButtonLabel;
+    var originalControlId;
 
-    var uploadButton = form.querySelector('button');
+    beforeEach(() => {
 
-    expect(uploadButton).not.toBeNull();
+      originalControlId = uploadControl.id;
+
+      // start module
+      window.GOVUK.notifyModules.start();
+
+      uploadButton = form.querySelector('button');
+
+    });
+
+    test("Its text should be set by the module config", () => {
+
+      expect(uploadButton).not.toBeNull();
+      expect(uploadButton.textContent.trim()).toEqual(uploadControl.dataset.buttonText);
+
+    });
+
+    // We generate links in the error summary to the original field, by id, so our new elements need to match this
+    test("The file field's id should be copied to the it and the original rewritten", () => {
+
+      var rewrittenId = `hidden-${originalControlId}`;
+
+      expect(uploadButton.id).toEqual(originalControlId);
+
+      expect(uploadControl.id).not.toEqual(originalControlId);
+      expect(uploadLabel.getAttribute('for')).toEqual(uploadControl.id);
+
+    });
 
     // Note: the existing form controls are also hidden but this is through CSS so out of scope
 


### PR DESCRIPTION
https://trello.com/c/fCjM227k/568-links-to-form-fields-in-the-branding-image-upload-error-summary-dont-work

When we generate the links in the error summary, we set them to the id of the field with that error so clicking them jumps you to it.

Replacing the upload field with a button broke this link because the field linked to was now hidden. This copies the field id to the button so any error links will still work.