### PR TITLE
Update optional-content.html

### DIFF
--- a/app/templates/partials/templates/guidance-optional-content.html
+++ b/app/templates/partials/templates/guidance-optional-content.html
@@ -14,6 +14,9 @@
 </p>
 <pre class="formatting-example"><code class="lang-md">((under18??Please get your application signed by a parent or guardian.))
 </code></pre>
+<div class="govuk-inset-text"> 
+    <p class="govuk-body">You cannot add a placeholder for personalisation within optional content. </p>
+ </div>
 <p class="govuk-body">
   For each person you send this message to, specify ‘yes’ or ‘no’ to
   show or hide this content.

--- a/app/templates/views/guidance/using-notify/optional-content.html
+++ b/app/templates/views/guidance/using-notify/optional-content.html
@@ -25,7 +25,7 @@
   <pre class="formatting-example">((under18??Please get your application signed by a parent or guardian.))</code></pre>
 
 <div class="govuk-inset-text"> 
-    <p class="govuk-body">You cannot add placeholders for personalisation within optional content. </p>
+    <p class="govuk-body">You cannot add a placeholder for personalisation within optional content. </p>
  </div>
  
 <p class="govuk-body">For each person you send the message to, specify ‘yes’ or ‘no’ to show or hide the optional content.</p>

--- a/app/templates/views/guidance/using-notify/optional-content.html
+++ b/app/templates/views/guidance/using-notify/optional-content.html
@@ -24,7 +24,11 @@
 
   <pre class="formatting-example">((under18??Please get your application signed by a parent or guardian.))</code></pre>
 
-  <p class="govuk-body">For each person you send the message to, specify ‘yes’ or ‘no’ to show or hide the optional content.</p>
+<div class="govuk-inset-text"> 
+    <p class="govuk-body">You cannot add placeholders for personalisation within optional content. </p>
+ </div>
+ 
+<p class="govuk-body">For each person you send the message to, specify ‘yes’ or ‘no’ to show or hide the optional content.</p>
 
   <p class="govuk-body">You can either:</p>
 


### PR DESCRIPTION
Added content to advise users they cannot add placeholders for personalisation within optional content. Users frequently ask this question in zendesk.