### PR TITLE
Bump pricing page date and add a link

### DIFF
--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -39,7 +39,7 @@
     From 1 April 2024, GP surgeries:
   </p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>will not get an annual allowance of free text messages</li>
+    <li>will not get an <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages') }}">annual allowance of free text messages</a></li>
     <li>cannot send any text messages in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a></li>
   </ul>
 

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -17,7 +17,7 @@ Text message pricing
 
     {{ content_metadata(
       data={
-        "Last updated": "4 March 2024"
+        "Last updated": "8 March 2024"
       }
     ) }}
 


### PR DESCRIPTION
This PR bumps the `Last updated` date on the **Text message pricing** page.

The announcement has been delayed by several days and we forgot to bump the date to reflect this on our last deploy.

The PR also adds a link from the **Who can use Notify** page to the **Text message pricing** page.