### PR TITLE
Update the pricing pages ready for April 1 2024

### DIFF
--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -36,10 +36,10 @@
     NHS-funded GP surgeries can use GOV.UK&nbsp;Notify.
   </p>
   <p class="govuk-body">
-    From 1 April 2024, GP surgeries:
+    NHS-funded GP surgeries can use GOV.UK Notify, but they:
   </p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>will not get an <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages') }}">annual allowance of free text messages</a></li>
+    <li>do not get an annual allowance of free text messages <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages') }}">annual allowance of free text messages</a></li>
     <li>cannot send any text messages in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a></li>
   </ul>
 

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -33,13 +33,10 @@
 
   <h2 class="govuk-heading-m" id="gp">GP surgeries</h2>
   <p class="govuk-body">
-    NHS-funded GP surgeries can use GOV.UK&nbsp;Notify.
-  </p>
-  <p class="govuk-body">
     NHS-funded GP surgeries can use GOV.UK Notify, but they:
   </p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>do not get an annual allowance of free text messages <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages') }}">annual allowance of free text messages</a></li>
+    <li>do not get an <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages') }}">annual allowance of free text messages</a></li>
     <li>cannot send any text messages in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a></li>
   </ul>
 

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -43,6 +43,8 @@ Text message pricing
 
   <h2 class="heading-medium" id="free-text-message-allowance">Free text message allowance</h2>
 
+  <p class="govuk-body">Each unique service you add has a separate allowance.</p>
+
   <p class="govuk-body">The current allowance is:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>30,000 free text messages for national services</li>
@@ -51,8 +53,6 @@ Text message pricing
     </ul>
 <p class=”govuk-body”><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a>
  will no longer get a free allowance.</p>
-
-  <p class="govuk-body">Each unique service you add has a separate allowance.</p>
 
     <p class="govuk-body">GOV.UK Notify covers the cost of the free allowance. We do this to help support those teams who need it most. If your service sends a very high volume of text messages in a single year, we may not renew your free allowance the following year.</p>
 

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -18,7 +18,7 @@ Text message pricing
     {{ content_metadata(
       data={
         "Last updated": [
-          "2024-03-08",
+          "2024-03-28",
           sms_rate.valid_from
         ]|max|format_date_normal
       }

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -45,22 +45,14 @@ Text message pricing
 
   <p class="govuk-body">The current allowance is:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>40,000 free text messages for national services</li>
-        <li>20,000 free text messages for regional services</li>
-        <li>10,000 free text messages for state-funded schools and GP surgeries</li>
-    </ul>
-  <p class="govuk-body">Each unique service you add has a separate allowance.</p>
-
-  <div class="govuk-inset-text">
-    <p class="govuk-body">From 1 April 2024 the free allowance will be:</p>
-      <ul class="govuk-list govuk-list--bullet">
         <li>30,000 free text messages for national services</li>
         <li>10,000 free text messages for regional services</li>
         <li>5,000 free text messages for state-funded schools</li>
     </ul>
-    <p class=”govuk-body”><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a>
+<p class=”govuk-body”><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a>
  will no longer get a free allowance.</p>
-  </div>
+
+  <p class="govuk-body">Each unique service you add has a separate allowance.</p>
 
     <p class="govuk-body">GOV.UK Notify covers the cost of the free allowance. We do this to help support those teams who need it most. If your service sends a very high volume of text messages in a single year, we may not renew your free allowance the following year.</p>
 

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -43,7 +43,6 @@ Text message pricing
 
   <h2 class="heading-medium" id="free-text-message-allowance">Free text message allowance</h2>
 
-  <p class="govuk-body">Each unique service you add has a separate allowance.</p>
 
   <p class="govuk-body">The current allowance is:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -52,7 +51,7 @@ Text message pricing
         <li>5,000 free text messages for state-funded schools</li>
     </ul>
 <p class=”govuk-body”><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a>
- will no longer get a free allowance.</p>
+ do not get a free allowance.</p>
 
     <p class="govuk-body">GOV.UK Notify covers the cost of the free allowance. We do this to help support those teams who need it most. If your service sends a very high volume of text messages in a single year, we may not renew your free allowance the following year.</p>
 

--- a/app/templates/views/guidance/using-notify/trial-mode.html
+++ b/app/templates/views/guidance/using-notify/trial-mode.html
@@ -21,7 +21,7 @@
   </ul>
 
   <div class="govuk-inset-text"> 
-    <p class="govuk-body">From 1 April 2024, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a> will not be able to send any text messages in trial mode.</p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_who_can_use_notify') }}">GP surgeries</a> cannot send any text messages in trial mode.</p>
   </div>
 
     {% if current_service and current_service.trial_mode %}

--- a/tests/app/main/views/test_pricing.py
+++ b/tests/app/main/views/test_pricing.py
@@ -20,7 +20,7 @@ def test_guidance_pricing_letters(client_request, mock_get_letter_rates):
     "valid_from, expected_last_updated",
     (
         ("2040-04-01T12:00:00", "Last updated 1 April 2040"),
-        ("2023-04-01T12:00:00", "Last updated 8 March 2024"),
+        ("2023-04-01T12:00:00", "Last updated 28 March 2024"),
     ),
 )
 @pytest.mark.parametrize(
@@ -40,7 +40,7 @@ def test_guidance_pricing_letters(client_request, mock_get_letter_rates):
                 "When a service has used its annual allowance, it costs 2.27 pence (plus VAT)"
                 " for each text message you send."
             ),
-            "From 1 April 2024 the free allowance will be:",
+            None,
         ),
     ),
 )
@@ -65,4 +65,5 @@ def test_guidance_pricing_sms(
 
     assert normalize_spaces(page.select_one(".content-metadata").text) == expected_last_updated
     assert normalize_spaces(page.select("main .govuk-body")[1].text) == expected_current_paragraph
-    assert normalize_spaces(page.select_one(".govuk-inset-text .govuk-body").text) == expected_new_paragraph
+    if expected_new_paragraph:
+        assert normalize_spaces(page.select_one(".govuk-inset-text .govuk-body").text) == expected_new_paragraph


### PR DESCRIPTION
Changes on text message pricing page:

- 'last updated'
- removed price announcement
- updated allowance
- separated GP surgeries from bulleted list

Changes to Who can use Notify:

- removed 1 April date for GP Surgeries
- adjusted bullet point for GP Surgeries

Trial mode page changes to allowance/pricing:

- removed date (1 April) for GP surgeries using trial mode

***

Depends on:
- [ ] https://github.com/alphagov/notifications-admin/pull/5019

***

🚨 Should not be deployed until Thursday 28 March 🚨