### PR TITLE
Fix error when platform admin users try to use the make service live journey when a service has no organisation

### DIFF
--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -13,7 +13,7 @@ def org_member_make_service_live_start(service_id):
     if current_service.live:
         return render_template("views/service-settings/service-already-live.html", prompt_to_switch_service=False), 410
 
-    if not current_service.organisation_id:
+    if current_user.platform_admin and not current_service.organisation_id:
         return render_template("views/service-settings/service-no-organisation.html"), 410
 
     if not current_user.can_make_service_live(current_service):

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -13,6 +13,9 @@ def org_member_make_service_live_start(service_id):
     if current_service.live:
         return render_template("views/service-settings/service-already-live.html", prompt_to_switch_service=False), 410
 
+    if not current_service.organisation_id:
+        return render_template("views/service-settings/service-no-organisation.html"), 410
+
     if not current_user.can_make_service_live(current_service):
         abort(403)
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -462,6 +462,8 @@ class User(BaseUser, UserMixin):
     def can_make_service_live(self, service):
         if not service.has_active_go_live_request:
             return False
+        if not service.organisation_id:
+            return False
         if self.platform_admin:
             return True
         return (

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -460,14 +460,15 @@ class User(BaseUser, UserMixin):
         return False
 
     def can_make_service_live(self, service):
+        if not service.has_active_go_live_request:
+            return False
+        if self.platform_admin:
+            return True
         return (
-            self.platform_admin
-            or (
-                self.belongs_to_organisation(service.organisation_id)
-                and service.organisation.can_approve_own_go_live_requests
-                and self.has_permission_for_organisation(service.organisation_id, PERMISSION_CAN_MAKE_SERVICES_LIVE)
-            )
-        ) and service.has_active_go_live_request
+            self.belongs_to_organisation(service.organisation_id)
+            and service.organisation.can_approve_own_go_live_requests
+            and self.has_permission_for_organisation(service.organisation_id, PERMISSION_CAN_MAKE_SERVICES_LIVE)
+        )
 
 
 class InvitedUser(BaseUser):

--- a/app/templates/views/service-settings/service-no-organisation.html
+++ b/app/templates/views/service-settings/service-no-organisation.html
@@ -1,0 +1,20 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+
+{% set title = "This service does not belong to an organisation" %}
+
+{% block service_page_title %}
+  {{ title }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(title) }}
+
+  <p class="govuk-body">
+    You need to
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.link_service_to_organisation', service_id=current_service.id) }}">link this service to an organisation</a>
+    before you can make it live.
+  </p>
+
+{% endblock %}

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -116,6 +116,27 @@ def test_get_org_member_make_service_live_start(
         assert button.get("href") == f"/services/{SERVICE_ONE_ID}/make-service-live/unique-service"
 
 
+def test_make_service_live_start_with_no_organisation(
+    mocker,
+    client_request,
+    service_one,
+):
+    service_one["has_active_go_live_request"] = True
+    service_one["organisation"] = None
+
+    page = client_request.get(
+        "main.org_member_make_service_live_start",
+        service_id=SERVICE_ONE_ID,
+        _expected_status=410,
+    )
+
+    assert normalize_spaces(page.select_one("h1").text) == "This service does not belong to an organisation"
+    assert page.select_one("main a")["href"] == url_for(
+        ".link_service_to_organisation",
+        service_id=SERVICE_ONE_ID,
+    )
+
+
 @pytest.mark.parametrize(*test_user_auth_combinations)
 def test_get_org_member_make_service_live_service_name(
     mocker,

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -124,6 +124,23 @@ def test_make_service_live_start_with_no_organisation(
     service_one["has_active_go_live_request"] = True
     service_one["organisation"] = None
 
+    client_request.get(
+        "main.org_member_make_service_live_start",
+        service_id=SERVICE_ONE_ID,
+        _expected_status=403,
+    )
+
+
+def test_make_service_live_start_with_no_organisation_platform_admin(
+    mocker,
+    client_request,
+    service_one,
+    platform_admin_user,
+):
+    service_one["has_active_go_live_request"] = True
+    service_one["organisation"] = None
+    client_request.login(platform_admin_user)
+
     page = client_request.get(
         "main.org_member_make_service_live_start",
         service_id=SERVICE_ONE_ID,


### PR DESCRIPTION
Code elsewhere was assuming that the service has an organisation by the time it gets to this point.

For platform admin users it’s possible to get into the new ‘make service live’ journey without the service having an organisation.

This pull request first makes sure that the user gets a `403` instead of `500` at any point in the make service live journey. Then it adds a custom error page which is shown at the start of the journey.

***

<img width="768" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/f79cbe11-345c-40ea-9036-c19cc5806aa2">
