### PR TITLE
Update Security information

### DIFF
--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -236,15 +236,6 @@
   <h3 class="heading-small">Governance</h3>
   <p class="govuk-body">The Senior Responsible Owner (SRO) is the senior civil servant accountable for all aspects of our governance.</p>
   <p class="govuk-body">The Chief Operating Officer (COO) ensures that GDS meets its objectives.</p>
-  <p class="govuk-body">The Information Assurance team:</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>conducts risk assessments of Notify</li>
-    <li>reviews whether Notify is following government security policies</li>
-    <li>organises information assurance activities</li>
-    <li>oversees risk treatment activities</li>
-    <li>reports its findings and recommendations to the SRO and COO</li>
-    <li>escalates risk management decisions to the GDS Senior Leadership Team as necessary</li>
-  </ul>
   <p class="govuk-body">The Data Protection, Privacy and Accessibility Monitoring teams make sure that Notify complies with any legal and regulatory requirements.</p>
 
 {% endblock %}

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -24,7 +24,8 @@
     <li><a class="govuk-link govuk-link--no-visited-state" href="#protecting-our-website-and-api">protecting our website and API</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#email-security">email security</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#security-classifications">security classifications</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#staff-suppliers-and-governance">staff, suppliers and governance</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#staff">GOV.UK Notify staff</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#suppliers">staff</a></li>
   </ul>
 
   <h2 class="heading-medium" id="running-a-secure-service">Running a secure service</h2>
@@ -205,8 +206,7 @@
   </ul>
   <p class="govuk-body">Notify must not be used to process data classified as ‘SECRET’ or ‘TOP SECRET’.</p>
 
-  <h2 class="heading-medium" id="staff-suppliers-and-governance">Staff, suppliers and governance</h2>
-  <h3 class="heading-small">GOV.UK Notify staff</h3>
+  <h2 class="heading-medium" id="staff">GOV.UK Notify staff</h2>
   <p class="govuk-body">We restrict the number of people that can access your data on GOV.UK Notify.</p>
   <p class="govuk-body">We follow the principle of least privilege. This means we give our team members the lowest level of permissions needed to do their job.</p>
   <p class="govuk-body">All our staff:</p>
@@ -222,7 +222,8 @@
     <li>in relation to a specific change request or support ticket</li>
   </ul>
   <p class="govuk-body">The GDS security operations team logs and tracks privileged users’ access to our production environment.</p>
-  <h3 class="heading-small">Suppliers</h3>
+
+  <h2 class="heading-medium" id="suppliers">Suppliers</h2>
   <p class="govuk-body">GOV.UK Notify uses third-party providers to send emails, text messages and letters.</p>
   <p class="govuk-body">Suppliers sign a contract or memorandum of understanding that includes our security requirements.</p>
   <p class="govuk-body">All our suppliers:</p>
@@ -235,9 +236,4 @@
     <li>before we decide whether to use them</li>
     <li>at regular intervals to make sure they still meet our requirements</li>
   </ul>
-  <h3 class="heading-small">Governance</h3>
-  <p class="govuk-body">The Senior Responsible Owner (SRO) is the senior civil servant accountable for all aspects of our governance.</p>
-  <p class="govuk-body">The Chief Operating Officer (COO) ensures that GDS meets its objectives.</p>
-  <p class="govuk-body">The Data Protection, Privacy and Accessibility Monitoring teams make sure that Notify complies with any legal and regulatory requirements.</p>
-
 {% endblock %}

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -125,6 +125,24 @@
     <li>use AWS secrets manager</li>
   </ul>
 
+  <h3 class="heading-small" id="how-we-manage-code-changes">How we manage code changes</h3>
+  <p class="govuk-body">To manage GOV.UK Notify, we use:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>GDS-managed devices</li>
+    <li>multi-factor authentication (MFA)</li>
+  </ul>
+  <p class="govuk-body">We manage Notify through the www.notifications.service.gov.uk website.</p>
+  <p class="govuk-body">AWS manages the hardware we use.</p>
+  <p class="govuk-body">We use infrastructure as code (IaC) to manage the systems and services that host Notify.</p>
+  <p class="govuk-body">All code changes must be reviewed by the team before we can deploy them.</p>
+  <p class="govuk-body">We monitor our production environment for unauthorised changes.</p>
+  <p class="govuk-body">The GDS Information Assurance team assesses significant code changes for any potential security impact.</p>
+  <p class="govuk-body">We give our users appropriate notice before:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>any planned outages or downtime</li>
+    <li>making significant functional changes</li>
+  </ul>
+  <p class="govuk-body">We announce planned downtime on the <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">Notify status page</a>.</p>
 
 
 {% endblock %}

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -123,7 +123,7 @@
     <li>run separate development, testing and production environments</li>
     <li>deploy code through a continuous integration/continuous delivery (CI/CD) pipeline</li>
     <li>track vulnerabilities for any third-party libraries we use</li>
-    <li>use AWS Secrets Manager</li>
+    <li>store production secrets in a secure environment with audited access</li>
   </ul>
 
   <h3 class="heading-small" id="how-we-manage-code-changes">How we manage code changes</h3>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -144,7 +144,7 @@
   </ul>
   <p class="govuk-body">We announce planned downtime on the <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">Notify status page</a>.</p>
 
-  <h2 class="heading-medium" id="building-and-managing-notify">Finding and fixing security issues</h2>
+  <h2 class="heading-medium" id="finding-and-fixing-security-issues">Finding and fixing security issues</h2>
   <p class="govuk-body">GOV.UK Notify:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>follows <a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/collection/developers-collection/principles">secure development principles</a></li>
@@ -163,5 +163,83 @@
     <li>hardware</li>
     <li>operating system (OS) kernel</li>
   </ul>
+
+  <h2 class="heading-medium" id="security-incidents">Security incidents</h2>
+  <p class="govuk-body">We provide a 24-hour response in case of an incident.</p>
+  <p class="govuk-body">If there is a data loss event, we will contact you directly.</p>
+  <p class="govuk-body">If there is another type of incident, we’ll publish details and updates on our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status page</a>.</p>
+
+  <h2 class="heading-medium" id="sign-in-and-api-access">Sign in and API access</h2>
+  <h3 class="heading-small">Signing in to Notify</h3>
+  <p class="govuk-body">GOV.UK Notify uses two-factor authentication for sign-in.</p>
+  <p class="govuk-body">Find out more about the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">sign-in method</a>.</p>
+  <p class="govuk-body">You must keep to our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.terms_of_use') }}">terms of use for signing in to Notify</a>.</p>
+  <h3 class="heading-small">Accessing the GOV.UK Notify API</h3>
+  <p class="govuk-body">Services access the GOV.UK Notify API with an API key, encoded using <a class="govuk-link govuk-link--no-visited-state" href="https://jwt.io/">JSON Web Tokens</a>.</p>
+  <p class="govuk-body">For more information, see our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a>.</p>
+
+  <h2 class="heading-medium" id="protecting-our-website-and-api">Protecting our website and API</h2>
+  <p class="govuk-body">The GOV.UK Notify website, API and any files sent by email are protected by:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>AWS <a class="govuk-link govuk-link--no-visited-state" href="https://aws.amazon.com/waf/">Web Application Firewall</a> (WAF)</li>
+    <li>AWS <a class="govuk-link govuk-link--no-visited-state" href="https://aws.amazon.com/shield/">Shield Advanced</a></li>
+    <li>rate limiting</li>
+  </ul>
+  <p class="govuk-body">We use publicly-verifiable digital certificates, so you’ll always know you’ve connected to the real GOV.UK Notify.</p>
+
+  <h2 class="heading-medium" id="email-security">Email security</h2>
+  <p class="govuk-body">To make it easier for recipients’ email services to spot spam, we use:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/domainkeys-identified-mail-dkim#:~:text=DomainKeys%20Identified%20Mail%20(%20DKIM%20)%20verifies,that%20fails%20the%20DKIM%20check.">DomainKeys Identified Mail (DKIM)</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf#:~:text=Sender%20Policy%20Framework%20(%20SPF%20)%20lets,service%20in%20your%20SPF%20record.">Sender Policy Framework (SPF) records</a></li>
+  </ul>
+
+  <h2 class="heading-medium" id="security-classifications">Security classifications</h2>
+  <p class="govuk-body">You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications policy</a>.</p>
+  <p class="govuk-body">Notify does not process data classified as ‘SECRET’ or ‘TOP SECRET’.</p>
+
+  <h2 class="heading-medium" id="staff-suppliers-and-governance">Staff, suppliers and governance</h2>
+  <h3 class="heading-small">GOV.UK Notify staff</h3>
+  <p class="govuk-body">We restrict the number of people that can access your data on GOV.UK Notify.</p>
+  <p class="govuk-body">We follow the principle of least privilege. This means we give our team members the lowest level of permissions needed to do their job.</p>
+  <p class="govuk-body">All our staff:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>receive security training</li>
+    <li>complete <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-baseline-personnel-security-standard">personnel screening equivalent to BPSS</a></li>
+  </ul>
+  <p class="govuk-body">Team members who need greater access must complete <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/united-kingdom-security-vetting-clearance-levels/national-security-vetting-clearance-levels#security-check-sc">National Security Vetting to Security Check (SC) level</a>.</p>
+  <p class="govuk-body">We only give additional access to GOV.UK Notify’s production environment to privileged users:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>by exception</li>
+    <li>on a temporary basis</li>
+    <li>in relation to a specific change request or support ticket</li>
+  </ul>
+  <p class="govuk-body">The GDS security operations team logs and tracks privileged users’ access to our production environment.</p>
+  <h3 class="heading-small">Suppliers</h3>
+  <p class="govuk-body">GOV.UK Notify uses third-party providers to send emails, text messages and letters.</p>
+  <p class="govuk-body">Suppliers sign a contract or memorandum of understanding that includes our security requirements.</p>
+  <p class="govuk-body">All our suppliers:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>receive security training</li>
+    <li>complete <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-baseline-personnel-security-standard">personnel screening equivalent to BPSS</a></li>
+  </ul>
+  <p class="govuk-body">The GDS Information Assurance team assesses suppliers:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>before we decide whether to use them</li>
+    <li>at regular intervals to make sure they still meet our requirements</li>
+  </ul>
+  <h3 class="heading-small">Governance</h3>
+  <p class="govuk-body">The Senior Responsible Owner (SRO) is the senior civil servant accountable for all aspects of our governance.</p>
+  <p class="govuk-body">The Chief Operating Officer (COO) ensures that GDS meets its objectives.</p>
+  <p class="govuk-body">The Information Assurance team:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>conducts risk assessments of Notify</li>
+    <li>reviews whether Notify is following government security policies</li>
+    <li>organises information assurance activities</li>
+    <li>oversees risk treatment activities</li>
+    <li>reports its findings and recommendations to the SRO and COO</li>
+    <li>escalate risk management decisions to the GDS Senior Leadership Team as necessary</li>
+  </ul>
+  <p class="govuk-body">The Data Protection, Privacy and Accessibility Monitoring teams make sure that Notify complies with any legal and regulatory requirements.</p>
 
 {% endblock %}

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -86,4 +86,45 @@
     <li>the phone’s country of origin (for international numbers)</li>
   </ul>
 
+  <h2 class="heading-medium" id="protecting-data-in-transit">Protecting data in transit</h2>
+  <p class="govuk-body">GOV.UK Notify uses Transport Layer Security (TLS) version 1.2 to encrypt data when:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>users access the Notify website or API</li>
+    <li>data passes through Notify</li>
+    <li>we exchange data with our sub-processors</li>
+  </ul>
+
+  <h3 class="heading-small">Emails</h3>
+  <p class="govuk-body">We always try to encrypt emails using TLS 1.2, 1.1 or 1.0. If the recipient’s mail server does not support TLS, we will send the email without protection.</p>
+  <p class="govuk-body">Email cannot provide end-to-end encryption.</p>
+
+  <h3 class="heading-small">Text messages</h3>
+  <p class="govuk-body">Text messages cannot provide end-to-end encryption.</p>
+
+  <h2 class="heading-medium" id="protecting-data-at-rest">Protecting data at rest</h2>
+  <p class="govuk-body">GOV.UK Notify encrypts the data stored in our databases and backups using AES-256 encryption.</p>
+  <p class="govuk-body">This includes any files that you upload to Notify when you:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_bulk_sending') }}">send messages in bulk</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_attach_pages') }}">attach pages to a letter template</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">upload a letter</a></li>
+  </ul>
+
+  <h3 class="heading-small" id="sending-files-by-email">Sending files by email</h3>
+  <p class="govuk-body">When you upload a file we encrypt it with <a class="govuk-link govuk-link--no-visited-state" href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html">AWS SSE-C</a>, which uses AES-256 encryption.</p>
+  <p class="govuk-body">We will only share the unique link with the intended recipient. We cannot access or decrypt your file.</p>
+  <p class="govuk-body">For more information about this feature, see <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_send_files_by_email') }}">send files by email</a>.</p>
+
+  <h2 class="heading-medium" id="building-and-managing-notify">Building and managing GOV.UK Notify</h2>
+  <p class="govuk-body">We follow an Agile software development lifecycle, as described in <a class="govuk-link govuk-link--no-visited-state" href="https://gds-way.cloudapps.digital/">the GDS Way</a>.</p>
+  <p class="govuk-body">To protect our code, we:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>run separate development, testing and production environments</li>
+    <li>deploy code through a continuous integration/continuous delivery (CI/CD) pipeline</li>
+    <li>track vulnerabilities for any third-party libraries we use</li>
+    <li>use AWS secrets manager</li>
+  </ul>
+
+
+
 {% endblock %}

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -116,7 +116,7 @@
   <p class="govuk-body">For more information about this feature, see <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_send_files_by_email') }}">send files by email</a>.</p>
 
   <h2 class="heading-medium" id="building-and-managing-notify">Building and managing GOV.UK Notify</h2>
-  <p class="govuk-body">We follow an Agile software development lifecycle, as described in <a class="govuk-link govuk-link--no-visited-state" href="https://gds-way.cloudapps.digital/">the GDS Way</a>.</p>
+  <p class="govuk-body">We follow an Agile software development lifecycle.</p>
   <p class="govuk-body">To protect our code, we:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>run separate development, testing and production environments</li>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -190,7 +190,8 @@
   <h2 class="heading-medium" id="email-security">Email security</h2>
   <p class="govuk-body">To help recipient’s email services tell the difference between our emails and spam, we use:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/domainkeys-identified-mail-dkim#:~:text=DomainKeys%20Identified%20Mail%20(%20DKIM%20)%20verifies,that%20fails%20the%20DKIM%20check.">DomainKeys Identified Mail (DKIM)</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/domain-based-message-authentication-reporting-and-conformance-dmarc">Domain-based Message Authentication, Reporting and Conformance (DMARC)</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/domainkeys-identified-mail-dkim">DomainKeys Identified Mail (DKIM)</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf#:~:text=Sender%20Policy%20Framework%20(%20SPF%20)%20lets,service%20in%20your%20SPF%20record.">Sender Policy Framework (SPF) records</a></li>
   </ul>
 

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -187,7 +187,7 @@
   <p class="govuk-body">We use publicly-verifiable digital certificates, so you’ll always know you’ve connected to the real GOV.UK Notify.</p>
 
   <h2 class="heading-medium" id="email-security">Email security</h2>
-  <p class="govuk-body">To make it easier for recipients’ email services to spot spam, we use:</p>
+  <p class="govuk-body">To help recipient’s email services tell the difference between our emails and spam, we use:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/domainkeys-identified-mail-dkim#:~:text=DomainKeys%20Identified%20Mail%20(%20DKIM%20)%20verifies,that%20fails%20the%20DKIM%20check.">DomainKeys Identified Mail (DKIM)</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf#:~:text=Sender%20Policy%20Framework%20(%20SPF%20)%20lets,service%20in%20your%20SPF%20record.">Sender Policy Framework (SPF) records</a></li>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -168,7 +168,7 @@
   <h2 class="heading-medium" id="security-incidents">Security incidents</h2>
   <p class="govuk-body">We provide a 24-hour response in case of an incident.</p>
   <p class="govuk-body">If there is a data loss event, we will contact you directly.</p>
-  <p class="govuk-body">If there is another type of incident, we’ll publish details and updates on our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status page</a>.</p>
+  <p class="govuk-body">If there is another type of incident, we’ll publish details and updates on the <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">Notify status page</a>.</p>
 
   <h2 class="heading-medium" id="sign-in-and-api-access">Sign in and API access</h2>
   <h3 class="heading-small">Signing in to Notify</h3>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -25,7 +25,7 @@
     <li><a class="govuk-link govuk-link--no-visited-state" href="#email-security">email security</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#security-classifications">security classifications</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#staff">GOV.UK Notify staff</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#suppliers">staff</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#suppliers">suppliers</a></li>
   </ul>
 
   <h2 class="heading-medium" id="running-a-secure-service">Running a secure service</h2>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -4,7 +4,7 @@
 {% set navigation_label_prefix = 'About Notify' %}
 
 {% block per_page_title %}
-  Security
+  Security features
 {% endblock %}
 
 {% block content_column_content %}

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -60,7 +60,7 @@
   <p class="govuk-body">Once your service is live, you can choose the number of days you want Notify to keep details of the messages you send.</p>
   <p class="govuk-body">For more information, see <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_data_retention_period') }}">data retention period</a>.</p>
 
-  <h3 class="heading-small" id="how-long-we-keep-your-data">Who can access your data</h3>
+  <h3 class="heading-small" id="who-can-access-your-data">Who can access your data</h3>
   <p class="govuk-body">Your data could be accessed by:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>the Notify team</li>
@@ -70,5 +70,20 @@
   <p class="govuk-body">Teams using GOV.UK Notify can only access their own data.</p>
   <p class="govuk-body">You can set <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_team_members_and_permissions') }}">different permissions for each member of your team</a>.</p>
   <p class="govuk-body">AWS provides logical separation between different AWS customers.</p>
+
+  <h3 class="heading-small" id="data-centre-security">Data centre security</h3>
+  <p class="govuk-body">AWS provides a description of their:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://aws.amazon.com/compliance/data-center/controls/">physical security measures, data sanitisation and equipment disposal arrangements</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://aws.amazon.com/compliance/programs/">security assurance materials</a></li>
+  </ul>
+
+  <h3 class="heading-small" id="how-text-messages-are-stored-and-processed">How text messages are stored and processed</h3>
+  <p class="govuk-body">Text messages are stored and processed in:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>the UK and Ireland</li>
+    <li>the country where the recipient’s phone is</li>
+    <li>the phone’s country of origin (for international numbers)</li>
+  </ul>
 
 {% endblock %}

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -31,7 +31,7 @@
   <p class="govuk-body">GOV.UK Notify:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>follows the principles of the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/service-standard">Service Standard</a></li>
-    <li>has been through a successful live service assessment</li>
+    <li>has been through a successful <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/service-assessments">live service assessment</a></li>
   </ul>
   <p class="govuk-body">We monitor the threat landscape so we can:</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -173,7 +173,9 @@
   <h2 class="heading-medium" id="sign-in-and-api-access">Sign in and API access</h2>
   <h3 class="heading-small">Signing in to Notify</h3>
   <p class="govuk-body">GOV.UK Notify uses two-factor authentication for sign-in.</p>
-  <p class="govuk-body">Find out more about the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">sign-in method</a>.</p>
+  <p class="govuk-body">Team members can sign in with a text message code or a link that’s sent in an email.</p>
+  <p class="govuk-body">For security, you’ll need to confirm that you still have access to your email address every 3 months.</p>
+  <p class="govuk-body">Find out more about our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">sign-in methods</a>.</p>
   <p class="govuk-body">You must keep to our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.terms_of_use') }}">terms of use for signing in to Notify</a>.</p>
   <h3 class="heading-small">Accessing the GOV.UK Notify API</h3>
   <p class="govuk-body">Services access the GOV.UK Notify API with an API key, encoded using <a class="govuk-link govuk-link--no-visited-state" href="https://jwt.io/">JSON Web Tokens</a>.</p>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -33,16 +33,17 @@
     <li>follows the principles of the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/service-standard">Service Standard</a></li>
     <li>has been through a successful <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/service-assessments">live service assessment</a></li>
   </ul>
-  <p class="govuk-body">We monitor the threat landscape so we can:</p>
+  <p class="govuk-body">We regularly assess and review our security in line with:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>the <a class="govuk-link govuk-link--no-visited-state" href="https://www.security.gov.uk/guidance/govassure/">GovAssure approach</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/collection/caf/caf-principles-and-guidance">UK government cyber security standards</a></li>
+  </ul>
+<p class="govuk-body">We monitor the threat landscape and conduct regular <a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/information/check-penetration-testing">CHECK penetration testing</a> so we can:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>continue to improve our security</li>
-    <li>meet <a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/collection/caf/caf-principles-and-guidance">UK government cyber security standards</a></li>
-    <li>deal with common threats like Distributed Denial of Service (DDoS) attacks</li>
+    </li>deal with common threats like Distributed Denial of Service (DDoS) attacks</li>
   </ul>
-  <p class="govuk-body">We conduct regular <a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/information/check-penetration-testing">CHECK penetration testing</a> to confirm that our data protection is effective.</p>
-  <p class="govuk-body">Notify’s cyber security is periodically assessed in line with the <a class="govuk-link govuk-link--no-visited-state" href="https://www.security.gov.uk/guidance/govassure/">GovAssure approach</a>.</p>
-
-  <h2 class="heading-medium" id="storing-and-processing-your-data">Storing and processing your data</h2>
+<h2 class="heading-medium" id="storing-and-processing-your-data">Storing and processing your data</h2>
   <p class="govuk-body">GOV.UK Notify uses Amazon Web Services (AWS) as our cloud service provider.</p>
   <p class="govuk-body">Data on Notify is stored and processed in:</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -9,79 +9,66 @@
 
 {% block content_column_content %}
 
-  <h1 class="heading-large">Security</h1>
-  <p class="govuk-body">GOV.UK Notify is built for the needs of government services. It has processes in place to:</p>
+  <h1 class="heading-large">Security features</h1>
+  <p class="govuk-body">GOV.UK Notify is built for the security needs of government services.</p>
+  <p class="govuk-body">This page describes our approach to:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>protect user data</li>
-    <li>keep systems secure</li>
-    <li>manage risks around information</li>
+    <li>running a secure service</li>
+    <li>storing and processing your data</li>
+    <li>protecting data in transit</li>
+    <li>protecting data at rest</li>
+    <li>building and managing Notify</li>
+    <li>finding and fixing security issues</li>
+    <li>security incidents</li>
+    <li>sign in and API access</li>
+    <li>protecting our website and API</li>
+    <li>email security</li>
+    <li>security classifications</li>
+    <li>staff, suppliers and governance</li>
   </ul>
 
-  <h2 class="heading-medium" id="data">Data</h2>
-  <p class="govuk-body">On Notify, data is encrypted when:</p>
+  <h2 class="heading-medium" id="running-a-secure-service">Running a secure service</h2>
+  <p class="govuk-body">GOV.UK Notify:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>it passes through the service</li>
-    <li>it’s stored on the service</li>
+    <li>follows the principles of the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/service-standard">Service Standard</a></li>
+    <li>has been through a successful live service assessment</li>
   </ul>
-  <p class="govuk-body">Any recipient data you upload is only held for 7 days.</p>
-  <p class="govuk-body">If you <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("main.guidance_send_files_by_email") }}">send a file by email</a>, the file will be available for the recipient to download for up to 78 weeks (18 months).</p>
-  <p class="govuk-body">The Cabinet Office acts as data processor for Notify. Your organisation is the data controller.</p>
-  <h3 class="heading-small">Data Protection Act</h3>
-  <p class="govuk-body">Notify complies with data protection law. To make sure it stays compliant, there are regular legal reviews of the service’s:</p>
+  <p class="govuk-body">We monitor the threat landscape so we can:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>privacy policy</li>
-    <li>terms of use</li>
-    <li>approach to data sharing</li>
+    <li>continue to improve our security</li>
+    <li>meet <a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/collection/caf/caf-principles-and-guidance">UK government cyber security standards</a></li>
+    <li>deal with common threats like Distributed Denial of Service (DDoS) attacks</li>
   </ul>
+  <p class="govuk-body">We conduct regular <a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/information/check-penetration-testing">CHECK penetration testing</a> to confirm that our data protection is effective.</p>
+  <p class="govuk-body">Notify’s cyber security is periodically assessed in line with the <a class="govuk-link govuk-link--no-visited-state" href="https://www.security.gov.uk/guidance/govassure/">GovAssure approach</a>.</p>
 
-  <h2 class="heading-medium" id="technical-security">Technical security</h2>
-  <p class="govuk-body">Other technical security controls on Notify include:</p>
+  <h2 class="heading-medium" id="storing-and-processing-your-data">Storing and processing your data</h2>
+  <p class="govuk-body">GOV.UK Notify uses Amazon Web Services (AWS) as our cloud service provider.</p>
+  <p class="govuk-body">Data on Notify is stored and processed in:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>compliance with National Cyber Security Centre (NCSC) Cloud Security Principles</li>
-    <li>protective monitoring to record activity, and raise alerts about any suspicious activity</li>
-    <li>using JSON Web Tokens, to avoid sending API keys when your service talks to Notify</li>
+    <li>AWS data centres in the UK and Ireland</li>
+    <li>locations where our sub-processors store and process data (UK and EEA)</li>
   </ul>
 
-  <h3 class="heading-small">Protect sensitive information</h3>
-  <p class="govuk-body">Some messages include sensitive information like security codes or password reset links.</p>
-  <p class="govuk-body">If you’re sending a message with sensitive information, you can choose to hide those details on the Notify dashboard once the message has been sent. This means that only the message recipient will be able to see that information.</p>
-
-  <h2 class="heading-medium" id="user-permissions-signing-in">User permissions and signing in</h2>
-  <p class="govuk-body">You can set different user permissions in Notify. This lets you control who in your team has access to certain parts of the service.</p>
-  <h3 class="heading-small">Two-factor authentication</h3>
-  <p class="govuk-body">To sign in to Notify, you’ll need to enter:</p>
+  <h3 class="heading-small" id="how-long-we-keep-your-data">How long we keep your data</h3>
+  <p class="govuk-body">GOV.UK Notify keeps a temporary record of:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>your email address and password</li>
-    <li>a text message code that Notify sends to your phone</li>
+    <li>the content of the emails, text messages and letters you send</li>
+    <li>recipient email addresses, mobile numbers and addresses</li>
   </ul>
-  <p class="govuk-body">If signing in with a text message is a problem for your team, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a> to find out about using an email link instead.</p>
+  <p class="govuk-body">By default, we keep this data for 7 days.</p>
+  <p class="govuk-body">Once your service is live, you can choose the number of days you want Notify to keep details of the messages you send.</p>
+  <p class="govuk-body">For more information, see <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_data_retention_period') }}">data retention period</a>.</p>
 
-  <h2 class="heading-medium" id="information-risk-management">Information risk management</h2>
-  <p class="govuk-body">Our approach to information risk management follows NCSC guidance. It assesses:</p>
+  <h3 class="heading-small" id="how-long-we-keep-your-data">Who can access your data</h3>
+  <p class="govuk-body">Your data could be accessed by:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>how Notify is built</li>
-    <li>the infrastructure Notify is built upon</li>
-    <li>support for the Notify service</li>
+    <li>the Notify team</li>
+    <li>our sub-processors</li>
+    <li>law enforcement agencies (where legally required)</li>
   </ul>
-  <p class="govuk-body">This approach also applies to the service providers Notify uses to send messages.</p>
-
-  <h2 class="heading-medium" id="how-we-manage-risk">How we manage risks on Notify</h2>
-  <p class="govuk-body">Things we do to manage risks on Notify include:</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>formal risk assessments based on <a class="govuk-link govuk-link--no-visited-state" href="http://www.iso.org/iso/catalogue_detail?csnumber=56742">ISO 27005:2011</a> and National Cyber Security Centre guidance</li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/information/check-penetration-testing">CHECK</a>-based testing, both annually and when any major changes are made to Notify</li>
-    <li>residual risk statement preparation and active management of the risk treatment plan</li>
-    <li>regular updates to the Privacy Impact Assessment</li>
-    <li>security impact assessments</li>
-  </ul>
-
-  <h2 class="heading-medium" id="cabinet-office-approval">Cabinet Office approval</h2>
-  <p class="govuk-body">Notify has been assessed and approved by the Cabinet Office Senior Information Risk Officer (SIRO). The SIRO checks this approval once a year.</p>
-  <p class="govuk-body">Notify also has approval from the Office of the Government’s SIRO to host data within the EEA.</p>
-
-  <h2 class="heading-medium" id="classifications-and-security-vetting">Classifications and security vetting</h2>
-  <p class="govuk-body">You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications</a> policy.</p>
-  <p class="govuk-body">Notify does not process data classified as ‘SECRET’ or ‘TOP SECRET’.</p>
-  <p class="govuk-body">The Notify team has Security Check (SC) level clearance from <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/organisations/united-kingdom-security-vetting">United Kingdom Security Vetting</a> (UKSV).</p>
+  <p class="govuk-body">Teams using GOV.UK Notify can only access their own data.</p>
+  <p class="govuk-body">You can set <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_team_members_and_permissions') }}">different permissions for each member of your team</a>.</p>
+  <p class="govuk-body">AWS provides logical separation between different AWS customers.</p>
 
 {% endblock %}

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -193,7 +193,7 @@
   <ul class="govuk-list govuk-list--bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/domain-based-message-authentication-reporting-and-conformance-dmarc">Domain-based Message Authentication, Reporting and Conformance (DMARC)</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/domainkeys-identified-mail-dkim">DomainKeys Identified Mail (DKIM)</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf">Sender Policy Framework (SPF)</a></li>
   </ul>
 
   <h2 class="heading-medium" id="security-classifications">Security classifications</h2>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -144,5 +144,24 @@
   </ul>
   <p class="govuk-body">We announce planned downtime on the <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">Notify status page</a>.</p>
 
+  <h2 class="heading-medium" id="building-and-managing-notify">Finding and fixing security issues</h2>
+  <p class="govuk-body">GOV.UK Notify:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>follows <a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/collection/developers-collection/principles">secure development principles</a></li>
+    <li>tracks third-party dependencies in our code base</li>
+    <li>monitors our logs for attacks, misuse and malfunctions</li>
+    <li>provides <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">24-hour online support</a></li>
+  </ul>
+  <p class="govuk-body">We use <a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/information/web-check">Web Check</a> and other services to:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>scan for vulnerabilities</li>
+    <li>prioritise which software patches to test and deploy first</li>
+  </ul>
+  <p class="govuk-body">AWS is responsible for patching our infrastructure:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>firmware</li>
+    <li>hardware</li>
+    <li>operating system (OS) kernel</li>
+  </ul>
 
 {% endblock %}

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -136,7 +136,6 @@
   <p class="govuk-body">We use infrastructure as code (IaC) to manage the systems and services that host Notify.</p>
   <p class="govuk-body">All code changes must be reviewed by the team before we can deploy them.</p>
   <p class="govuk-body">We monitor our production environment for unauthorised changes.</p>
-  <p class="govuk-body">The GDS Information Assurance team assesses significant code changes for any potential security impact.</p>
   <p class="govuk-body">We give our users appropriate notice before:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>any planned outages or downtime</li>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -228,7 +228,7 @@
     <li>receive security training</li>
     <li>complete <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-baseline-personnel-security-standard">personnel screening equivalent to BPSS</a></li>
   </ul>
-  <p class="govuk-body">The GDS Information Assurance team assesses suppliers:</p>
+  <p class="govuk-body">GDS assesses suppliers:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>before we decide whether to use them</li>
     <li>at regular intervals to make sure they still meet our requirements</li>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -13,18 +13,18 @@
   <p class="govuk-body">GOV.UK Notify is built for the security needs of government services.</p>
   <p class="govuk-body">This page describes our approach to:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>running a secure service</li>
-    <li>storing and processing your data</li>
-    <li>protecting data in transit</li>
-    <li>protecting data at rest</li>
-    <li>building and managing Notify</li>
-    <li>finding and fixing security issues</li>
-    <li>security incidents</li>
-    <li>sign in and API access</li>
-    <li>protecting our website and API</li>
-    <li>email security</li>
-    <li>security classifications</li>
-    <li>staff, suppliers and governance</li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#running-a-secure-service">running a secure service</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#storing-and-processing-your-data">storing and processing your data</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#protecting-data-in-transit">protecting data in transit</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#protecting-data-at-rest">protecting data at rest</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#building-and-managing-notify">building and managing Notify</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#finding-and-fixing-security-issues">finding and fixing security issues</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#security-incidents">security incidents</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#sign-in-and-api-access">sign in and API access</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#protecting-our-website-and-api">protecting our website and API</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#email-security">email security</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#security-classifications">security classifications</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#staff-suppliers-and-governance">staff, suppliers and governance</a></li>
   </ul>
 
   <h2 class="heading-medium" id="running-a-secure-service">Running a secure service</h2>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -192,7 +192,7 @@
   <ul class="govuk-list govuk-list--bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/domain-based-message-authentication-reporting-and-conformance-dmarc">Domain-based Message Authentication, Reporting and Conformance (DMARC)</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/domainkeys-identified-mail-dkim">DomainKeys Identified Mail (DKIM)</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf#:~:text=Sender%20Policy%20Framework%20(%20SPF%20)%20lets,service%20in%20your%20SPF%20record.">Sender Policy Framework (SPF) records</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf</a></li>
   </ul>
 
   <h2 class="heading-medium" id="security-classifications">Security classifications</h2>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -42,7 +42,7 @@
 <p class="govuk-body">We monitor the threat landscape and conduct regular <a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/information/check-penetration-testing">CHECK penetration testing</a> so we can:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>continue to improve our security</li>
-    </li>deal with common threats like Distributed Denial of Service (DDoS) attacks</li>
+    <li>deal with common threats like Distributed Denial of Service (DDoS) attacks</li>
   </ul>
 <h2 class="heading-medium" id="storing-and-processing-your-data">Storing and processing your data</h2>
   <p class="govuk-body">GOV.UK Notify uses Amazon Web Services (AWS) as our cloud service provider.</p>

--- a/app/templates/views/guidance/features/security.html
+++ b/app/templates/views/guidance/features/security.html
@@ -105,7 +105,7 @@
   <p class="govuk-body">GOV.UK Notify encrypts the data stored in our databases and backups using AES-256 encryption.</p>
   <p class="govuk-body">This includes any files that you upload to Notify when you:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_bulk_sending') }}">send messages in bulk</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_bulk_sending') }}">send a batch of messages</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_attach_pages') }}">attach pages to a letter template</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">upload a letter</a></li>
   </ul>
@@ -122,7 +122,7 @@
     <li>run separate development, testing and production environments</li>
     <li>deploy code through a continuous integration/continuous delivery (CI/CD) pipeline</li>
     <li>track vulnerabilities for any third-party libraries we use</li>
-    <li>use AWS secrets manager</li>
+    <li>use AWS Secrets Manager</li>
   </ul>
 
   <h3 class="heading-small" id="how-we-manage-code-changes">How we manage code changes</h3>
@@ -195,8 +195,14 @@
   </ul>
 
   <h2 class="heading-medium" id="security-classifications">Security classifications</h2>
-  <p class="govuk-body">You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications policy</a>.</p>
-  <p class="govuk-body">Notify does not process data classified as ‘SECRET’ or ‘TOP SECRET’.</p>
+  <p class="govuk-body">We have designed GOV.UK Notify for sending messages classified as ‘OFFICIAL’, including ‘OFFICIAL-SENSITIVE’, under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications policy</a>.</p>
+  <p class="govuk-body">Before you send any messages classified as ‘OFFICIAL’, you must make sure that GOV.UK Notify meets your organisation’s standards for:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>using, processing, storing and sending information</li>
+    <li>cyber security</li>
+    <li>data protection</li>
+  </ul>
+  <p class="govuk-body">Notify must not be used to process data classified as ‘SECRET’ or ‘TOP SECRET’.</p>
 
   <h2 class="heading-medium" id="staff-suppliers-and-governance">Staff, suppliers and governance</h2>
   <h3 class="heading-small">GOV.UK Notify staff</h3>
@@ -207,7 +213,7 @@
     <li>receive security training</li>
     <li>complete <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-baseline-personnel-security-standard">personnel screening equivalent to BPSS</a></li>
   </ul>
-  <p class="govuk-body">Team members who need greater access must complete <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/united-kingdom-security-vetting-clearance-levels/national-security-vetting-clearance-levels#security-check-sc">National Security Vetting to Security Check (SC) level</a>.</p>
+  <p class="govuk-body">Team members who need greater access to the data stored on Notify must complete <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/united-kingdom-security-vetting-clearance-levels/national-security-vetting-clearance-levels#security-check-sc">National Security Vetting to Security Check (SC) level</a>.</p>
   <p class="govuk-body">We only give additional access to GOV.UK Notify’s production environment to privileged users:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>by exception</li>
@@ -238,7 +244,7 @@
     <li>organises information assurance activities</li>
     <li>oversees risk treatment activities</li>
     <li>reports its findings and recommendations to the SRO and COO</li>
-    <li>escalate risk management decisions to the GDS Senior Leadership Team as necessary</li>
+    <li>escalates risk management decisions to the GDS Senior Leadership Team as necessary</li>
   </ul>
   <p class="govuk-body">The Data Protection, Privacy and Accessibility Monitoring teams make sure that Notify complies with any legal and regulatory requirements.</p>
 


### PR DESCRIPTION
We’ve rewritten the `Security features` page to:

* provide more detailed information for prospective users
* link to other useful pages on GOV.UK Notify and the web
* include specific information requested by the Information Assurance team

The content on the new page should match the draft in [this Google document](https://docs.google.com/document/d/1Xb0OwP8UQoql-Me0nioY7uWaYgMG_HDj5wxPZj6Cw9I/edit?usp=sharing).