### PR TITLE
Stop platform admin users making services live if the organisation hasn’t signed the agreement

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -255,6 +255,11 @@ def submit_request_to_go_live(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/switch-live", methods=["GET", "POST"])
 @user_is_platform_admin
 def service_switch_live(service_id):
+    if current_service.trial_mode and (
+        not current_service.organisation or current_service.organisation.agreement_signed is False
+    ):
+        abort(403)
+
     form = OnOffSettingForm(name="Make service live", enabled=not current_service.trial_mode)
 
     if form.validate_on_submit():

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -358,6 +358,9 @@
             {% if current_service.trial_mode and not current_service.organisation_id %}
               {{ text_field('No (organisation must be set first)') }}
               {{ text_field('') }}
+            {% elif current_service.trial_mode and current_service.organisation.agreement_signed is false %}
+              {{ text_field('No (organisation must accept the data sharing and financial agreement)') }}
+              {{ text_field('') }}
             {% else %}
               {{ boolean_field(not current_service.trial_mode) }}
               {{ edit_field('Change', url_for('main.service_switch_live', service_id=current_service.id), suffix='service status') }}

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -4,6 +4,7 @@ import pytest
 from flask import url_for
 
 from app.main.views.service_settings.index import PLATFORM_ADMIN_SERVICE_PERMISSIONS
+from tests import organisation_json
 from tests.conftest import normalize_spaces
 
 
@@ -160,6 +161,10 @@ def test_service_setting_toggles_show(
     kwargs,
     text,
 ):
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_json(agreement_signed=True),
+    )
     link_url = url_for(endpoint, **kwargs, service_id=service_one["id"])
     service_one.update(service_fields)
     page = get_service_settings_page()


### PR DESCRIPTION
We already stop platform admin users from making services live withou an organisation.

Sometimes they create and organisation, assign the service to it, then make it live.

This inadvertantly skips the step where the service needs to sign the agreement on behalf of their organisation.

This commit puts a restriction in place to stop that from being possible.

Note we still have the concept of a service-specific agreement (defined as `agreement_signed=None`) which this continues to support. Argument for another day whether we should remove that concept entirely.