### PR TITLE
Set up prototype for ‘join a service’ user research

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -153,6 +153,7 @@ class Test(Development):
 
 
 class Preview(Config):
+    ADMIN_BASE_URL = "https://notify-admin-prototype-preview.cloudapps.digital"
     HTTP_PROTOCOL = "https"
     HEADER_COLOUR = "#F499BE"  # $baby-pink
     S3_BUCKET_CSV_UPLOAD = "preview-notifications-csv-upload"
@@ -190,6 +191,7 @@ class Staging(Config):
 
 
 class Production(Config):
+    ADMIN_BASE_URL = "https://notify-admin-prototype-production.cloudapps.digital"
     HEADER_COLOUR = "#1d70b8"  # $govuk-blue
     HTTP_PROTOCOL = "https"
     S3_BUCKET_CSV_UPLOAD = "live-notifications-csv-upload"

--- a/app/config.py
+++ b/app/config.py
@@ -166,8 +166,8 @@ class Preview(Config):
     LOGO_CDN_DOMAIN = "static-logos.notify.works"
     NOTIFY_ENVIRONMENT = "preview"
     CHECK_PROXY_HEADER = False
-    ASSET_DOMAIN = "static.notify.works"
-    ASSET_PATH = "https://static.notify.works/"
+    ASSET_DOMAIN = "notify-admin-prototype-preview.cloudapps.digital"
+    ASSET_PATH = "https://notify-admin-prototype-preview.cloudapps.digital/static/"
 
     # On preview, extend the validation timeout to allow more leniency when running functional tests
     REPLY_TO_EMAIL_ADDRESS_VALIDATION_TIMEOUT = 120
@@ -204,8 +204,8 @@ class Production(Config):
     LOGO_CDN_DOMAIN = "static-logos.notifications.service.gov.uk"
     NOTIFY_ENVIRONMENT = "production"
     CHECK_PROXY_HEADER = False
-    ASSET_DOMAIN = "static.notifications.service.gov.uk"
-    ASSET_PATH = "https://static.notifications.service.gov.uk/"
+    ASSET_DOMAIN = "notify-admin-prototype-production.cloudapps.digital"
+    ASSET_PATH = "https://notify-admin-prototype-production.cloudapps.digital/static/"
 
 
 class CloudFoundryConfig(Config):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2884,6 +2884,6 @@ class AddOrJoinServiceForm(StripWhitespaceForm):
         "Start using Notify",
         choices=(
             ("main.add_service", "Add a new service"),
-            ("main.choose_service_to_join", "Join an existing team"),
+            ("main.choose_service_to_join", "Join an existing service"),
         ),
     )

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -169,7 +169,7 @@ class Organisation(JSONModel):
 
     @property
     def can_ask_to_join_a_service(self):
-        return "can_ask_to_join_a_service" in self.permissions
+        return True
 
     @cached_property
     def invited_users(self):

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -78,7 +78,10 @@ class Organisation(JSONModel):
 
     @classmethod
     def from_domain(cls, domain):
-        return cls(organisations_client.get_organisation_by_domain(domain))
+        organisation_json = organisations_client.get_organisation_by_domain(domain)
+        if not organisation_json:
+            organisation_json = organisations_client.get_organisation_by_domain("example.gov.uk")
+        return cls(organisation_json)
 
     @classmethod
     def from_service(cls, service_id):

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -117,7 +117,7 @@
       {% if current_user.default_organisation.can_ask_to_join_a_service %}
         {{ govukButton({
           "element": "a",
-          "text": "Join an existing team",
+          "text": "Join an existing service",
           "href": url_for('main.choose_service_to_join'),
           "classes": "govuk-button--secondary"
         }) }}

--- a/app/templates/views/choose-service-to-join.html
+++ b/app/templates/views/choose-service-to-join.html
@@ -36,9 +36,6 @@
           <p class="browse-list-hint">
               {% if current_user.belongs_to_service(service.id) %}
                 You are already a team member of this service
-              {% else %}
-                {% set team_members = service.active_users_with_permission("manage_service") %}
-                {{ team_members | length | format_thousands }} team member{{ "" if team_members | length == 1 else "s" }}
               {% endif %}
           </p>
         </li>

--- a/app/templates/views/choose-service-to-join.html
+++ b/app/templates/views/choose-service-to-join.html
@@ -2,7 +2,7 @@
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% set heading = 'Join an existing team' %}
+{% set heading = 'Join an existing service' %}
 
 {% block per_page_title %}
   {{ heading }}
@@ -19,8 +19,11 @@
 {% block maincolumn_content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="heading-large"> {{ heading }} </h1>
-    <p class="govuk-body govuk-!-margin-bottom-6">These are all the {{ current_user.default_organisation.name }} teams who have a live service on Notify.</p>
+    <h1 class="heading-large">
+      {{ heading }}
+    </h1>
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      {{ current_user.default_organisation.name }} has {{ current_user.default_organisation.live_services | length }} live service{{ '' if current_user.default_organisation.live_services | length == 1 else 's' }}</p>
 
     {{ live_search(
       target_selector='.browse-list-item',

--- a/app/templates/views/join-service-requested.html
+++ b/app/templates/views/join-service-requested.html
@@ -18,11 +18,16 @@
         If they accept your request you’ll get an email with an invite.
       </p>
       <p class="govuk-body">
-        In the mean time you can
-        <a href="{{ url_for('main.add_service') }}" class="govuk-link govuk-link--no-visited-state">try out Notify by creating your own service</a>
-        or
-        <a href="{{ url_for('main.sign_out') }}" class="govuk-link govuk-link--no-visited-state">sign out for now</a>.
+        In the meantime you can:
       </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <a href="{{ url_for('main.add_service') }}" class="govuk-link govuk-link--no-visited-state">add a new service</a> and try Notify for yourself
+        </li>
+        <li>
+          <a href="{{ url_for('main.sign_out') }}" class="govuk-link govuk-link--no-visited-state">sign out for now</a>
+        </li>
+      </ul>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/views/join-service.html
+++ b/app/templates/views/join-service.html
@@ -4,7 +4,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% set heading = 'Ask to join {}'.format(service.name) %}
+{% set heading = 'Ask to join ‘{}’'.format(service.name) %}
 
 {% block per_page_title %}
   {{ heading }}
@@ -21,7 +21,7 @@
     {% call form_wrapper() %}
       {{ form.users }}
       {{ form.reason }}
-      {{ page_footer('Ask for access') }}
+      {{ page_footer('Ask to join this service') }}
     {% endcall %}
   </div>
 </div>


### PR DESCRIPTION
This branch should not be merged, but instead deployed to the prototype environment, following the instructions here: https://github.com/alphagov/notifications-manuals/wiki/Deploy-a-prototype

To test this you need to set up a fake organisation in the relevant environment, and assign the `example.gov.uk` domain to it.