### PR TITLE
Explain how text message ‘fragments’ affect pricing and the free allowance

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -25,7 +25,7 @@ Text message pricing
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} pence (plus VAT) for each text message you send.</p>
   <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">Long text messages</a> cost more, and will use more of your allowance.</p>
 
-  <p class="govuk-body">You may also pay more per message if you:</p>
+  <p class="govuk-body">You may also use more of your allowance, or pay more per message, if you:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>use certain <a class="govuk-link govuk-link--no-visited-state" href="#symbols">signs and symbols</a></li>
     <li>use <a class="govuk-link govuk-link--no-visited-state" href="#accents">accents and accented letters</a></li>

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -23,7 +23,7 @@ Text message pricing
 
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} pence (plus VAT) for each text message you send.</p>
-  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">Long text messages</a> cost more, and will use more of your allowance.</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">Long text messages</a> cost more, and will use more of your free allowance.</p>
 
   <p class="govuk-body">You may also use more of your allowance, or pay more per message, if you:</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -23,10 +23,10 @@ Text message pricing
 
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} pence (plus VAT) for each text message you send.</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">Long text messages</a> cost more, and will use more of your allowance.</p>
 
-  <p class="govuk-body">You may use more free messages, or pay more for each message, if you:</p>
+  <p class="govuk-body">You may also pay more per message if you:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">text messages longer than 160 characters</a></li>
     <li>use certain <a class="govuk-link govuk-link--no-visited-state" href="#symbols">signs and symbols</a></li>
     <li>use <a class="govuk-link govuk-link--no-visited-state" href="#accents">accents and accented letters</a></li>
     <li>send text messages to <a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">international numbers</a></li>
@@ -41,9 +41,12 @@ Text message pricing
         <li>10,000 free text messages for state-funded schools and GP practices</li>
     </ul>
   <p class="govuk-body">Each unique service you add has a separate allowance.</p>
+  <p class="govuk-body">Sending long text messages will use more of your allowance.</p>
 
   <h2 class="heading-medium" id="long-text-messages">Long text messages</h2>
   <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it counts as more than one message.</p>
+  <p class="govuk-body">To calculate the cost of a long message we split it into smaller messages, called fragments.</p>
+  <p class="govuk-body">You can see the total number of fragments you have sent on the {{ service_link(current_service, 'main.usage', 'Usage') }} page.</p>
 
   <div class="bottom-gutter-3-2">
     {% call mapping_table(


### PR DESCRIPTION
Users need to understand the difference between the number of text messages they send and the number of actual text message ‘fragments’ they use.

In the past we’ve always avoided using the term ‘fragments’ as its meaning may not be clear.

This pull request makes a few small changes to the `Text message pricing` page to introduce and explain fragments.

Updating our pricing information probably won’t solve the problem though. We also need to think about updating the UI content on the:
* Usage page
* Edit template page
* Template preview page

We might also want to think about whether our offline touchpoints (invoices, emails etc) are consistent with what we say on the Notify website.

Once we’ve discussed and agreed how we want to change content across Notify (and beyond), we can collate all those changes in this PR.