### PR TITLE
Only ask for recipients once in one-off journey

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -15,7 +15,7 @@ from flask import (
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
-from notifications_utils.insensitive_dict import InsensitiveDict
+from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
 from notifications_utils.postal_address import PostalAddress, address_lines_1_to_7_keys
 from notifications_utils.recipients import RecipientCSV, first_column_headings
 from notifications_utils.sanitise_text import SanitiseASCII
@@ -782,14 +782,10 @@ def start_job(service_id, upload_id):
 
 def fields_to_fill_in(template, prefill_current_user=False):
     if "letter" == template.template_type:
-        return tuple(InsensitiveDict.from_keys(letter_address_columns + list(template.placeholders)).values())
+        return InsensitiveSet(letter_address_columns + list(template.placeholders))
 
     if not prefill_current_user:
-        return tuple(
-            InsensitiveDict.from_keys(
-                first_column_headings[template.template_type] + list(template.placeholders)
-            ).values()
-        )
+        return InsensitiveSet(first_column_headings[template.template_type] + list(template.placeholders))
 
     if template.template_type == "sms":
         session["recipient"] = current_user.mobile_number
@@ -798,7 +794,7 @@ def fields_to_fill_in(template, prefill_current_user=False):
         session["recipient"] = current_user.email_address
         session["placeholders"]["email address"] = current_user.email_address
 
-    return tuple(InsensitiveDict.from_keys(template.placeholders).values())
+    return InsensitiveSet(template.placeholders)
 
 
 def get_normalised_placeholders_from_session():

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -782,10 +782,14 @@ def start_job(service_id, upload_id):
 
 def fields_to_fill_in(template, prefill_current_user=False):
     if "letter" == template.template_type:
-        return letter_address_columns + list(template.placeholders)
+        return tuple(InsensitiveDict.from_keys(letter_address_columns + list(template.placeholders)).values())
 
     if not prefill_current_user:
-        return first_column_headings[template.template_type] + list(template.placeholders)
+        return tuple(
+            InsensitiveDict.from_keys(
+                first_column_headings[template.template_type] + list(template.placeholders)
+            ).values()
+        )
 
     if template.template_type == "sms":
         session["recipient"] = current_user.mobile_number
@@ -794,7 +798,7 @@ def fields_to_fill_in(template, prefill_current_user=False):
         session["recipient"] = current_user.email_address
         session["placeholders"]["email address"] = current_user.email_address
 
-    return list(template.placeholders)
+    return tuple(InsensitiveDict.from_keys(template.placeholders).values())
 
 
 def get_normalised_placeholders_from_session():

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ rtreelib==0.2.0
 fido2==1.1.0
 
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.2.0
 govuk-frontend-jinja==2.8.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.2.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1356,12 +1356,12 @@ def test_send_one_off_shows_placeholders_in_correct_order(
     (
         (
             "sms",
-            "((phone_number)) ((Phone Number)) ((PHONENUMBER)) ((name))",
+            "((phone_number)) ((Phone Number)) ((PHONENUMBER)) ((name)) ((NAME))",
             "07900900123",
             {"phonenumber": "07900900123"},
             1,
             ".sms-message-wrapper",
-            "service one: 07900900123 07900900123 07900900123 ((name))",
+            "service one: 07900900123 07900900123 07900900123 ((name)) ((NAME))",
         ),
         (
             "email",


### PR DESCRIPTION
If someone uses a placeholder which is the same as the key we use for the recipient <sup>1</sup>, we ask for the value twice, but only store it once.

This is even worse if the user has a the same placeholder with different space/casing in the same template<sup>2</sup>. In this case we would ask for the value once for each different variant of spacing/case, but still only store the first one entered.

This commit normalises all the placeholders after merging them with the special recipient keys.

This means that every instance of that placeholder will be populated in the template straight away, and the user won’t be asked for it again.

***

1. For example, `email address`, `phone number` or `address line 1`, `address line 2`, etc
2. For example `email address` and `EMAILADDRESS`

***

https://www.pivotaltracker.com/story/show/181220935