### PR TITLE
Fix page counts for different template versions

### DIFF
--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -152,7 +152,9 @@ class TemplatedLetterImageTemplate(BaseLetterImageTemplate):
             self._all_page_counts = get_page_counts_for_letter(self._template, self.values)
             return self._all_page_counts
 
-        cache_key = f"service-{self._template['service']}-template-{self.id}-all-page-counts"
+        cache_key = (
+            f"service-{self.get_raw('service')}-template-{self.id}-version-{self.get_raw('version')}-all-page-counts"
+        )
         if cached_value := redis_client.get(cache_key):
             self._all_page_counts = json.loads(cached_value)
             return self._all_page_counts

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -56,9 +56,9 @@ def test_get_page_counts_for_letter_caches(
         assert template.page_count == 5
 
     # Redis and template preview only get called once each because the instance also caches the value
-    mock_redis_get.assert_called_once_with(f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-all-page-counts")
+    mock_redis_get.assert_called_once_with(f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-version-1-all-page-counts")
     mock_redis_set.assert_called_once_with(
-        f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-all-page-counts",
+        f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-version-1-all-page-counts",
         '{"count": 5, "welsh_page_count": 0, "attachment_page_count": 0}',
         ex=2_419_200,
     )
@@ -91,7 +91,7 @@ def test_get_page_counts_for_letter_returns_cached_value(
         assert template.page_count == 5
 
     # Redis only gets called once because the instance also caches the value
-    mock_redis_get.assert_called_once_with(f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-all-page-counts")
+    mock_redis_get.assert_called_once_with(f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-version-1-all-page-counts")
 
 
 def test_get_page_counts_for_letter_does_not_cache_for_personalised_letters(


### PR DESCRIPTION
Make sure that we are caching page counts for template versions independently of each other, by including the version number in the cache key.