### PR TITLE
Bump govuk frontend to 4.8.0

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -59,19 +59,6 @@ $govuk-destructive-link-active-colour: $govuk-text-colour;
   @include govuk-link-style-destructive-no-visited-state;
 }
 
-// TODO: Remove when updating to v5 of govuk-frontend
-// Absolute positioning has the unintended consequence of removing any
-// whitespace surrounding visually hidden text from the accessibility tree.
-// Insert a space character before and after visually hidden text to separate
-// it from any visible text surrounding it.
-.govuk-visually-hidden::before {
-  content: "\00a0";
-}
-
-.govuk-visually-hidden::after {
-  content: "\00a0";
-}
-
 // GOVUK Frontend's grid-column classes are built from the $govuk-grid-widths map
 // that means we can extend the map to get extra classes
 $notify-grid-widths: (

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -92,23 +92,6 @@ $button-shadow-size: $govuk-border-width-form-element;
   // based on the govuk-button styles:
   // https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/button/_button.scss
   @include govuk-font($size: 24, $weight: bold);
-  color: $product-page-blue;
   box-shadow: 0 $button-shadow-size 0 govuk-shade($colour: $product-page-blue, $percentage: 15%);
-  background: govuk-colour("white");
-
-  &:link,
-  &:visited,
-  &:hover {
-    color: $product-page-blue;
-  }
-
-  &:focus {
-    background: govuk-colour("white");
-  }
-
-  &:hover {
-    background: govuk-tint(govuk-colour("light-blue"), 75);
-    outline: none;
-  }
 
 }

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -52,7 +52,8 @@
     "productName": "Notify",
     "navigation": header_navigation.visible_header_nav(),
     "navigationClasses": "govuk-header__navigation--end",
-    "assetsPath": asset_path + "images"
+    "assetsPath": asset_path + "images",
+    "useTudorCrown": True
   }) }}
 {% endblock %}
 

--- a/app/templates/govuk_frontend_jinja_overrides/templates/components/checkboxes/macro.html
+++ b/app/templates/govuk_frontend_jinja_overrides/templates/components/checkboxes/macro.html
@@ -1,4 +1,4 @@
-{#- Copied from https://github.com/LandRegistry/govuk-frontend-jinja/blob/1.5.1/govuk_frontend_jinja/templates/components/checkboxes/macro.html
+{#- Copied from https://github.com/LandRegistry/govuk-frontend-jinja/blob/2.8.0/govuk_frontend_jinja/templates/components/checkboxes/macro.html
     Changes we have made
     - `classes` option added to `item` allow custom classes on the `.govuk-checkboxes__item` element
     - `asList` option added the root `params` object to allow setting of the `.govuk-checkboxes` and `.govuk-checkboxes__item` element types
@@ -13,16 +13,16 @@
 {% from "govuk_frontend_jinja/components/label/macro.html" import govukLabel %}
 
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
-   instead. We need this for error messages and hints as well -#}
+  instead. We need this for error messages and hints as well -#}
 {% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
 
 {% set ns = namespace() %}
 
 {#- a record of other elements that we need to associate with the input using
-   aria-describedby – for example hints or error messages -#}
+  aria-describedby – for example hints or error messages -#}
 {% set ns.describedBy = params.describedBy if params.describedBy else "" %}
 {% if params.fieldset and params.fieldset.describedBy %}
-   {% set ns.describedBy = params.fieldset.describedBy %}
+  {% set ns.describedBy = params.fieldset.describedBy %}
 {% endif %}
 
 {#- fieldset is false by default -#}
@@ -44,7 +44,7 @@
     'attributes': params.hint.attributes,
     'html': params.hint.html,
     'text': params.hint.text
-  }) | trim }}
+  }) | indent(2) | trim }}
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = idPrefix + '-error' %}
@@ -56,7 +56,7 @@
     'html': params.errorMessage.html,
     'text': params.errorMessage.text,
     'visuallyHiddenText': params.errorMessage.visuallyHiddenText
-  }) | trim }}
+  }) | indent(2) | trim }}
 {% endif %}
   <{{ groupElement }} class="govuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in (params.attributes.items() if params.attributes else {}.items()) %} {{ attribute }}="{{ value }}"{% endfor %}
@@ -79,11 +79,11 @@
         {%- if item.divider %}
           <div class="govuk-checkboxes__divider">{{ item.divider }}</div>
         {%- else %}
+          {% set isChecked = item.checked | default(params.get("values", false) and item.value in params.get('values', [])) %}
           {% set hasHint = True if (item.hint.text if item.hint and item.hint.text) or (item.hint.html if item.hint and item.hint.html) %}
           {% set itemHintId = id + "-item-hint" if hasHint else "" %}
           {% set itemDescribedBy = ns.describedBy if not hasFieldset else "" %}
           {% set itemDescribedBy = (itemDescribedBy + " " + itemHintId) | trim %}
-
           {% set conditionalHtml %}
             {% if item.conditional and item.conditional.html %}
               <div class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
@@ -91,11 +91,10 @@
               </div>
             {% endif %}
           {% endset %}
-
           <{{ groupItemElement }} class="govuk-checkboxes__item {%- if item.classes %} {{ item.classes }}{% endif %}">
             {%- if item.before %}{{ item.before }}{% endif -%}
             <input class="govuk-checkboxes__input" id="{{ id }}" name="{{ name }}" type="checkbox" value="{{ item.value }}"
-            {{-" checked" if item.checked }}
+            {{-" checked" if isChecked }}
             {{-" disabled" if item.disabled }}
             {%- if item.conditional and item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
             {%- if item.behaviour %} data-behaviour="{{ item.behaviour }}"{% endif -%}
@@ -107,7 +106,7 @@
               'classes': 'govuk-checkboxes__label' + (' ' + item.label.classes if item.label and item.label.classes else ''),
               'attributes': (item.label.attributes if item.label and item.label.attributes),
               'for': id
-            }) | trim }}
+            }) | indent(6) | trim }}
             {% if hasHint %}
             {{ govukHint({
               'id': itemHintId,
@@ -115,21 +114,24 @@
               'attributes': item.hint.attributes,
               'html': item.hint.html,
               'text': item.hint.text
-            }) | trim }}
+            }) | indent(6) | trim }}
             {% endif %}
+             {%- if item.children %}
+               {{ item.children | safe }}
+             {%- endif %}
 
-            {%- if item.children %}
-              {{ item.children | safe }}
-            {%- endif %}
-
-            {% if params.asList %} {{ conditionalHtml }} {% endif %}
-            {%- if item.after %}{{ item.after }}{% endif -%}
+             {% if params.asList %} {{ conditionalHtml }} {% endif %}
+             {%- if item.after %}{{ item.after }}{% endif -%}
           </{{ groupItemElement }}>
-          {% if not params.asList %} {{ conditionalHtml }} {% endif %}
+          {% if item.conditional and item.conditional.html %}
+            <div class="govuk-checkboxes__conditional{% if not isChecked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+              {{ item.conditional.html | safe }}
+            </div>
+          {% endif %}
         {% endif %}
       {% endif %}
     {% endfor %}
-  </{{ groupElement }}>
+  </{{groupElement}}>
 {% endset -%}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup and params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">

--- a/app/templates/govuk_frontend_jinja_overrides/templates/components/nested-radios/macro.html
+++ b/app/templates/govuk_frontend_jinja_overrides/templates/components/nested-radios/macro.html
@@ -1,6 +1,6 @@
 {#
-  A copy of the radios component from v2.6.0 of govuk_frontend_jinja
-  Blob permalink: https://raw.githubusercontent.com/LandRegistry/govuk-frontend-jinja/2.6.0/govuk_frontend_jinja/templates/components/radios/macro.html
+  A copy of the radios component from v2.8.0 of govuk_frontend_jinja
+  Blob permalink: https://raw.githubusercontent.com/LandRegistry/govuk-frontend-jinja/2.8.0/govuk_frontend_jinja/templates/components/radios/macro.html
 
   Changes we have made:
   1) Rename macro to `govukNestedRadios`
@@ -78,9 +78,7 @@
         {%- else %}
         {% set isChecked = item.checked | default(params.value and item.value == params.value) %}
         {% set hasHint = True if (item.hint.text if item.hint and item.hint.text) or (item.hint.html if item.hint and item.hint.html) %}
-
         {% set itemHintId = id + '-item-hint' %}
-
         <li class="govuk-radios__item">
           <input class="govuk-radios__input" id="{{ id }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
           {{-" checked" if isChecked }}
@@ -88,30 +86,26 @@
           {%- if item.conditional and item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
           {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
           {%- for attribute, value in (item.attributes.items() if item.attributes else {}.items()) %} {{ attribute }}="{{ value }}"{% endfor -%}>
-
-            {{ govukLabel({
-                'html': item.html,
-                'text': item.text,
-                'classes': 'govuk-radios__label' + (' ' + item.label.classes if item.label and item.label.classes else ''),
-                'attributes': (item.label.attributes if item.label and item.label.attributes),
-                'for': id
-              }) | indent(6) | trim }}
-
-            {% if hasHint %}
-              {{ govukHint({
-                'id': itemHintId,
-                'classes': 'govuk-radios__hint' + (' ' + item.hint.classes if item.hint.classes else ''),
-                'attributes': item.hint.attributes,
-                'html': item.hint.html,
-                'text': item.hint.text
-              }) | indent(6) | trim }}
-            {% endif %}
-
-            {%- if item.children %}
-              {{ item.children | safe }}
-            {%- endif %}
+          {{ govukLabel({
+            'html': item.html,
+            'text': item.text,
+            'classes': 'govuk-radios__label' + (' ' + item.label.classes if item.label and item.label.classes else ''),
+            'attributes': (item.label.attributes if item.label and item.label.attributes),
+            'for': id
+          }) | indent(6) | trim }}
+          {% if hasHint %}
+          {{ govukHint({
+            'id': itemHintId,
+            'classes': 'govuk-radios__hint' + (' ' + item.hint.classes if item.hint.classes else ''),
+            'attributes': item.hint.attributes,
+            'html': item.hint.html,
+            'text': item.hint.text
+          }) | indent(6) | trim }}
+          {% endif %}
+          {%- if item.children %}
+            {{ item.children | safe }}
+          {%- endif %}
         </li>
-
         {% if item.conditional and item.conditional.html %}
           <div class="govuk-radios__conditional{% if not isChecked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
             {{ item.conditional.html | safe }}

--- a/app/templates/govuk_frontend_jinja_overrides/templates/components/radios-with-images/macro.html
+++ b/app/templates/govuk_frontend_jinja_overrides/templates/components/radios-with-images/macro.html
@@ -1,6 +1,6 @@
 {#
-  A copy of the radios component from v1.5.1 of govuk_frontend_jinja
-  Blob permalink: https://raw.githubusercontent.com/LandRegistry/govuk-frontend-jinja/1.5.1/govuk_frontend_jinja/templates/components/radios/macro.html
+  A copy of the radios component from v2.8.0 of govuk_frontend_jinja
+  Blob permalink: https://raw.githubusercontent.com/LandRegistry/govuk-frontend-jinja/2.8.0/govuk_frontend_jinja/templates/components/radios/macro.html
 
   Changes:
   1) Rename macro to `govukRadiosWithImages`
@@ -29,7 +29,6 @@
   6) Change <div class="govuk-radios__item"> to:
           <div class="govuk-radios__item notify-radios-with-images__item">
 #}
-
 {% macro govukRadiosWithImages(params) %}
 {% from "govuk_frontend_jinja/components/error-message/macro.html" import govukErrorMessage -%}
 {% from "govuk_frontend_jinja/components/fieldset/macro.html" import govukFieldset %}
@@ -37,21 +36,14 @@
 {% from "govuk_frontend_jinja/components/label/macro.html" import govukLabel %}
 
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
-   instead. We need this for error messages and hints as well -#}
+  instead. We need this for error messages and hints as well -#}
 {% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
 
 {% set ns = namespace() %}
 
 {#- a record of other elements that we need to associate with the input using
-   aria-describedby – for example hints or error messages -#}
+  aria-describedby – for example hints or error messages -#}
 {% set ns.describedBy = params.fieldset.describedBy if params.fieldset and params.fieldset.describedBy else "" %}
-
-{% set ns.isConditional = False %}
-{% for item in params['items'] %}
-  {% if item.conditional and item.conditional.html %}
-    {% set ns.isConditional = True %}
-  {% endif %}
-{% endfor %}
 
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
@@ -64,7 +56,7 @@
     'attributes': params.hint.attributes,
     'html': params.hint.html,
     'text': params.hint.text
-  }) | trim }}
+  }) | indent(2) | trim }}
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = idPrefix + '-error' %}
@@ -76,11 +68,11 @@
     'html': params.errorMessage.html,
     'text': params.errorMessage.text,
     'visuallyHiddenText': params.errorMessage.visuallyHiddenText
-  }) | trim }}
+  }) | indent(2) | trim }}
 {% endif %}
-  <div class="govuk-radios notify-radios-with-images {%- if params.classes %} {{ params.classes }}{% endif %}{%- if ns.isConditional %} govuk-radios--conditional{% endif -%}"
+  <div class="govuk-radios notify-radios-with-images {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in (params.attributes.items() if params.attributes else {}.items()) %} {{ attribute }}="{{ value }}"{% endfor %}
-    {%- if ns.isConditional %} data-module="govuk-radios"{% endif -%}>
+    data-module="govuk-radios">
     {% for item in params['items'] %}
       {% if item %}
         {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
@@ -98,6 +90,7 @@
         {%- if item.divider %}
         <div class="govuk-radios__divider">{{ item.divider }}</div>
         {%- else %}
+        {% set isChecked = item.checked | default(params.value and item.value == params.value) %}
         {% set hasHint = True if (item.hint.text if item.hint and item.hint.text) or (item.hint.html if item.hint and item.hint.html) %}
         {% set itemHintId = id + '-item-hint' %}
         <div class="govuk-radios__item notify-radios-with-images__item">
@@ -112,7 +105,7 @@
           />
           <div class="notify-radios-with-images__radio">
             <input class="govuk-radios__input" id="{{ id }}" name="{{ params.name }}" type="radio" value="{{ item.value }}" aria-describedby="{{ id }}-description"
-            {{-" checked" if item.checked }}
+            {{-" checked" if isChecked }}
             {{-" disabled" if item.disabled }}
             {%- if item.conditional and item.conditional.html %} data-aria-controls="{{ conditionalId }}"{% endif -%}
             {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
@@ -123,7 +116,7 @@
               'classes': 'govuk-radios__label' + (' ' + item.label.classes if item.label and item.label.classes else ''),
               'attributes': (item.label.attributes if item.label and item.label.attributes),
               'for': id
-            }) | trim }}
+            }) | indent(6) | trim }}
             {% if hasHint %}
             {{ govukHint({
               'id': itemHintId,
@@ -131,12 +124,12 @@
               'attributes': item.hint.attributes,
               'html': item.hint.html,
               'text': item.hint.text
-            }) | trim }}
+            }) | indent(6) | trim }}
             {% endif %}
           </div>
         </div>
         {% if item.conditional and item.conditional.html %}
-          <div class="govuk-radios__conditional{% if not item.checked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+          <div class="govuk-radios__conditional{% if not isChecked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
             {{ item.conditional.html | safe }}
           </div>
         {% endif %}
@@ -160,5 +153,4 @@
   {{ innerHtml | trim | safe }}
 {% endif %}
 </div>
-
 {% endmacro %}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -35,7 +35,7 @@
             {{ govukButton({
               "element": "a",
               "text": "Create an account",
-              "classes": "product-page-button button-container__button govuk-!-margin-right-3",
+              "classes": "product-page-button button-container__button govuk-button--inverse govuk-!-margin-right-3",
               "href": url_for('main.register' )
             }) }}
             or <a class="govuk-link govuk-link--inverse" href="{{ url_for('main.sign_in' )}}">sign in</a> if you’ve used

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cbor-js": "0.1.0",
-        "govuk-frontend": "4.2.0",
+        "govuk-frontend": "4.8.0",
         "hogan": "1.0.2",
         "jquery": "3.5.0",
         "morphdom": "2.6.1",
@@ -6578,9 +6578,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
-      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -21649,9 +21649,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
-      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor-js": "0.1.0",
-    "govuk-frontend": "4.2.0",
+    "govuk-frontend": "4.8.0",
     "hogan": "1.0.2",
     "jquery": "3.5.0",
     "morphdom": "2.6.1",

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ fido2==1.1.0
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.12.1
-govuk-frontend-jinja==2.3.0
+govuk-frontend-jinja==2.8.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ govuk-bank-holidays==0.11
     # via
     #   -r requirements.in
     #   notifications-utils
-govuk-frontend-jinja==2.3.0
+govuk-frontend-jinja==2.8.0
     # via -r requirements.in
 greenlet==3.0.3
     # via eventlet

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -12,8 +12,8 @@ def test_govuk_frontend_jinja_overrides_on_design_system_v3():
     govuk_frontend_jinja_version = Version(metadata.version("govuk-frontend-jinja"))
 
     # Compatibility between these two libs is defined at https://github.com/LandRegistry/govuk-frontend-jinja/
-    correct_govuk_frontend_version = Version("4.2.0") == govuk_frontend_version
-    correct_govuk_frontend_jinja_version = Version("2.3.0") == govuk_frontend_jinja_version
+    correct_govuk_frontend_version = Version("4.8.0") == govuk_frontend_version
+    correct_govuk_frontend_jinja_version = Version("2.8.0") == govuk_frontend_jinja_version
 
     assert correct_govuk_frontend_version and correct_govuk_frontend_jinja_version, (
         "After upgrading either of the Design System packages, you must validate that "


### PR DESCRIPTION
This updates govuk-frontend to version 4.8.0 as well as bumping the govuk-frontend-jinja to the compatible 2.8.0. 

It also switches on the crown logo in the top left and changes the favicon both to be the new tudor crown.

Before
![image](https://github.com/alphagov/notifications-admin/assets/10772338/762ac7a1-2b16-4f0a-a573-7de0bcf11ce3)
![Screenshot 2024-02-22 at 14 06 41](https://github.com/alphagov/notifications-admin/assets/10772338/a07d8032-1218-46b9-a271-a9252a5b8ca7)


After
![Screenshot 2024-02-22 at 14 01 16](https://github.com/alphagov/notifications-admin/assets/10772338/8add54de-889b-4613-b18d-9fcc36ec290f)
![Screenshot 2024-02-22 at 14 06 26](https://github.com/alphagov/notifications-admin/assets/10772338/d5dfad5c-b227-4bfb-892c-639655b0ea27)

