### PR TITLE
fix tests that rely on context

### DIFF
--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -118,6 +118,7 @@ def test_has_templates_of_type_includes_folders(
     ),
 )
 def test_get_consistent_data_retention_period(
+    notify_admin,
     mocker,
     service_one,
     mock_get_template_folders,

--- a/tests/app/models/test_webauthn_credential.py
+++ b/tests/app/models/test_webauthn_credential.py
@@ -53,7 +53,7 @@ def test_from_registration_encodes_as_unicode(webauthn_dev_server):
     assert type(serialized_credential["registration_response"]) == str
 
 
-def test_from_registration_handles_library_errors():
+def test_from_registration_handles_library_errors(notify_admin):
     registration_response = {
         "clientDataJSON": CLIENT_DATA_JSON,
         "attestationObject": ATTESTATION_OBJECT,

--- a/tests/app/s3_client/test_s3_letter_upload_client.py
+++ b/tests/app/s3_client/test_s3_letter_upload_client.py
@@ -33,7 +33,7 @@ def test_backup_original_letter_to_s3(mocker, notify_admin):
     )
 
 
-def test_upload_letter_to_s3(mocker):
+def test_upload_letter_to_s3(mocker, notify_admin):
     s3_mock = mocker.patch("app.s3_client.s3_letter_upload_client.utils_s3upload")
 
     recipient = "Bugs Bunny\n123 Big Hole\nLooney Town"
@@ -60,7 +60,7 @@ def test_upload_letter_to_s3(mocker):
     )
 
 
-def test_upload_letter_to_s3_with_message_and_invalid_pages(mocker):
+def test_upload_letter_to_s3_with_message_and_invalid_pages(mocker, notify_admin):
     s3_mock = mocker.patch("app.s3_client.s3_letter_upload_client.utils_s3upload")
 
     upload_letter_to_s3(
@@ -107,7 +107,7 @@ def test_lettermetadata_unquotes_special_keys():
     "will_raise_custom_error,expected_exception",
     [(True, LetterNotFoundError), (False, botocore.exceptions.ClientError)],
 )
-def test_get_letter_s3_object_raises_custom_error(will_raise_custom_error, expected_exception):
+def test_get_letter_s3_object_raises_custom_error(will_raise_custom_error, expected_exception, notify_admin):
     bucket_name = current_app.config["S3_BUCKET_TRANSIENT_UPLOADED_LETTERS"]
     s3 = boto3.client("s3", region_name="eu-west-1")
 


### PR DESCRIPTION
just some tests that rely on `current_app` or similar variables - these need the flask app so lets make sure they have it. these tests failed if i ran pytest without `-n auto`.