### PR TITLE
Highlight the relevant platform admin navigation item

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -86,6 +86,7 @@ from app.navigation import (
     HeaderNavigation,
     MainNavigation,
     OrgNavigation,
+    PlatformAdminNavigation,
 )
 from app.notify_client import InviteTokenError
 from app.notify_client.api_key_api_client import api_key_api_client
@@ -142,6 +143,7 @@ navigation = {
     "main_navigation": MainNavigation(),
     "header_navigation": HeaderNavigation(),
     "org_navigation": OrgNavigation(),
+    "platform_admin_navigation": PlatformAdminNavigation(),
 }
 
 

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -400,3 +400,62 @@ class OrgNavigation(Navigation):
             "organisation_billing",
         },
     }
+
+
+class PlatformAdminNavigation(Navigation):
+    mapping = {
+        "search": {
+            "platform_admin_search",
+        },
+        "summary": {
+            "platform_admin",
+        },
+        "live-services": {
+            "live_services",
+        },
+        "trial-mode-services": {
+            "trial_services",
+        },
+        "organisations": {
+            "organisations",
+        },
+        "providers": {
+            "view_providers",
+            "edit_sms_provider_ratio",
+        },
+        "reports": {
+            "platform_admin_reports",
+            "notifications_sent_by_service",
+            "get_billing_report",
+            "get_dvla_billing_report",
+            "get_volumes_by_service",
+            "get_daily_volumes",
+            "get_daily_sms_provider_volumes",
+        },
+        "email-branding": {
+            "email_branding",
+            "platform_admin_view_email_branding",
+            "platform_admin_update_email_branding",
+            "platform_admin_create_email_branding",
+            "create_email_branding_government_identity_logo",
+            "create_email_branding_government_identity_colour",
+        },
+        "letter-branding": {
+            "letter_branding",
+            "platform_admin_view_letter_branding",
+            "create_letter_branding",
+            "update_letter_branding",
+        },
+        "inbound-sms-numbers": {
+            "inbound_sms_admin",
+        },
+        "email-complaints": {
+            "platform_admin_list_complaints",
+        },
+        "returned-letters": {
+            "platform_admin_returned_letters",
+        },
+        "clear-cache": {
+            "clear_cache",
+        },
+    }

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -14,23 +14,23 @@
       <div class="govuk-grid-column-one-quarter">
         <nav class="navigation" aria-label="Platform admin">
           <ul class="govuk-list">
-          {% for link_text, url in [
-            ('Search', url_for('main.platform_admin_search')),
-            ('Summary', url_for('main.platform_admin')),
-            ('Live services', url_for('main.live_services')),
-            ('Trial mode services', url_for('main.trial_services')),
-            ('Organisations', url_for('main.organisations')),
-            ('Providers', url_for('main.view_providers')),
-            ('Reports', url_for('main.platform_admin_reports')),
-            ('Email branding', url_for('main.email_branding')),
-            ('Letter branding', url_for('main.letter_branding')),
-            ('Inbound SMS numbers', url_for('main.inbound_sms_admin')),
-            ('Email complaints', url_for('main.platform_admin_list_complaints')),
-            ('Returned letters', url_for('main.platform_admin_returned_letters')),
-            ('Clear cache', url_for('main.clear_cache')),
+          {% for link_text, selected_class, url in [
+            ('Search', platform_admin_navigation.is_selected('search'), url_for('main.platform_admin_search')),
+            ('Summary', platform_admin_navigation.is_selected('summary'), url_for('main.platform_admin')),
+            ('Live services', platform_admin_navigation.is_selected('live-services'), url_for('main.live_services')),
+            ('Trial mode services', platform_admin_navigation.is_selected('trial-mode-services'), url_for('main.trial_services')),
+            ('Organisations', platform_admin_navigation.is_selected('organisations'), url_for('main.organisations')),
+            ('Providers', platform_admin_navigation.is_selected('providers'), url_for('main.view_providers')),
+            ('Reports', platform_admin_navigation.is_selected('reports'), url_for('main.platform_admin_reports')),
+            ('Email branding', platform_admin_navigation.is_selected('email-branding'), url_for('main.email_branding')),
+            ('Letter branding',platform_admin_navigation.is_selected('letter-branding'), url_for('main.letter_branding')),
+            ('Inbound SMS numbers', platform_admin_navigation.is_selected('inbound-sms-numbers'), url_for('main.inbound_sms_admin')),
+            ('Email complaints', platform_admin_navigation.is_selected('email-complaints'), url_for('main.platform_admin_list_complaints')),
+            ('Returned letters', platform_admin_navigation.is_selected('returned-letters'), url_for('main.platform_admin_returned_letters')),
+            ('Clear cache', platform_admin_navigation.is_selected('clear-cache'), url_for('main.clear_cache')),
           ] %}
             <li>
-              <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url }}">
+              <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{selected_class}}" href="{{ url }}">
                 {{ link_text }}
               </a>
             </li>

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -8,6 +8,7 @@ from app.navigation import (
     MainNavigation,
     Navigation,
     OrgNavigation,
+    PlatformAdminNavigation,
 )
 from tests.conftest import ORGANISATION_ID, SERVICE_ONE_ID, normalize_spaces
 
@@ -400,6 +401,7 @@ navigation_instances = (
     HeaderNavigation(),
     OrgNavigation(),
     CaseworkNavigation(),
+    PlatformAdminNavigation(),
 )
 
 
@@ -501,6 +503,27 @@ def test_a_page_should_nave_selected_org_navigation_item(
 ):
     mocker.patch("app.organisations_client.get_services_and_usage", return_value={"services": [], "updated_at": None})
     page = client_request.get(endpoint, org_id=ORGANISATION_ID)
+    selected_nav_items = page.select(".navigation a.selected")
+    assert len(selected_nav_items) == 1
+    assert selected_nav_items[0].text.strip() == selected_nav_item
+
+
+@pytest.mark.parametrize(
+    "endpoint, selected_nav_item",
+    [
+        ("main.platform_admin_search", "Search"),
+        ("main.email_branding", "Email branding"),
+    ],
+)
+def test_a_page_should_nave_selected_platform_admin_navigation_item(
+    client_request,
+    platform_admin_user,
+    mock_get_all_email_branding,
+    endpoint,
+    selected_nav_item,
+):
+    client_request.login(platform_admin_user)
+    page = client_request.get(endpoint)
     selected_nav_items = page.select(".navigation a.selected")
     assert len(selected_nav_items) == 1
     assert selected_nav_items[0].text.strip() == selected_nav_item


### PR DESCRIPTION
This highlights the relevant link in the left hand platform admin navigation when viewing a platform admin page. We do this for the other types of left hand navigation, so this just adds the same approach to the platform admin pages.

### Before
<img width="500" alt="Screenshot 2024-01-05 at 16 54 17" src="https://github.com/alphagov/notifications-admin/assets/12881990/54324b3a-1342-415d-a685-af2a701c9370">

### After
<img width="500" alt="Screenshot 2024-01-05 at 16 54 02" src="https://github.com/alphagov/notifications-admin/assets/12881990/b461a789-6363-4e5f-b540-234f43e85154">
