### PR TITLE
Bump utils to 73.0.0

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -10,7 +10,7 @@ from flask import (
 )
 from flask_login import current_user
 from notifications_utils.recipients import RecipientCSV
-from notifications_utils.template import HTMLEmailTemplate, LetterImageTemplate
+from notifications_utils.template import HTMLEmailTemplate
 
 from app import letter_branding_client, status_api_client
 from app.formatters import message_count
@@ -19,6 +19,7 @@ from app.main.forms import FieldWithNoneOption
 from app.main.views.pricing import CURRENT_SMS_RATE
 from app.main.views.sub_navigation_dictionaries import features_nav, using_notify_nav
 from app.models.branding import EmailBranding
+from app.utils.templates import TemplatedLetterImageTemplate
 
 redirects = Blueprint("redirects", __name__)
 main.register_blueprint(redirects)
@@ -121,10 +122,10 @@ def letter_template():
     image_url = url_for("no_cookie.letter_branding_preview_image", filename=filename)
 
     template_image = str(
-        LetterImageTemplate(
+        TemplatedLetterImageTemplate(
             template,
             image_url=image_url,
-            page_count=1,
+            page_counts={"count": 1, "welsh_page_count": 0, "attachment_page_count": 0},
         )
     )
 

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -136,9 +136,10 @@ class TemplatedLetterImageTemplate(BaseLetterImageTemplate):
         image_url=None,
         contact_block=None,
         include_letter_edit_ui_overlay=False,
+        page_counts=None,
     ):
         super().__init__(template, values, image_url=image_url, page_count=None, contact_block=contact_block)
-        self._all_page_counts = None
+        self._all_page_counts = page_counts
         self.include_letter_edit_ui_overlay = include_letter_edit_ui_overlay
 
     @property

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.0.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,7 +124,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.0.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
 ## 73.0.0

* Removes `LetterImageTemplate`. This has been moved to admin, as that is the only app using it.

---

Then, re-allow passing in `page_counts`

By passing this value in for the letter branding endpoint, we can prevent a request to template-preview.