### PR TITLE
Fix copied letter previews across services

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -409,7 +409,7 @@ def copy_template(service_id, template_id):
         template_id,
         letter_preview_url=url_for(
             "no_cookie.view_letter_template_preview",
-            service_id=service_id,
+            service_id=from_service.id,
             template_id=template_id,
             filetype="png",
         ),


### PR DESCRIPTION
When copying letter templates across a service boundary, the letter preview was trying to render the template as if it existed on the target service. This led to the previews never loading.

This patch fixes it to look at the source service correctly.