### PR TITLE
requirements: notifications-utils: 73.0.0 -> 73.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,7 +124,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
https://trello.com/c/Q5S5m4ge/446-add-http-logging-to-all-of-our-ecs-apps

See https://github.com/alphagov/notifications-utils/pull/1077, this should bring flask request logging to apps in desired circumstances.