### PR TITLE
Update form_wrapper macro action attribute

### DIFF
--- a/app/templates/components/form.html
+++ b/app/templates/components/form.html
@@ -1,6 +1,6 @@
 {% macro form_wrapper(
   method="post",
-  action=None,
+  action="#",
   autocomplete=False,
   class=None,
   id=None,


### PR DESCRIPTION
 This PR fixes the issue raised in [this](https://trello.com/c/bnjIRzze/695-fix-accessibility-issue-with-post-redirect-get-form-submission-pattern) ticket.
Updating the `form_wrapper` macro deploys the change across all the form pages on Notify.
Setting the `action` attribute to `#` seems to be the simplest and optimal solution