### PR TITLE
Migrate Jest config into package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,15 @@ make bootstrap
 # run all the tests
 make test
 
+# run the js tests
+npx jest
+
+# run a single js test
+npx jest <pathToAJavascriptTestfile>
+
 # continuously run js tests
 npm run test-watch
+
 ```
 
 To run a specific JavaScript test, you'll need to copy the full command from `package.json`.

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "node": ">=10.15.3"
   },
   "scripts": {
-    "test": "gulp lint && jest --config tests/javascripts/jest.config.js tests/javascripts",
-    "test-watch": "jest --watch --config tests/javascripts/jest.config.js tests/javascripts",
+    "test": "gulp lint && jest",
+    "test-watch": "jest --watch",
     "build": "gulp",
     "watch": "gulp watch",
     "audit": "better-npm-audit audit --production --level high"
@@ -61,5 +61,14 @@
   "overrides": {
     "minimist": "1.2.6",
     "lodash.template": "4.5.0"
+  },
+  "jest": {
+    "setupFiles": [
+      "<rootDir>/tests/javascripts/support/setup.js"
+    ],
+    "testEnvironmentOptions": {
+      "url": "https://www.notifications.service.gov.uk"
+    },
+    "testEnvironment": "jsdom"
   }
 }

--- a/tests/javascripts/jest.config.js
+++ b/tests/javascripts/jest.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  setupFiles: ['./support/setup.js'],
-  testEnvironmentOptions: { url: 'https://www.notifications.service.gov.uk' },
-  testEnvironment: 'jsdom'
-}


### PR DESCRIPTION
We currently run test to test individual files with a verbose `npx jest --config tests/javascripts/jest.config.js <fileNamePath>` command

As Jest can also read the config from a package.json file if "jest" key is present, the above command can just be `npx jest <fileNamePath>`

This PR moves the Jest config from a separate file to package.json and removes the path to teh Jest config file from  `npm test` and `npm test-watch` NPM script commands

## How to test

- run `npx jest <pathToAJavascriptTestfile>` to run a Javascript test
- run `npm test` to run all Javascript tests
- run `npm test-watch` and make a change to a Javascript test file