### PR TITLE
Include onwards request headers in requests to template-preview, api

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -62,10 +62,7 @@ from app.s3_client.s3_letter_upload_client import (
     upload_letter_attachment_to_s3,
     upload_letter_to_s3,
 )
-from app.template_previews import (
-    TemplatePreview,
-    sanitise_letter,
-)
+from app.template_previews import TemplatePreview
 from app.utils import (
     NOTIFICATION_TYPES,
     should_skip_template_page,
@@ -1164,7 +1161,7 @@ def _process_letter_attachment_form(service_id, template, form, upload_id):
     file_location = get_transient_letter_file_location(service_id, upload_id)
 
     try:
-        response = sanitise_letter(
+        response = TemplatePreview.sanitise_letter(
             BytesIO(pdf_file_bytes),
             upload_id=upload_id,
             allow_international_letters=current_service.has_permission("international_letters"),

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -43,7 +43,7 @@ from app.s3_client.s3_letter_upload_client import (
     get_transient_letter_file_location,
     upload_letter_to_s3,
 )
-from app.template_previews import TemplatePreview, sanitise_letter
+from app.template_previews import TemplatePreview
 from app.utils import unicode_truncate
 from app.utils.csv import Spreadsheet, get_errors_for_csv
 from app.utils.letters import (
@@ -164,7 +164,7 @@ def upload_letter(service_id):
         file_location = get_transient_letter_file_location(service_id, upload_id)
 
         try:
-            response = sanitise_letter(
+            response = TemplatePreview.sanitise_letter(
                 BytesIO(pdf_file_bytes),
                 upload_id=upload_id,
                 allow_international_letters=current_service.has_permission("international_letters"),

--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -30,18 +30,14 @@ class NotifyAdminAPIClient(BaseAPIClient):
             "X-Custom-Forwarder": self.route_secret,
             "User-agent": f"NOTIFY-API-PYTHON-CLIENT/{__version__}",
         }
-        return self._add_request_id_header(headers)
-
-    @staticmethod
-    def _add_request_id_header(headers):
-        if not has_request_context():
-            return headers
-
-        headers["X-B3-TraceId"] = request.request_id
-        headers["X-B3-SpanId"] = request.span_id
-
-        if g.user_id:
-            headers["X-Notify-User-Id"] = g.user_id
+        if has_request_context():
+            if hasattr(request, "get_onwards_request_headers"):
+                headers = {
+                    **request.get_onwards_request_headers(),
+                    **headers,
+                }
+            if g.user_id:
+                headers["X-Notify-User-Id"] = g.user_id
 
         return headers
 

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -16,6 +16,10 @@ class TemplatePreview:
         return allowed_headers.items()
 
     @classmethod
+    def _get_outbound_headers(cls):
+        return {"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"}
+
+    @classmethod
     def get_preview_for_templated_letter(cls, db_template, filetype, values=None, page=None, branding_filename=None):
         if db_template["is_precompiled_letter"]:
             raise ValueError
@@ -36,7 +40,7 @@ class TemplatePreview:
                 "?page={}".format(page) if page else "",
             ),
             json=data,
-            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
+            headers=cls._get_outbound_headers(),
         )
         return response.content, response.status_code, cls.get_allowed_headers(response.headers)
 
@@ -49,7 +53,7 @@ class TemplatePreview:
                 current_app.config["TEMPLATE_PREVIEW_API_HOST"], "?hide_notify=true" if page == "1" else ""
             ),
             data=base64.b64encode(pdf_page).decode("utf-8"),
-            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
+            headers=cls._get_outbound_headers(),
         )
         return response.content, response.status_code, cls.get_allowed_headers(response.headers)
 
@@ -63,7 +67,7 @@ class TemplatePreview:
                 f"?page_number={page}&is_an_attachment={is_an_attachment}",
             ),
             data=pdf_page,
-            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
+            headers=cls._get_outbound_headers(),
         )
         return response.content, response.status_code, cls.get_allowed_headers(response.headers)
 
@@ -79,7 +83,7 @@ class TemplatePreview:
                 "?page={}".format(page) if page else "",
             ),
             json=data,
-            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
+            headers=cls._get_outbound_headers(),
         )
         return response.content, response.status_code, cls.get_allowed_headers(response.headers)
 
@@ -101,7 +105,7 @@ class TemplatePreview:
         response = requests.post(
             f"{current_app.config['TEMPLATE_PREVIEW_API_HOST']}/preview.json".format(),
             json=data,
-            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
+            headers=cls._get_outbound_headers(),
         )
 
         page_count = json.loads(response.content.decode("utf-8"))
@@ -120,5 +124,5 @@ class TemplatePreview:
         return requests.post(
             url,
             data=pdf_file,
-            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
+            headers=cls._get_outbound_headers(),
         )

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -108,17 +108,17 @@ class TemplatePreview:
 
         return page_count
 
-
-def sanitise_letter(pdf_file, *, upload_id, allow_international_letters, is_an_attachment=False):
-    url = "{host_url}/precompiled/sanitise?allow_international_letters={allow_intl}&upload_id={upload_id}".format(
-        host_url=current_app.config["TEMPLATE_PREVIEW_API_HOST"],
-        allow_intl="true" if allow_international_letters else "false",
-        upload_id=upload_id,
-    )
-    if is_an_attachment:
-        url = url + "&is_an_attachment=true"
-    return requests.post(
-        url,
-        data=pdf_file,
-        headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
-    )
+    @classmethod
+    def sanitise_letter(cls, pdf_file, *, upload_id, allow_international_letters, is_an_attachment=False):
+        url = "{host_url}/precompiled/sanitise?allow_international_letters={allow_intl}&upload_id={upload_id}".format(
+            host_url=current_app.config["TEMPLATE_PREVIEW_API_HOST"],
+            allow_intl="true" if allow_international_letters else "false",
+            upload_id=upload_id,
+        )
+        if is_an_attachment:
+            url = url + "&is_an_attachment=true"
+        return requests.post(
+            url,
+            data=pdf_file,
+            headers={"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"},
+        )

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -2,7 +2,8 @@ import base64
 from io import BytesIO
 
 import requests
-from flask import abort, current_app, json
+from flask import abort, current_app, json, request
+from flask.ctx import has_request_context
 from notifications_utils.pdf import extract_page_from_pdf
 
 from app import current_service
@@ -17,7 +18,10 @@ class TemplatePreview:
 
     @classmethod
     def _get_outbound_headers(cls):
-        return {"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"}
+        headers = {"Authorization": f"Token {current_app.config['TEMPLATE_PREVIEW_API_KEY']}"}
+        if has_request_context() and hasattr(request, "get_onwards_request_headers"):
+            headers.update(request.get_onwards_request_headers())
+        return headers
 
     @classmethod
     def get_preview_for_templated_letter(cls, db_template, filetype, values=None, page=None, branding_filename=None):

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -143,13 +143,13 @@ class TemplatedLetterImageTemplate(BaseLetterImageTemplate):
 
     @property
     def all_page_counts(self):
-        from app.template_previews import get_page_counts_for_letter
+        from app.template_previews import TemplatePreview
 
         if self._all_page_counts:
             return self._all_page_counts
 
         if self.values:
-            self._all_page_counts = get_page_counts_for_letter(self._template, self.values)
+            self._all_page_counts = TemplatePreview.get_page_counts_for_letter(self._template, self.values)
             return self._all_page_counts
 
         cache_key = (
@@ -159,7 +159,7 @@ class TemplatedLetterImageTemplate(BaseLetterImageTemplate):
             self._all_page_counts = json.loads(cached_value)
             return self._all_page_counts
 
-        self._all_page_counts = get_page_counts_for_letter(self._template, self.values)
+        self._all_page_counts = TemplatePreview.get_page_counts_for_letter(self._template, self.values)
         redis_client.set(cache_key, json.dumps(self._all_page_counts), ex=cache.DEFAULT_TTL)
 
         return self._all_page_counts

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,9 +80,7 @@ govuk-frontend-jinja==2.3.0
 greenlet==3.0.3
     # via eventlet
 gunicorn[eventlet]==21.2.0
-    # via
-    #   -r requirements.in
-    #   gunicorn
+    # via -r requirements.in
 humanize==4.4.0
     # via -r requirements.in
 idna==3.3
@@ -121,7 +119,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx
@@ -195,9 +193,7 @@ s3transfer==0.6.0
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 six==1.16.0
     # via
     #   awscli-cwlogs

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1934,6 +1934,7 @@ def test_dont_show_preview_letter_templates_for_bad_filetype(
 def test_letter_branding_preview_image(
     mocker,
     client_request,
+    mock_onwards_request_headers,
     original_filename,
     new_filename,
 ):
@@ -1961,7 +1962,10 @@ def test_letter_branding_preview_image(
             "values": None,
             "filename": new_filename,
         },
-        headers={"Authorization": "Token my-secret-key"},
+        headers={
+            "Authorization": "Token my-secret-key",
+            "some-onwards": "request-headers",
+        },
     )
     assert response.get_data(as_text=True) == "foo"
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1191,7 +1191,7 @@ def test_post_attach_pages_errors_when_content_outside_printable_area(
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
     mock_sanitise_response.json = lambda: {"message": "content-outside-printable-area", "invalid_pages": [1]}
-    mocker.patch("app.main.views.templates.sanitise_letter", return_value=mock_sanitise_response)
+    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", return_value=mock_sanitise_response)
 
     with open("tests/test_pdf_files/one_page_pdf.pdf", "rb") as file:
         file_contents = file.read()
@@ -1248,7 +1248,7 @@ def test_post_attach_pages_errors_when_base_template_plus_attachment_too_long(
             "data": template_version_json(SERVICE_ONE_ID, fake_uuid, api_user_active, version=1, type_="letter")
         },
     )
-    mocker.patch("app.main.views.templates.sanitise_letter")
+    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter")
     do_mock_get_page_counts_for_letter(mocker, count=9)
 
     with open("tests/test_pdf_files/multi_page_pdf.pdf", "rb") as file:
@@ -1277,7 +1277,7 @@ def test_post_attach_pages_redirects_to_template_view_when_validation_successful
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
-    mock_sanitise = mocker.patch("app.main.views.templates.sanitise_letter")
+    mock_sanitise = mocker.patch("app.template_previews.TemplatePreview.sanitise_letter")
 
     # page count for the attachment
     mocker.patch("app.main.views.templates.pdf_page_count", return_value=page_count)
@@ -1322,7 +1322,7 @@ def test_post_attach_pages_archives_existing_attachment_when_it_exists(
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
-    mock_sanitise = mocker.patch("app.main.views.templates.sanitise_letter")
+    mock_sanitise = mocker.patch("app.template_previews.TemplatePreview.sanitise_letter")
 
     # page count for the attachment
     mocker.patch("app.main.views.templates.pdf_page_count", return_value=1)
@@ -1380,7 +1380,7 @@ def test_post_attach_pages_doesnt_replace_existing_attachment_if_new_attachment_
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
     mock_sanitise_response.json = lambda: {"message": "content-outside-printable-area", "invalid_pages": [1]}
-    mocker.patch("app.main.views.templates.sanitise_letter", return_value=mock_sanitise_response)
+    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", return_value=mock_sanitise_response)
 
     mocker.patch("app.main.views.templates.upload_letter_to_s3")
     mocker.patch("app.main.views.templates.pdf_page_count", return_value=1)

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -38,7 +38,7 @@ def test_post_upload_letter_redirects_for_valid_file(
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     antivirus_mock = mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mock_sanitise = mocker.patch(
-        "app.main.views.uploads.sanitise_letter",
+        "app.template_previews.TemplatePreview.sanitise_letter",
         return_value=Mock(
             content="The sanitised content",
             json=lambda: {"file": "VGhlIHNhbml0aXNlZCBjb250ZW50", "recipient_address": "The Queen"},
@@ -124,7 +124,7 @@ def test_post_upload_letter_shows_letter_preview_for_valid_file(
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mocker.patch(
-        "app.main.views.uploads.sanitise_letter",
+        "app.template_previews.TemplatePreview.sanitise_letter",
         return_value=Mock(
             content="The sanitised content",
             json=lambda: {"file": "VGhlIHNhbml0aXNlZCBjb250ZW50", "recipient_address": "The Queen"},
@@ -192,7 +192,7 @@ def test_upload_international_letter_shows_preview_with_no_choice_of_postage(
 
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch(
-        "app.main.views.uploads.sanitise_letter",
+        "app.template_previews.TemplatePreview.sanitise_letter",
         return_value=Mock(
             content="The sanitised content",
             json=lambda: {"file": "VGhlIHNhbml0aXNlZCBjb250ZW50", "recipient_address": "The Queen"},
@@ -362,7 +362,7 @@ def test_post_upload_letter_with_invalid_file(mocker, client_request, fake_uuid)
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
     mock_sanitise_response.json = lambda: {"message": "content-outside-printable-area", "invalid_pages": [1]}
-    mocker.patch("app.main.views.uploads.sanitise_letter", return_value=mock_sanitise_response)
+    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", return_value=mock_sanitise_response)
     mocker.patch("app.models.service.service_api_client.get_precompiled_template")
     mocker.patch(
         "app.main.views.uploads.get_letter_metadata",
@@ -418,7 +418,7 @@ def test_post_upload_letter_shows_letter_preview_for_invalid_file(mocker, client
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
     mock_sanitise_response.json = lambda: {"message": "template preview error", "recipient_address": "The Queen"}
-    mocker.patch("app.main.views.uploads.sanitise_letter", return_value=mock_sanitise_response)
+    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", return_value=mock_sanitise_response)
     mocker.patch("app.models.service.service_api_client.get_precompiled_template", return_value=letter_template)
     mocker.patch(
         "app.main.views.uploads.get_letter_metadata",
@@ -463,7 +463,7 @@ def test_post_upload_letter_does_not_upload_to_s3_if_template_preview_raises_unk
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mock_s3 = mocker.patch("app.main.views.uploads.upload_letter_to_s3")
 
-    mocker.patch("app.main.views.uploads.sanitise_letter", side_effect=RequestException())
+    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", side_effect=RequestException())
 
     with pytest.raises(RequestException):
         with open("tests/test_pdf_files/one_page_pdf.pdf", "rb") as file:

--- a/tests/app/notify_client/test_notify_admin_api_client.py
+++ b/tests/app/notify_client/test_notify_admin_api_client.py
@@ -20,11 +20,11 @@ def test_generate_headers_sets_standard_headers(notify_admin):
     assert headers["X-Custom-Forwarder"] == "proxy-secret"
 
 
-def test_generate_headers_sets_request_id_if_in_request_context(notify_admin):
+def test_generate_headers_sets_request_id_if_in_request_context(notify_admin, mock_onwards_request_headers):
     api_client = NotifyAdminAPIClient()
     api_client.init_app(notify_admin)
 
-    with notify_admin.test_request_context() as request_context:
+    with notify_admin.test_request_context():
         notify_admin.preprocess_request()
         headers = api_client.generate_headers("api_token")
 
@@ -33,11 +33,9 @@ def test_generate_headers_sets_request_id_if_in_request_context(notify_admin):
         "Content-type",
         "User-agent",
         "X-Custom-Forwarder",
-        "X-B3-TraceId",
-        "X-B3-SpanId",
+        "some-onwards",
     }
-    assert headers["X-B3-TraceId"] == request_context.request.request_id
-    assert headers["X-B3-SpanId"] == request_context.request.span_id
+    assert headers["some-onwards"] == "request-headers"
 
 
 def test_get_notification_status_by_service(mocker):

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -7,10 +7,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from app import load_service_before_request
 from app.models.branding import LetterBranding
-from app.template_previews import (
-    TemplatePreview,
-    sanitise_letter,
-)
+from app.template_previews import TemplatePreview
 from tests.conftest import create_notification
 
 
@@ -277,7 +274,9 @@ def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file(
 ):
     request_mock = mocker.patch("app.template_previews.requests.post")
 
-    sanitise_letter("pdf_data", upload_id=fake_uuid, allow_international_letters=allow_international_letters)
+    TemplatePreview.sanitise_letter(
+        "pdf_data", upload_id=fake_uuid, allow_international_letters=allow_international_letters
+    )
 
     expected_url = (
         f"http://localhost:9999/precompiled/sanitise"
@@ -297,7 +296,9 @@ def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file_for_
 ):
     request_mock = mocker.patch("app.template_previews.requests.post")
 
-    sanitise_letter("pdf_data", upload_id=fake_uuid, allow_international_letters=False, is_an_attachment=True)
+    TemplatePreview.sanitise_letter(
+        "pdf_data", upload_id=fake_uuid, allow_international_letters=False, is_an_attachment=True
+    )
 
     expected_url = (
         f"http://localhost:9999/precompiled/sanitise"

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -9,7 +9,6 @@ from app import load_service_before_request
 from app.models.branding import LetterBranding
 from app.template_previews import (
     TemplatePreview,
-    get_page_counts_for_letter,
     sanitise_letter,
 )
 from tests.conftest import create_notification
@@ -220,7 +219,7 @@ def test_get_png_for_invalid_pdf_page_makes_request(mocker, client_request):
 
 @pytest.mark.parametrize("template_type", ["email", "sms"])
 def test_page_count_returns_none_for_non_letter_templates(template_type):
-    assert get_page_counts_for_letter({"template_type": template_type}) is None
+    assert TemplatePreview.get_page_counts_for_letter({"template_type": template_type}) is None
 
 
 @pytest.mark.parametrize(
@@ -251,7 +250,7 @@ def test_page_count_makes_a_call_to_template_preview_and_gets_page_count(
     mocker.patch("app.template_previews.current_service", letter_branding=LetterBranding({"filename": "hm-government"}))
     template = mock_get_service_letter_template("123", "456")["data"]
 
-    assert get_page_counts_for_letter(template, values=values) == {
+    assert TemplatePreview.get_page_counts_for_letter(template, values=values) == {
         "count": 9,
         "welsh_page_count": 4,
         "attachment_page_count": 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3743,7 +3743,7 @@ def mock_get_returned_letter_summary_with_no_returned_letters(mocker):
 
 def do_mock_get_page_counts_for_letter(mocker, count, welsh_page_count=0, attachment_page_count=0):
     return mocker.patch(
-        "app.template_previews.get_page_counts_for_letter",
+        "app.template_previews.TemplatePreview.get_page_counts_for_letter",
         return_value={
             "count": count,
             "welsh_page_count": welsh_page_count,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4278,3 +4278,10 @@ def mock_get_letter_rates(mocker):
         ]
 
     return mocker.patch("app.models.letter_rates.LetterRates.client_method", side_effect=_get_letter_rates)
+
+
+@pytest.fixture(scope="function")
+def mock_onwards_request_headers(mocker):
+    mock_gorh = mocker.patch("notifications_utils.request_helper.NotifyRequest.get_onwards_request_headers")
+    mock_gorh.return_value = {"some-onwards": "request-headers"}
+    return mock_gorh


### PR DESCRIPTION
https://trello.com/c/n4FmWuff/585-annotate-logs-with-cloudfront-http-request-ids

For api requests, we were already including trace id and span id manually, but this formalises that using `NotifyRequest.get_onwards_request_headers()` (and as a result handles parent span id properly too).

For template-preview, I did a little refactoring to pull `get_page_counts_for_letter` and `sanitise_letter` into the singleton pseudo-client class you already have. This allowed me to factor the auth header generation into a shared method and at the same time include the onwards request headers.

Requests the the antivirus api are handled by utils' `AntivirusClient` which was instrumented in https://github.com/alphagov/notifications-utils/pull/1093 and the utils bump should bring that to this app.

That said, I've actually got another utils tracing improvement waiting in https://github.com/alphagov/notifications-utils/pull/1094 that I'd love to include in this PR if someone would review that...