### PR TITLE
Only call template preview for letter templates

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -296,7 +296,11 @@ def letter_branding_preview_image(filename):
     }
     branding_filename = None if filename == "no-branding" else filename
 
-    return TemplatePreview.get_png_for_example_template(template, branding_filename)
+    return TemplatePreview.get_preview_for_templated_letter(
+        template,
+        filetype="png",
+        branding_filename=branding_filename,
+    )
 
 
 def _view_template_version(service_id, template_id, version):

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -64,21 +64,6 @@ class TemplatePreview:
         return response.content, response.status_code, cls.get_allowed_headers(response.headers)
 
     @classmethod
-    def get_png_for_example_template(cls, template, branding_filename):
-        data = {
-            "letter_contact_block": template.get("reply_to_text"),
-            "template": template,
-            "values": None,
-            "filename": branding_filename,
-        }
-        response = requests.post(
-            f"{current_app.config['TEMPLATE_PREVIEW_API_HOST']}/preview.png",
-            json=data,
-            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
-        )
-        return response.content, response.status_code, cls.get_allowed_headers(response.headers)
-
-    @classmethod
     def get_png_for_letter_attachment_page(cls, attachment_id, page=None):
         data = {
             "letter_attachment_id": attachment_id,

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -2,7 +2,7 @@ import base64
 from io import BytesIO
 
 import requests
-from flask import current_app, json
+from flask import abort, current_app, json
 from notifications_utils.pdf import extract_page_from_pdf
 
 from app import current_service
@@ -19,6 +19,8 @@ class TemplatePreview:
     def get_preview_for_templated_letter(cls, db_template, filetype, values=None, page=None):
         if db_template["is_precompiled_letter"]:
             raise ValueError
+        if db_template["template_type"] != "letter":
+            abort(404)
         data = {
             "letter_contact_block": db_template.get("reply_to_text", ""),
             "template": db_template,

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -21,6 +21,8 @@ class TemplatePreview:
             raise ValueError
         if db_template["template_type"] != "letter":
             abort(404)
+        if filetype == "pdf" and page:
+            abort(400)
         data = {
             "letter_contact_block": db_template.get("reply_to_text", ""),
             "template": db_template,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1938,7 +1938,7 @@ def test_letter_branding_preview_image(
     new_filename,
 ):
     mocked_preview = mocker.patch(
-        "app.main.views.templates.TemplatePreview.get_png_for_example_template", return_value="foo"
+        "app.main.views.templates.TemplatePreview.get_preview_for_templated_letter", return_value="foo"
     )
     response = client_request.get_response(
         "no_cookie.letter_branding_preview_image",
@@ -1951,7 +1951,8 @@ def test_letter_branding_preview_image(
             "content": ANY,
             "template_type": "letter",
         },
-        new_filename,
+        filetype="png",
+        branding_filename=new_filename,
     )
     assert response.get_data(as_text=True) == "foo"
 

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -209,20 +209,6 @@ def test_page_count_makes_a_call_to_template_preview_and_gets_page_count(
     request_mock.assert_called_once_with("http://localhost:9999/preview.json", json=data, headers=headers)
 
 
-def test_get_png_for_example_template_makes_request(mocker, client_request):
-    request_mock = mocker.patch("app.template_previews.requests.post")
-    template = {}
-    branding_filename = "geo"
-
-    TemplatePreview.get_png_for_example_template(template, branding_filename)
-
-    request_mock.assert_called_once_with(
-        "http://localhost:9999/preview.png",
-        headers={"Authorization": "Token my-secret-key"},
-        json={"values": None, "template": template, "filename": branding_filename, "letter_contact_block": None},
-    )
-
-
 @pytest.mark.parametrize("allow_international_letters, query_param_value", [[False, "false"], [True, "true"]])
 def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file(
     mocker,

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -3,7 +3,7 @@ from functools import partial
 from unittest.mock import Mock
 
 import pytest
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import BadRequest, NotFound
 
 from app import load_service_before_request
 from app.models.branding import LetterBranding
@@ -131,6 +131,21 @@ def test_get_preview_for_templated_letter_from_notification_404s_non_letter_temp
     with pytest.raises(NotFound):
         TemplatePreview.get_preview_for_templated_letter(
             notification["template"], file_type, notification["personalisation"]
+        )
+
+
+def test_get_preview_for_templated_letter_from_notification_400s_for_page_of_pdf(mocker):
+    notification = create_notification(
+        service_id="abcd",
+        template_type="letter",
+        template_name="sample template",
+    )
+
+    with pytest.raises(BadRequest):
+        TemplatePreview.get_preview_for_templated_letter(
+            notification["template"],
+            "pdf",
+            page=1,
         )
 
 

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -3,6 +3,7 @@ from functools import partial
 from unittest.mock import Mock
 
 import pytest
+from werkzeug.exceptions import NotFound
 
 from app import load_service_before_request
 from app.models.branding import LetterBranding
@@ -115,6 +116,21 @@ def test_get_preview_for_templated_letter_from_notification_rejects_precompiled_
     with pytest.raises(ValueError):
         TemplatePreview.get_preview_for_templated_letter(
             notification["template"], "png", notification["personalisation"]
+        )
+
+
+@pytest.mark.parametrize("template_type", ("email", "sms"))
+@pytest.mark.parametrize("file_type", ("pdf", "png"))
+def test_get_preview_for_templated_letter_from_notification_404s_non_letter_templates(mocker, template_type, file_type):
+    notification = create_notification(
+        service_id="abcd",
+        template_type=template_type,
+        template_name="sample template",
+    )
+
+    with pytest.raises(NotFound):
+        TemplatePreview.get_preview_for_templated_letter(
+            notification["template"], file_type, notification["personalisation"]
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3771,7 +3771,6 @@ def mock_template_preview(mocker, mock_get_page_counts_for_letter):
 
     mocker.patch("app.template_previews.TemplatePreview.get_png_for_valid_pdf_page", return_value=example_response)
     mocker.patch("app.template_previews.TemplatePreview.get_png_for_invalid_pdf_page", return_value=example_response)
-    mocker.patch("app.template_previews.TemplatePreview.get_png_for_example_template", return_value=example_response)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
If someone hacks the URL to try to get a preview of an email template then they will get a 500 back from template preview.

Lets catch this early and return a 404 instead because we have no way of showing a PNG or PDF for an email or text message template.