### PR TITLE
Allow multiple distinct services to be mocked

### DIFF
--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -50,7 +50,7 @@ def test_services_pages_that_org_users_are_allowed_to_see(
     mock_get_annual_usage_for_service,
     mock_get_monthly_usage_for_service,
     mock_get_free_sms_fragment_limit,
-    mock_get_service,
+    mocked_get_service_data,
     mock_get_invites_for_service,
     mock_get_users_by_service,
     mock_get_organisation,
@@ -78,9 +78,7 @@ def test_services_pages_that_org_users_are_allowed_to_see(
         organisation_id=ORGANISATION_ID,
     )
 
-    mock_get_service = mocker.patch(
-        "app.notify_client.service_api_client.service_api_client.get_service", return_value={"data": service}
-    )
+    mocked_get_service_data[service["id"]] = service
     mocker.patch("app.template_folder_api_client.get_template_folders", return_value=[create_folder(id=sample_uuid())])
 
     client_request.login(
@@ -91,8 +89,6 @@ def test_services_pages_that_org_users_are_allowed_to_see(
     client_request.get(
         endpoint, service_id=SERVICE_ONE_ID, _expected_status=expected_status, _test_page_title=False, **extra_args
     )
-
-    assert mock_get_service.called is organisation_checked
 
 
 # check both regular users and org users

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -322,7 +322,7 @@ def test_should_show_back_to_service_if_user_belongs_to_service(
     service_one,
 ):
     mock_get_service.return_value = service_one
-    expected_page_text = "Test Service   Switch service " "Dashboard Templates Uploads Team members"
+    expected_page_text = "service one   Switch service Dashboard Templates Uploads Team members"
 
     page = client_request.get(
         "main.view_template",

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -6,7 +6,7 @@ from notifications_python_client.errors import HTTPError
 
 from app.utils.user import is_gov_user
 from tests import organisation_json
-from tests.conftest import SERVICE_ONE_ID, normalize_spaces
+from tests.conftest import normalize_spaces
 
 
 def test_non_gov_user_cannot_see_add_service_button(
@@ -372,8 +372,8 @@ def test_email_auth_user_creates_service_with_email_auth_permission(
     api_user_active_email_auth,
     client_request,
     mock_get_no_organisation_by_domain,
-    mock_create_service,
     mock_get_services,
+    mock_create_service,
     mock_create_service_template,
     mock_update_service,
 ):
@@ -391,7 +391,5 @@ def test_email_auth_user_creates_service_with_email_auth_permission(
         ),
     )
     assert mock_create_service.called
-    # confusingly not the same as the id of `101` returned by mock_create_service that we see
-    # in the redirect, because Service.from_id is mocked to return `service_one`
-    assert mock_update_service.call_args[0][0] == SERVICE_ONE_ID
+    assert mock_update_service.call_args[0][0] == 101
     assert "email_auth" in mock_update_service.call_args[1]["permissions"]

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3023,7 +3023,7 @@ def test_check_messages_back_link(
     [
         (None, "‘example.csv’ contains 1,234 phone numbers."),
         ("0", "‘example.csv’ contains 1,234 phone numbers."),
-        ("1", "You can still send 49 text messages today, but ‘example.csv’ contains 1,234 phone numbers."),
+        ("1", "You can still send 999 text messages today, but ‘example.csv’ contains 1,234 phone numbers."),
     ],
     ids=["none_sent", "none_sent", "some_sent"],
 )


### PR DESCRIPTION
`mock_get_service` uses a naive implementation which returns a fixed set of service JSON, with a service_id depending on what is passed into the `get_service` call.

This makes it difficult to test code that touches multiple services with different attributes.

This updates `mock_get_service` to use a dictionary underneath that can store custom service JSON blobs. If a request is made for a service that isn't in the explicit dict, we return a default service still.