### PR TITLE
block people putting @ sign in custom sender names

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1970,6 +1970,7 @@ class ServiceEmailSenderForm(StripWhitespaceForm):
             self.custom_email_sender_name.validators = [
                 NotifyDataRequired(thing="a sender name"),
                 MustContainAlphanumericCharacters(thing="sender name"),
+                CharactersNotAllowed("@"),
                 Length(max=255, thing="sender name"),
             ]
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -6571,6 +6571,7 @@ class TestServiceEmailSenderChange:
             ("ALERT", "Sender name needs to be more specific"),
             # under the 255 db col length, but too long when combined with email_sender_local_part to make an email
             ("a" * 150 + " " * 100 + "a", "Sender name cannot be longer than 143 characters"),
+            ("foo@example.com", "Cannot contain @"),
         ],
     )
     def test_service_email_sender_change_fails_if_new_name_fails_validation(


### PR DESCRIPTION
we've seen people try and use their own emails as a custom sender name. we'll want to look at our content and guidance to make sure people understand what they're setting, but in the meantime we can also block the @ sign since this field shouldn't be an email address

(pic includes karl's latest content draft)

![image](https://github.com/alphagov/notifications-admin/assets/5020841/1925766b-8d92-430d-80d2-d0a2615bbbb5)
