### PR TITLE
Bumping utils for crown in email template preview

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ fido2==1.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.12.1
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,7 +119,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.12.1
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/tests/app/main/views/test_email_preview.py
+++ b/tests/app/main/views/test_email_preview.py
@@ -38,7 +38,7 @@ def test_displays_both_branding(client_request, mock_get_email_branding_with_bot
 
     assert page.select_one("a")["href"] == "https://www.gov.uk"
     assert page.select("img")[0]["src"] == (
-        "https://static.notifications.service.gov.uk/images/gov.uk_logotype_crown.png"
+        "https://static.notifications.service.gov.uk/images/govuk-logotype-tudor-crown.png"
     )
     assert page.select("img")[1]["src"] == "https://static-logos.test.com/example.png"
     assert (


### PR DESCRIPTION
**74.12.1**
email template: use the new crown and associated styling
**74.12.0**
Remove celery.* structured logging for now. It can return when we have more certainty over what values it will log or can rule out that it is ever given sensitive values.
**74.11.0**

- Add option to ignore list of web paths from request logging. Defaults to /_status and /metrics.
- Add new fields to web request log messages (user_agent, host, path)

**74.9.1**
logging: set celery.worker.strategy logging to WARNING to prevent sensitive information being logged
**74.9.0**
logging: also attach handlers etc. to celery.worker and celery.redirected
**74.8.1**
Always hide barcodes when printing a letter - not only when adding a NOTIFY tag
