### PR TITLE
Revert "Set notify API client timeout to 40 seconds"

### DIFF
--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -22,8 +22,6 @@ class NotifyAdminAPIClient(BaseAPIClient):
         self.service_id = app.config["ADMIN_CLIENT_USER_NAME"]
         self.api_key = app.config["ADMIN_CLIENT_SECRET"]
         self.route_secret = app.config["ROUTE_SECRET_KEY_1"]
-        # TODO: remove this increase after the live services CSV report is taking less than 30 seconds
-        self.timeout = 40
 
     def generate_headers(self, api_token):
         headers = {


### PR DESCRIPTION
Reverts alphagov/notifications-admin#5012

This approach is no nlonger needed because Casey found a way to speed up the page dramatically in https://github.com/alphagov/notifications-api/pull/4035 (usually under 5 seconds), so let us revert the hacky fix.