### PR TITLE
Fix API unknown errors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ import pathlib
 from time import monotonic
 
 import jinja2
+import requests
 import werkzeug
 from flask import (
     current_app,
@@ -383,9 +384,9 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
     @application.errorhandler(HTTPError)
     def render_http_error(error):
         application.logger.warning(
-            "API %(api)s failed with status %(status)s message %(message)s",
+            "API %(api)s failed with status=%(status)s, message='%(message)s'",
             dict(
-                api=error.response.url if error.response else "unknown",
+                api=error.response.url if isinstance(error.response, requests.Response) else "unknown",
                 status=error.status_code,
                 message=error.message,
             ),
@@ -396,9 +397,9 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
             # it might be a 400, which we should handle as if it's an internal server error. If the API might
             # legitimately return a 400, we should handle that within the view or the client that calls it.
             application.logger.exception(
-                "API %(api)s failed with status %(status)s message %(message)s",
+                "API %(api)s failed with status=%(status)s message='%(message)s'",
                 dict(
-                    api=error.response.url if error.response else "unknown",
+                    api=error.response.url if isinstance(error.response, requests.Response) else "unknown",
                     status=error.status_code,
                     message=error.message,
                 ),

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -1,4 +1,8 @@
+import logging
+from io import BytesIO
+
 import pytest
+import requests
 from flask import Response, g, url_for
 from flask_wtf.csrf import CSRFError
 from notifications_python_client.errors import HTTPError
@@ -120,3 +124,31 @@ def test_405_returns_something_went_wrong_page(client_request, mocker):
 
     assert page.select_one("h1").string.strip() == "Sorry, there’s a problem with GOV.UK Notify"
     assert page.select_one("title").string.strip() == "Sorry, there’s a problem with the service – GOV.UK Notify"
+
+
+def test_api_error_response_logging(
+    mocker,
+    fake_uuid,
+    requests_mock,
+    client_request,
+    caplog,
+):
+    response = requests.Response()
+    response.status_code = 400
+    response.headers["content-type"] = "application/json"
+    response.raw = BytesIO(b'{"message": "not found"}')
+    response.url = "http://localhost:6012/user/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/organisations-and-services"
+    requests_mock.get(
+        "http://you-forgot-to-mock-an-api-call-to/user/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/organisations-and-services",
+        exc=requests.HTTPError(response=response),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        client_request.get(
+            ".choose_account", _expected_status=500, _test_page_title=False, _test_for_elements_without_class=False
+        )
+
+    assert (
+        "API http://localhost:6012/user/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/organisations-and-services "
+        "failed with status=400, message='not found'"
+    ) in caplog.messages


### PR DESCRIPTION
`requests.Response` defines `__bool__` as `self.ok`, which returns True if the status code is < 400.

Therefore, all 4xx and 5xx responses are considered `False`. Which means that when we try to log errors, and check `if error.response`, it always evaluates to `False`, and so we never log the response URL - just `unknown`.