### PR TITLE
Update default Welsh content for letters

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1527,16 +1527,22 @@ class EmailTemplateForm(BaseTemplateForm, TemplateNameMixin):
 
 
 class LetterTemplateForm(BaseTemplateForm, TemplateNameMixin):
-    subject = TextAreaField("Main heading", validators=[NotifyDataRequired(thing="a main heading for your letter")])
+    subject = TextAreaField("Heading", validators=[NotifyDataRequired(thing="a main heading for your letter")])
     template_content = TextAreaField(
-        "Body", validators=[NotifyDataRequired(thing="the body text of your letter"), NoCommasInPlaceHolders()]
+        "Body text", validators=[NotifyDataRequired(thing="the body text of your letter"), NoCommasInPlaceHolders()]
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if kwargs.get("letter_languages") == LetterLanguageOptions.welsh_then_english:
+            self.subject.label.text = f"{self.subject.label.text} (English)"
+            self.template_content.label.text = f"{self.template_content.label.text} (English)"
 
 
 class WelshLetterTemplateForm(BaseTemplateForm, TemplateNameMixin):
-    subject = TextAreaField("Main heading in Welsh", validators=[DataRequired(message="Cannot be empty")])
+    subject = TextAreaField("Heading (Welsh)", validators=[DataRequired(message="Cannot be empty")])
     template_content = TextAreaField(
-        "Body in Welsh", validators=[DataRequired(message="Cannot be empty"), NoCommasInPlaceHolders()]
+        "Body text (Welsh)", validators=[DataRequired(message="Cannot be empty"), NoCommasInPlaceHolders()]
     )
 
     def __init__(self, *args, subject, content, letter_welsh_subject, letter_welsh_content, **kwargs):

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -727,6 +727,9 @@ def edit_service_template(service_id, template_id, language=None):
         form=form,
         template=template,
         heading_action="Edit",
+        language=language,
+        letter_languages=template.get_raw("letter_languages"),
+        language_options=LetterLanguageOptions,
         back_link=url_for("main.view_template", service_id=current_service.id, template_id=template.id),
     )
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -346,9 +346,9 @@ def _add_template_by_type(template_type, template_folder_id):
         blank_letter = service_api_client.create_service_template(
             name="Untitled letter template",
             type_="letter",
-            content="Body",
+            content="Body text",
             service_id=current_service.id,
-            subject="Main heading",
+            subject="Heading",
             parent_folder_id=template_folder_id,
         )
         return redirect(
@@ -1256,15 +1256,15 @@ def _change_template_language(service_id, template, language: LetterLanguageOpti
 
     if language == LetterLanguageOptions.english:
         if template.subject == "English heading":
-            update_kwargs["subject"] = "Main heading"
+            update_kwargs["subject"] = "Heading"
         if template.content == "English body text":
-            update_kwargs["content"] = "Body"
+            update_kwargs["content"] = "Body text"
         update_kwargs["letter_welsh_subject"] = None
         update_kwargs["letter_welsh_content"] = None
     else:
-        if template.subject == "Main heading":
+        if template.subject == "Heading":
             update_kwargs["subject"] = "English heading"
-        if template.content == "Body":
+        if template.content == "Body text":
             update_kwargs["content"] = "English body text"
         update_kwargs["letter_welsh_subject"] = "Welsh heading"
         update_kwargs["letter_welsh_content"] = "Welsh body text"

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -5,8 +5,22 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
+{% set heading %}
+  {% if heading_action == 'Edit' %}
+    {% if letter_languages == language_options.english.value %}
+      Edit heading and body text
+    {% elif language is none %}
+      Edit English heading and body text
+    {% else %}
+      Edit Welsh heading and body text
+    {% endif %}
+  {% else %}
+    {{ heading_action }} letter template
+  {% endif %}
+{% endset %}
+
 {% block service_page_title %}
-  {{ heading_action }} letter template
+  {{ heading }}
 {% endblock %}
 
 {% block backLink %}
@@ -17,7 +31,7 @@
 
 {% block maincolumn_content %}
 
-    {{ page_header('{} letter template'.format(heading_action)) }}
+    {{ page_header(heading) }}
 
     {% call form_wrapper() %}
       <div class="govuk-grid-row">

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -972,7 +972,6 @@ def test_GET_letter_template_change_language_404s_if_template_is_not_a_letter(
     service_one,
     mock_get_service_template,
     active_user_with_permissions,
-    mocker,
     fake_uuid,
 ):
     service_one["permissions"].append("extra_letter_formatting")
@@ -1012,8 +1011,67 @@ def test_POST_letter_template_change_to_welsh_and_english_sets_subject_and_conte
         SERVICE_ONE_ID,
         fake_uuid,
         letter_languages="welsh_then_english",
-        letter_welsh_subject="Welsh subject line goes here",
-        letter_welsh_content="Welsh content goes here",
+        letter_welsh_subject="Welsh heading",
+        letter_welsh_content="Welsh body text",
+    )
+
+
+@pytest.mark.parametrize(
+    "subject, content, extra_kwargs",
+    (
+        ("Main heading", "Body", {"subject": "English heading", "content": "English body text"}),
+        ("Some custom heading", "Body", {"content": "English body text"}),
+        ("Main heading", "Some custom body", {"subject": "English heading"}),
+        ("Some custom heading", "Some custom body", {}),
+    ),
+)
+def test_POST_letter_template_change_to_welsh_and_english_resets_english_subject_and_content(
+    client_request,
+    service_one,
+    mocker,
+    fake_uuid,
+    active_user_with_permissions,
+    subject,
+    content,
+    extra_kwargs,
+):
+    def _get(service_id, template_id, version=None, postage="second"):
+        template = template_json(
+            service_id=service_id,
+            id_=template_id,
+            name="Two week reminder",
+            type_="letter",
+            content=content,
+            subject=subject,
+            postage=postage,
+        )
+        return {"data": template}
+
+    mocker.patch("app.service_api_client.get_service_template", side_effect=_get)
+
+    service_one["permissions"].append("extra_letter_formatting")
+    client_request.login(active_user_with_permissions)
+
+    mock_template_change_language = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
+
+    client_request.post(
+        "main.letter_template_change_language",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _data={"languages": "welsh_then_english"},
+        _expected_redirect=url_for(
+            "main.view_template",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+        ),
+    )
+    mock_template_change_language.assert_called_with(
+        SERVICE_ONE_ID,
+        fake_uuid,
+        letter_languages="welsh_then_english",
+        letter_welsh_subject="Welsh heading",
+        letter_welsh_content="Welsh body text",
+        **extra_kwargs,
     )
 
 
@@ -1095,6 +1153,65 @@ def test_POST_letter_template_confirm_remove_welsh(
         letter_languages="english",
         letter_welsh_subject=None,
         letter_welsh_content=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "subject, content, extra_kwargs",
+    (
+        ("English heading", "English body text", {"subject": "Main heading", "content": "Body"}),
+        ("Some custom heading", "English body text", {"content": "Body"}),
+        ("English heading", "Some custom body", {"subject": "Main heading"}),
+        ("Some custom heading", "Some custom body", {}),
+    ),
+)
+def test_POST_letter_template_confirm_remove_welsh_resets_english_subject_and_content(
+    client_request,
+    service_one,
+    mocker,
+    fake_uuid,
+    active_user_with_permissions,
+    subject,
+    content,
+    extra_kwargs,
+):
+    def _get(service_id, template_id, version=None, postage="second"):
+        template = template_json(
+            service_id=service_id,
+            id_=template_id,
+            name="Two week reminder",
+            type_="letter",
+            content=content,
+            subject=subject,
+            postage=postage,
+        )
+        return {"data": template}
+
+    mocker.patch("app.service_api_client.get_service_template", side_effect=_get)
+
+    service_one["permissions"].append("extra_letter_formatting")
+    client_request.login(active_user_with_permissions)
+
+    mock_template_change_language = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
+
+    client_request.post(
+        "main.letter_template_confirm_remove_welsh",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _data={"confirm": "true"},
+        _expected_redirect=url_for(
+            "main.view_template",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+        ),
+    )
+    mock_template_change_language.assert_called_with(
+        SERVICE_ONE_ID,
+        fake_uuid,
+        letter_languages="english",
+        letter_welsh_subject=None,
+        letter_welsh_content=None,
+        **extra_kwargs,
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1035,19 +1035,20 @@ def test_POST_letter_template_change_to_welsh_and_english_resets_english_subject
     content,
     extra_kwargs,
 ):
-    def _get(service_id, template_id, version=None, postage="second"):
-        template = template_json(
-            service_id=service_id,
-            id_=template_id,
-            name="Two week reminder",
-            type_="letter",
-            content=content,
-            subject=subject,
-            postage=postage,
-        )
-        return {"data": template}
-
-    mocker.patch("app.service_api_client.get_service_template", side_effect=_get)
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={
+            "data": template_json(
+                service_id=SERVICE_ONE_ID,
+                id_=fake_uuid,
+                name="Two week reminder",
+                type_="letter",
+                content=content,
+                subject=subject,
+                postage="second",
+            )
+        },
+    )
 
     service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1019,9 +1019,9 @@ def test_POST_letter_template_change_to_welsh_and_english_sets_subject_and_conte
 @pytest.mark.parametrize(
     "subject, content, extra_kwargs",
     (
-        ("Main heading", "Body", {"subject": "English heading", "content": "English body text"}),
-        ("Some custom heading", "Body", {"content": "English body text"}),
-        ("Main heading", "Some custom body", {"subject": "English heading"}),
+        ("Heading", "Body text", {"subject": "English heading", "content": "English body text"}),
+        ("Some custom heading", "Body text", {"content": "English body text"}),
+        ("Heading", "Some custom body", {"subject": "English heading"}),
         ("Some custom heading", "Some custom body", {}),
     ),
 )
@@ -1160,9 +1160,9 @@ def test_POST_letter_template_confirm_remove_welsh(
 @pytest.mark.parametrize(
     "subject, content, extra_kwargs",
     (
-        ("English heading", "English body text", {"subject": "Main heading", "content": "Body"}),
-        ("Some custom heading", "English body text", {"content": "Body"}),
-        ("English heading", "Some custom body", {"subject": "Main heading"}),
+        ("English heading", "English body text", {"subject": "Heading", "content": "Body text"}),
+        ("Some custom heading", "English body text", {"content": "Body text"}),
+        ("English heading", "Some custom body", {"subject": "Heading"}),
         ("Some custom heading", "Some custom body", {}),
     ),
 )
@@ -2067,9 +2067,9 @@ def test_choosing_letter_creates(
     mock_create_service_template.assert_called_once_with(
         name="Untitled letter template",
         type_="letter",
-        content="Body",
+        content="Body text",
         service_id=SERVICE_ONE_ID,
-        subject="Main heading",
+        subject="Heading",
         parent_folder_id=None,
     )
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -571,10 +571,10 @@ def test_GET_edit_service_template_for_welsh_letter(
     )
 
     subject_label = page.select_one("label[for=subject]")
-    assert subject_label.text.strip() == "Main heading in Welsh"
+    assert subject_label.text.strip() == "Heading (Welsh)"
 
     content_label = page.select_one("label[for=template_content]")
-    assert content_label.text.strip() == "Body in Welsh"
+    assert content_label.text.strip() == "Body text (Welsh)"
 
 
 def test_broadcast_template_doesnt_highlight_placeholders_but_does_count_characters(


### PR DESCRIPTION
And also toggle the English letter content to be language-specific for Welsh templates. Remove the language specification when removing Welsh.

![2023-12-05 16 46 21](https://github.com/alphagov/notifications-admin/assets/2920760/7cca517b-c609-4469-962e-849b3e65133e)

