### PR TITLE
Stop trial mode GPs sending SMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ htmlcov/
 coverage.xml
 test_results.xml
 *,cover
+.testmon*
+
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ test: ## Run tests
 	source $(HOME)/.nvm/nvm.sh && npm test
 	py.test -n auto --maxfail=10 tests/
 
+.PHONY: watch-tests
+watch-tests: ## Watch tests and run on change
+	ptw --runner "pytest --testmon -n auto"
+
 .PHONY: fix-imports
 fix-imports: ## Fix imports using ruff
 	ruff --fix --select=I .

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -5,6 +5,7 @@ from notifications_python_client.errors import HTTPError
 from app import service_api_client
 from app.main import main
 from app.main.forms import AddOrJoinServiceForm, CreateNhsServiceForm, CreateServiceForm
+from app.models.organisation import Organisation
 from app.models.service import Service
 from app.utils.user import user_is_gov_user, user_is_logged_in
 
@@ -84,10 +85,16 @@ def add_service():
         )
         if error:
             return _render_add_service_page(form, default_organisation_type)
+
+        new_service = Service.from_id(service_id)
+
+        # GPs have a zero message limit (to prevent them sending messages while in trial mode)
+        if form.organisation_type.data == Organisation.TYPE_NHS_GP:
+            new_service.update(sms_message_limit=0)
+
         if len(service_api_client.get_active_services({"user_id": session["user_id"]}).get("data", [])) > 1:
             # if user has email auth, it makes sense that people they invite to their new service can have it too
             if current_user.email_auth:
-                new_service = Service.from_id(service_id)
                 new_service.force_permission("email_auth", on=True)
 
             return redirect(url_for("main.service_dashboard", service_id=service_id))

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -92,8 +92,11 @@ def add_service():
         if form.organisation_type.data == Organisation.TYPE_NHS_GP:
             new_service.update(sms_message_limit=0)
 
-        # show the tour if the user doesn't have any other services
-        show_tour = len(service_api_client.get_active_services({"user_id": session["user_id"]}).get("data", [])) <= 1
+        # show the tour if the user doesn't have any other services. Never show for NHS GPs
+        show_tour = (
+            len(service_api_client.get_active_services({"user_id": session["user_id"]}).get("data", [])) <= 1
+            and form.organisation_type.data != Organisation.TYPE_NHS_GP
+        )
 
         if show_tour:
             example_sms_template = _create_example_template(service_id)

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -6,6 +6,8 @@ pytest-env==0.8.1
 pytest-mock==3.10.0
 pytest-xdist==3.0.2
 pytest-freezegun==0.4.2
+pytest-testmon==2.1.0
+pytest-watch==4.2.0
 beautifulsoup4==4.11.1
 freezegun==1.2.2
 moto==4.0.9

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -5604,6 +5604,46 @@ def test_update_service_organisation(
     mock_update_service_organisation.assert_called_once_with(service_one["id"], "7aa5d4e9-4385-4488-a489-07812ba13384")
 
 
+def test_update_service_organisation_sets_daily_sms_limit_to_zero_for_trial_mode_gp(
+    client_request,
+    platform_admin_user,
+    service_one,
+    mock_get_organisation_nhs_gp,
+    mock_get_organisations,
+    mock_update_service_organisation,
+    mock_update_service,
+):
+    service_one["restricted"] = True
+    client_request.login(platform_admin_user)
+    client_request.post(
+        ".link_service_to_organisation",
+        service_id=service_one["id"],
+        _data={"organisations": "7aa5d4e9-4385-4488-a489-07812ba13384"},
+    )
+    mock_update_service_organisation.assert_called_once_with(service_one["id"], "7aa5d4e9-4385-4488-a489-07812ba13384")
+    mock_update_service.assert_called_once_with(service_one["id"], sms_message_limit=0)
+
+
+def test_update_service_organisation_doesnt_change_daily_sms_limit_for_live_gp(
+    client_request,
+    platform_admin_user,
+    service_one,
+    mock_get_organisation_nhs_gp,
+    mock_get_organisations,
+    mock_update_service_organisation,
+    mock_update_service,
+):
+    service_one["restricted"] = False
+    client_request.login(platform_admin_user)
+    client_request.post(
+        ".link_service_to_organisation",
+        service_id=service_one["id"],
+        _data={"organisations": "7aa5d4e9-4385-4488-a489-07812ba13384"},
+    )
+    mock_update_service_organisation.assert_called_once_with(service_one["id"], "7aa5d4e9-4385-4488-a489-07812ba13384")
+    assert mock_update_service.called is False
+
+
 def test_update_service_organisation_does_not_update_if_same_value(
     client_request,
     platform_admin_user,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1061,9 +1061,11 @@ def create_service_templates(service_id, number_of_templates=6):
                 name=f"{template_type}_template_{template_number}",
                 type_=template_type,
                 content=f"{template_type} template {template_number} content",
-                subject=f"{template_type} template {template_number} subject"
-                if template_type in ["email", "letter"]
-                else None,
+                subject=(
+                    f"{template_type} template {template_number} subject"
+                    if template_type in ["email", "letter"]
+                    else None
+                ),
             )
         )
 
@@ -3358,6 +3360,14 @@ def mock_get_organisation_by_domain(mocker):
         "app.organisations_client.get_organisation_by_domain",
         side_effect=_get_organisation_by_domain,
     )
+
+
+@pytest.fixture(scope="function")
+def mock_get_organisation_nhs_gp(mocker):
+    def _get_organisation(domain):
+        return organisation_json(ORGANISATION_ID, organisation_type="nhs_gp")
+
+    return mocker.patch("app.organisations_client.get_organisation", side_effect=_get_organisation)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
I haven't had time to test this manually but unit tests work well

* Set sms_message_limit=0 for GPs when the service is added
* skip the tour for GPs as this would now error
* Set sms_message_limit=0 for a trial mode service if its organisation is changed to GP


we already handle by default the sms limit being set to 250k when a service goes live