### PR TITLE
Remove whitespace from examples of bullet points

### DIFF
--- a/app/templates/partials/templates/guidance-bullet-points.html
+++ b/app/templates/partials/templates/guidance-bullet-points.html
@@ -13,13 +13,12 @@
 <!-- TEMPLATED BULLET POINTS -->
 <p class="govuk-body">Copy this example to add bullet points:</p>
 
-<pre class="formatting-example"><code class="lang-md">
-    Introduce bullet points with a lead-in line ending in a colon:
+<pre class="formatting-example"><code class="lang-md">Introduce bullet points with a lead-in line ending in a colon:
 
-    * leave one empty line space after the lead-in line
-    * use an asterisk or a dash followed by a space to add an item
-    * start each item with a lowercase letter, do not end with a full stop
-    * leave one empty line space after the last item
+* leave one empty line space after the lead-in line
+* use an asterisk or a dash followed by a space to add an item
+* start each item with a lowercase letter, do not end with a full stop
+* leave one empty line space after the last item
 </code></pre>
 
 <p class="govuk-body">To create sub-items, add an indent of 2 spaces before the asterisk or dash.</p>
@@ -28,13 +27,12 @@
 {% set personalisedBullets %}
     <p class="govuk-body">Copy this example to add a <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_personalisation') }}">placeholder</a> to your message template:</p>
 
-    <pre class="formatting-example"><code class="lang-md">
-        Introduce bullet points with a lead-in line ending in a colon:
+    <pre class="formatting-example"><code class="lang-md">Introduce bullet points with a lead-in line ending in a colon:
 
-        ((bullet points))
+((bullet points))
 
-        Leave one empty line space before the next paragraph.
-    </code></pre>
+Leave one empty line space before the next paragraph.
+</code></pre>
 
     <p class="govuk-body">To send the message, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_bulk_sending') }}">upload a list of recipient details</a>.</p>
 


### PR DESCRIPTION
Because these examples are in `<pre>` tags any extra whitespace gets rendered to the page.

I tried to make a macro that does this automatically but couldn’t figure out a way in Jinja.

Before | After
---|---
<img width="657" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/efafa52c-c9dd-4af2-9896-be81cb1c9359"> | <img width="651" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/a28547d1-a8b0-4b81-b742-23713ad0367d">

