### PR TITLE
Set notify API client timeout to 40 seconds

### DIFF
--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -22,6 +22,8 @@ class NotifyAdminAPIClient(BaseAPIClient):
         self.service_id = app.config["ADMIN_CLIENT_USER_NAME"]
         self.api_key = app.config["ADMIN_CLIENT_SECRET"]
         self.route_secret = app.config["ROUTE_SECRET_KEY_1"]
+        # TODO: remove this increase after the live services CSV report is taking less than 30 seconds
+        self.timeout = 40
 
     def generate_headers(self, api_token):
         headers = {


### PR DESCRIPTION
https://trello.com/c/B9uMKurV/707-address-download-of-live-services-timeout

The default is currently 30 seconds as set in the notifications python client
https://github.com/alphagov/notifications-python-client/blob/main/notifications_python_client/base.py#L34

We currently have a problematic page to download one of the CSV platform admin reports. This report was quite flakey and sometimes was working and sometimes would timeout after 30 seconds. If the report was successful to download, it would usually take about 25-30 seconds to process.

Since moving to ECS, the API is a little bit slower and now all attempts to download the CSV report are taking over 30 seconds and getting timed out and failing. Specifically what is happening is

- User makes a request to the admin app
- Admin app does a little bit of python processing before sending a request to the api
- Api picks up the request, starts processing….
- Admin app after 30 seconds of waiting on the API, reaches a 30 second client timeout and declares failure by returning a 500 to the user

We are also sometimes seeing gunicorn errors. Gunicorn has a default timeout of 30 seconds. https://docs.gunicorn.org/en/stable/settings.html#timeout However we only see these on the API, they don't always happen when the user gets a 500, and they don't seem to be at exactly 30 seconds, often much later like 45 seconds.

I can see a bunch of logs saying that the API does respond to the request (although the client, the admin app, has already given up so doesn't care). In these logs, it says that the API requests take between about 30-50 seconds to process, mostly under 40 seconds.

This pull request increases that time out period very slightly, hoping that the API will respond in under 40 seconds and that will fix the problem. We could go for a higher timeout period but cautious of raising this further than we need to, just in case there could be any unexpected affects.

We might find that this pull request doesn't fix the problem. If so, we might need to also change the gunicorn timeout settings for the admin and api.

Note, this pull request isn't expected to fix all of the 500 errors. The SQL query will take a varying amount of times, but hopefully it will make the page work at least some of the time. And then we can put in place a longer term fix as this page shouldn't be taking 30 seconds anyway...