### PR TITLE
Adding validators for numeric and generic sender IDs

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -71,6 +71,8 @@ from app.main.validators import (
     CsvFileValidator,
     DoesNotStartWithDoubleZero,
     FileIsVirusFree,
+    IsAUKMobileNumberOrShortCode,
+    IsNotAGenericSenderID,
     Length,
     MustContainAlphanumericCharacters,
     NoCommasInPlaceHolders,
@@ -1886,6 +1888,8 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
                 ),
             ),
             DoesNotStartWithDoubleZero(),
+            IsNotAGenericSenderID(),
+            IsAUKMobileNumberOrShortCode(),
         ],
     )
     is_default = GovukCheckboxField("Make this text message sender ID the default")

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -165,6 +165,39 @@ class DoesNotStartWithDoubleZero:
             raise ValidationError(self.message)
 
 
+class IsNotAGenericSenderID:
+    generic_sender_ids = ["info", "verify", "alert"]
+
+    def __init__(
+        self,
+        message="Text message sender ID cannot be Alert, Info or Verify as those are prohibited due to "
+        "usage by spam",
+    ):
+        self.message = message
+
+    def __call__(self, form, field):
+        if field.data and field.data.lower() in self.generic_sender_ids:
+            raise ValidationError(self.message)
+
+
+class IsAUKMobileNumberOrShortCode:
+    number_regex = re.compile(r"^[0-9\.]+$")
+    mobile_regex = re.compile(r"^07[0-9]{9}$")
+    shortcode_regex = re.compile(r"^[6-8][0-9]{4}$")
+
+    def __init__(self, message="A numeric sender id should be a valid mobile number or short code"):
+        self.message = message
+
+    def __call__(self, form, field):
+        if (
+            field.data
+            and re.match(self.number_regex, field.data)
+            and not re.match(self.mobile_regex, field.data)
+            and not re.match(self.shortcode_regex, field.data)
+        ):
+            raise ValidationError(self.message)
+
+
 class MustContainAlphanumericCharacters:
     regex = re.compile(r".*[a-zA-Z0-9].*[a-zA-Z0-9].*")
 

--- a/tests/app/main/forms/test_service_sms_senders_form.py
+++ b/tests/app/main/forms/test_service_sms_senders_form.py
@@ -8,7 +8,15 @@ from app.main.forms import ServiceSmsSenderForm
     [
         ("", True, "Enter a text message sender ID"),
         ("22", True, "Text message sender ID must be at least 3 characters long"),
-        ("333", False, None),
+        ("333", True, "A numeric sender id should be a valid mobile number or short code"),
+        ("70000", False, None),
+        ("07000000000", False, None),
+        (
+            "Info",
+            True,
+            "Text message sender ID cannot be Alert, Info or Verify as those are prohibited due to usage by spam",
+        ),
+        ("Inform Uk", False, None),
         ("elevenchars", False, None),  # 11 chars
         ("twelvecharas", True, "Text message sender ID cannot be longer than 11 characters"),  # 12 chars
         (


### PR DESCRIPTION
Numeric sender IDs should be valid uk mobile phone numbers or shortcodes.

Generic sender IDs (like Info, Verify and Alert) are being used by spam, so should be avoided.

Further work would be needed if we were going to have a long list of generic wordsm which might be coming soon. But I'm not sure it is worth it now.
