### PR TITLE
Fix display of ‘no organisation’ hint text

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -356,10 +356,16 @@
           {% call row() %}
             {{ text_field('Live')}}
             {% if current_service.trial_mode and not current_service.organisation_id %}
-              {{ text_field('No (organisation must be set first)') }}
+              {% call field() %}
+                No
+                <div class="hint">Organisation must be set first</div>
+              {% endcall %}
               {{ text_field('') }}
             {% elif current_service.trial_mode and current_service.organisation.agreement_signed is false %}
-              {{ text_field('No (organisation must accept the data sharing and financial agreement)') }}
+              {% call field(wrap=True) %}
+                No
+                <div class="hint">Organisation must accept the data sharing and financial agreement first</div>
+              {% endcall %}
               {{ text_field('') }}
             {% else %}
               {{ boolean_field(not current_service.trial_mode) }}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -126,7 +126,7 @@ def mock_get_service_settings_page_common(
                 "Label Value Action",
                 "Send letters Off Change your settings for sending letters",
                 "Label Value Action",
-                "Live No (organisation must accept the data sharing and financial agreement)",
+                "Live No Organisation must accept the data sharing and financial agreement first",
                 "Count in list of live services Yes Change if service is counted in list of live services",
                 "Billing details None Change billing details for service",
                 "Notes None Change the notes for the service",
@@ -162,7 +162,7 @@ def mock_get_service_settings_page_common(
                 "Sender addresses Not set Manage sender addresses",
                 "Letter branding Not set Change letter branding",
                 "Label Value Action",
-                "Live No (organisation must accept the data sharing and financial agreement)",
+                "Live No Organisation must accept the data sharing and financial agreement first",
                 "Count in list of live services Yes Change if service is counted in list of live services",
                 "Billing details None Change billing details for service",
                 "Notes None Change the notes for the service",
@@ -270,9 +270,9 @@ def test_no_go_live_link_for_service_without_organisation(
     assert page.select_one("h1").text == "Settings"
 
     is_live = find_element_by_tag_and_partial_text(page, tag="td", string="Live")
-    assert normalize_spaces(is_live.find_next_sibling().text) == "No (organisation must be set first)"
+    assert normalize_spaces(is_live.find_next_sibling().text) == "No Organisation must be set first"
 
-    organisation = find_element_by_tag_and_partial_text(page, tag="td", string="Organisation")
+    organisation = find_element_by_tag_and_partial_text(page, tag="td:first-child", string="Organisation")
     assert normalize_spaces(organisation.find_next_siblings()[0].text) == "Not set Central government"
     assert normalize_spaces(organisation.find_next_siblings()[1].text) == "Change organisation for service"
 
@@ -292,7 +292,7 @@ def test_organisation_name_links_to_org_dashboard(
     client_request.login(platform_admin_user, service_one)
     response = client_request.get("main.service_settings", service_id=SERVICE_ONE_ID)
 
-    org_row = find_element_by_tag_and_partial_text(response, tag="tr", string="Organisation")
+    org_row = find_element_by_tag_and_partial_text(response, tag="td:first-child", string="Organisation").parent
     assert org_row.find("a")["href"] == url_for("main.organisation_dashboard", org_id=ORGANISATION_ID)
     assert normalize_spaces(org_row.find("a").text) == "Test organisation"
 


### PR DESCRIPTION
Stops it wrapping and generally makes it look a bit nicer by making it hint text instead of just in brackets.

This is why it’s good to always put screenshots in pull requests 🙃 

Before | After
---|---
<img width="758" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/f6421441-8771-48bd-bf34-268dc1b0b8b2"> | <img width="753" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/c2fc846f-6d9f-45a1-aa70-db0835cf5f15">
