### PR TITLE
Add dependencies to test Dockerfile stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,6 +88,7 @@ RUN echo "Install OS dependencies for test build" && \
       sudo \
       make \
       curl \
+      libxml2-dev libxslt-dev zlib1g-dev \
       git && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
These are added so we can run `make test-requirements` with Docker.