### PR TITLE
Remove direct dependency on govuk-bank-holidays

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,6 @@
 # with package version changes made in requirements-app.txt
 
 ago==0.0.95
-govuk-bank-holidays==0.11
 humanize==4.4.0
 Flask==3.0.0
 Flask-WTF==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,9 +63,7 @@ flask-wtf==1.2.1
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
 govuk-bank-holidays==0.11
-    # via
-    #   -r requirements.in
-    #   notifications-utils
+    # via notifications-utils
 govuk-frontend-jinja==2.8.0
     # via -r requirements.in
 greenlet==3.0.3


### PR DESCRIPTION
We only use this indirectly through the module in utils: https://github.com/alphagov/notifications-utils/blob/6791aebe7c68b8ad7de7b1dd5b02791974f8ae07/notifications_utils/bank_holidays.py

Not pinning the dependency will make it easier to keep the list of bank holidays up to date, because we will only need to bump the version in utils.