### PR TITLE
Change h1 and title of all confirm branding pages

### DIFF
--- a/app/templates/views/service-settings/branding/branding-nhs.html
+++ b/app/templates/views/service-settings/branding/branding-nhs.html
@@ -6,10 +6,12 @@
 {% from "components/branding-preview.html" import email_branding_preview %}
 {% from "components/branding-preview.html" import letter_branding_preview %}
 
-{% set page_title = "Check your new branding" %}
+{% set page_title %}
+  Confirm {{ branding_type }} branding
+{% endset %}
 
 {% block service_page_title %}
-{{ page_title }}
+  {{ page_title }}
 {% endblock %}
 
 {% block backLink %}
@@ -41,7 +43,7 @@
   </p>
 
   {% call form_wrapper() %}
-    {{ page_footer('Use this branding') }}
+    {{ page_footer(page_title) }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/branding/branding-option-preview.html
+++ b/app/templates/views/service-settings/branding/branding-option-preview.html
@@ -6,10 +6,12 @@
 {% from "components/branding-preview.html" import email_branding_preview %}
 {% from "components/branding-preview.html" import letter_branding_preview %}
 
-{% set page_title = "Change {} branding".format(branding_type) %}
+{% set page_title %}
+  Confirm {{ branding_type }} branding
+{% endset %}
 
 {% block service_page_title %}
-{{ page_title }}
+  {{ page_title }}
 {% endblock %}
 
 {% block backLink %}
@@ -34,7 +36,7 @@
 
 
   {% call form_wrapper() %}
-    {{ page_footer('Change {} branding'.format(branding_type)) }}
+    {{ page_footer(page_title) }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/branding/email-branding-govuk.html
+++ b/app/templates/views/service-settings/branding/email-branding-govuk.html
@@ -5,8 +5,10 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/branding-preview.html" import email_branding_preview %}
 
+{% set page_title = 'Confirm email branding ' %}
+
 {% block service_page_title %}
-  Check your new branding
+  {{ page_title }}
 {% endblock %}
 
 {% block backLink %}
@@ -17,7 +19,7 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header('Check your new branding') }}
+  {{ page_header(page_title) }}
 
   <p class="govuk-body">
     Emails from {{ current_service.name }} will look like this.
@@ -37,7 +39,7 @@
   </p>
 
   {% call form_wrapper() %}
-    {{ page_footer('Use this branding') }}
+    {{ page_footer(page_title) }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/branding/email-branding-options.html
+++ b/app/templates/views/service-settings/branding/email-branding-options.html
@@ -5,8 +5,10 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/branding-preview.html" import email_branding_preview %}
 
+{% set page_title = 'Change email branding' %}
+
 {% block service_page_title %}
-  Change email branding
+  {{ page_title }}
 {% endblock %}
 
 {% block backLink %}
@@ -17,7 +19,7 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header('Change email branding') }}
+  {{ page_header(page_title) }}
 
   <p class="govuk-body">
     Your emails currently have {{ current_service.email_branding.name }} branding.

--- a/app/templates/views/service-settings/branding/letter-branding-options.html
+++ b/app/templates/views/service-settings/branding/letter-branding-options.html
@@ -5,8 +5,10 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/branding-preview.html" import letter_branding_preview %}
 
+{% set page_title = 'Change letter branding' %}
+
 {% block service_page_title %}
-  Change letter branding
+  {{ page_title }}
 {% endblock %}
 
 {% block backLink %}
@@ -17,7 +19,7 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header('Change letter branding') }}
+  {{ page_header(page_title) }}
 
   <p class="govuk-body">
     Your letters currently have {{ current_service.letter_branding.name or 'no' }} branding.

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -590,12 +590,12 @@ def test_email_branding_govuk_and_nhs_pages(
         service_id=SERVICE_ONE_ID,
         **extra_args,
     )
-    assert page.select_one("h1").text == "Check your new branding"
+    assert page.select_one("h1").text.strip() == "Confirm email branding"
     assert "Emails from service one will look like this" in normalize_spaces(page.text)
     assert page.select_one("iframe")["src"] == url_for(
         "main.email_template", branding_style=branding_preview_id, title=iframe_title, email_branding_preview=True
     )
-    assert normalize_spaces(page.select_one(".page-footer button").text) == "Use this branding"
+    assert normalize_spaces(page.select_one(".page-footer button").text.strip()) == "Confirm email branding"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Makes the h1 and title different from the previous page which makes it clearer that a navigation has
taken place and also helps us meet WCAG 2.4.2 (Page titled).

https://trello.com/c/Hi2QRecy/666-give-first-2-pages-of-set-branding-journeys-unique-titles-h1s

Note: also includes a bit of tidy up of how the h1 and title for each page is set.

## Emails (with these changes)

### Previous page

<img width="755" alt="change_email_branding" src="https://github.com/alphagov/notifications-admin/assets/87140/3dffa5c8-8d4f-468a-8cd0-f4ba1af623ee">

### Next page if branding chosen is NHS

<img width="749" alt="confirm_email_branding_nhs" src="https://github.com/alphagov/notifications-admin/assets/87140/0d22abe4-8611-40b4-9765-d110c372f63a">

### Next page if branding chosen is GOV.UK

<img width="748" alt="confirm_email_branding_govuk" src="https://github.com/alphagov/notifications-admin/assets/87140/27dbbc5b-e92c-4e72-b4d2-9a292f23e206">

### Next page if branding chosen is an existing custom branding

<img width="759" alt="confirm_email_branding_custom" src="https://github.com/alphagov/notifications-admin/assets/87140/3d31304d-b271-437c-b367-c0bdcd29c8ba">

## Letters (with these changes)

### Previous page

<img width="755" alt="change_letter_branding" src="https://github.com/alphagov/notifications-admin/assets/87140/85c38ab2-b5ec-4695-bed9-74c474865fa2">

### Next page if branding chosen is NHS

<img width="752" alt="confirm_letter_branding_nhs" src="https://github.com/alphagov/notifications-admin/assets/87140/958e7495-6829-4643-8f94-0af5c27ea238">

### Next page if branding chosen is an existing custom branding

<img width="758" alt="confirm_letter_branding_custom" src="https://github.com/alphagov/notifications-admin/assets/87140/fd8ee7da-beb7-4af9-9de7-ef45bb2ebf55">
