### PR TITLE
Update unsubscribe links guidance

### DIFF
--- a/app/templates/views/guidance/using-notify/unsubscribe-links.html
+++ b/app/templates/views/guidance/using-notify/unsubscribe-links.html
@@ -12,16 +12,26 @@
   <h1 class="heading-large">Unsubscribe links</h1>
 
   <p class="govuk-body">Subscription emails must include an unsubscribe link in the body of the message.</p>
-
+  <p class="govuk-body">If they do not:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>recipients could report your emails as spam</li>
+    <li>email providers may refuse to deliver your messages</li>
+  </ul>
   <p class="govuk-body">Transactional emails do not need to include an unsubscribe link.</p>
-
   <p class="govuk-body">The GOV.​UK Service Manual explains the difference between <a class="govuk-link govuk-link--no-visited-state"
-    href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#transactional-messages">transactional messages and subscription emails</a>.</p>
+    href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#transactional-messages">transactional and subscription messages</a>.</p>
+
+  <h2 class="heading-medium">Add your unsubscribe links by 1 April 2024</h2>
+
+  <p class="govuk-body">Google and Yahoo are introducing new measures to protect people from unwanted emails. They will stop delivering emails from senders that do not follow their rules.</p>
+  <p class="govuk-body">You must check that your subscription emails include an unsubscribe link.</p>
+  <p class="govuk-body">If they do not, you must add one by 1 April or you will no longer be able to send these emails using Notify.</p>
+  <p class="govuk-body">We understand that Google and Yahoo will enforce the rules gradually. This should give us time to find out how they will work in practice before making any changes.</p>
+  <p class="govuk-body">We will not stop you from sending any emails without contacting you first.</p>
 
   <h2 class="heading-medium">How to add an unsubscribe link to an email</h2>
 
   <p class="govuk-body">GOV.UK Notify uses Markdown to format links.</p>
-
   <p class="govuk-body">To add an unsubscribe link, use square brackets around the link text and round brackets around the URL. Make sure there are no spaces between the brackets or the link will not work.</p>
   <p class="govuk-body">Use this example if you have a webpage for users to manage their email subscriptions:</p>
 


### PR DESCRIPTION
This PR adds more information to the Unsubscribe links guidance page.

We’ve learned quite a lot about users’ concerns from the support questions they’ve sent us since we announced Google and Yahoo’s new regulations. We’re now in a position to add some useful additional context to the original guidance we published.