### PR TITLE
Fix editing SMS templates

### DIFF
--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -34,7 +34,9 @@
 
   {% call form_wrapper() %}
     <input type="hidden" name="name" value="{{ new_template.name }}" />
-    <input type="hidden" name="subject" value="{{ form.subject.data or '' }}" />
+    {% if form.subject %}
+      <input type="hidden" name="subject" value="{{ form.subject.data or '' }}" />
+    {% endif %}
     <input type="hidden" name="template_content" value="{{ form.template_content.data }}" />
     <input type="hidden" name="template_id" value="{{ new_template.id }}" />
 


### PR DESCRIPTION
SMS templates do not have a subject field, and so trying to render the 'subject' form field on this page for the SMS form just throws an error.

This means that it was impossible to edit SMS templates if you were adding a new placeholder.