### PR TITLE
Bump utils to 74.0.0

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -24,7 +24,7 @@ from notifications_utils.recipients import (
     validate_phone_number,
 )
 from notifications_utils.safe_string import make_string_safe_for_email_local_part
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 from werkzeug.utils import cached_property
 from wtforms import (
     BooleanField,

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -6,7 +6,7 @@ from notifications_utils.field import Field
 from notifications_utils.formatters import formatted_list
 from notifications_utils.recipients import InvalidEmailError, validate_email_address
 from notifications_utils.sanitise_text import SanitiseSMS
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 from wtforms import ValidationError
 from wtforms.validators import URL, DataRequired, InputRequired, StopValidation
 from wtforms.validators import Length as WTFormsLength

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -4,7 +4,7 @@ from itertools import chain
 from flask import abort, g, make_response, request
 from flask_login import current_user
 from notifications_utils.field import Field
-from orderedset._orderedset import OrderedSet
+from ordered_set import OrderedSet
 from werkzeug.datastructures import MultiDict
 from werkzeug.routing import RequestRedirect
 

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ cachetools==5.2.0
     # via notifications-utils
 certifi==2023.7.22
     # via
-    #   pyproj
     #   requests
     #   sentry-sdk
 cffi==1.15.1
@@ -124,11 +123,11 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx
-orderedset==2.0.3
+ordered-set==4.1.0
     # via notifications-utils
 packaging==23.1
     # via gunicorn
@@ -165,8 +164,6 @@ pyjwt==2.4.0
     # via notifications-python-client
 pypdf==3.13.0
     # via notifications-utils
-pyproj==3.4.1
-    # via notifications-utils
 python-dateutil==2.8.2
     # via
     #   awscli-cwlogs
@@ -201,8 +198,6 @@ segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
     # via -r requirements.in
-shapely==1.8.4
-    # via notifications-utils
 six==1.16.0
     # via
     #   awscli-cwlogs

--- a/tests/app/notify_client/test_template_folder_client.py
+++ b/tests/app/notify_client/test_template_folder_client.py
@@ -2,7 +2,7 @@ import uuid
 from unittest.mock import call
 
 import pytest
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 
 from app.notify_client.template_folder_api_client import TemplateFolderAPIClient
 

--- a/tests/app/test_jinja_templates.py
+++ b/tests/app/test_jinja_templates.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from flask import current_app
 from jinja2.nodes import Call, FromImport, Name
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 
 
 class UnusedJinjaImports(Exception):

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 from freezegun import freeze_time
 from markupsafe import Markup
 from notifications_utils.template import SubjectMixin, Template
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 
 from app import load_service_before_request
 from app.utils.templates import TemplatedLetterImageTemplate, get_sample_template


### PR DESCRIPTION
 ## 74.0.0

Removes Emergency-Alerts-related code

* the `polygons` module has been removed
* `template.BroadcastPreviewTemplate` and `template.BroadcastMessageTemplate` have been removed

 ## 73.2.1

* Fix utils packaging to allow access to subpackages again.

 ## 73.2.0

* Adds a `include_notify_tag` parameter to `LetterPrintTemplate` so that bilingual letters can disable the NOTIFY tag on the English pages of a letter.

This is only used for recording changes for major version bumps. More minor changes may optionally be recorded here too.

 ## 73.1.3

* Add compatibility with Python 3.11 and 3.12

 ## 73.1.2

* Change how utils is packaged to exclude tests.

 ## 73.1.1

 (no info)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/73.1.0...74.0.0