### PR TITLE
Include git dir in test docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 venv
-.git
 .env
 .envrc
 node_modules

--- a/tests/app/test_accessibility_statement.py
+++ b/tests/app/test_accessibility_statement.py
@@ -8,12 +8,19 @@ def test_last_review_date():
 
     # test local changes against main for a full diff of what will be merged
     statement_diff = subprocess.run(
-        [f"git diff --unified=0 --exit-code origin/main -- {statement_file_path}"], stdout=subprocess.PIPE, shell=True
+        [f"git diff --unified=0 --exit-code origin/main -- {statement_file_path}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
     )
 
+    assert not statement_diff.stderr, (
+        "Error comparing the accessiblity_statement.html file to origin/main - "
+        "make sure this test is run from a local git checkout"
+    )
     date_format = "%d %B %Y"
 
-    # if statement has changed, test the review date was part of those changes
+    # if statement has changed, make sure the review date was part of those changes
     if statement_diff.returncode == 1:
         raw_diff = statement_diff.stdout.decode("utf-8")
         with open(statement_file_path, "r") as statement_file:


### PR DESCRIPTION
[remove .git from .dockerignore](https://github.com/alphagov/notifications-admin/commit/e7d221d76d05510c4dc64f2ca0ea9bdd3402721b) 

our unit tests (specifically test_accessibility_statement.py) expect to be run in a folder with a local git checkout, so that it can compare the local changes to main to make sure that any changes to the accessibility statement have been made correctly.

however, in the test image we were previously excluding the .git folder via the dockerignore, so the test would error with an unhelpful message.

as the test image calls `copy . .` it will now pull in the .git folder so will be able to diff succesfully.

note: the production image only copies across app, application.py, entrypoint.sh and gunicorn_config.py so our prod tasks won't have the git folder floating about

----

[add error message handling for when running outside of git](https://github.com/alphagov/notifications-admin/commit/0c2b9d1a2699111dd534ab99996f838274970e83) 

makes it a bit clearer how to resolve if the test errors

----

making sure we don't accidentally include .git in our prod images:

```
❯ docker build --target production -f docker/Dockerfile -t admin-prod .
[+] Building 5.6s (27/27) FINISHED                                                                                                                               
❯ docker run -it --entrypoint bash admin-prod
notify@97a99de08839:~/app$ ls -la
total 36
drwxr-xr-x 1 notify notify 4096 Dec 28 17:11 .
drwxr-xr-x 1 notify notify 4096 Dec 28 16:33 ..
drwxr-xr-x 1 notify notify 4096 Dec 28 17:23 app
-rw-r--r-- 1 notify notify  208 Apr  4  2023 application.py
-rwxr-xr-x 1 notify notify  292 Nov 16 15:40 entrypoint.sh
-rw-r--r-- 1 notify notify 1406 Sep 18 16:52 gunicorn_config.py
```