### PR TITLE
Update content for edit letter template buttons

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -16,38 +16,44 @@
 
 .edit-template-link-letter-contact {
   @extend %edit-template-link;
-  right: -40px;
-  top: 232px; // align to bottom of contact block
+
+  // position underneath contact block
+  left: 61.3%;
+  top: 285px;
+
   &:active {
     margin-top: -2px;
-    top: 232px;
+    top: 285px;
   }
 }
 
 .edit-template-link-letter-address {
   @extend %edit-template-link;
   top: 14.65%; // align bottom edge to bottom of address
-  left: -20px;
+  left: -5px;
+
   &:active {
     margin-top: -2px;
     top: 14.65%;
   }
+
 }
 
 .edit-template-link-letter-body {
   @extend %edit-template-link;
-  top: 400px; // aligns to top of subject
+  top: 393px; // aligns to top of subject
   left: -20px;
   &:active {
     margin-top: -2px;
-    top: 400px;
+    top: 393px;
   }
 }
 
 .edit-template-link-letter-postage {
   @extend %edit-template-link;
   top: 51px; // aligns bottom edge to bottom of postmark
-  right: 130px; // Aligns right edge to midpoint of postmark and fold
+  left: 61.3%; // Aligns left edge to ‘Change sender address’ button
+
   &:active {
     margin-top: -2px;
     top: 51px;
@@ -70,11 +76,11 @@
 
 .edit-template-link-get-ready-to-send {
   @extend %edit-template-link;
-  top: 232px; // covers MDI barcode and aligns to bottom of contact block
+  top: 234px; // covers MDI barcode and aligns to bottom of contact block
   left: 51px; // Aligns to left of logo area
   &:active {
     margin-top: -2px;
-    top: 232px;
+    top: 234px;
   }
 }
 

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -35,7 +35,7 @@
     {% if template.welsh_page_count and page_number == first_page_of_english %}
       <div id="first-page-of-english-in-bilingual-letter"></div>
       {% if template.include_letter_edit_ui_overlay  %}
-        <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> English</span> body<span class="govuk-visually-hidden"> text</span></a>
+        <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> English body text</span></a>
       {% endif %}
     {% endif %}
     {% if page_number == first_page_of_attachment %}

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -18,7 +18,7 @@
       <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> body text</span></a>
     {% endif %}
     {% if current_service.count_letter_contact_details %}
-      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Change sender address</a>
+      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Change your contact details</a>
     {% else %}
       <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Add your contact details</a>
     {% endif %}

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -35,7 +35,7 @@
     {% if template.welsh_page_count and page_number == first_page_of_english %}
       <div id="first-page-of-english-in-bilingual-letter"></div>
       {% if template.include_letter_edit_ui_overlay  %}
-        <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> English heading and body text</span></a>
+        <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> English</span> body<span class="govuk-visually-hidden"> text</span></a>
       {% endif %}
     {% endif %}
     {% if page_number == first_page_of_attachment %}

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -15,7 +15,7 @@
     {% if template.welsh_page_count %}
       <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit Welsh heading and body text</a>
     {% else %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit heading and body text</a>
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> heading and body text</span></a>
     {% endif %}
     {% if current_service.count_letter_contact_details %}
       <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Change sender address</a>

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -15,7 +15,7 @@
     {% if template.welsh_page_count %}
       <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh body text</span></a>
     {% else %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit body<span class="govuk-visually-hidden"> text</span></a>
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> body text</span></a>
     {% endif %}
     {% if current_service.count_letter_contact_details %}
       <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Change sender address</a>

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -13,7 +13,7 @@
   {% if current_user.has_permissions('manage_templates') %}
     <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-postage">Change postage</a>
     {% if template.welsh_page_count %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh</span> body<span class="govuk-visually-hidden"> text</span></a>
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh body text</span></a>
     {% else %}
       <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit body<span class="govuk-visually-hidden"> text</span></a>
     {% endif %}

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -13,7 +13,7 @@
   {% if current_user.has_permissions('manage_templates') %}
     <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-postage">Change postage</a>
     {% if template.welsh_page_count %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh heading and body text</span></a>
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh</span> body<span class="govuk-visually-hidden"> text</span></a>
     {% else %}
       <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> heading and body text</span></a>
     {% endif %}

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -11,16 +11,16 @@
     {% endif %}
   {% endif %}
   {% if current_user.has_permissions('manage_templates') %}
-    <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-postage">Change<span class="govuk-visually-hidden"> postage</span></a>
+    <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-postage">Change postage</a>
     {% if template.welsh_page_count %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh pages of the letter template</span></a>
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit Welsh heading and body text</a>
     {% else %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> letter template</span></a>
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit heading and body text</a>
     {% endif %}
     {% if current_service.count_letter_contact_details %}
-      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Edit<span class="govuk-visually-hidden"> letter contact block</span></a>
+      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Change sender address</a>
     {% else %}
-      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Edit<span class="govuk-visually-hidden"> letter contact block</span></a>
+      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Add a sender address</a>
     {% endif %}
   {% endif %}
 {% endif %}
@@ -35,7 +35,7 @@
     {% if template.welsh_page_count and page_number == first_page_of_english %}
       <div id="first-page-of-english-in-bilingual-letter"></div>
       {% if template.include_letter_edit_ui_overlay  %}
-        <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> English pages of the letter template</span></a>
+        <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit English heading and body text</a>
       {% endif %}
     {% endif %}
     {% if page_number == first_page_of_attachment %}
@@ -55,7 +55,7 @@
   {%- endfor -%}
   </ul>
   <h3>
-    Contact block
+    Sender address
   </h3>
   <p>
     {{ contact_block }}

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -55,7 +55,7 @@
   {%- endfor -%}
   </ul>
   <h3>
-    Sender address
+    Your contact details
   </h3>
   <p>
     {{ contact_block }}

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -15,7 +15,7 @@
     {% if template.welsh_page_count %}
       <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh</span> body<span class="govuk-visually-hidden"> text</span></a>
     {% else %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> heading and body text</span></a>
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit body<span class="govuk-visually-hidden"> text</span></a>
     {% endif %}
     {% if current_service.count_letter_contact_details %}
       <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Change sender address</a>

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -20,7 +20,7 @@
     {% if current_service.count_letter_contact_details %}
       <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Change sender address</a>
     {% else %}
-      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Add a sender address</a>
+      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Add your contact details</a>
     {% endif %}
   {% endif %}
 {% endif %}

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -35,7 +35,7 @@
     {% if template.welsh_page_count and page_number == first_page_of_english %}
       <div id="first-page-of-english-in-bilingual-letter"></div>
       {% if template.include_letter_edit_ui_overlay  %}
-        <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit English heading and body text</a>
+        <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> English heading and body text</span></a>
       {% endif %}
     {% endif %}
     {% if page_number == first_page_of_attachment %}

--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -13,7 +13,7 @@
   {% if current_user.has_permissions('manage_templates') %}
     <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-postage">Change postage</a>
     {% if template.welsh_page_count %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit Welsh heading and body text</a>
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh heading and body text</span></a>
     {% else %}
       <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> heading and body text</span></a>
     {% endif %}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -15,7 +15,7 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header('Add a new address') }}
+  {{ page_header('Add a new sender address') }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {% call form_wrapper() %}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -6,7 +6,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
-  Add a new address
+  Add a new sender address
 {% endblock %}
 
 {% block backLink %}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -6,7 +6,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
-  Add a new sender address
+  Add your contact details
 {% endblock %}
 
 {% block backLink %}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -15,7 +15,7 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header('Add a new sender address') }}
+  {{ page_header('Add your contact details') }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {% call form_wrapper() %}

--- a/app/templates/views/templates/set-template-sender.html
+++ b/app/templates/views/templates/set-template-sender.html
@@ -3,7 +3,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% set page_title = 'Change your sender address' %}
+{% set page_title = 'Change your contact details' %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/app/templates/views/templates/set-template-sender.html
+++ b/app/templates/views/templates/set-template-sender.html
@@ -3,7 +3,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% set page_title = 'Set letter contact block' %}
+{% set page_title = 'Add a sender address' %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/app/templates/views/templates/set-template-sender.html
+++ b/app/templates/views/templates/set-template-sender.html
@@ -3,7 +3,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% set page_title = 'Add a sender address' %}
+{% set page_title = 'Change your sender address' %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1700,7 +1700,7 @@ def test_should_be_able_to_view_a_letter_template_with_links(
                 service_id=SERVICE_ONE_ID,
                 template_id=fake_uuid,
             ),
-            "Change sender address",
+            "Change your contact details",
         ),
         (
             url_for(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1692,7 +1692,7 @@ def test_should_be_able_to_view_a_letter_template_with_links(
                 service_id=SERVICE_ONE_ID,
                 template_id=fake_uuid,
             ),
-            "Edit heading and body text",
+            "Edit body text",
         ),
         (
             url_for(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -841,7 +841,7 @@ def test_view_letter_template_does_not_display_send_button_if_template_over_10_p
         _test_page_title=False,
     )
 
-    assert "Send" not in page.text
+    assert "Get ready to send" not in page.text
     assert page.select_one("h1", {"data-error-type": "letter-too-long"})
 
 
@@ -1692,7 +1692,7 @@ def test_should_be_able_to_view_a_letter_template_with_links(
                 service_id=SERVICE_ONE_ID,
                 template_id=fake_uuid,
             ),
-            "Edit letter template",
+            "Edit heading and body text",
         ),
         (
             url_for(
@@ -1700,7 +1700,7 @@ def test_should_be_able_to_view_a_letter_template_with_links(
                 service_id=SERVICE_ONE_ID,
                 template_id=fake_uuid,
             ),
-            "Edit letter contact block",
+            "Change sender address",
         ),
         (
             url_for(


### PR DESCRIPTION
This PR updates the button labels on the Letter template preview page to provide more context for users.

Up to now, the context was visually hidden – but with so many different things you can edit on the page, we need to do more to differentiate the buttons.

We also need to make sure that the pages where you add and choose a sender address are consistent with the button label, as we’ve called this part of the template a number of different things over the years (for example ‘contact block’).