### PR TITLE
Automatically add note if org can self-approve

### DIFF
--- a/app/templates/support-tickets/go-live-request.txt
+++ b/app/templates/support-tickets/go-live-request.txt
@@ -12,6 +12,7 @@ Agreement signed: {{ organisation.agreement_signed|format_yes_no(none='Can’t t
 {%- elif organisation.name %} (organisation is {{ organisation.name }}, {{ organisation.crown|format_yes_no(yes='a crown body', no='a non-crown body', none='crown status unknown') }})
 {%- else %} (domain is {{ user.email_domain }})
 {%- endif %}.
+{%- if organisation.can_approve_own_go_live_requests %} This organisation can approve its own go live requests. No action should be needed from us.{% endif %}
 {%- if organisation.request_to_go_live_notes %} {{ organisation.request_to_go_live_notes }}{% endif %}
 {%- if organisation.agreement_signed_by %}
 Agreement signed by: {{ organisation.agreement_signed_by.email_address }}


### PR DESCRIPTION
At the moment we manually add a request to go live note on (most) organisations that can approve their own go live requests.

This commit adds that note automatically so it is guaranteed to always be present and we don't have to check the list each time.