### PR TITLE
Update guidance for scheduling jobs

### DIFF
--- a/app/templates/views/guidance/using-notify/schedule-messages.html
+++ b/app/templates/views/guidance/using-notify/schedule-messages.html
@@ -12,7 +12,7 @@
 {% block content_column_content %}
   <h1 class="heading-large">Schedule emails and text messages</h1>
 
-  <p class="govuk-body">You can schedule messages up to 4 days in advance.</p>
+  <p class="govuk-body">You can schedule messages up to one week in advance.</p>
 
   <p class="govuk-body">To schedule a batch of emails or text messages:</p>
   <ol class="govuk-list govuk-list--number">


### PR DESCRIPTION
We updated Notify to be able to schedule jobs a week in advance, but forgot to update the guidance page.

<img width="590" alt="image" src="https://github.com/alphagov/notifications-admin/assets/2920760/2646eb1c-1e7c-4b13-81ab-9d25e4c64a9f">
