### PR TITLE
Fix letter branding preview when no service present

### DIFF
--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -27,7 +27,7 @@ class TemplatePreview:
             "letter_contact_block": db_template.get("reply_to_text", ""),
             "template": db_template,
             "values": values,
-            "filename": branding_filename or current_service.letter_branding.filename,
+            "filename": branding_filename or (current_service.letter_branding.filename if current_service else None),
         }
         response = requests.post(
             "{}/preview.{}{}".format(


### PR DESCRIPTION
Because we serve letter branding images without cookies there’s no`current_service` available in the request context.

This was causing an error when trying to preview a letter with no branding, because the fallback is to look at the branding for the current service.

This commit adds a conditional for this case, and makes the test more end-to-end to ensure this edge case is accounted for.