### PR TITLE
bump international letter rates

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -14,11 +14,11 @@ class LetterLanguageOptions(str, enum.Enum):
 
 
 LETTER_PRICES_BY_SHEETS = {
-    1: {"second": 54, "first": 82, "international": 126},
-    2: {"second": 59, "first": 86, "international": 131},
-    3: {"second": 63, "first": 90, "international": 135},
-    4: {"second": 68, "first": 96, "international": 140},
-    5: {"second": 73, "first": 100, "international": 145},
+    1: {"second": 54, "first": 82, "international": 144},
+    2: {"second": 59, "first": 86, "international": 149},
+    3: {"second": 63, "first": 90, "international": 153},
+    4: {"second": 68, "first": 96, "international": 158},
+    5: {"second": 73, "first": 100, "international": 163},
 }
 MIN_LETTER_PRICE = min(pennies for prices in LETTER_PRICES_BY_SHEETS.values() for pennies in prices.values())
 MAX_LETTER_PRICE = max(pennies for prices in LETTER_PRICES_BY_SHEETS.values() for pennies in prices.values())

--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -16,7 +16,7 @@
 
     {{ content_metadata(
       data={
-        "Last updated": "1 November 2023"
+        "Last updated": "2 January 2024"
       }
     ) }}
 
@@ -49,9 +49,5 @@
       {% endfor %}
     {% endcall %}
   </div>
-
-<div class="govuk-inset-text">
-  International postage prices will go up on 2 January 2024.
-</div>
 
 {% endblock %}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4505,7 +4505,7 @@ def test_unknown_channel_404s(
     [
         (
             "letter",
-            "It costs between 54 pence and £1.45 to send a letter using Notify.",
+            "It costs between 54 pence and £1.63 to send a letter using Notify.",
             "Send letters",
             ["email", "sms"],
             "False",
@@ -4514,7 +4514,7 @@ def test_unknown_channel_404s(
         ),
         (
             "letter",
-            "It costs between 54 pence and £1.45 to send a letter using Notify.",
+            "It costs between 54 pence and £1.63 to send a letter using Notify.",
             "Send letters",
             ["email", "sms", "letter"],
             "True",

--- a/tests/app/main/views/test_pricing.py
+++ b/tests/app/main/views/test_pricing.py
@@ -7,4 +7,4 @@ def test_guidance_pricing_letters(client_request):
     # Update these values if letter prices change
     assert "54p + VAT" in first_row.text
     assert "82p + VAT" in first_row.text
-    assert "£1.26 + VAT" in first_row.text
+    assert "£1.44 + VAT" in first_row.text


### PR DESCRIPTION
doesn't depend on, but should be merged around

* https://github.com/alphagov/notifications-api/pull/3993

rates from spreadsheet ["International letter price increases January 24"](https://docs.google.com/spreadsheets/d/1GUKToPuLWr_wvhuDcw0hocQ06NoM8mlHcplOhGuGTIA/edit#gid=1367978351)