### PR TITLE
New 'copy template' journey

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2850,3 +2850,9 @@ class JoinServiceForm(StripWhitespaceForm):
         },
     )
     reason = GovukTextareaField("Explain why you need access (optional)")
+
+
+class CopyTemplateForm(StripWhitespaceForm, TemplateNameMixin):
+    template_id = HiddenField(
+        "The template ID to copy", validators=[NotifyDataRequired(thing="the template ID to copy")]
+    )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -583,11 +583,6 @@ def delete_template_folder(service_id, template_folder_id):
 )
 @user_has_permissions("manage_templates")
 def add_service_template(service_id, template_type, template_folder_id=None):
-    # letter templates are created for the user straight from the choose_template page, but this
-    # code path is still accessed if the user has come via the copy an existing template flow
-    if template_type == "letter" and request.endpoint == "main.add_service_template":
-        abort(404)
-
     if template_type not in current_service.available_template_types:
         return redirect(
             url_for(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -36,6 +36,7 @@ from app.constants import QR_CODE_TOO_LONG, LetterLanguageOptions
 from app.formatters import character_count, message_count
 from app.main import main, no_cookie
 from app.main.forms import (
+    CopyTemplateForm,
     EmailTemplateForm,
     LetterTemplateForm,
     LetterTemplateLanguagesForm,
@@ -399,42 +400,66 @@ def choose_template_to_copy(
 @main.route("/services/<uuid:service_id>/templates/copy/<uuid:template_id>", methods=["GET", "POST"])
 @user_has_permissions("manage_templates")
 def copy_template(service_id, template_id):
-    from_service = request.args.get("from_service")
+    from_service_id = request.args.get("from_service")
 
-    current_user.belongs_to_service_or_403(from_service)
+    current_user.belongs_to_service_or_403(from_service_id)
+    from_service = Service.from_id(from_service_id)
 
-    template = service_api_client.get_service_template(from_service, template_id)["data"]
+    template = from_service.get_template(
+        template_id,
+        letter_preview_url=url_for(
+            "no_cookie.view_letter_template_preview",
+            service_id=service_id,
+            template_id=template_id,
+            filetype="png",
+        ),
+        show_recipient=True,
+        sms_sender=current_service.default_sms_sender,
+    )
+    if template.template_type == "email":
+        template.from_name = current_service.email_sender_name
+    template.name = _get_template_copy_name(template._template, current_service.all_templates)
 
-    template_folder = template_folder_api_client.get_template_folder(from_service, template["folder"])
+    template_folder = template_folder_api_client.get_template_folder(from_service_id, template.get_raw("folder"))
     if not current_user.has_template_folder_permission(template_folder, service=current_service):
         abort(403)
 
+    form = CopyTemplateForm(template_id=template.id, name=template.name)
+
     if request.method == "POST":
-        return add_service_template(service_id, template["template_type"])
+        new_template = service_api_client.create_service_template(
+            name=form.name.data,
+            type_=template.template_type,
+            service_id=current_service.id,
+            subject=template.get_raw("subject"),
+            content=template.content,
+            letter_languages=template.get_raw("letter_languages"),
+            letter_welsh_subject=template.get_raw("letter_welsh_subject"),
+            letter_welsh_content=template.get_raw("letter_welsh_content"),
+        )["data"]
+        if template.template_type == "letter" and template.get_raw("letter_attachment"):
+            # TODO: handle letter attachments
+            pass
+        return redirect(url_for(".view_template", service_id=service_id, template_id=new_template["id"]))
 
-    template["name"] = _get_template_copy_name(template, current_service.all_templates)
-    form = get_template_form(template["template_type"])(**template)
-
-    if template["folder"]:
+    if template.get_raw("folder"):
         back_link = url_for(
             ".choose_template_to_copy",
             service_id=current_service.id,
-            from_service=from_service,
-            from_folder=template["folder"],
+            from_service=from_service_id,
+            from_folder=template.get_raw("folder"),
         )
     else:
         back_link = url_for(
             ".choose_template_to_copy",
             service_id=current_service.id,
-            from_service=from_service,
+            from_service=from_service_id,
         )
 
     return render_template(
-        f"views/edit-{template['template_type']}-template.html",
-        form=form,
+        "views/copy-template.html",
         template=template,
-        heading_action="Add",
-        show_name_field=True,
+        form=form,
         services=current_user.service_ids,
         back_link=back_link,
     )

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from typing import Optional
 
 from notifications_utils.clients.redis import daily_limit_cache_key
 
+from app.constants import LetterLanguageOptions
 from app.extensions import redis_client
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 
@@ -169,7 +171,18 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.delete(endpoint, data)
 
     @cache.delete("service-{service_id}-templates")
-    def create_service_template(self, name, type_, content, service_id, subject=None, parent_folder_id=None):
+    def create_service_template(
+        self,
+        name,
+        type_,
+        content,
+        service_id,
+        subject=None,
+        parent_folder_id=None,
+        letter_languages: Optional[LetterLanguageOptions] = None,
+        letter_welsh_subject: str = None,
+        letter_welsh_content: str = None,
+    ):
         """
         Create a service template.
         """
@@ -184,6 +197,12 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             data.update({"subject": subject})
         if parent_folder_id:
             data.update({"parent_folder_id": parent_folder_id})
+        if letter_languages is not None:
+            data |= {
+                "letter_languages": letter_languages,
+                "letter_welsh_subject": letter_welsh_subject,
+                "letter_welsh_content": letter_welsh_content,
+            }
         data = _attach_current_user(data)
         endpoint = f"/service/{service_id}/template"
         return self.post(endpoint, data)

--- a/app/templates/views/copy-template.html
+++ b/app/templates/views/copy-template.html
@@ -5,7 +5,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set heading %}
-  Copy template
+  Copy an existing template
 {% endset %}
 
 {% block service_page_title %}
@@ -27,7 +27,7 @@
       {{ form.name }}
       {{ template|string }}
       {{ sticky_page_footer(
-        'Copy template'
+        'Copy this template'
       ) }}
     {% endcall %}
 

--- a/app/templates/views/copy-template.html
+++ b/app/templates/views/copy-template.html
@@ -1,0 +1,34 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import sticky_page_footer %}
+{% from "components/form.html" import form_wrapper %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set heading %}
+  Copy template
+{% endset %}
+
+{% block service_page_title %}
+  {{ heading }}
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    "href": back_link
+  }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+    {{ page_header(heading) }}
+
+    {% call form_wrapper() %}
+      {{ form.template_id }}
+      {{ form.name }}
+      {{ template|string }}
+      {{ sticky_page_footer(
+        'Copy template'
+      ) }}
+    {% endcall %}
+
+{% endblock %}

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -3,7 +3,7 @@
 {% import "components/svgs.html" as svgs %}
 
 {% extends "withnav_template.html" %}
-{% set page_title = "Copy an existing template" %}
+{% set page_title = "Choose an existing template to copy" %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -322,7 +322,7 @@ def template_json(
     postage=None,
     folder=None,
     letter_attachment=None,
-    letter_languages="english",
+    letter_languages=None,
     letter_welsh_subject=None,
     letter_welsh_content=None,
 ):
@@ -343,7 +343,7 @@ def template_json(
         "folder": folder,
         "postage": postage,
         "letter_attachment": letter_attachment,
-        "letter_languages": letter_languages,
+        "letter_languages": letter_languages or "english" if type_ == "letter" else None,
         "letter_welsh_subject": letter_welsh_subject,
         "letter_welsh_content": letter_welsh_content,
     }

--- a/tests/app/main/views/test_letters.py
+++ b/tests/app/main/views/test_letters.py
@@ -10,21 +10,6 @@ letters_urls = [
 ]
 
 
-@pytest.mark.parametrize("method", ("get", "post"))
-def test_add_template_page_doesnt_work_for_letters(
-    client_request,
-    service_one,
-    method,
-):
-    service_one["permissions"] += ["letter"]
-    getattr(client_request, method)(
-        "main.add_service_template",
-        template_type="letter",
-        service_id=service_one["id"],
-        _expected_status=404,
-    )
-
-
 @pytest.mark.parametrize("url", letters_urls)
 @pytest.mark.parametrize("permissions, response_code", [(["letter"], 200), ([], 403)])
 def test_letters_access_restricted(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2137,8 +2137,11 @@ def test_choose_a_template_to_copy_from_folder_within_service(
     ),
 )
 def test_load_edit_template_with_copy_of_template(
+    mocker,
+    api_user_active,
     client_request,
     active_user_with_permission_to_two_services,
+    multiple_sms_senders,
     mock_get_service_templates,
     mock_get_service_email_template,
     mock_get_non_empty_organisations_and_services_for_user,
@@ -2168,18 +2171,16 @@ def test_load_edit_template_with_copy_of_template(
 
     assert page.select_one("form")["method"] == "post"
 
-    assert page.select_one("input")["value"] == (expected_name)
-    assert page.select_one("textarea").text == "\r\nYour ((thing)) is due soon"
-    mock_get_service_email_template.assert_called_once_with(
-        SERVICE_TWO_ID,
-        TEMPLATE_ONE_ID,
-    )
+    assert page.select_one("input[id=name]")["value"] == expected_name
+    assert page.select_one("div[class=email-message]") is not None  # template is rendered on page
+    assert mock_get_service_email_template.call_args_list == [mocker.call(SERVICE_TWO_ID, TEMPLATE_ONE_ID, None)]
 
 
 def test_copy_template_loads_template_from_within_subfolder(
     client_request,
     active_user_with_permission_to_two_services,
     mock_get_service_templates,
+    multiple_sms_senders,
     mock_get_non_empty_organisations_and_services_for_user,
     mocker,
 ):
@@ -2209,9 +2210,9 @@ def test_copy_template_loads_template_from_within_subfolder(
         from_folder=PARENT_FOLDER_ID,
     )
 
-    assert page.select_one("input")["value"] == "foo (copy)"
-    mock_get_service_template.assert_called_once_with(SERVICE_TWO_ID, TEMPLATE_ONE_ID)
-    mock_get_template_folder.assert_called_once_with(SERVICE_TWO_ID, PARENT_FOLDER_ID)
+    assert page.select_one("input[id=name]")["value"] == "foo (copy)"
+    assert mock_get_service_template.call_args_list == [mocker.call(SERVICE_TWO_ID, TEMPLATE_ONE_ID, None)]
+    assert mock_get_template_folder.call_args_list == [mocker.call(SERVICE_TWO_ID, PARENT_FOLDER_ID)]
 
 
 def test_cant_copy_template_from_non_member_service(
@@ -2232,27 +2233,39 @@ def test_cant_copy_template_from_non_member_service(
 def test_post_copy_template(
     mocker,
     client_request,
+    active_user_with_permissions,
+    mock_get_service,
+    multiple_sms_senders,
     mock_get_service_email_template,
+    mock_get_service_templates,
     mock_get_organisations_and_services_for_user,
     mock_create_service_template,
 ):
+    active_user_with_permissions["services"].append(SERVICE_TWO_ID)
+    active_user_with_permissions["permissions"][SERVICE_TWO_ID] = active_user_with_permissions["permissions"][
+        SERVICE_ONE_ID
+    ]
     client_request.post(
         "main.copy_template",
         service_id=SERVICE_ONE_ID,
-        from_service=SERVICE_ONE_ID,
+        from_service=SERVICE_TWO_ID,
         template_id=TEMPLATE_ONE_ID,
         _data={
-            "name": "template (copy)",
-            "subject": "some email",
-            "template_content": "this is a copy of that other template",
-            "template_type": "sms",
             "service": SERVICE_ONE_ID,
+            "name": "Two week reminder (copy)",
         },
         _expected_status=302,
     )
     assert mock_create_service_template.call_args_list == [
         mocker.call(
-            "template (copy)", "email", "this is a copy of that other template", SERVICE_ONE_ID, "some email", None
+            name="Two week reminder (copy)",
+            type_="email",
+            service_id=SERVICE_ONE_ID,
+            subject="Your ((thing)) is due soon",
+            content="Your vehicle tax expires on ((date))",
+            letter_languages=None,
+            letter_welsh_subject=None,
+            letter_welsh_content=None,
         )
     ]
 
@@ -2261,6 +2274,8 @@ def test_post_copy_letter_template(
     mocker,
     client_request,
     mock_get_service_letter_template,
+    mock_get_service_templates,
+    multiple_sms_senders,
     mock_get_organisations_and_services_for_user,
     mock_create_service_template,
     service_one,
@@ -2273,17 +2288,21 @@ def test_post_copy_letter_template(
         from_service=SERVICE_ONE_ID,
         template_id=TEMPLATE_ONE_ID,
         _data={
-            "name": "template (copy)",
-            "subject": "some letter",
-            "template_content": "this is a copy of that other template",
-            "template_type": "letter",
             "service": SERVICE_ONE_ID,
+            "name": "Two week reminder (copy)",
         },
         _expected_status=302,
     )
     assert mock_create_service_template.call_args_list == [
         mocker.call(
-            "template (copy)", "letter", "this is a copy of that other template", SERVICE_ONE_ID, "some letter", None
+            name="Two week reminder (copy)",
+            type_="letter",
+            service_id=SERVICE_ONE_ID,
+            subject="Subject",
+            content="Template <em>content</em> with & entity",
+            letter_languages="english",
+            letter_welsh_subject=None,
+            letter_welsh_content=None,
         )
     ]
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2400,7 +2400,6 @@ def test_should_not_allow_creation_of_template_through_form_without_correct_perm
     [
         ("email", 403, "Sending emails has been disabled for your service."),
         ("sms", 403, "Sending text messages has been disabled for your service."),
-        ("letter", 404, None),
         ("foo", 404, None),
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import json
 import os
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta
+from typing import Optional
 from unittest import mock
 from unittest.mock import Mock, PropertyMock
 from uuid import UUID, uuid4
@@ -948,7 +949,17 @@ def mock_get_service_letter_template_with_qr_placeholder(mocker):
 
 @pytest.fixture(scope="function")
 def mock_create_service_template(mocker, fake_uuid):
-    def _create(name, type_, content, service_id, subject=None, parent_folder_id=None):
+    def _create(
+        name,
+        type_,
+        content,
+        service_id,
+        subject=None,
+        parent_folder_id=None,
+        letter_languages: Optional[LetterLanguageOptions] = None,
+        letter_welsh_subject: str = None,
+        letter_welsh_content: str = None,
+    ):
         template = template_json(
             service_id=service_id, id_=fake_uuid, name=name, type_=type_, content=content, folder=parent_folder_id
         )


### PR DESCRIPTION
 - [x] **Sits on top of #4938 and https://github.com/alphagov/notifications-api/pull/3975 - to be reviewed/merged first**

---

The current 'copy template' journey is a bit more of a 'pre-filled
create new template' journey. The user is shown a list of all templates
they can see, and when they select one, we take them to the 'add new
template' page with the relevant form fields pre-filled.

This means that all data from the source template needs to be shown on
the page in order to get copied into the new template. As templates get
more complex (eg letter templates with welsh and english pages, and
possibly attachments), this falls outside of our existing design
pattern.

Instead we can simply show confirmation of the template they've
selected, by showing the template preview, and give them a chance to
provide a new name for the template copy (but pre-filled with a sensible
copy name).

This means that we can make sure all of the data is copied correctly
behind-the-scenes. When a user confirms that they're copying the correct
template, we still do a POST to our API to create a new template, but
populated with all of the data from the source data automatically.

To minimise the changeset, I am leaving letter attachments aside for now
still. That will be handled in a future PR.

## Copying a text template
![2023-12-12 16 41 09](https://github.com/alphagov/notifications-admin/assets/2920760/ca187edb-b5e0-408e-8b76-9d42cacbffcb)

## Copying an email template
![2023-12-12 16 41 31](https://github.com/alphagov/notifications-admin/assets/2920760/c68cfa06-983d-4890-98dc-f61aeb53be71)

## Copying a letter template
![2023-12-12 16 41 51](https://github.com/alphagov/notifications-admin/assets/2920760/b8c27ee0-ec6f-4ee3-8c6c-73a14462f0f2)

