### PR TITLE
Show letter name field when copying

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -440,6 +440,7 @@ def copy_template(service_id, template_id):
         form=form,
         template=template,
         heading_action="Add",
+        show_name_field=True,
         services=current_user.service_ids,
         back_link=back_link,
     )

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -22,14 +22,18 @@
     {% call form_wrapper() %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-five-sixths">
+          {% if show_name_field %}
+            {{ form.name(param_extensions={"classes": "govuk-!-width-full"}) }}
+          {% else %}
+            {# this needs to be passed through if we're showing this from the copy page #}
+            <input type="hidden" name="name" value="{{ form.name.data }}" />
+          {% endif %}
+
           {{ textbox(form.subject, width='1-1', highlight_placeholders=True, rows=2) }}
           {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=8) }}
           {{ sticky_page_footer(
             'Save'
           ) }}
-
-          {# this needs to be passed through if we're showing this from the copy page #}
-          <input type="hidden" name="name" value="{{ form.name.data }}" />
 
         </div>
         <div class="govuk-grid-column-full">


### PR DESCRIPTION
If a letter template is being copied, show the name field so that it's (more) obvious that it's actually a copy of a template, rather than editing the existing one.

## Before
<img width="1893" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/f15a868a-27aa-46a4-9e84-f5824bf6cd99">


## After
<img width="1696" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/0ded78a1-1d5e-49ab-9085-53e15913f924">

