### PR TITLE
Show organisation membership on user page for platform admins

### DIFF
--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -13,6 +13,22 @@
       <p class="govuk-body">{{ user.email_address }}</p>
       <p class="{{ '' if user.mobile_number else 'hint' }}">{{ user.mobile_number or 'No mobile number'}}</p>
 
+      <h2 class="heading-medium">Organisations</h2>
+      <nav class="browse-list">
+        {% if user.organisations %}
+          <ul>
+          {% for org in user.organisations|sort %}
+            <li class="browse-list-item">
+              <a class="govuk-link govuk-link--no-visited-state browse-list-hint" href={{url_for('main.organisation_dashboard', org_id=org.id)}}>{{ org.name }}</a>
+          {% endfor %}
+          </ul>
+        {% else %}
+          <p class="hint">
+            No organisations
+          </p>
+        {% endif %}
+      </nav>
+
       <h2 class="heading-medium">Live services</h2>
       <nav class="browse-list">
         {% if user.live_services %}

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -17,6 +17,7 @@ def test_user_information_page_shows_information_about_user(
     client_request.login(platform_admin_user)
     user_service_one = uuid.uuid4()
     user_service_two = uuid.uuid4()
+    user_organisation = uuid.uuid4()
     mocker.patch(
         "app.user_api_client.get_user",
         return_value=user_json(name="Apple Bloom", services=[user_service_one, user_service_two]),
@@ -25,7 +26,9 @@ def test_user_information_page_shows_information_about_user(
     mocker.patch(
         "app.user_api_client.get_organisations_and_services_for_user",
         return_value={
-            "organisations": [],
+            "organisations": [
+                {"id": user_organisation, "name": "Nature org"},
+            ],
             "services": [
                 {"id": user_service_one, "name": "Fresh Orchard Juice", "restricted": True},
                 {"id": user_service_two, "name": "Nature Therapy", "restricted": False},
@@ -47,6 +50,7 @@ def test_user_information_page_shows_information_about_user(
     assert "0 failed login attempts" not in page.text
 
     assert [normalize_spaces(h2.text) for h2 in page.select("main h2")] == [
+        "Organisations",
         "Live services",
         "Trial mode services",
         "Authentication",
@@ -54,6 +58,7 @@ def test_user_information_page_shows_information_about_user(
     ]
 
     assert [normalize_spaces(a.text) for a in page.select("main li a")] == [
+        "Nature org",
         "Nature Therapy",
         "Fresh Orchard Juice",
     ]


### PR DESCRIPTION
As requested in:
https://gds.slack.com/archives/C037E9EL8RE/p1713261630095319

Follows the same pattern as the services shown below. We can move this section higher or lower on the page if we wish.

<img width="702" alt="image" src="https://github.com/alphagov/notifications-admin/assets/7228605/d252e74c-7c57-48c0-8d1e-617c1acf1ed6">
