### PR TITLE
Add api_key_id to notifications sent report that users can download

### DIFF
--- a/app/utils/csv.py
+++ b/app/utils/csv.py
@@ -59,7 +59,18 @@ def generate_notifications_csv(**kwargs):
         original_column_headers = original_upload.column_headers
         fieldnames = ["Row number"] + original_column_headers + ["Template", "Type", "Job", "Status", "Time"]
     else:
-        fieldnames = ["Recipient", "Reference", "Template", "Type", "Sent by", "Sent by email", "Job", "Status", "Time"]
+        fieldnames = [
+            "Recipient",
+            "Reference",
+            "Template",
+            "Type",
+            "Sent by",
+            "Sent by email",
+            "Job",
+            "Status",
+            "Time",
+            "API key id",
+        ]
 
     yield ",".join(fieldnames) + "\n"
 
@@ -95,6 +106,7 @@ def generate_notifications_csv(**kwargs):
                     notification["job_name"] or "",
                     notification["status"],
                     notification["created_at"],
+                    notification["api_key_id"] or "",
                 ]
             yield Spreadsheet.from_rows([map(str, values)]).as_csv_data
 

--- a/app/utils/csv.py
+++ b/app/utils/csv.py
@@ -69,13 +69,14 @@ def generate_notifications_csv(**kwargs):
             "Job",
             "Status",
             "Time",
-            "API key id",
+            "API key name",
         ]
 
     yield ",".join(fieldnames) + "\n"
 
     while kwargs["page"]:
         notifications_resp = notification_api_client.get_notifications_for_service(**kwargs)
+
         for notification in notifications_resp["notifications"]:
             if kwargs.get("job_id"):
                 values = (
@@ -106,7 +107,7 @@ def generate_notifications_csv(**kwargs):
                     notification["job_name"] or "",
                     notification["status"],
                     notification["created_at"],
-                    notification["api_key_id"] or "",
+                    notification["api_key_name"] or "",
                 ]
             yield Spreadsheet.from_rows([map(str, values)]).as_csv_data
 

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -21,6 +21,7 @@ def _get_notifications_csv(
     job_id=fake_uuid,
     created_by_name=None,
     created_by_email_address=None,
+    api_key_id=None,
 ):
     def _get(
         service_id,
@@ -52,6 +53,7 @@ def _get_notifications_csv(
                     "updated_at": None,
                     "created_by_name": created_by_name,
                     "created_by_email_address": created_by_email_address,
+                    "api_key_id": api_key_id,
                 }
                 for i in range(rows)
             ],
@@ -76,20 +78,22 @@ def _get_notifications_csv_mock(
 
 
 @pytest.mark.parametrize(
-    "created_by_name, expected_content",
+    "created_by_name, api_key_id, expected_content",
     [
         (
             None,
+            "some-id",
             [
-                "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time\n",
-                "foo@bar.com,ref 1234,foo,sms,,sender@email.gov.uk,,Delivered,1943-04-19 12:00:00\r\n",
+                "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time,API key id\n",
+                "foo@bar.com,ref 1234,foo,sms,,sender@email.gov.uk,,Delivered,1943-04-19 12:00:00,some-id\r\n",
             ],
         ),
         (
             "Anne Example",
+            None,
             [
-                "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time\n",
-                "foo@bar.com,ref 1234,foo,sms,Anne Example,sender@email.gov.uk,,Delivered,1943-04-19 12:00:00\r\n",
+                "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time,API key id\n",
+                "foo@bar.com,ref 1234,foo,sms,Anne Example,sender@email.gov.uk,,Delivered,1943-04-19 12:00:00,\r\n",
             ],
         ),
     ],
@@ -98,12 +102,17 @@ def test_generate_notifications_csv_without_job(
     notify_admin,
     mocker,
     created_by_name,
+    api_key_id,
     expected_content,
 ):
     mocker.patch(
         "app.notification_api_client.get_notifications_for_service",
         side_effect=_get_notifications_csv(
-            created_by_name=created_by_name, created_by_email_address="sender@email.gov.uk", job_id=None, job_name=None
+            created_by_name=created_by_name,
+            created_by_email_address="sender@email.gov.uk",
+            job_id=None,
+            job_name=None,
+            api_key_id=api_key_id,
         ),
     )
     assert list(generate_notifications_csv(service_id=fake_uuid)) == expected_content

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -21,7 +21,7 @@ def _get_notifications_csv(
     job_id=fake_uuid,
     created_by_name=None,
     created_by_email_address=None,
-    api_key_id=None,
+    api_key_name=None,
 ):
     def _get(
         service_id,
@@ -53,7 +53,7 @@ def _get_notifications_csv(
                     "updated_at": None,
                     "created_by_name": created_by_name,
                     "created_by_email_address": created_by_email_address,
-                    "api_key_id": api_key_id,
+                    "api_key_name": api_key_name,
                 }
                 for i in range(rows)
             ],
@@ -78,21 +78,21 @@ def _get_notifications_csv_mock(
 
 
 @pytest.mark.parametrize(
-    "created_by_name, api_key_id, expected_content",
+    "created_by_name, api_key_name, expected_content",
     [
         (
             None,
-            "some-id",
+            "my-key-name",
             [
-                "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time,API key id\n",
-                "foo@bar.com,ref 1234,foo,sms,,sender@email.gov.uk,,Delivered,1943-04-19 12:00:00,some-id\r\n",
+                "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time,API key name\n",
+                "foo@bar.com,ref 1234,foo,sms,,sender@email.gov.uk,,Delivered,1943-04-19 12:00:00,my-key-name\r\n",
             ],
         ),
         (
             "Anne Example",
             None,
             [
-                "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time,API key id\n",
+                "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time,API key name\n",
                 "foo@bar.com,ref 1234,foo,sms,Anne Example,sender@email.gov.uk,,Delivered,1943-04-19 12:00:00,\r\n",
             ],
         ),
@@ -102,7 +102,7 @@ def test_generate_notifications_csv_without_job(
     notify_admin,
     mocker,
     created_by_name,
-    api_key_id,
+    api_key_name,
     expected_content,
 ):
     mocker.patch(
@@ -112,7 +112,7 @@ def test_generate_notifications_csv_without_job(
             created_by_email_address="sender@email.gov.uk",
             job_id=None,
             job_name=None,
-            api_key_id=api_key_id,
+            api_key_name=api_key_name,
         ),
     )
     assert list(generate_notifications_csv(service_id=fake_uuid)) == expected_content


### PR DESCRIPTION
We already provide sender name and email, and job id, makes sense to tell users which api key notifications were sent with. Added after a user requested it.

Needs to go in after: https://github.com/alphagov/notifications-api/pull/3985