### PR TITLE
Announce January 2024 postage rate increase

### DIFF
--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -50,4 +50,8 @@
     {% endcall %}
   </div>
 
+<div class="govuk-inset-text">
+  International postage prices will go up on 2 January 2024.
+</div>
+
 {% endblock %}


### PR DESCRIPTION
This PR adds an announcement that international postage prices will go up on 2 January 2024.

At this point, we do not know exactly how much they’ll go up by.