### PR TITLE
Copy templates to target folder

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2856,6 +2856,7 @@ class CopyTemplateForm(StripWhitespaceForm, TemplateNameMixin):
     template_id = HiddenField(
         "The template ID to copy", validators=[NotifyDataRequired(thing="the template ID to copy")]
     )
+    parent_folder_id = HiddenField("The folder ID to copy the template into")
 
 
 class AddOrJoinServiceForm(StripWhitespaceForm):

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -333,6 +333,7 @@ def _add_template_by_type(template_type, template_folder_id):
             url_for(
                 ".choose_template_to_copy",
                 service_id=current_service.id,
+                to_folder_id=template_folder_id,
             )
         )
 
@@ -375,6 +376,7 @@ def choose_template_to_copy(
     from_service=None,
     from_folder=None,
 ):
+    to_folder_id = request.args.get("to_folder_id")
     if from_service:
         current_user.belongs_to_service_or_403(from_service)
         service = Service(service_api_client.get_service(from_service)["data"])
@@ -387,6 +389,7 @@ def choose_template_to_copy(
             template_folder_path=service.get_template_folder_path(from_folder),
             from_service=service,
             _search_form=SearchTemplatesForm(current_service.api_keys),
+            to_folder_id=to_folder_id,
         )
 
     else:
@@ -394,6 +397,7 @@ def choose_template_to_copy(
             "views/templates/copy.html",
             services_templates_and_folders=UserTemplateLists(current_user),
             _search_form=SearchTemplatesForm(current_service.api_keys),
+            to_folder_id=to_folder_id,
         )
 
 
@@ -401,6 +405,7 @@ def choose_template_to_copy(
 @user_has_permissions("manage_templates")
 def copy_template(service_id, template_id):
     from_service_id = request.args.get("from_service")
+    to_folder_id = request.args.get("to_folder_id")
 
     current_user.belongs_to_service_or_403(from_service_id)
     from_service = Service.from_id(from_service_id)
@@ -424,7 +429,7 @@ def copy_template(service_id, template_id):
     if not current_user.has_template_folder_permission(template_folder, service=current_service):
         abort(403)
 
-    form = CopyTemplateForm(template_id=template.id, name=template.name)
+    form = CopyTemplateForm(template_id=template.id, name=template.name, parent_folder_id=to_folder_id)
 
     if request.method == "POST":
         new_template = service_api_client.create_service_template(
@@ -433,6 +438,7 @@ def copy_template(service_id, template_id):
             service_id=current_service.id,
             subject=template.get_raw("subject"),
             content=template.content,
+            parent_folder_id=form.parent_folder_id.data,
             letter_languages=template.get_raw("letter_languages"),
             letter_welsh_subject=template.get_raw("letter_welsh_subject"),
             letter_welsh_content=template.get_raw("letter_welsh_content"),
@@ -448,12 +454,14 @@ def copy_template(service_id, template_id):
             service_id=current_service.id,
             from_service=from_service_id,
             from_folder=template.get_raw("folder"),
+            to_folder_id=to_folder_id,
         )
     else:
         back_link = url_for(
             ".choose_template_to_copy",
             service_id=current_service.id,
             from_service=from_service_id,
+            to_folder_id=to_folder_id,
         )
 
     return render_template(

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -46,12 +46,13 @@
   folder_path,
   current_service_id,
   from_service,
-  current_user
+  current_user,
+  to_folder_id
 ) %}
   {% if folder_path %}
     <h2 class="heading-medium folder-heading">
       {% if folder_path|length == 1 %}
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id) }}">Services</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, to_folder_id=to_folder_id) }}">Services</a>
         {{ folder_path_separator() }}
       {% endif %}
       {% for folder in folder_path %}
@@ -63,7 +64,7 @@
         {% else %}
           {% if folder.id %}
             {% if current_user.has_template_folder_permission(folder, service=from_service) %}
-              <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
+              <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
                 {{ svgs.folder(classes="folder-heading-folder__icon") }}
                 {{ folder.name }}
               </a>
@@ -75,12 +76,12 @@
             {% endif %}
             {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% elif folder.parent_id == None %}
-            <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
+            <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
               {{ svgs.folder(classes="folder-heading-folder__icon") }}
               {{ from_service.name }}
             </a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% else %}
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id) }}">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, to_folder_id=to_folder_id) }}">
               {{ svgs.folder(classes="folder-heading-folder__icon") }}
               {{ from_service.name }}
             </a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -13,7 +13,7 @@
 
     <div class="bottom-gutter-1-2">
       <h1 class="heading-large">{{ page_title }}</h1>
-      {{ copy_folder_path(template_folder_path, current_service.id, from_service, current_user) }}
+      {{ copy_folder_path(template_folder_path, current_service.id, from_service, current_user, to_folder_id) }}
     </div>
     {% if not services_templates_and_folders.templates_to_show %}
       <p class="template-list-empty">
@@ -31,26 +31,26 @@
           <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
             {% for ancestor in item.ancestors %}
               {% if ancestor.is_service %}
-                <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+                <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {% else %}
-                <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+                <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {% endif %}
                 {{ svgs.folder(classes="template-list-folder__icon") }}
                 {{ ancestor.name }}
               </a> <span class="message-name-separator"></span>
             {% endfor %}
             {% if item.is_service %}
-              <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+              <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
                 {{ svgs.folder(classes="template-list-folder__icon") }}
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% elif item.is_folder %}
-              <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+              <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
                 {{ svgs.folder(classes="template-list-folder__icon") }}
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% else %}
-              <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('main.copy_template', service_id=current_service.id, template_id=item.id, from_service=item.service_id) }}">
+              <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('main.copy_template', service_id=current_service.id, template_id=item.id, from_service=item.service_id, to_folder_id=to_folder_id) }}">
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% endif %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1913,6 +1913,29 @@ def test_choosing_to_copy_redirects(
     )
 
 
+def test_choosing_to_copy_redirects_and_includes_folder_id(
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+):
+    mock_get_template_folders.return_value = [
+        _folder("Parent folder", PARENT_FOLDER_ID),
+    ]
+    client_request.post(
+        "main.choose_template",
+        service_id=SERVICE_ONE_ID,
+        template_folder_id=PARENT_FOLDER_ID,
+        _data={"operation": "add-new-template", "add_template_by_template_type": "copy-existing"},
+        _expected_status=302,
+        _expected_redirect=url_for(
+            "main.choose_template_to_copy",
+            service_id=SERVICE_ONE_ID,
+            to_folder_id=PARENT_FOLDER_ID,
+        ),
+    )
+
+
 def test_choosing_letter_creates(
     client_request,
     service_one,
@@ -1996,6 +2019,66 @@ def test_choose_a_template_to_copy(
         service_id=SERVICE_ONE_ID,
         template_id=TEMPLATE_ONE_ID,
         from_service=SERVICE_TWO_ID,
+    )
+
+
+def test_choose_a_template_to_copy_passes_through_folder_id(
+    client_request,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    mock_get_no_api_keys,
+    mock_get_just_services_for_user,
+):
+    page = client_request.get(
+        "main.choose_template_to_copy",
+        service_id=SERVICE_ONE_ID,
+        to_folder_id=PARENT_FOLDER_ID,
+    )
+
+    assert page.select(".folder-heading") == []
+
+    expected = [
+        "Service 1 6 templates",
+        "Service 1 sms_template_one Text message template",
+        "Service 1 sms_template_two Text message template",
+        "Service 1 email_template_one Email template",
+        "Service 1 email_template_two Email template",
+        "Service 1 letter_template_one Letter template",
+        "Service 1 letter_template_two Letter template",
+        "Service 2 6 templates",
+        "Service 2 sms_template_one Text message template",
+        "Service 2 sms_template_two Text message template",
+        "Service 2 email_template_one Email template",
+        "Service 2 email_template_two Email template",
+        "Service 2 letter_template_one Letter template",
+        "Service 2 letter_template_two Letter template",
+    ]
+    actual = page.select(".template-list-item")
+
+    assert len(actual) == len(expected)
+
+    for actual, expected in zip(actual, expected):  # noqa: B020
+        assert normalize_spaces(actual.text) == expected
+
+    links = page.select(".template-list-item a")
+    assert links[0]["href"] == url_for(
+        "main.choose_template_to_copy",
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_TWO_ID,
+        to_folder_id=PARENT_FOLDER_ID,
+    )
+    assert links[1]["href"] == url_for(
+        "main.choose_template_to_copy",
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_TWO_ID,
+        to_folder_id=PARENT_FOLDER_ID,
+    )
+    assert links[2]["href"] == url_for(
+        "main.copy_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=TEMPLATE_ONE_ID,
+        from_service=SERVICE_TWO_ID,
+        to_folder_id=PARENT_FOLDER_ID,
     )
 
 
@@ -2287,8 +2370,51 @@ def test_post_copy_template(
             name="Two week reminder (copy)",
             type_="email",
             service_id=SERVICE_ONE_ID,
+            parent_folder_id=None,
             subject="Your ((thing)) is due soon",
             content="Your vehicle tax expires on ((date))",
+            letter_languages=None,
+            letter_welsh_subject=None,
+            letter_welsh_content=None,
+        )
+    ]
+
+
+def test_post_copy_template_into_folder(
+    mocker,
+    client_request,
+    active_user_with_permissions,
+    mock_get_service,
+    multiple_sms_senders,
+    mock_get_service_email_template,
+    mock_get_service_templates,
+    mock_get_organisations_and_services_for_user,
+    mock_create_service_template,
+):
+    active_user_with_permissions["services"].append(SERVICE_TWO_ID)
+    active_user_with_permissions["permissions"][SERVICE_TWO_ID] = active_user_with_permissions["permissions"][
+        SERVICE_ONE_ID
+    ]
+    client_request.post(
+        "main.copy_template",
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_TWO_ID,
+        template_id=TEMPLATE_ONE_ID,
+        to_folder_id=PARENT_FOLDER_ID,
+        _data={
+            "service": SERVICE_ONE_ID,
+            "name": "Two week reminder (copy)",
+        },
+        _expected_status=302,
+    )
+    assert mock_create_service_template.call_args_list == [
+        mocker.call(
+            name="Two week reminder (copy)",
+            type_="email",
+            service_id=SERVICE_ONE_ID,
+            subject="Your ((thing)) is due soon",
+            content="Your vehicle tax expires on ((date))",
+            parent_folder_id=PARENT_FOLDER_ID,
             letter_languages=None,
             letter_welsh_subject=None,
             letter_welsh_content=None,
@@ -2325,6 +2451,7 @@ def test_post_copy_letter_template(
             type_="letter",
             service_id=SERVICE_ONE_ID,
             subject="Subject",
+            parent_folder_id=None,
             content="Template <em>content</em> with & entity",
             letter_languages="english",
             letter_welsh_subject=None,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2219,7 +2219,7 @@ def test_choose_a_template_to_copy_from_folder_within_service(
         (["Two week reminder (copy)", "Two week reminder (copy 10)"], "Two week reminder (copy 2)"),
     ),
 )
-def test_load_edit_template_with_copy_of_template(
+def test_copy_template_page_renders_preview(
     mocker,
     api_user_active,
     client_request,


### PR DESCRIPTION
If a user is in a folder when they start the 'copy template' journey, we
should make sure to create the new template inside that folder (as
opposed to just at the root).