### PR TITLE
Add unsubscribe links guidance to the edit template page

### DIFF
--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -6,7 +6,7 @@
   Transactional emails do not need to include an unsubscribe link.
 </p>
 <p class="bottom-gutter-1-3">
-  Use this example if you have a webpage where users can manage their email subscriptions:
+  Use this example if you have a webpage for users to manage their email subscriptions:
 </p>
 <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.example.gov.uk/unsubscribe)
 </code></pre>

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,4 +1,21 @@
 <h2 class="heading-medium">Formatting</h2>
+<h3 class="heading-small">Unsubscribe links</h3>
+<p class="bottom-gutter-1-3">
+  Subscription emails must include an unsubscribe link in the body of the message.
+</p>
+<p class="bottom-gutter-1-3">
+  Transactional emails do not need to include an unsubscribe link.
+</p>
+<p class="bottom-gutter-1-3">
+  Use this example if you have a webpage where users can manage their email subscriptions:
+</p>
+<pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.example.gov.uk/unsubscribe)
+</code></pre>
+<p class="bottom-gutter-1-3">
+  If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
+</p>
+<pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
+</code></pre>
 <h3 class="heading-small">Headings and subheadings</h3>
 <p class="bottom-gutter-1-3">
   Use one hash symbol followed by a space for a heading, for example:

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,5 +1,4 @@
-<h2 class="heading-medium">Formatting</h2>
-<h3 class="heading-small">Unsubscribe links</h3>
+<h2 class="heading-medium">Unsubscribe links</h2>
 <p class="bottom-gutter-1-3">
   Subscription emails must include an unsubscribe link in the body of the message.
 </p>
@@ -16,6 +15,7 @@
 </p>
 <pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
 </code></pre>
+<h2 class="heading-medium">Formatting</h2>
 <h3 class="heading-small">Headings and subheadings</h3>
 <p class="bottom-gutter-1-3">
   Use one hash symbol followed by a space for a heading, for example:

--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -23,7 +23,7 @@
   <p class="govuk-body">GOV.UK Notify uses Markdown to format links.</p>
 
   <p class="govuk-body">To add an unsubscribe link, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.</p>
-  <p class="govuk-body">Use this example if you have a webpage where users can manage their email subscriptions:</p>
+  <p class="govuk-body">Use this example if you have a webpage for users to manage their email subscriptions:</p>
 
   <pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.example.gov.uk/unsubscribe)</code></pre>
   


### PR DESCRIPTION
This PR adds unsubscribe links guidance to the edit template page.

We may not want this to be top of the list in the long term, but while there’s a focus on getting this done it should be as high up the page as possible.