### PR TITLE
Add NPM script for debugging tests in chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ make test
 
 # continuously run js tests
 npm run test-watch
+
+# debug a js test in chrome
+npm run debug --test=[name of test file]
 ```
 
 To run a specific JavaScript test, you'll need to copy the full command from `package.json`.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "test": "gulp lint && jest --config tests/javascripts/jest.config.js tests/javascripts",
     "test-watch": "jest --watch --config tests/javascripts/jest.config.js tests/javascripts",
+    "debug": "node --inspect-brk node_modules/.bin/jest --runInBand --config tests/javascripts/jest.config.js $npm_config_test",
     "build": "gulp",
     "watch": "gulp watch",
     "audit": "better-npm-audit audit --production --level high"


### PR DESCRIPTION
It's sometimes useful to debug a js test in chrome, using the devtools as a debugger. You can do this with Jest (the test runner) but the command is a bit verbose:

https://jestjs.io/docs/troubleshooting

This adds a script to make it easier to do.