### PR TITLE
Change validation error for gov logo text

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2350,7 +2350,7 @@ class BrandingRequestForm(StripWhitespaceForm):
 class GovernmentIdentityLogoForm(StripWhitespaceForm):
     logo_text = GovukTextInputField(
         "Enter the text that will appear in your logo",
-        validators=[DataRequired("Enter the text that will appear in your logo")],
+        validators=[NotifyDataRequired(thing="the text that will appear in your logo")],
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2350,7 +2350,7 @@ class BrandingRequestForm(StripWhitespaceForm):
 class GovernmentIdentityLogoForm(StripWhitespaceForm):
     logo_text = GovukTextInputField(
         "Enter the text that will appear in your logo",
-        validators=[DataRequired("Cannot be empty")],
+        validators=[DataRequired("Enter the text that will appear in your logo")],
     )
 
 


### PR DESCRIPTION
https://trello.com/c/QzsiMA8c/569-fix-error-message-for-gov-identity-name

A recent accessibility audit raised an issue with the error 'Cannot be empty' being too general.

This updates it to be in line with new content created as part of the validation audit.

<img width="745" alt="image" src="https://github.com/alphagov/notifications-admin/assets/87140/1cd48929-1bb6-4a08-990e-1f1f7b9fbf9e">
