### PR TITLE
Make data tables focusable only when they scroll

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -9,6 +9,7 @@
       this.$table = this.$component.find('table');
       this.nativeHeight = this.$component.innerHeight() + 20; // 20px to allow room for scrollbar
       this.topOffset = this.$component.offset().top;
+      this.isFocusable = this.$table.width() > this.$component.width(); // only make focusable if table scrolls
 
       this.insertShims();
       this.maintainWidth();
@@ -21,8 +22,11 @@
 
       this.$scrollableTable
         .on('scroll', this.toggleShadows)
-        .on('scroll', this.maintainHeight)
-        .on('focus blur', () => this.$component.toggleClass('js-focus-style'));
+        .on('scroll', this.maintainHeight);
+
+      if (this.isFocusable) {
+        this.$scrollableTable.on('focus blur', () => this.$component.toggleClass('js-focus-style'));
+      }
 
       if (
         window.GOVUK.stickAtBottomWhenScrolling &&
@@ -37,11 +41,12 @@
 
     this.insertShims = () => {
 
-      const attributesForFocus = 'role aria-labelledby tabindex';
       let captionId = this.$table.find('caption').text().toLowerCase().replace(/[^A-Za-z]+/g, '');
+      const attributesForFocus = ` role="region" aria-labelledby="${captionId}" tabindex="0"`;
+      const namesOfAttributesForFocus = 'role aria-labelledby tabindex';
 
       this.$table.find('caption').attr('id', captionId);
-      this.$table.wrap(`<div class="fullscreen-scrollable-table" role="region" aria-labelledby="${captionId}" tabindex="0"/>`);
+      this.$table.wrap(`<div class="fullscreen-scrollable-table"${this.isFocusable ? attributesForFocus : ''}/>`);
 
       this.$component
         .append(
@@ -49,7 +54,7 @@
             .clone()
             .addClass('fullscreen-fixed-table')
             .removeClass('fullscreen-scrollable-table')
-            .removeAttr(attributesForFocus)
+            .removeAttr(namesOfAttributesForFocus)
             .attr('aria-hidden', true)
             .find('caption')
             .removeAttr('id')

--- a/tests/javascripts/fullscreenTable.test.js
+++ b/tests/javascripts/fullscreenTable.test.js
@@ -146,18 +146,59 @@ describe('FullscreenTable', () => {
 
     });
 
-    test("the scrolling section is focusable and has an accessible name matching the table caption", () => {
+    describe("and the scrolling section is wider than its container", () => {
 
-      // start module
-      window.GOVUK.notifyModules.start();
+      beforeEach(() => {
+        $(container).css({ 'width': '640px' });
+        $('table', container).css({ 'width': '990px' });
 
-      tableFrame = document.querySelector('.fullscreen-scrollable-table');
-      caption = tableFrame.querySelector('caption');
+        window.GOVUK.notifyModules.start();
+      });
 
-      expect(tableFrame.hasAttribute('role')).toBe(true);
-      expect(tableFrame.getAttribute('role')).toEqual('region');
-      expect(tableFrame.hasAttribute('aria-labelledby')).toBe(true);
-      expect(tableFrame.getAttribute('aria-labelledby')).toEqual(caption.getAttribute('id'));
+      test("it should be made focusable and have an accessible name matching the table caption", () => {
+
+        tableFrame = document.querySelector('.fullscreen-scrollable-table');
+        caption = tableFrame.querySelector('caption');
+
+        // focusable
+        expect(tableFrame.hasAttribute('tabindex')).toBe(true);
+        expect(tableFrame.getAttribute('tabindex')).toEqual('0');
+
+        // has a semantic role
+        expect(tableFrame.hasAttribute('role')).toBe(true);
+        expect(tableFrame.getAttribute('role')).toEqual('region');
+
+        // has an accessible name
+        expect(tableFrame.hasAttribute('aria-labelledby')).toBe(true);
+        expect(tableFrame.getAttribute('aria-labelledby')).toEqual(caption.getAttribute('id'));
+
+      });
+
+    });
+
+    describe("and the scrolling section is the same width as its container", () => {
+
+      beforeEach(() => {
+        $(container).css({ 'width': '640px' });
+        $('table', container).css({ 'width': '640px' });
+
+        window.GOVUK.notifyModules.start();
+      });
+
+      test("it shouldn't be made focusable or have an accessible name", () => {
+
+        tableFrame = document.querySelector('.fullscreen-scrollable-table');
+
+        // isn't focusable
+        expect(tableFrame.hasAttribute('tabindex')).toBe(false);
+
+        // has no semantic role
+        expect(tableFrame.hasAttribute('role')).toBe(false);
+
+        // has no accessible name
+        expect(tableFrame.hasAttribute('aria-labelledby')).toBe(false);
+
+      });
 
     });
 
@@ -386,6 +427,10 @@ describe('FullscreenTable', () => {
   describe("when the table is focused", () => {
 
     beforeEach(() => {
+
+      // make table wider than its container so it is made focusable
+      $(container).css({ 'width': '640px' });
+      $('table', container).css({ 'width': '990px' });
 
       // start module
       window.GOVUK.notifyModules.start();


### PR DESCRIPTION
Adds logic to see if the data tables need to scroll before making them focusable. To fix this issue:

https://trello.com/c/X63MGfzJ/668-address-placeholder-data-tables-are-focusable-even-if-they-dont-scroll

<img width="754" alt="image" src="https://github.com/alphagov/notifications-admin/assets/87140/ce19d1a2-8ff1-4f22-9cf8-9afee0a15a8f">

It's confusing for anyone using the keyboard to navigate to have these tables focusable when they don't need to scroll (which was the point of them being given focus in the first place).

Scrolling is possible via the keyboard using arrow keys but the thing you're scrolling needs to be focusable for this to work.

Note: also includes a fix for the test that checks the component is set up properly for receiving focus. It didn't check tabindex=0 was set before.

## Notes for reviewers

I've tested this in all [the browsers we support](https://github.com/alphagov/notifications-manuals/wiki/Support-for-browsers,-email-clients-and-assistive-technologies) so, other than seeing if the code is ok, it's worth trying these tables with data that makes them scroll (usually >=4 columns) and with data that doesn't.