### PR TITLE
Add price change announcement

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1158,7 +1158,7 @@ class RenameOrganisationForm(StripWhitespaceForm):
 class AddGPOrganisationForm(StripWhitespaceForm):
     def __init__(self, *args, service_name="unknown", **kwargs):
         super().__init__(*args, **kwargs)
-        self.same_as_service_name.label.text = f"Is your GP practice called ‘{service_name}’?"
+        self.same_as_service_name.label.text = f"Is your GP surgery called ‘{service_name}’?"
         self.service_name = service_name
         self.same_as_service_name.param_extensions = {
             "items": [
@@ -1173,7 +1173,7 @@ class AddGPOrganisationForm(StripWhitespaceForm):
         return self.name.data
 
     same_as_service_name = OnOffField(
-        "Is your GP practice called the same name as your service?",
+        "Is your GP surgery called the same name as your service?",
         choices=[
             (True, "Yes"),
             (False, "No"),
@@ -1182,7 +1182,7 @@ class AddGPOrganisationForm(StripWhitespaceForm):
     )
 
     name = GovukTextInputField(
-        "What’s your practice called?",
+        "What’s your GP surgery called?",
     )
 
     def validate_name(self, field):

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -36,7 +36,7 @@ class Organisation(JSONModel):
         TYPE_LOCAL: "Local government",
         TYPE_NHS_CENTRAL: "NHS – central government agency or public body",
         TYPE_NHS_LOCAL: "NHS Trust or Clinical Commissioning Group",
-        TYPE_NHS_GP: "GP practice",
+        TYPE_NHS_GP: "GP surgery",
         TYPE_EMERGENCY_SERVICE: "Emergency service",
         TYPE_SCHOOL_OR_COLLEGE: "School or college",
         TYPE_OTHER: "Other",

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -23,14 +23,27 @@
     <li>emergency services</li>
     <li>local authorities</li>
     <li>the armed forces</li>
-    <li>the NHS and GP practices</li>
+    <li>the NHS</li>
+    <li>GP surgeries</li>
     <li>state-funded schools</li>
   </ul>
   <p class="govuk-body">
     If you work for one of these organisations but get an error when you try to create an account, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact support</a>.
   </p>
 
-  <h2 class="govuk-heading-m" id="suppliers">Suppliers</h2>
+  <h2 class="govuk-heading-m" id="gp">GP surgeries</h2>
+  <p class="govuk-body">
+    NHS-funded GP surgeries can use GOV.UK&nbsp;Notify.
+  </p>
+  <p class="govuk-body">
+    From 1 April 2024, GP surgeries:
+  </p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>will not get an annual allowance of free text messages</li>
+    <li>cannot send any text messages in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a></li>
+  </ul>
+
+<h2 class="govuk-heading-m" id="suppliers">Suppliers</h2>
   <p class="govuk-body">
     If you’re doing work for a public sector organisation you can use GOV.UK&nbsp;Notify.
   </p>
@@ -38,9 +51,14 @@
     Someone from the public sector organisation you’re working with needs to set up the account. Then they can invite you as a team member.
   </p>
 
+  <h2 class="govuk-heading-m" id="universities">Universities</h2>
+  <p class="govuk-body">
+    GOV.UK Notify is not available to universities.
+  </p>
+
   <h2 class="govuk-heading-m" id="charities">Charities</h2>
   <p class="govuk-body">
-    Notify is not currently available to charities.
+    GOV.UK Notify is not currently available to charities.
   </p>
 
   <h2 class="govuk-heading-m" id="public">Members of the public</h2>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -43,6 +43,8 @@
     <li>cannot send any text messages in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a></li>
   </ul>
 
+  <p class="govuk-body">This is because GP surgeries will soon be able to <a class="govuk-link govuk-link--no-visited-state" href="https://digital.nhs.uk/services/nhs-notify">use NHS Notify to send messages</a>.</p>
+
 <h2 class="govuk-heading-m" id="suppliers">Suppliers</h2>
   <p class="govuk-body">
     If you’re doing work for a public sector organisation you can use GOV.UK&nbsp;Notify.

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -25,7 +25,7 @@ Text message pricing
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} pence (plus VAT) for each text message you send.</p>
 
   <div class="govuk-inset-text">  
-    <p class="govuk-body">On 1 April 2024 the cost of sending a text message will go up to 2.2 pence (plus VAT).</p>
+    <p class="govuk-body">On 1 April 2024 the cost of sending a text message will go up to NEW_PRICE pence (plus VAT).</p>
   </div>
 
   <p class="govuk-body">You may use more free messages, or pay more for each message, if you:</p>

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -17,12 +17,16 @@ Text message pricing
 
     {{ content_metadata(
       data={
-        "Last updated": "11 July 2023"
+        "Last updated": "4 March 2024"
       }
     ) }}
 
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} pence (plus VAT) for each text message you send.</p>
+
+  <div class="govuk-inset-text">  
+    <p class="govuk-body">On 1 April 2024 the cost of sending a text message will go up to 2.2 pence (plus VAT).</p>
+  </div>
 
   <p class="govuk-body">You may use more free messages, or pay more for each message, if you:</p>
   <ul class="govuk-list govuk-list--bullet">
@@ -38,9 +42,20 @@ Text message pricing
       <ul class="govuk-list govuk-list--bullet">
         <li>40,000 free text messages for national services</li>
         <li>20,000 free text messages for regional services</li>
-        <li>10,000 free text messages for state-funded schools and GP practices</li>
+        <li>10,000 free text messages for state-funded schools and GP surgeries</li>
     </ul>
   <p class="govuk-body">Each unique service you add has a separate allowance.</p>
+
+  <div class="govuk-inset-text">  
+    <p class="govuk-body">From 1 April 2024 the free allowance will be:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>30,000 free text messages for national services</li>
+        <li>10,000 free text messages for regional services</li>
+        <li>5,000 free text messages for state-funded schools</li>
+    </ul>
+    <p class=”govuk-body”><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a>
+ will no longer get a free allowance.</p>
+  </div>
 
   <h2 class="heading-medium" id="long-text-messages">Long text messages</h2>
   <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it counts as more than one message.</p>

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -25,7 +25,7 @@ Text message pricing
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} pence (plus VAT) for each text message you send.</p>
 
   <div class="govuk-inset-text">  
-    <p class="govuk-body">On 1 April 2024 the cost of sending a text message will go up to NEW_PRICE pence (plus VAT).</p>
+    <p class="govuk-body">On 1 April 2024 the cost of sending a text message will go up to 2.27 pence (plus VAT).</p>
   </div>
 
   <p class="govuk-body">You may use more free messages, or pay more for each message, if you:</p>

--- a/app/templates/views/guidance/using-notify/trial-mode.html
+++ b/app/templates/views/guidance/using-notify/trial-mode.html
@@ -20,7 +20,7 @@
     <li>create letter templates, but not send them</li>
   </ul>
 
-  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a> cannot send any text messages in trial mode.</p>
+  <p class="govuk-body">From 1 April 2024, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a> will not be able to send any text messages in trial mode.</p>
 
     {% if current_service and current_service.trial_mode %}
   <p class="govuk-body">

--- a/app/templates/views/guidance/using-notify/trial-mode.html
+++ b/app/templates/views/guidance/using-notify/trial-mode.html
@@ -20,6 +20,8 @@
     <li>create letter templates, but not send them</li>
   </ul>
 
+  <p class="govuk-body">GP surgeries cannot send any text messages in trial mode.</p>
+
     {% if current_service and current_service.trial_mode %}
   <p class="govuk-body">
     To remove these restrictions, you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.</p>

--- a/app/templates/views/guidance/using-notify/trial-mode.html
+++ b/app/templates/views/guidance/using-notify/trial-mode.html
@@ -20,7 +20,9 @@
     <li>create letter templates, but not send them</li>
   </ul>
 
-  <p class="govuk-body">From 1 April 2024, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a> will not be able to send any text messages in trial mode.</p>
+  <div class="govuk-inset-text"> 
+    <p class="govuk-body">From 1 April 2024, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a> will not be able to send any text messages in trial mode.</p>
+  </div>
 
     {% if current_service and current_service.trial_mode %}
   <p class="govuk-body">

--- a/app/templates/views/guidance/using-notify/trial-mode.html
+++ b/app/templates/views/guidance/using-notify/trial-mode.html
@@ -20,7 +20,7 @@
     <li>create letter templates, but not send them</li>
   </ul>
 
-  <p class="govuk-body">GP surgeries cannot send any text messages in trial mode.</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a> cannot send any text messages in trial mode.</p>
 
     {% if current_service and current_service.trial_mode %}
   <p class="govuk-body">

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -234,7 +234,7 @@ def test_gps_can_create_own_organisations(
         return
 
     assert page.select_one("input[type=text]")["name"] == "name"
-    assert normalize_spaces(page.select_one("label[for=name]").text) == "What’s your practice called?"
+    assert normalize_spaces(page.select_one("label[for=name]").text) == "What’s your GP surgery called?"
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1319,7 +1319,7 @@ def test_archive_organisation_does_not_allow_orgs_with_team_members_or_services_
                 {"value": "local", "label": "Local government"},
                 {"value": "nhs_central", "label": "NHS – central government agency or public body"},
                 {"value": "nhs_local", "label": "NHS Trust or Clinical Commissioning Group"},
-                {"value": "nhs_gp", "label": "GP practice"},
+                {"value": "nhs_gp", "label": "GP surgery"},
                 {"value": "emergency_service", "label": "Emergency service"},
                 {"value": "school_or_college", "label": "School or college"},
                 {"value": "other", "label": "Other"},

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -46,7 +46,7 @@ def test_get_should_render_add_service_template(
         "Local government",
         "NHS – central government agency or public body",
         "NHS Trust or Clinical Commissioning Group",
-        "GP practice",
+        "GP surgery",
         "Emergency service",
         "School or college",
         "Other",
@@ -241,7 +241,7 @@ def test_get_should_only_show_nhs_org_types_radios_if_user_has_nhs_email(
     assert [label.text.strip() for label in page.select(".govuk-radios__item label")] == [
         "NHS – central government agency or public body",
         "NHS Trust or Clinical Commissioning Group",
-        "GP practice",
+        "GP surgery",
     ]
     assert [radio["value"] for radio in page.select(".govuk-radios__item input")] == [
         "nhs_central",


### PR DESCRIPTION
Text message prices will change on 1 April 2024.

This year, the changes will have an impact on who can use Notify and how trial mode works for some users.

---

~**We’re still waiting on SMS price confirmation – so we’ll need to replace the placeholders before merging.**~

~**This is not a blocker to reviewing the rest of the PR.**~

---

This PR adds a description of the upcoming changes to the following pages:
* [text message pricing](https://www.notifications.service.gov.uk/pricing/text-messages)
* [who can use notify](https://www.notifications.service.gov.uk/features/who-can-use-notify)
* [trial mode](https://www.notifications.service.gov.uk/using-notify/trial-mode)

We’ll need to update all 3 pages again to remove references to `1 April 2024` when the changes come into effect on 1 April.

## Additional changes

This PR also changes every instance of `GP practice` to `GP surgery` so that we’re consistent with the language used on the NHS website.