### PR TITLE
Bump utils to 74.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,8 +71,6 @@ flask-wtf==1.2.1
     # via -r requirements.in
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
-geojson==2.5.0
-    # via notifications-utils
 govuk-bank-holidays==0.11
     # via
     #   -r requirements.in
@@ -123,7 +121,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
 ## 74.4.0

* Reverts the 'single session' change from 74.1.0, which may be causing us some connection errors.

 ## 74.3.0

* Add `decrby` method to the RedisClient

 ## 74.2.0

* Change logging's date formatting to include microseconds

 ## 74.1.0

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.0.0...74.4.0
