### PR TITLE
Use the internal API host name, rather than the external

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -43,7 +43,7 @@ applications:
       # Credentials variables
       ADMIN_CLIENT_SECRET: '{{ ADMIN_CLIENT_SECRET }}'
       ADMIN_BASE_URL: '{{ ADMIN_BASE_URL }}'
-      API_HOST_NAME: '{{ API_HOST_NAME }}'
+      API_HOST_NAME: '{{ API_HOST_NAME_INTERNAL }}'
       DANGEROUS_SALT: '{{ DANGEROUS_SALT }}'
       SECRET_KEY: '{{ SECRET_KEY }}'
       ROUTE_SECRET_KEY_1: '{{ ROUTE_SECRET_KEY_1 }}'


### PR DESCRIPTION
For the admin to talk to the API in PaaS, we want it to always use the PaaS route (the internal one). This keeps things consistent with ECS where all inter app requests stay in ECS (so we want all inter app requests in the PaaS to stay in PaaS).

For the moment, this change won't actually do anything because in the credentials repo the API_HOST_NAME_INTERNAL is still set to the external address, but we will shortly change the value to be the PaaS internal address.

This PR Relies on the creation of the internal secret in alphagov/notifications-credentials#417