### PR TITLE
Update roadmap to show migration off PaaS as done

### DIFF
--- a/app/templates/views/guidance/features/roadmap.html
+++ b/app/templates/views/guidance/features/roadmap.html
@@ -15,7 +15,7 @@
 
   {{ content_metadata(
     data={
-      "Last updated": "23 February 2024",
+      "Last updated": "3 April 2024",
       "Next review due": "15 April 2024"
     }
   ) }}
@@ -31,7 +31,6 @@
     <li>Improve our front-end code to meet our targets for accessibility</li>
     <li>Let organisations approve new services (<a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/agile-delivery/how-the-beta-phase-works">public beta</a>)</li>
     <li>Provide more detailed reporting and usage data for services</li>
-    <li>Migrate our applications from <a class="govuk-link govuk-link--no-visited-state" href="https://gds.blog.gov.uk/2022/07/12/why-weve-decided-to-decommission-gov-uk-paas-platform-as-a-service/">GOV.UK PaaS</a> to Amazon ECS</li>
     <li>Test Rich Communication Services (RCS)</li>
     <li>Explore alternative letter suppliers</li>
   </ul>
@@ -48,6 +47,7 @@
   <h2 class="heading-medium" id="things-we-have-done">Things we’ve done</h2>
 
   <ul class="govuk-list govuk-list--bullet">
+    <li>Migrated our applications from <a class="govuk-link govuk-link--no-visited-state" href="https://gds.blog.gov.uk/2022/07/12/why-weve-decided-to-decommission-gov-uk-paas-platform-as-a-service/">GOV.UK PaaS</a> to Amazon ECS</li>
     <li>Explored new channels for notifications (discovery)</li>
     <li>Let services set a custom sender name and email address</li>
     <li>Let services create letter templates that comply with the <a class="govuk-link govuk-link--no-visited-state" href="https://law.gov.wales/culture/welsh-language/welsh-language-act-1993">Welsh Language Act 1993</a></li>


### PR DESCRIPTION
Page after:

<img width="743" alt="Screenshot 2024-04-03 at 13 48 36" src="https://github.com/alphagov/notifications-admin/assets/12881990/3231abbe-ca0e-49d6-a02d-f14b80c6c548">
