### PR TITLE
Tell users about the free allowance cap

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -57,6 +57,8 @@ Text message pricing
  will no longer get a free allowance.</p>
   </div>
 
+    <p class="govuk-body">We cover the cost of the free allowance to help support those teams who need it the most. Services that send a very high volume of text messages in a single year will not get a free allowance. We’ll contact you if we need to stop your allowance.</p>
+
   <h2 class="heading-medium" id="long-text-messages">Long text messages</h2>
   <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it counts as more than one message.</p>
 

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -57,7 +57,7 @@ Text message pricing
  will no longer get a free allowance.</p>
   </div>
 
-    <p class="govuk-body">GOV.UK Notify covers the cost of the free allowance. We do this to help support those teams who need it most. If your service sends a very high volume of text messages in a single year, we may have to stop your free allowance.</p>
+    <p class="govuk-body">GOV.UK Notify covers the cost of the free allowance. We do this to help support those teams who need it most. If your service sends a very high volume of text messages in a single year, we may not renew your free allowance the following year.</p>
 
   <h2 class="heading-medium" id="long-text-messages">Long text messages</h2>
   <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it counts as more than one message.</p>

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -57,7 +57,7 @@ Text message pricing
  will no longer get a free allowance.</p>
   </div>
 
-    <p class="govuk-body">We cover the cost of the free allowance to help support those teams who need it the most. Services that send a very high volume of text messages in a single year may not be eligible for the free allowance. We’ll contact you in advance if we need to stop your allowance.</p>
+    <p class="govuk-body">GOV.UK Notify covers the cost of the free allowance. We do this to help support those teams who need it most. If your service sends a very high volume of text messages in a single year, we may have to stop your free allowance.</p>
 
   <h2 class="heading-medium" id="long-text-messages">Long text messages</h2>
   <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it counts as more than one message.</p>

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -57,7 +57,7 @@ Text message pricing
  will no longer get a free allowance.</p>
   </div>
 
-    <p class="govuk-body">We cover the cost of the free allowance to help support those teams who need it the most. Services that send a very high volume of text messages in a single year will not get a free allowance. We’ll contact you if we need to stop your allowance.</p>
+    <p class="govuk-body">We cover the cost of the free allowance to help support those teams who need it the most. Services that send a very high volume of text messages in a single year may not be eligible for the free allowance. We’ll contact you in advance if we need to stop your allowance.</p>
 
   <h2 class="heading-medium" id="long-text-messages">Long text messages</h2>
   <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it counts as more than one message.</p>


### PR DESCRIPTION
This PR adds some content to the ‘Text message pricing’ page to explain that we may remove the free allowance from high-volume services.

The content is not specific about thresholds because these can change year-on-year – so using old numbers is a bit misleading.