### PR TITLE
Update unsubscribe examples

### DIFF
--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -25,10 +25,10 @@
   <p class="govuk-body">To add an unsubscribe link, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.</p>
   <p class="govuk-body">Use this example if you have a webpage where users can manage their email subscriptions:</p>
 
-  <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.gov.uk/example/unsubscribe)</code></pre>
+  <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.example.gov.uk/unsubscribe)</code></pre>
   
   <p class="govuk-body">If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:</p>  
-  <pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:unsubscribe@gov.uk?subject=unsubscribe)</code></pre>
+  <pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)</code></pre>
   <p class="govuk-body">The email address should be a shared inbox managed by your team, not your own email address.</p>
 
 {% endblock %}


### PR DESCRIPTION
This PR updates the examples for unsubscribe links to make it more obvious that they’re not real email addresses or URLs.