### PR TITLE
Remove OpenStreetMap from safe image sources

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -354,7 +354,7 @@ def useful_headers_after_request(response):
             "connect-src 'self' *.google-analytics.com;"
             "object-src 'self';"
             "font-src 'self' {asset_domain} data:;"
-            "img-src 'self' {asset_domain} *.tile.openstreetmap.org *.google-analytics.com"
+            "img-src 'self' {asset_domain} *.google-analytics.com"
             " *.notifications.service.gov.uk {logo_domain} data:;"
             "frame-src 'self';".format(
                 asset_domain=current_app.config["ASSET_DOMAIN"],

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -18,7 +18,7 @@ def test_owasp_useful_headers_set(
         "object-src 'self';"
         "font-src 'self' static.example.com data:;"
         "img-src "
-        "'self' static.example.com *.tile.openstreetmap.org *.google-analytics.com"
+        "'self' static.example.com *.google-analytics.com"
         " *.notifications.service.gov.uk static-logos.test.com data:;"
         "frame-src 'self';"
     )
@@ -49,7 +49,7 @@ def test_headers_non_ascii_characters_are_replaced(
         "object-src 'self';"
         "font-src 'self' static.example.com data:;"
         "img-src"
-        " 'self' static.example.com *.tile.openstreetmap.org *.google-analytics.com"
+        " 'self' static.example.com *.google-analytics.com"
         " *.notifications.service.gov.uk static-logos??.test.com data:;"
         "frame-src 'self';"
     )


### PR DESCRIPTION
We were loading map tiles from OpenStreetMap for Emergency Alerts. Now that Emergency Alerts is no longer part of Notify we don’t need to load any images from OpenStreetMap’s servers, so we can remove their domain from our content security policy.