### PR TITLE
Add unsubscribe links page

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -374,6 +374,14 @@ def guidance_upload_a_letter():
     )
 
 
+@main.route("/using-notify/unsubscribe-links")
+def guidance_unsubscribe_links():
+    return render_template(
+        "views/guidance/using-notify/unsubscribe-links.html",
+        navigation_links=using_notify_nav(),
+    )
+
+
 # --- Redirects --- #
 
 

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -174,6 +174,10 @@ def using_notify_nav():
                     "name": "Upload a letter",
                     "link": "main.guidance_upload_a_letter",
                 },
+                {
+                    "name": "Unsubscribe links",
+                    "link": "main.guidance_unsubscribe_links",
+                },
             ],
         },
     ]

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -79,6 +79,7 @@ class HeaderNavigation(Navigation):
             "guidance_team_members_and_permissions",
             "guidance_templates",
             "guidance_text_message_sender",
+            "guidance_unsubscribe_links",
             "guidance_upload_a_letter",
         },
         "user-profile": {

--- a/app/templates/views/guidance/using-notify/index.html
+++ b/app/templates/views/guidance/using-notify/index.html
@@ -34,6 +34,7 @@
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_optional_content') }}">Optional content</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_personalisation') }}">Personalisation</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_qr_codes') }}">Add a QR code to a letter template</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_unsubscribe_links') }}">Unsubscribe links</a></li>
    </ul>
 
   <h2 class="heading-medium">Branding</h2>

--- a/app/templates/views/guidance/using-notify/index.html
+++ b/app/templates/views/guidance/using-notify/index.html
@@ -56,7 +56,7 @@
 
  <ul class="govuk-list govuk-list--bullet">
    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">Trial mode</a></li>
-   <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">Sign-in method</a></li> 
+   <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">Sign-in method</a></li>
    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_team_members_and_permissions') }}">Team members and permissions</a></li>
    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_data_retention_period') }}">Data retention period</a></li>
   </ul>

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/service-link.html" import service_link %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Using Notify' %}
 

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -15,8 +15,8 @@
 
   <p class="govuk-body">Transactional emails do not need to include an unsubscribe link.</p>
 
-  <p class="govuk-body">For more information, read the <a class="govuk-link govuk-link--no-visited-state"
-    href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">GOV.UK Service Manual</a>.</p>
+  <p class="govuk-body">The GOV.​UK Service Manual explains the difference between <a class="govuk-link govuk-link--no-visited-state"
+    href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#transactional-messages">transactional messages and subscription emails</a>.</p>
 
   <h2 class="heading-medium">How to add an unsubscribe link to an email</h2>
 

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -23,7 +23,7 @@
   <p class="govuk-body">GOV.UK Notify uses Markdown to format links.</p>
 
   <p class="govuk-body">To add an unsubscribe link, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.</p>
-  <p class="govuk-body">Use this example if you have a webpage were users can manage their email subscriptions:</p>
+  <p class="govuk-body">Use this example if you have a webpage where users can manage their email subscriptions:</p>
 
   <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.gov.uk/example/unsubscribe)</code></pre>
   

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -20,7 +20,7 @@
 
   <h2 class="heading-medium">How to add an unsubscribe link to an email</h2>
 
-  <p class="govuk-body">GOV.UK Notify uses Markdown to format unsubscribe links.</p>
+  <p class="govuk-body">GOV.UK Notify uses Markdown to format links.</p>
 
   <p class="govuk-body">Use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work. For example:</p>
 

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -31,11 +31,6 @@
   <pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:unsubscribe@gov.uk?subject=unsubscribe)</code></pre>
   <p class="govuk-body">The email address should be a shared inbox managed by your team, not your own email address.</p>
 
-  <h2 class="heading-medium">One-click unsubscribe</h2>
-
-  <p class="govuk-body">We are working on adding one-click unsubscribe to GOV.UK Notify. We expect to make this feature available by June 2024.</p>
-
-  <p class="govuk-body">Your emails will still need to include unsubscribe links in the body of the message.</p>
 
 
 {% endblock %}

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -25,7 +25,11 @@
   <p class="govuk-body">To add an unsubscribe link, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.</p>
   <p class="govuk-body">Use this example if you have a webpage were users can manage their email subscriptions:</p>
 
-  <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.gov.uk/example)</code></pre>
+  <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.gov.uk/example/unsubscribe)</code></pre>
+  
+  <p class="govuk-body">If you do not have your own webpage, you can let users send an email to your team instead. For example:</p>  
+  <pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:unsubscribe@gov.uk?subject=unsubscribe)</code></pre>
+  <p class="govuk-body">The email address should be a shared inbox managed by your team, not your own email address.</p>
 
   <h2 class="heading-medium">One-click unsubscribe</h2>
 

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -31,6 +31,4 @@
   <pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:unsubscribe@gov.uk?subject=unsubscribe)</code></pre>
   <p class="govuk-body">The email address should be a shared inbox managed by your team, not your own email address.</p>
 
-
-
 {% endblock %}

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -32,20 +32,5 @@
 
   <p class="govuk-body">Your emails will still need to include unsubscribe links in the body of the message.</p>
 
-  <h2 class="heading-medium">Only send emails to people who want them</h2>
-
-  <p class="govuk-body">You should only send emails to people who want to hear from you.</p>
-
-  <p class="govuk-body">You must:</p>
-
-  <ul class="govuk-list govuk-list--bullet">
-    <li>make sure recipients opt in to get messages from you</li>
-    <li>confirm each recipient’s email address before subscribing them</li>
-    <li>send regular messages to confirm that recipients want to stay subscribed</li>
-  </ul>
-
-  <p class="govuk-body">Recipients who have agreed to receive emails from you are less likely to report them as spam.</p>
-
-  <p class="govuk-body">If recipients do report your emails as spam, it has a negative effect on everyone using Notify.</p>
 
 {% endblock %}

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -1,0 +1,53 @@
+{% extends "content_template.html" %}
+
+{% from "components/service-link.html" import service_link %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
+
+{% block per_page_title %}
+  Unsubscribe links
+{% endblock %}
+
+{% block content_column_content %}
+
+  <h1 class="heading-large">Unsubscribe links</h1>
+
+  <p class="govuk-body">Subscription emails must include an unsubscribe link in the body of the message.</p>
+
+  <p class="govuk-body">Transactional emails do not need to include an unsubscribe link.</p>
+
+  <p class="govuk-body">For more information, read the <a class="govuk-link govuk-link--no-visited-state"
+    href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">GOV.UK Service Manual</a>.</p>
+
+  <h2 class="heading-medium">How to add an unsubscribe link to an email</h2>
+
+  <p class="govuk-body">GOV.UK Notify uses Markdown to format unsubscribe links.</p>
+
+  <p class="govuk-body">Use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work. For example:</p>
+
+  <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.gov.uk/example)</code></pre>
+
+  <h2 class="heading-medium">One-click unsubscribe</h2>
+
+  <p class="govuk-body">We are working on adding one-click unsubscribe to GOV.UK Notify. We expect to make this feature available by June 2024.</p>
+
+  <p class="govuk-body">Your emails will still need to include unsubscribe links in the body of the message.</p>
+
+  <h2 class="heading-medium">Only send emails to people who want them</h2>
+
+  <p class="govuk-body">You should only send emails to people who want to hear from you.</p>
+
+  <p class="govuk-body">You must:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>make sure recipients opt in to get messages from you</li>
+    <li>confirm each recipient’s email address before subscribing them</li>
+    <li>send regular messages to confirm that recipients want to stay subscribed</li>
+  </ul>
+
+  <p class="govuk-body">Recipients who have agreed to receive emails from you are less likely to report them as spam.</p>
+
+  <p class="govuk-body">If recipients do report your emails as spam, it has a negative effect on everyone using Notify.</p>
+
+{% endblock %}

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -22,7 +22,7 @@
 
   <p class="govuk-body">GOV.UK Notify uses Markdown to format links.</p>
 
-  <p class="govuk-body">Use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work. For example:</p>
+  <p class="govuk-body">To add an unsubscribe link, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work. For example:</p>
 
   <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.gov.uk/example)</code></pre>
 

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -27,7 +27,7 @@
 
   <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.gov.uk/example/unsubscribe)</code></pre>
   
-  <p class="govuk-body">If you do not have your own webpage, you can let users send an email to your team instead. For example:</p>  
+  <p class="govuk-body">If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:</p>  
   <pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:unsubscribe@gov.uk?subject=unsubscribe)</code></pre>
   <p class="govuk-body">The email address should be a shared inbox managed by your team, not your own email address.</p>
 

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -22,7 +22,8 @@
 
   <p class="govuk-body">GOV.UK Notify uses Markdown to format links.</p>
 
-  <p class="govuk-body">To add an unsubscribe link, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work. For example:</p>
+  <p class="govuk-body">To add an unsubscribe link, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.</p>
+  <p class="govuk-body">Use this example if you have a webpage were users can manage their email subscriptions:</p>
 
   <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.gov.uk/example)</code></pre>
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -111,6 +111,7 @@ def test_hiding_pages_from_search_engines(
         "guidance_send_files_by_email",
         "guidance_templates",
         "guidance_text_message_sender",
+        "guidance_unsubscribe_links",
         "guidance_upload_a_letter",
         "guidance_using_notify",
         "guidance_who_can_use_notify",

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -157,6 +157,7 @@ EXCLUDED_ENDPOINTS = set(
             "guidance_templates",
             "guidance_text_message_sender",
             "guidance_trial_mode",
+            "guidance_unsubscribe_links",
             "guidance_upload_a_letter",
             "guidance_using_notify",
             "guidance_who_can_use_notify",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -416,6 +416,7 @@
     "/using-notify/templates",
     "/using-notify/text-message-sender",
     "/using-notify/trial-mode",
+    "/using-notify/unsubscribe-links",
     "/using-notify/upload-a-letter",
     "/using-notify/who-can-use-notify",
     "/using-notify/who-its-for",


### PR DESCRIPTION
This PR adds a new Using Notify guidance page about Unsubscribe links.

We’re publishing this guidance in support of the new email sender requirements from Google and Yahoo.

The PR also adds links to this page to the left-hand navigation and Using Notify landing page.