### PR TITLE
Fix missing `branding_filename` argument

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -293,6 +293,7 @@ def letter_branding_preview_image(filename):
             "here, content here’, making it look like readable English."
         ),
         "template_type": "letter",
+        "is_precompiled_letter": False,
     }
     branding_filename = None if filename == "no-branding" else filename
 

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -16,7 +16,7 @@ class TemplatePreview:
         return allowed_headers.items()
 
     @classmethod
-    def get_preview_for_templated_letter(cls, db_template, filetype, values=None, page=None):
+    def get_preview_for_templated_letter(cls, db_template, filetype, values=None, page=None, branding_filename=None):
         if db_template["is_precompiled_letter"]:
             raise ValueError
         if db_template["template_type"] != "letter":
@@ -27,7 +27,7 @@ class TemplatePreview:
             "letter_contact_block": db_template.get("reply_to_text", ""),
             "template": db_template,
             "values": values,
-            "filename": current_service.letter_branding.filename,
+            "filename": branding_filename or current_service.letter_branding.filename,
         }
         response = requests.post(
             "{}/preview.{}{}".format(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1950,6 +1950,7 @@ def test_letter_branding_preview_image(
             "subject": "An example letter",
             "content": ANY,
             "template_type": "letter",
+            "is_precompiled_letter": False,
         },
         filetype="png",
         branding_filename=new_filename,


### PR DESCRIPTION
…and add a test that doesn’t rely on a mock to pass