### PR TITLE
Launch email sender name feature

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -126,10 +126,8 @@ def service_name_change(service_id):
     )
 
 
-# TODO: change permissions to manage_service
-# @user_has_permissions("manage_service")
 @main.route("/services/<uuid:service_id>/service-settings/email-sender", methods=["GET", "POST"])
-@user_is_platform_admin
+@user_has_permissions("manage_service")
 def service_email_sender_change(service_id):
     form = ServiceEmailSenderForm(
         use_custom_email_sender_name=current_service.custom_email_sender_name is not None,

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -603,6 +603,10 @@ class Service(JSONModel):
 
         return SIGN_IN_METHOD_TEXT
 
+    @property
+    def email_sender_name(self) -> str:
+        return self.custom_email_sender_name or self.name
+
 
 class Services(SerialisedModelCollection):
     model = Service

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -91,7 +91,7 @@ def get_template(
     if "email" == template["template_type"]:
         return EmailPreviewTemplate(
             template,
-            from_name=service.name,
+            from_name=service.email_sender_name,
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
             reply_to=email_reply_to,

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -6513,10 +6513,6 @@ def test_should_set_default_org_email_branding_succeeds_if_all_conditions_are_me
 
 
 class TestServiceEmailSenderChange:
-    # TODO: when we delete this test, make sure to update the existing tests below to remove the platform_admin_user too
-    def test_service_email_sender_change_page_is_platform_admin_only(self, client_request):
-        client_request.get("main.service_email_sender_change", service_id=SERVICE_ONE_ID, _expected_status=403)
-
     @pytest.mark.parametrize(
         "custom_email_sender_name, expected_value, expected_conditional_content",
         [
@@ -6535,7 +6531,6 @@ class TestServiceEmailSenderChange:
     def test_service_email_sender_change_page_shows_your_current_email_sender_name(
         self,
         client_request,
-        platform_admin_user,
         service_one,
         custom_email_sender_name,
         expected_value,
@@ -6543,7 +6538,6 @@ class TestServiceEmailSenderChange:
     ):
         service_one["custom_email_sender_name"] = custom_email_sender_name
         service_one["email_sender_local_part"] = "local.part"
-        client_request.login(platform_admin_user)
         page = client_request.get("main.service_email_sender_change", service_id=SERVICE_ONE_ID, _expected_status=200)
         assert page.select_one("h1").text == "Sender name and email address"
         assert [normalize_spaces(radio.text) for radio in page.select(".govuk-radios__item")] == [
@@ -6577,9 +6571,8 @@ class TestServiceEmailSenderChange:
         ],
     )
     def test_service_email_sender_change_fails_if_new_name_fails_validation(
-        self, client_request, mock_update_service, custom_email_sender_name, error_message, platform_admin_user
+        self, client_request, mock_update_service, custom_email_sender_name, error_message
     ):
-        client_request.login(platform_admin_user)
         page = client_request.post(
             "main.service_email_sender_change",
             service_id=SERVICE_ONE_ID,
@@ -6602,10 +6595,7 @@ class TestServiceEmailSenderChange:
             ),
         ],
     )
-    def test_service_preview_email_sender_name(
-        self, client_request, platform_admin_user, mock_update_service, custom_email_sender_name, expected_preview
-    ):
-        client_request.login(platform_admin_user)
+    def test_service_preview_email_sender_name(self, client_request, custom_email_sender_name, expected_preview):
         response = client_request.post_response(
             "main.service_email_sender_preview",
             service_id=SERVICE_ONE_ID,
@@ -6630,9 +6620,7 @@ class TestServiceEmailSenderChange:
         use_custom_email_sender_name,
         custom_email_sender_name,
         expected_custom_email_sender_name,
-        platform_admin_user,
     ):
-        client_request.login(platform_admin_user)
         client_request.post(
             "main.service_email_sender_change",
             service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -472,6 +472,40 @@ def test_should_add_data_attributes_for_services_that_only_allow_one_type_of_not
         assert page.select_one("#add_new_template_form").attrs.get("data-service") is None
 
 
+@pytest.mark.parametrize(
+    "custom_email_sender_name, expected_email_from",
+    (
+        (None, "service one"),
+        ("custom", "custom"),
+    ),
+)
+def test_should_show_page_for_email_template(
+    client_request,
+    mock_get_service_email_template,
+    service_one,
+    fake_uuid,
+    custom_email_sender_name,
+    expected_email_from,
+):
+    service_one["custom_email_sender_name"] = custom_email_sender_name
+    page = client_request.get(
+        ".view_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+
+    assert [
+        (normalize_spaces(row.select_one("th").text), normalize_spaces(row.select_one("td").text))
+        for row in page.select("table.email-message-meta tr")
+    ] == [
+        ("From", expected_email_from),
+        ("To", "email address"),
+        ("Subject", "Your ((thing)) is due soon"),
+    ]
+    assert normalize_spaces(page.select_one(".email-message-body").text) == "Your vehicle tax expires on ((date))"
+
+
 def test_should_show_page_for_one_template(
     client_request,
     mock_get_service_template,


### PR DESCRIPTION
This pull request removes the platform admin flag and makes it so that anyone can change their email sender name.

***

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/3956
- [x] https://github.com/alphagov/notifications-api/pull/3957