### PR TITLE
remove use of `NOTIFY_RUNTIME_PLATFORM` & `NOTIFY_LOG_PATH` flask config parameters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -92,8 +92,6 @@ class Config:
         ],
     }
 
-    NOTIFY_RUNTIME_PLATFORM = os.environ.get("NOTIFY_RUNTIME_PLATFORM", "ecs")
-
     EMAIL_BRANDING_MIN_LOGO_HEIGHT_PX = 108
     EMAIL_BRANDING_MAX_LOGO_WIDTH_PX = 640
 
@@ -126,7 +124,6 @@ class Development(Config):
 
     REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
     REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"
-    NOTIFY_RUNTIME_PLATFORM = "local"
 
 
 class Test(Development):

--- a/app/config.py
+++ b/app/config.py
@@ -17,7 +17,6 @@ class Config:
 
     # Logging
     DEBUG = False
-    NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
     ADMIN_CLIENT_USER_NAME = "notify-admin"
 
@@ -98,7 +97,6 @@ class Config:
 
 class Development(Config):
     SERVER_NAME = os.getenv("SERVER_NAME")
-    NOTIFY_LOG_PATH = "application.log"
     DEBUG = True
     SESSION_COOKIE_SECURE = False
     SESSION_PROTECTION = None

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ rtreelib==0.2.0
 fido2==1.1.0
 
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
 govuk-frontend-jinja==2.8.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
https://trello.com/c/kuPbusFR/724-check-if-we-should-and-then-remove-notifyruntimeplatform-functionality

~Depends on https://github.com/alphagov/notifications-utils/pull/1109 (though actually doesn't technically require it)~
