### PR TITLE
Fix back link to join service journey appearing on ‘Add service’ page

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -1,4 +1,4 @@
-from flask import current_app, redirect, render_template, session, url_for
+from flask import abort, current_app, redirect, render_template, session, url_for
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
@@ -48,6 +48,9 @@ def _create_example_template(service_id):
 @user_is_logged_in
 @user_is_gov_user
 def add_or_join_service():
+    if not current_user.default_organisation.can_ask_to_join_a_service:
+        abort(403)
+
     form = AddOrJoinServiceForm(organisation=current_user.default_organisation)
 
     if form.validate_on_submit():

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -6,11 +6,11 @@
 
 {% set heading = 'Enter a service name' %}
 
-{% if request.args.get("back") == "add_or_join" %}
-  {% block backLink %}
+{% block backLink %}
+  {% if request.args.get("back") == "add_or_join" %}
     {{ govukBackLink({ "href": url_for('main.add_or_join_service') }) }}
-  {% endblock %}
-{% endif %}
+  {% endif %}
+{% endblock %}
 
 {% block per_page_title %}
   {{ heading }}

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -6,7 +6,7 @@ from notifications_python_client.errors import HTTPError
 
 from app.utils.user import is_gov_user
 from tests import organisation_json, service_json
-from tests.conftest import SERVICE_ONE_ID, SERVICE_TWO_ID, normalize_spaces
+from tests.conftest import ORGANISATION_ID, SERVICE_ONE_ID, SERVICE_TWO_ID, normalize_spaces
 
 
 def test_non_gov_user_cannot_see_add_service_button(
@@ -395,12 +395,36 @@ def test_email_auth_user_creates_service_with_email_auth_permission(
     assert "email_auth" in mock_update_service.call_args[1]["permissions"]
 
 
+@pytest.mark.parametrize(
+    "organisation",
+    (
+        None,
+        organisation_json(ORGANISATION_ID),
+    ),
+)
+def test_join_or_add_service_page_redirects_without_permission(
+    mocker,
+    client_request,
+    organisation,
+):
+    mocker.patch(
+        "app.organisations_client.get_organisation_by_domain",
+        return_value=organisation,
+    )
+    client_request.get(
+        "main.add_or_join_service",
+        _expected_status=403,
+    )
+
+
 def test_join_or_add_service_page(
     mocker,
     client_request,
-    mock_get_organisation_by_domain,
-    mock_get_organisation_services,
 ):
+    mocker.patch(
+        "app.organisations_client.get_organisation_by_domain",
+        return_value=organisation_json(ORGANISATION_ID, can_ask_to_join_a_service=True),
+    )
     mocker.patch(
         "app.organisations_client.get_organisation_services",
         return_value=[
@@ -441,11 +465,15 @@ def test_join_or_add_service_page(
     ),
 )
 def test_post_join_or_add_service_page(
+    mocker,
     client_request,
-    mock_get_organisation_by_domain,
     mock_get_organisation_services,
     choice,
 ):
+    mocker.patch(
+        "app.organisations_client.get_organisation_by_domain",
+        return_value=organisation_json(ORGANISATION_ID, can_ask_to_join_a_service=True),
+    )
     client_request.post(
         "main.add_or_join_service",
         _data={

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -94,6 +94,15 @@ def test_show_different_page_content_based_on_user_org_type(client_request, mock
     assert page.select_one("h1").text.strip() == "Enter a service name"
     assert page.select_one("input[name=name]").get("value") is None
     assert all(content in page.select_one("main").text for content in expected_content_lines)
+    assert not page.select(".govuk-back-link")
+
+
+def test_shows_back_link_if_come_from_join_service_page(
+    client_request,
+    mock_get_no_organisation_by_domain,
+):
+    page = client_request.get("main.add_service", back="add_or_join")
+    assert page.select_one(".govuk-back-link")["href"] == url_for("main.add_or_join_service")
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -411,7 +411,7 @@ def test_email_auth_user_creates_service_with_email_auth_permission(
         organisation_json(ORGANISATION_ID),
     ),
 )
-def test_join_or_add_service_page_redirects_without_permission(
+def test_join_or_add_service_page_403s_without_permission(
     mocker,
     client_request,
     organisation,


### PR DESCRIPTION
Apparently `block` tags in Jinja are always evaluated even if they are inside a conditional which evaluates to `False`.

Moving the `if` inside the `block` makes things work as intended.

This also `403`s the page that was being linked to for good measure.