### PR TITLE
Fix images in IE11 & mobile viewports

### DIFF
--- a/app/assets/stylesheets/components/radios-with-images.scss
+++ b/app/assets/stylesheets/components/radios-with-images.scss
@@ -1,6 +1,13 @@
 .notify-radios-with-images {
   display: flex;
+  flex-direction: column;
   margin-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    flex-direction: row;
+    margin-bottom: 0;
+  }
 }
 
 .notify-radios-with-images__item {
@@ -8,6 +15,11 @@
   @include govuk-responsive-margin(4, "right");
 
   padding-left: 0;
+  margin-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: 0
+  }
 
   &:last-of-type {
     margin-right: 0;
@@ -16,7 +28,7 @@
 
 .notify-radios-with-images__image {
   display: block;
-  max-width: 100%;
+  width: 100%;
   height: auto;
   box-sizing: border-box;
   margin-bottom: govuk-spacing(4);

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2389,7 +2389,7 @@ class EmailBrandingChooseBanner(OrderableFieldsForm):
             "image": {
                 "url": asset_fingerprinter.get_url("images/branding/org_banner.png"),
                 "alt_text": "An example of an email with a logo on a blue banner.",
-                "dimensions": {"width": 404, "height": 454},
+                "dimensions": {"width": 606, "height": 404},
             },
         },
         "org": {
@@ -2397,7 +2397,7 @@ class EmailBrandingChooseBanner(OrderableFieldsForm):
             "image": {
                 "url": asset_fingerprinter.get_url("images/branding/org.png"),
                 "alt_text": "An example of an email with a logo on a clear background.",
-                "dimensions": {"width": 404, "height": 454},
+                "dimensions": {"width": 606, "height": 404},
             },
         },
     }


### PR DESCRIPTION
Spotted a few visual issues with the radios-with-images component when doing other work. This adds some fixes for the IE11 issue and a proposed redsign for smaller screens.

## Images stretching to their full size in IE11

All screenshots are from IE11 but have also been tested in our other supported browsers.

### Current version

<img width="1291" alt="choose_logo_type_depart_or_custom_ie11_current" src="https://github.com/alphagov/notifications-admin/assets/87140/1eee5065-b88f-4d83-b723-85c6a33991c2">

<img width="1062" alt="choose_custom_logo_type_ie11_current" src="https://github.com/alphagov/notifications-admin/assets/87140/453d8d05-6885-4072-b25f-40427500a654">

### With fix

<img width="943" alt="choose_logo_type_depart_or_custom_ie11_after" src="https://github.com/alphagov/notifications-admin/assets/87140/f3aa72c6-b9b9-49f2-8610-d2eb6c57fa36">

<img width="943" alt="choose_custom_logo_type_ie11_after" src="https://github.com/alphagov/notifications-admin/assets/87140/3fd3724e-ad75-468f-abec-48b33b15aba3">

## Redesign for smaller screens

### Before

<img width="317" alt="radios_with_images_now" src="https://github.com/alphagov/notifications-admin/assets/87140/da9c90e9-1b32-4c61-aaaa-b5d01a9e4270">

### After

<img width="322" alt="choose_logo_type_depart_or_custom_mobile_after" src="https://github.com/alphagov/notifications-admin/assets/87140/dbbf6bbd-2001-4d4b-b5fe-419da4a76bcf">

## Background to the fixes / redesign

IE11 didn't respect the use of `max-width: 100%` and instead went by the widths set on each of the images. This changes to `width: 100%` to make sure they always fill the space in their container (which I think was always the intent of `max-width` anyway) but in a way that IE11 respects over the width on the element.

We also didn't do much work on this component on smaller screens and the current implementation makes the images small enough that some users might not be able to see the text in them properly. This stacks them vertically which gives
enough space for their text to be legible.
