### PR TITLE
Make it explicit that link text only works in emails

### DIFF
--- a/app/templates/views/guidance/using-notify/links-and-URLs.html
+++ b/app/templates/views/guidance/using-notify/links-and-URLs.html
@@ -48,16 +48,18 @@
 
   <p class="govuk-body">Never use ‘click here’, ‘click link’, ‘this link’ or ‘more’, as these do not make sense when read out of context.</p>
 
-  <h3 class="heading-small">How to format link text</h3>
+  <h3 class="heading-small">How to add link text to an email</h3>
   <p class="govuk-body">GOV.UK Notify uses Markdown to format link text.</p>
   <p class="govuk-body">To convert text into a link, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work. For example:</p>
 
   <pre class="formatting-example"><code class="lang-md">[Apply now](https://www.gov.uk/example)</code></pre>
 
-  <p class="govuk-body">To see formatting instructions while you’re editing a template:</p>
+  <p class="govuk-body">You cannot add link text to text message or letter templates.</p>
+
+  <p class="govuk-body">To see formatting instructions while you’re editing an email template:</p>
    <ol class="govuk-list govuk-list--number">
     <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
-    <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
+    <li>Add a new email template or choose an existing email template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
     <li>Scroll down to see a guide to the available Markdown.</li>
   </ol>
 

--- a/app/templates/views/guidance/using-notify/links-and-URLs.html
+++ b/app/templates/views/guidance/using-notify/links-and-URLs.html
@@ -54,7 +54,7 @@
 
   <pre class="formatting-example"><code class="lang-md">[Apply now](https://www.gov.uk/example)</code></pre>
 
-  <p class="govuk-body">You cannot add link text to text message or letter templates.</p>
+  <p class="govuk-body">You cannot use Markdown to add link text to a text message or letter template.</p>
 
   <p class="govuk-body">To see formatting instructions while you’re editing an email template:</p>
    <ol class="govuk-list govuk-list--number">


### PR DESCRIPTION
We’ve had a couple of support tickets in the last few months where users were trying to add Markdown for link text to text message templates.

This PR makes a few small changes to (hopefully) make it clearer that this is not possible.