### PR TITLE
Make bilingual templates live for all services that send letters

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -66,7 +66,6 @@ from app.template_previews import (
 )
 from app.utils import (
     NOTIFICATION_TYPES,
-    service_has_permission,
     should_skip_template_page,
 )
 from app.utils.letters import (
@@ -655,9 +654,6 @@ def abort_for_unauthorised_bilingual_letters_or_invalid_options(language: Option
 
     if template.template_type != "letter":
         abort(404)
-
-    if not current_service.has_permission("extra_letter_formatting"):
-        abort(403)
 
     if language.lower() != "welsh":
         abort(404)
@@ -1250,7 +1246,6 @@ def _get_page_numbers(page_count):
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/change-language", methods=["GET", "POST"])
 @user_has_permissions("manage_templates")
-@service_has_permission("extra_letter_formatting")
 def letter_template_change_language(template_id, service_id):
     template = current_service.get_template(template_id)
 
@@ -1296,7 +1291,6 @@ def letter_template_change_language(template_id, service_id):
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/change-language/confirm", methods=["GET", "POST"])
 @user_has_permissions("manage_templates")
-@service_has_permission("extra_letter_formatting")
 def letter_template_confirm_remove_welsh(template_id, service_id):
     template = current_service.get_template(template_id)
 

--- a/app/templates/views/templates/_letter_template.html
+++ b/app/templates/views/templates/_letter_template.html
@@ -30,17 +30,15 @@
     "classes": "govuk-button--secondary edit-template-link-attachment"
     }) }}
 
-    {% if 'extra_letter_formatting' in current_service.permissions %}
-      {{ govukButton({
-      "element": "a",
-      "text": "Change language",
-      "href": url_for(
-      '.letter_template_change_language',
-      service_id=current_service.id,
-      template_id=template.id
-      ),
-      "classes": "govuk-button--secondary change-language"
-      }) }}
-    {% endif %}
+    {{ govukButton({
+    "element": "a",
+    "text": "Change language",
+    "href": url_for(
+    '.letter_template_change_language',
+    service_id=current_service.id,
+    template_id=template.id
+    ),
+    "classes": "govuk-button--secondary change-language"
+    }) }}
   </div>
 </div>

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -564,7 +564,6 @@ def test_GET_edit_service_template_for_welsh_letter(
     client_request, mock_get_service_letter_template_welsh_language, fake_uuid, service_one
 ):
     service_one["permissions"].append("letter")
-    service_one["permissions"].append("extra_letter_formatting")
     template_id = fake_uuid
     page = client_request.get(
         ".edit_service_template", service_id=SERVICE_ONE_ID, template_id=template_id, language="welsh"
@@ -914,7 +913,6 @@ def test_view_letter_template_displays_change_language_button(
     fake_uuid,
     mock_get_page_counts_for_letter,
 ):
-    service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
     template_id = fake_uuid
     mocker.patch(
@@ -939,7 +937,6 @@ def test_view_letter_template_displays_change_language_button(
 def test_GET_letter_template_change_language(
     client_request, service_one, fake_uuid, mocker, mock_get_service_letter_template, active_user_with_permissions
 ):
-    service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
     page = client_request.get(
         "main.letter_template_change_language",
@@ -975,7 +972,6 @@ def test_GET_letter_template_change_language_404s_if_template_is_not_a_letter(
     mocker,
     fake_uuid,
 ):
-    service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
     page = client_request.get(
         "main.letter_template_change_language", service_id=SERVICE_ONE_ID, template_id=fake_uuid, _expected_status=404
@@ -992,7 +988,6 @@ def test_POST_letter_template_change_to_welsh_and_english_sets_subject_and_conte
     active_user_with_permissions,
     mock_get_service_letter_template,
 ):
-    service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
 
     mock_template_change_language = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
@@ -1025,7 +1020,6 @@ def test_POST_letter_template_change_to_english_redirects_to_confirmation_page(
     active_user_with_permissions,
     mock_get_service_letter_template_welsh_language,
 ):
-    service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
 
     mock_template_change_language = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
@@ -1050,7 +1044,6 @@ def test_GET_letter_template_confirm_remove_welsh(
     active_user_with_permissions,
     mock_get_service_letter_template,
 ):
-    service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
 
     mock_template_change_language = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
@@ -1073,7 +1066,6 @@ def test_POST_letter_template_confirm_remove_welsh(
     active_user_with_permissions,
     mock_get_service_letter_template,
 ):
-    service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
 
     mock_template_change_language = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
@@ -2806,7 +2798,7 @@ def test_confirm_breaking_change_on_letter_template_saves_correct_language_conte
     mocker,
     url_kwargs,
 ):
-    service_one["permissions"] += ["letter", "extra_letter_formatting"]
+    service_one["permissions"].append("letter")
 
     letter_template = template_json(
         id_=fake_uuid,
@@ -3065,10 +3057,9 @@ def test_should_redirect_when_saving_a_template_letter(
 
 
 @pytest.mark.parametrize(
-    "letter_formatting_permission, language, mock_fixturename",
+    "language, mock_fixturename",
     (
         pytest.param(
-            False,
             "welsh",
             "mock_get_service_letter_template",
             marks=pytest.mark.xfail(
@@ -3077,7 +3068,6 @@ def test_should_redirect_when_saving_a_template_letter(
             ),
         ),
         pytest.param(
-            True,
             "welsh",
             "mock_get_service_letter_template",
             marks=pytest.mark.xfail(
@@ -3086,16 +3076,6 @@ def test_should_redirect_when_saving_a_template_letter(
             ),
         ),
         pytest.param(
-            False,
-            "welsh",
-            "mock_get_service_letter_template_welsh_language",
-            marks=pytest.mark.xfail(
-                raises=AssertionError,
-                reason="Cannot edit Welsh content as service does not have extra_letter_formatting set",
-            ),
-        ),
-        pytest.param(
-            False,
             "gaelic",
             "mock_get_service_letter_template_welsh_language",
             marks=pytest.mark.xfail(
@@ -3104,7 +3084,6 @@ def test_should_redirect_when_saving_a_template_letter(
             ),
         ),
         (
-            True,
             "welsh",
             "mock_get_service_letter_template_welsh_language",
         ),
@@ -3117,7 +3096,6 @@ def test_update_template_for_welsh_language_content(
     mock_get_user_by_email,
     fake_uuid,
     service_one,
-    letter_formatting_permission,
     language,
     mock_fixturename,
 ):
@@ -3125,8 +3103,6 @@ def test_update_template_for_welsh_language_content(
     request.getfixturevalue(mock_fixturename)
 
     service_one["permissions"].append("letter")
-    if letter_formatting_permission:
-        service_one["permissions"].append("extra_letter_formatting")
     name = "new template name"
     content = "Welsh letter content"
     subject = "Welsh letter subject"


### PR DESCRIPTION
Needs to go in after Sam's PRs (https://github.com/alphagov/notifications-admin/pull/4931 and https://github.com/alphagov/notifications-functional-tests/pull/491)