### PR TITLE
Fix `None` appearing as hint text for textareas

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -662,7 +662,7 @@ class GovukTextareaField(GovukFrontendWidgetMixin, TextAreaField):
             "id": self.id,
             "rows": 8,
             "label": {"text": self.label.text, "classes": None, "isPageHeading": False},
-            "hint": {"text": None},
+            "hint": None,
             "errorMessage": error_message,
         }
 

--- a/tests/app/main/views/test_join_service.py
+++ b/tests/app/main/views/test_join_service.py
@@ -184,6 +184,7 @@ def test_page_lists_team_members_of_service(
 
     assert page.select_one("textarea")["name"] == page.select_one("textarea")["id"] == "reason"
     assert normalize_spaces(page.select_one("label[for=reason]").text) == "Explain why you need access (optional)"
+    assert not page.select("#reason-hint")
 
     mock_get_users.assert_called_once_with(SERVICE_ONE_ID)
 


### PR DESCRIPTION
If a textarea rendered using the GOV.UK Frontend component had didn’t have any hint text set, hint text of `None` was still being rendered to the page.

This commit makes the default no hint at all, rather than just text of `None`.