### PR TITLE
Remove autofocus from first placeholder field

### DIFF
--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -18,7 +18,7 @@
 
   {% call form_wrapper(
     class='js-stick-at-top-when-scrolling send-one-off-form' if template.template_type != 'sms' else 'send-one-off-form',
-    module="autofocus",
+    module="autofocus" if form.placeholder_value.label.text not in ['email address', 'phone number'] else None,
     data_kwargs={'force-focus': True}
   ) %}
     <div class="govuk-grid-row">


### PR DESCRIPTION
Stop the textbox for the first placeholder for email or sms (an email address or phone number) being focused when the page loads.

https://trello.com/c/fpx7WtLd/667-autofocus-on-recipient-email-textbox-is-confusing-for-screen-reader-users

The autofocus is confusing for screen reader users because it stops the screen reader announcing that a new page has loaded and what's in it.

<img width="738" alt="image" src="https://github.com/alphagov/notifications-admin/assets/87140/e9f4def0-a463-40df-a703-36cbbc3a8920">

Note: this retains the autofocus for other placeholders because this behaviour did not cause the same confusion. Our assumptions for this are that the user is already in the process of filling in placeholders at this stage so it is more useful to go straight to the next field than knowing whether this is because a new page has loaded or not.