### PR TITLE
config: set `NOTIFY_REQUEST_LOG_LEVEL` to `INFO`

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,7 @@ class Config:
 
     # Logging
     DEBUG = False
+    NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
 
     ADMIN_CLIENT_USER_NAME = "notify-admin"
 


### PR DESCRIPTION
To match other apps. This means we can see the same request logs on both paas and ECS, allowing us to e.g. set up common alert conditions.