### PR TITLE
Show estimate of how much a text message will cost on the templates page

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -118,7 +118,7 @@ def view_template(service_id, template_id):
     if should_skip_template_page(template):
         return redirect(url_for(".set_sender", service_id=service_id, template_id=template_id))
 
-    content_count_message = _get_content_count_message_for_template(template)
+    content_count_message = _get_fragment_count_message_for_template(template)
 
     return render_template(
         "views/templates/template.html",
@@ -779,17 +779,10 @@ def _get_content_count_error_and_message_for_template(template):
                 f"{character_count(template.content_count_without_prefix - SMS_CHAR_COUNT_LIMIT)} "
                 f"too many"
             )
-        if template.placeholders:
-            return False, (
-                f"Will be charged as {message_count(template.fragment_count, template.template_type)} "
-                f"(not including personalisation)"
-            )
-        return False, f"Will be charged as {message_count(template.fragment_count, template.template_type)} "
-
-    return (None, None)
+        return False, _get_fragment_count_message_for_template(template)
 
 
-def _get_content_count_message_for_template(template):
+def _get_fragment_count_message_for_template(template):
     if template.template_type != "sms":
         return None
     personalisation_hint = " (not including personalisation)" if template.placeholders else ""

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -118,10 +118,13 @@ def view_template(service_id, template_id):
     if should_skip_template_page(template):
         return redirect(url_for(".set_sender", service_id=service_id, template_id=template_id))
 
+    content_count_message = _get_content_count_message_for_template(template)
+
     return render_template(
         "views/templates/template.html",
         template=template,
         user_has_template_permission=user_has_template_permission,
+        content_count_message=content_count_message,
     )
 
 
@@ -782,6 +785,15 @@ def _get_content_count_error_and_message_for_template(template):
                 f"(not including personalisation)"
             )
         return False, f"Will be charged as {message_count(template.fragment_count, template.template_type)} "
+
+    return (None, None)
+
+
+def _get_content_count_message_for_template(template):
+    if template.template_type != "sms":
+        return None
+    personalisation_hint = " (not including personalisation)" if template.placeholders else ""
+    return f"Will be charged as {message_count(template.fragment_count, template.template_type)}{personalisation_hint}"
 
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/delete", methods=["GET", "POST"])

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -65,6 +65,10 @@
     {% include 'views/templates/_letter_template.html' %}
   {% endif %}
 
+  {% if content_count_message and current_user.has_permissions('manage_templates', 'manage_service', 'manage_api_keys') %}
+    <p class="govuk-body govuk-hint govuk-!-margin-bottom-5">{{ content_count_message }}</p>
+  {% endif %}
+
   <div class="govuk-!-margin-bottom-3">
     {{ copy_to_clipboard(template.id, name="Template ID", thing='template ID') }}
   </div>


### PR DESCRIPTION
At the moment only people who are editing templates get to see the estimated cost (added in https://github.com/alphagov/notifications-admin/pull/3763)

We think this is causing people to get confused about why they are being charged for sending more than one message.

We think that by also showing this to people who are just looking at the template we can help people understand the cost better.

For now not showing this to people who are only sending messages, since we have a long-standing principle that they shouldn’t be considering the cost when deciding whether or not to send a message (either the message needs sending or it doesn’t).

Before | After 
---|---
<img width="1004" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/edd58fa9-0869-4302-a210-3adf30020551"> | <img width="1011" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/fa300aff-7052-4697-9473-4a1085f8b4ce">
