### PR TITLE
Handle more verbose exception message in Python 3.11

### DIFF
--- a/tests/app/models/test_base_model.py
+++ b/tests/app/models/test_base_model.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from app.models import JSONModel
@@ -23,7 +25,12 @@ def test_raises_when_overriding_custom_properties():
     with pytest.raises(AttributeError) as e:
         Custom({"foo": "NOPE"})
 
-    assert str(e.value) == "can't set attribute"
+    if sys.version_info < (3, 11):
+        assert str(e.value) == "can't set attribute"
+    else:
+        assert str(e.value) == (
+            "property 'foo' of 'test_raises_when_overriding_custom_properties.<locals>.Custom' object has no setter"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This internal error message was changed in python/cpython@0cb765b

So that our tests keep passing we need to check for both the old or the new error message.

This matches the change made in https://github.com/alphagov/notifications-utils/pull/1078/commits/7c323fe0f17870c1c6b57ae07d4b489b5411486d (this still needs testing in both places because the behaviour of the 2 objects is subtly different).