### PR TITLE
Update welsh content when breaking changes

### DIFF
--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -34,8 +34,8 @@
 
   {% call form_wrapper() %}
     <input type="hidden" name="name" value="{{ new_template.name }}" />
-    <input type="hidden" name="subject" value="{{ new_template._subject or '' }}" />
-    <input type="hidden" name="template_content" value="{{ new_template.content }}" />
+    <input type="hidden" name="subject" value="{{ form.subject.data or '' }}" />
+    <input type="hidden" name="template_content" value="{{ form.template_content.data }}" />
     <input type="hidden" name="template_id" value="{{ new_template.id }}" />
 
     <input type="hidden" name="confirm" value="true" />

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.2.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,9 +83,7 @@ govuk-frontend-jinja==2.3.0
 greenlet==1.1.2
     # via eventlet
 gunicorn[eventlet]==21.2.0
-    # via
-    #   -r requirements.in
-    #   gunicorn
+    # via -r requirements.in
 humanize==4.4.0
     # via -r requirements.in
 idna==3.3
@@ -126,7 +124,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.2.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx
@@ -202,9 +200,7 @@ s3transfer==0.6.0
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 shapely==1.8.4
     # via notifications-utils
 six==1.16.0


### PR DESCRIPTION
When a breaking change is made to a template, we display an interstitial
page asking the user to confirm the change (new placeholders added).

This page contains some hidden form fields that contain the updated
subject/content. These fields always held the English content, which
would end up overwriting the Welsh content.

Change the form fields to read the subject/content from the submitted
form, which will be the correct English or Welsh data depending on which
language is being edited.