### PR TITLE
dont run accessibility statement tests if git errors

### DIFF
--- a/tests/app/test_accessibility_statement.py
+++ b/tests/app/test_accessibility_statement.py
@@ -8,13 +8,17 @@ def test_last_review_date():
 
     # test local changes against main for a full diff of what will be merged
     statement_diff = subprocess.run(
-        [f"git diff --unified=0 --exit-code origin/main -- {statement_file_path}"], stdout=subprocess.PIPE, shell=True
+        [f"git diff --unified=0 --exit-code origin/main -- {statement_file_path}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
     )
 
     date_format = "%d %B %Y"
 
-    # if statement has changed, test the review date was part of those changes
-    if statement_diff.returncode == 1:
+    # could be 1 either because there was a diff, or because there was an error (eg: not in a git checkout).
+    if statement_diff.returncode == 1 and not statement_diff.stderr:
+        # if statement has changed, test the review date was part of those changes
         raw_diff = statement_diff.stdout.decode("utf-8")
         with open(statement_file_path, "r") as statement_file:
             contents = statement_file.read()


### PR DESCRIPTION
we check the accessibility statement for local changes by using a subprocess to run `git diff` against the origin/main branch.

We check the status code of that git diff to determine if there's been any changes.

However, if we run the tests on a copy of the admin source code that doesn't have an active git checkout, then the command will error and will return statuscode 1.

So, to determine if there were changes to the accessibility statement that we should check the update date of, we should check the diff output (in stdout) as well to make sure that has content.

-----


You can test this by renaming your `.git` folder to something else in your local checkout and running `pytest tests/app/test_accessibility_statement.py`


```
❯ mv .git .git-backup
❯ git diff --unified=0 --exit-code origin/main -- app/templates/views/accessibility_statement.html
error: Could not access 'origin/main'
```