### PR TITLE
Update out-of-date response time content

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -85,7 +85,9 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = {
     "extra_letter_formatting": {"title": "Extra letter formatting options", "requires": "letter"},
 }
 
-THANKS_FOR_BRANDING_REQUEST_MESSAGE = "Thanks for your branding request. We’ll get back to you within one working day."
+THANKS_FOR_BRANDING_REQUEST_MESSAGE = (
+    "Thanks for your branding request. We’ll get back to you by the end of the next working day."
+)
 
 
 @main.route("/services/<uuid:service_id>/service-settings")

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -73,7 +73,7 @@
   </p>
 
   <p class="govuk-body">
-    We’ll consider your request and get back to you within one working day.
+    We’ll consider your request and get back to you by the end of the next working day.
   </p>
 
   <h2 class="heading-medium" id="reporting-accessibility-problems">Reporting accessibility problems with this website</h2>

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -16,7 +16,7 @@
       "Next review due": "15 April 2024"
     }
     ) }}
-    {# Last non-functional changes: 24 Mar 2023 #}
+    {# Last non-functional changes: 21 Feb 2024 #}
 
   <p class="govuk-body">
     This accessibility statement applies to the www.notifications.service.gov.uk domain. It does not apply to the <a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk">GOV.UK Notify API documentation subdomain</a>.

--- a/app/templates/views/guidance/using-notify/trial-mode.html
+++ b/app/templates/views/guidance/using-notify/trial-mode.html
@@ -34,7 +34,7 @@
   </ol>
     {% endif %}
  <p class="govuk-body">
-    When we receive your request we’ll get back to you within one working day.
+    When we receive your request we’ll get back to you by the end of the next working day.
   </p>
   <h2 class="heading-medium" id="before-you-request-to-go-live">Before you request to go live</h2>
   <p class="govuk-body">You must:</p>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -68,7 +68,7 @@
         </p>
       {% else %}
         <p class="govuk-body">
-          When we receive your request we’ll get back to you within one working day.
+          When we receive your request we’ll get back to you by the end of the next working day.
         </p>
         <p class="bottom-gutter">
           By requesting to go live you’re agreeing to our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.terms_of_use') }}">terms of use</a>.

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -797,7 +797,7 @@ def test_email_branding_request_submit(
     )
     mock_send_ticket_to_zendesk.assert_called_once()
     assert normalize_spaces(page.select_one(".banner-default").text) == (
-        "Thanks for your branding request. We’ll get back to you within one working day."
+        "Thanks for your branding request. We’ll get back to you by the end of the next working day."
     )
 
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -1071,7 +1071,7 @@ def test_should_not_show_go_live_button_if_checklist_not_complete(
         assert page.select_one("form")["method"] == "post"
         assert "action" not in page.select_one("form")
         assert normalize_spaces(page.select("main p")[0].text) == (
-            "When we receive your request we’ll get back to you within one working day."
+            "When we receive your request we’ll get back to you by the end of the next working day."
         )
         assert normalize_spaces(page.select("main p")[1].text) == (
             "By requesting to go live you’re agreeing to our terms of use."


### PR DESCRIPTION
This PR updates the wording we use to explain how long it takes for us to do something or reply to a request.

We’re replacing the phrase `within one working day` with `by the end of the next working day`. This is consistent with the work we did on user support response times.

The changes in this PR cover:

* requests to go live
* branding change requests
* accessibility statement queries