### PR TITLE
say deleted rather than edited on version history page

### DIFF
--- a/app/templates/views/templates/_template_history.html
+++ b/app/templates/views/templates/_template_history.html
@@ -8,7 +8,8 @@
   {% endif %}
   <p class="hint">
     {% if template.get_raw('version', 1) > 1 %}
-      Edit made {% if template.get_raw('updated_at', None) %}{{ template.get_raw('updated_at')|format_datetime_normal }}{% endif %}
+      {{ 'Deleted' if template.get_raw('archived') else 'Edit made' }}
+      {% if template.get_raw('updated_at', None) %}{{ template.get_raw('updated_at')|format_datetime_normal }}{% endif %}
     {% else %}
       Created
       {% if template.get_raw('created_at', None) %}{{ template.get_raw('created_at')|format_datetime_normal }}{% endif %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -325,6 +325,7 @@ def template_json(
     letter_languages=None,
     letter_welsh_subject=None,
     letter_welsh_content=None,
+    updated_at=None,
 ):
     template = {
         "id": id_,
@@ -333,7 +334,7 @@ def template_json(
         "content": content,
         "service": service_id,
         "version": version,
-        "updated_at": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f"),
+        "updated_at": updated_at or datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f"),
         "archived": archived,
         "process_type": "normal",
         "service_letter_contact": service_letter_contact,

--- a/tests/app/main/views/test_template_history.py
+++ b/tests/app/main/views/test_template_history.py
@@ -1,23 +1,52 @@
+from datetime import datetime
+
+import pytest
 from flask import url_for
 
 from tests import template_version_json
+from tests.conftest import normalize_spaces
 
 
+@pytest.mark.parametrize(
+    "archived, version, expected_hint",
+    [
+        (False, 1, "Created 31 May 2020 at 1:00pm by Test User"),
+        (False, 2, "Edit made 6 June 2020 at 1:00pm by Test User"),
+        (True, 2, "Deleted 6 June 2020 at 1:00pm by Test User"),
+        # This shouldn't happen in real life but just for completeness
+        (True, 1, "Created 31 May 2020 at 1:00pm by Test User"),
+    ],
+)
 def test_view_template_version(
     client_request,
     api_user_active,
-    mock_login,
-    mock_get_service,
-    mock_get_template_version,
-    mock_get_user,
-    mock_get_user_by_email,
     mock_has_permissions,
+    mocker,
     fake_uuid,
+    archived,
+    version,
+    expected_hint,
 ):
+    # 12pm utc = 1pm bst
+    created_at_timestamp = datetime(2020, 5, 31, 12, 0).strftime("%Y-%m-%d %H:%M:%S.%f")
+    updated_at_timestamp = datetime(2020, 6, 6, 12, 0).strftime("%Y-%m-%d %H:%M:%S.%f")
+
     service_id = fake_uuid
     template_id = fake_uuid
-    version = 1
     all_versions_link = url_for("main.view_template_versions", service_id=service_id, template_id=template_id)
+    template_version = template_version_json(
+        service_id,
+        template_id,
+        api_user_active,
+        version=version,
+        archived=archived,
+        created_at=created_at_timestamp,
+        updated_at=updated_at_timestamp,
+    )
+    mock_get_template_version = mocker.patch(
+        "app.service_api_client.get_service_template", return_value={"data": template_version}
+    )
+
     page = client_request.get(
         ".view_template_version",
         service_id=service_id,
@@ -25,9 +54,8 @@ def test_view_template_version(
         version=version,
     )
 
-    template = mock_get_template_version(service_id, template_id, version)
-    assert api_user_active["name"] in page.text
-    assert template["data"]["content"] in page.text
+    assert normalize_spaces(page.select_one("p.hint").text) == expected_hint
+    assert template_version["content"] in page.text
     assert all_versions_link in str(page)
     mock_get_template_version.assert_called_with(service_id, template_id, version)
 


### PR DESCRIPTION
this isn't perfect as it'll happen for every edit of a template that has been archived - but i think that's good enough for now as a template being edited while it's archived sounds very strange. If a template is restored manually, then it'd go back to saying edited again for future versions