### PR TITLE
Replace hardcoded 7 day retention statement with service specific

### DIFF
--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -39,9 +39,11 @@
         <p class="api-notifications-item__meta">
           When you send messages via the API they’ll appear here.
         </p>
+        {% if current_service.get_consistent_data_retention_period() %}
         <p class="api-notifications-item__meta">
-          Notify deletes messages after 7 days.
+          Notify deletes messages after {{ current_service.get_consistent_data_retention_period() }} days.
         </p>
+        {% endif %}
       </div>
     {% endif %}
     {% for notification in api_notifications.notifications %}
@@ -92,9 +94,11 @@
             Only showing the first 50 messages.
           </p>
         {% endif %}
+        {% if current_service.get_consistent_data_retention_period() %}
         <p class="api-notifications-item__meta">
-          Notify deletes messages after 7 days.
+          Notify deletes messages after {{ current_service.get_consistent_data_retention_period() }} days.
         </p>
+        {% endif %}
       </div>
     {% endif %}
   </div>

--- a/tests/app/test_notify_session.py
+++ b/tests/app/test_notify_session.py
@@ -26,7 +26,13 @@ class TestNotifyAdminSessionInterface:
             yield client
 
     def test_logged_user_session_expiration(
-        self, request, active_user_with_permissions, mock_get_service, mock_has_permissions, mock_get_notifications
+        self,
+        request,
+        active_user_with_permissions,
+        mock_get_service,
+        mock_has_permissions,
+        mock_get_notifications,
+        mock_get_service_data_retention,
     ):
         app = request.getfixturevalue("clean_app")
         client = request.getfixturevalue("clean_app_client")
@@ -60,7 +66,13 @@ class TestNotifyAdminSessionInterface:
             ), "A new anonymous session should be created with a permanent lifetime of 1 hour"
 
     def test_logged_platform_user_session_full_expiration(
-        self, request, platform_admin_user, mock_get_service, mock_has_permissions, mock_get_notifications
+        self,
+        request,
+        platform_admin_user,
+        mock_get_service,
+        mock_has_permissions,
+        mock_get_notifications,
+        mock_get_service_data_retention,
     ):
         # webauthn auth needs some more complex mocking/patching not relevant to the code under test, so let's bypass it
         platform_admin_user["auth_type"] = "sms_auth"


### PR DESCRIPTION
The API integration page was hardcoded to 7 days, which may not be correct as services can have retentions between 3 and 90 days.

## Before
![image](https://github.com/alphagov/notifications-admin/assets/7228605/e617bef5-7d60-4b84-9037-c05867004bb6)


If the service has consistent retention, ie email, letter and sms have the same retention periods, it is easy to update this number to make it accurate.

If the service does not have consistent retention, which is rare, but possible (only platform admins can put a service in this state) then I've opted for a quick solution of just removing the line from the page. Happy for this to be adapated as designers see fit (we could for example show the retention per channel again if we wanted to, or instead refer generically to the retention settings for their service).

I've tested this with both live and trial mode services (trial mode services don't have any rows in the service_data_retention table).

## Service with custom retention of 80 days for all channels
![image](https://github.com/alphagov/notifications-admin/assets/7228605/5c3601c9-3fd7-4f0b-a914-9a94bf4596c1)

## Trial mode service (which therefore has the default of 7 days for all channels)
![image](https://github.com/alphagov/notifications-admin/assets/7228605/5415ce51-28ba-460c-b278-595a9fef8809)

## Service with inconsistent custom retention across channels
![image](https://github.com/alphagov/notifications-admin/assets/7228605/a9083d1c-8cb9-4a98-bab1-ced26e65002c)

@karlchillmaid, @saimaghafoor, @quis - one to be aware of and review from a content/design perspective. Feel free to change the approach I've gone for too (but hopefully this is a positive improvement and further changes can build on top of it).

I also spotted some other places where 7 days is hardcoded.

https://github.com/alphagov/notifications-admin/blob/main/app/templates/views/guidance/features/security.html#L26
https://github.com/alphagov/notifications-admin/blob/main/app/templates/views/guidance/using-notify/delivery-times.html#L17

These will both want to be updated by a content designer please.
