### PR TITLE
Email branding iframe

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -70,6 +70,7 @@ def design_content():
 def email_template():
     branding_style = request.args.get("branding_style")
     subject = request.args.get("title", default="Preview of email branding")
+    email_branding_preview = request.args.get("email_branding_preview", False)
 
     if not branding_style or branding_style in {"govuk", FieldWithNoneOption.NONE_OPTION_VALUE}:
         branding = EmailBranding.govuk_branding()
@@ -83,7 +84,9 @@ def email_template():
     template = {
         "template_type": "email",
         "subject": subject,
-        "content": render_template("example-email.md"),
+        "content": render_template(
+            "example-email.md" if not email_branding_preview else "email-branding-preview-example-email.md"
+        ),
     }
 
     resp = make_response(
@@ -121,7 +124,6 @@ def letter_template():
         filename = letter_branding_client.get_letter_branding(branding_style)["filename"]
     elif not filename:
         filename = "no-branding"
-
     template = {"subject": subject, "content": "", "template_type": "letter"}
     image_url = url_for("no_cookie.letter_branding_preview_image", filename=filename)
 

--- a/app/templates/components/branding-preview.html
+++ b/app/templates/components/branding-preview.html
@@ -1,5 +1,5 @@
 {% macro branding_preview(endpoint, branding_style, title, url_kwargs=None, classes='') %}
-  <iframe src="{{ url_for(endpoint, branding_style=branding_style, title=title, **(url_kwargs or {})) }}" class="branding-preview {{ classes }}" scrolling="no" title="{{ title }}"></iframe>
+  <iframe src="{{ url_for(endpoint, branding_style=branding_style, title=title,**(url_kwargs or {})) }}" class="branding-preview {{ classes }}" scrolling="no" title="{{ title }}"></iframe>
 {% endmacro %}
 
 {% macro custom_email_branding_preview(preview_settings, title='Preview of email branding') %}
@@ -11,7 +11,7 @@
 {% endmacro %}
 
 {% macro email_branding_preview(branding_style, title='Preview of email branding', classes='') %}
-  {{ branding_preview('main.email_template', branding_style, title=title, classes=classes) }}
+  {{ branding_preview('main.email_template', branding_style, title=title, url_kwargs={"email_branding_preview":True},classes=classes)}}
 {% endmacro %}
 
 {% macro letter_branding_preview(branding_style, title='Preview of letter branding', classes='') %}

--- a/app/templates/email-branding-preview-example-email.md
+++ b/app/templates/email-branding-preview-example-email.md
@@ -1,0 +1,1 @@
+This is an example of an email sent using GOV.UK Notify.

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -54,7 +54,10 @@ def test_email_branding_options_page_shows_branding_if_set(
 
     page = client_request.get(".email_branding_options", service_id=SERVICE_ONE_ID)
     assert page.select_one("iframe")["src"] == url_for(
-        "main.email_template", branding_style="some-random-branding", title="Preview of current email branding"
+        "main.email_template",
+        branding_style="some-random-branding",
+        title="Preview of current email branding",
+        email_branding_preview=True,
     )
 
 
@@ -82,7 +85,10 @@ def test_email_branding_options_page_when_no_branding_is_set(
 
     assert mock_get_email_branding.called is False
     assert page.select_one("iframe")["src"] == url_for(
-        "main.email_template", branding_style="__NONE__", title="Preview of current email branding"
+        "main.email_template",
+        branding_style="__NONE__",
+        title="Preview of current email branding",
+        email_branding_preview=True,
     )
     assert mock_get_letter_branding_by_id.called is False
 
@@ -481,7 +487,10 @@ def test_email_branding_option_preview_page_displays_preview_of_chosen_branding(
     )
 
     assert page.select_one("iframe")["src"] == url_for(
-        "main.email_template", branding_style="email-branding-1-id", title="Preview of new email branding"
+        "main.email_template",
+        branding_style="email-branding-1-id",
+        title="Preview of new email branding",
+        email_branding_preview=True,
     )
 
 
@@ -584,7 +593,7 @@ def test_email_branding_govuk_and_nhs_pages(
     assert page.select_one("h1").text == "Check your new branding"
     assert "Emails from service one will look like this" in normalize_spaces(page.text)
     assert page.select_one("iframe")["src"] == url_for(
-        "main.email_template", branding_style=branding_preview_id, title=iframe_title
+        "main.email_template", branding_style=branding_preview_id, title=iframe_title, email_branding_preview=True
     )
     assert normalize_spaces(page.select_one(".page-footer button").text) == "Use this branding"
 
@@ -877,6 +886,7 @@ def test_email_branding_create_government_identity_logo(
             "main.email_template",
             branding_style=expected_branding_id_in_iframe,
             title="Example of an email with a government identity logo",
+            email_branding_preview=True,
         )
     else:
         assert not iframe


### PR DESCRIPTION
The iframe used to preview email branding currently fails WCAG reflow criteria.
This PR which is based on the requirements from this [ticket](https://trello.com/c/BhMRHbFK/590-preview-iframe-should-resize-with-page), addresses this issue by reducing the content of the example email displayed to the user.

 `main.email_template` now checks for an `email_branding_preview` flag that is set
 so that the content of `email-branding-preview-example-email.md` which is
 more compliant with WCAG reflow guidelines is served within the iframe.

To add more context, the iframe is set to no scrolling and the comparatively verbose text
 in `example-email.md` is not fully displayed within the iframe at any resolution.
 `example-email.md` is being preserved for it's content to be served by /_email for other purposes.

**Before**
<img width="465" alt="before 1" src="https://github.com/alphagov/notifications-admin/assets/32799090/997ab3d3-6658-4187-a2d5-c62eba69c3e6">
<img width="848" alt="before 2" src="https://github.com/alphagov/notifications-admin/assets/32799090/3f71d417-93aa-4173-9fac-eddf5e2098fe">



**After**
<img width="384" alt="after1" src="https://github.com/alphagov/notifications-admin/assets/32799090/86401a94-0e39-4f77-8664-70a2073098e4">

<img width="898" alt="after 2" src="https://github.com/alphagov/notifications-admin/assets/32799090/cb3499a0-d21b-4bc4-9184-21baa4e6ee72">

