### PR TITLE
Revert 'Revert "Accessibility fixes for data tables"'

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -85,16 +85,28 @@
 
     this.maintainWidth = () => {
 
-      let indexColumnWidth = this.$fixedTable.find('.table-field-index').outerWidth();
+      const $scrollableIndexColumnHeader = this.$scrollableTable.find('.table-field-heading-first').eq(0);
+      const $fixedIndexColumnHeader = this.$fixedTable.find('.table-field-heading-first').eq(0);
 
       this.$scrollableTable
         .css({
-            'width': this.$component.parent().width() - indexColumnWidth,
-            'margin-left': indexColumnWidth
+          'width': this.$component.parent().width()
         });
 
+      // The table layout algorithm can sometimes work differently on the two tables, because they are
+      // positioned differently. This results in both versions of the index column having different widths.
+      // If this happens, set both by the width of the fixed column.
+      if ($fixedIndexColumnHeader.width() !== $scrollableIndexColumnHeader.width()) {
+        $scrollableIndexColumnHeader.css({
+          'width': $fixedIndexColumnHeader.width()
+        });
+      }
+
+      // The fixed table container is positioned absolutely to needs a width set explicity
       this.$fixedTable
-        .width(indexColumnWidth + 4);
+        .css({
+          'width': $fixedIndexColumnHeader.outerWidth() + 4 // allow 4px space for the shadow
+        });
 
     };
 

--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -116,10 +116,15 @@ td {
   }
 
   th,
-  .table-field-index {
+  tbody th.table-field {
     background: govuk-colour("light-grey");
     font-weight: bold;
     text-align: center;
+  }
+
+  // precedence of spreadsheet CSS means we need this to stop this style being overwritten
+  & .fullscreen-scrollable-table tbody th.table-field {
+    background: govuk-colour("white");
   }
 
   th, td {
@@ -128,7 +133,8 @@ td {
     border: 1px solid $govuk-border-colour;
   }
 
-  td {
+  td,
+  tbody th {
 
     border-top: 0;
     // 194 is the width of the table * 1/3.5, so the overflow cuts off

--- a/app/assets/stylesheets/components/fullscreen-table.scss
+++ b/app/assets/stylesheets/components/fullscreen-table.scss
@@ -15,8 +15,8 @@
 
       margin-bottom: 0;
 
-      tr:last-child {
-        td {
+      tbody tr:last-child {
+        th, td {
           border-bottom: 1px solid govuk-colour("white");
         }
       }
@@ -57,9 +57,13 @@
     overflow-x: auto;
     overflow-y: hidden;
 
+    // hide the header cells, but only visually and in a way that doesn't disrupt the table layout
     .table-field-heading-first,
-    .table-field-index {
-      display: none;
+    tbody th.table-field {
+      color: transparent;
+      border-color: transparent;
+      border-right-color: $govuk-border-colour;
+      background: govuk-colour("white");
     }
 
     .table-field-left-aligned {
@@ -96,8 +100,11 @@
     top: 0;
     overflow: hidden;
 
-    .table-field-heading {
+    // hide all cells except the headers
+    .table-field-heading,
+    .table-field-left-aligned {
       visibility: hidden;
+      border-color: transparent;
     }
 
     .table-field-left-aligned {
@@ -108,7 +115,7 @@
     }
 
     .table-field-heading-first,
-    .table-field-index {
+    tbody th.table-field {
       transition: none;
       position: relative;
       z-index: 200;
@@ -122,7 +129,7 @@
     padding-bottom: 20px;
 
     .table-field-heading-first,
-    .table-field-index {
+    tbody th.table-field {
       transition: box-shadow 0.3s ease-in-out;
       box-shadow: 1px 0 0 0 $govuk-border-colour, 3px 0 0 0 rgba($govuk-border-colour, 0.2);
     }

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -79,7 +79,7 @@
 {%- endmacro %}
 
 {% macro row_heading() -%}
-  <th class="table-field">
+  <th class="table-field" scope="row">
     {{ caller() }}
   </th>
 {%- endmacro %}

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/table.html" import list_table, field, text_field, index_field %}
+{% from "components/table.html" import list_table, field, text_field, row_heading %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
@@ -161,7 +161,7 @@
           '<span class="govuk-visually-hidden">Row in file</span><span aria-hidden="true">1</span>'|safe
         ] + column_headers
       ) %}
-        {% call index_field() %}
+        {% call row_heading() %}
           <span>
             {% set displayed_index = item.index + 2 %}
             {% if (

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/table.html" import list_table, text_field, index_field %}
+{% from "components/table.html" import list_table, text_field, row_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/skip-link/macro.html" import govukSkipLink %}
@@ -79,7 +79,7 @@
           '<span class="govuk-visually-hidden">Row in file</span><span aria-hidden="true">1</span>'|safe
         ] + recipients.column_headers
       ) %}
-        {% call index_field() %}
+        {% call row_heading() %}
           <span>
             {% if (item.index + 2) == preview_row %}
               {{ item.index + 2 }}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -3,7 +3,7 @@
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/table.html" import list_table, text_field, index_field %}
+{% from "components/table.html" import list_table, text_field, row_heading %}
 
 {% block service_page_title %}
   {{ job.original_file_name }}
@@ -38,7 +38,7 @@
               '<span class="govuk-visually-hidden">Row in file</span><span aria-hidden="true">1</span>'|safe
             ] + scheduled_recipients.column_headers
           ) %}
-            {% call index_field() %}
+            {% call row_heading() %}
               <span>
                 {{ item.index + 2 }}
               </span>

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/table.html" import list_table, text_field, index_field %}
+{% from "components/table.html" import list_table, text_field, row_heading %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
@@ -42,7 +42,9 @@
       caption_visible=False,
       field_headings=[''] + column_headings
     ) %}
-      {{ index_field(row_number - 1) }}
+      {% call row_heading() %}
+        {{ row_number - 1 }}
+      {% endcall %}
       {% for column in item %}
         {{ text_field(column) }}
       {% endfor %}

--- a/app/templates/views/uploads/contact-list/too-many-columns.html
+++ b/app/templates/views/uploads/contact-list/too-many-columns.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/table.html" import list_table, text_field, index_field %}
+{% from "components/table.html" import list_table, text_field, row_heading %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
@@ -78,7 +78,9 @@
           '<span class="govuk-visually-hidden">Row in file</span> <span aria-hidden="true">1</span>'|safe
         ] + recipients._raw_column_headers
       ) %}
-        {{ index_field(item.index + 2) }}
+        {% call row_heading() %}
+        {{ item.index + 2 }}
+        {% endcall %}
         {% for column in column_headers %}
           {% if item[column].ignore %}
             {{ text_field(item[column].data or '', status='default') }}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -486,7 +486,8 @@ def test_should_show_scheduled_job(
         "name",
     ]
     assert [
-        [normalize_spaces(column.text) for column in row.select("td")] for row in recipients_table.select("tbody tr")
+        [normalize_spaces(column.text) for column in row.select("th, td")]
+        for row in recipients_table.select("tbody tr")
     ] == [
         ["2", "+447700900986", "John"],
         ["3", "+447700900986", "Smith"],

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -302,7 +302,10 @@ def test_example_spreadsheet_for_letters(
 
     assert list(
         zip(
-            *[[normalize_spaces(cell.text) for cell in page.select("tbody tr")[row].select("td")] for row in (0, 1)],
+            *[
+                [normalize_spaces(cell.text) for cell in page.select("tbody tr")[row].select("th, td")]
+                for row in (0, 1)
+            ],
             strict=True,
         )
     ) == [
@@ -1034,10 +1037,10 @@ def test_upload_valid_csv_shows_preview_and_table(
     assert page.select_one(".sms-message-recipient").text.strip() == expected_recipient
     assert page.select_one(".sms-message-wrapper").text.strip() == expected_message
 
-    assert page.select_one(".table-field-index").text.strip() == "2"
+    assert page.select_one("th.table-field").text.strip() == "2"
 
     if expected_link_in_first_row:
-        assert page.select_one(".table-field-index a")["href"] == url_for(
+        assert page.select_one("th.table-field a")["href"] == url_for(
             "main.check_messages",
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
@@ -1046,7 +1049,7 @@ def test_upload_valid_csv_shows_preview_and_table(
             original_file_name="example.csv",
         )
     else:
-        assert not page.select_one(".table-field-index").select_one("a")
+        assert not page.select_one("th.table-field").select_one("a")
 
     for row_index, row in enumerate(
         [
@@ -1094,7 +1097,7 @@ def test_upload_valid_csv_shows_preview_and_table(
         for index, cell in enumerate(row):
             row = page.select("table tbody tr")[row_index]
             assert "id" not in row
-            assert normalize_spaces(str(row.select("td")[index + 1])) == cell
+            assert normalize_spaces(str(row.select("th, td")[index + 1])) == cell
 
 
 def test_upload_valid_csv_only_sets_meta_if_filename_known(
@@ -3254,7 +3257,7 @@ def test_check_messages_shows_trial_mode_error_for_letters(
     assert len(page.select(".letter img")) == 3
 
     if number_of_rows > 1:
-        assert page.select_one(".table-field-index a").text == "3"
+        assert page.select_one("th.table-field a").text == "3"
 
 
 @pytest.mark.parametrize(

--- a/tests/javascripts/fullscreenTable.test.js
+++ b/tests/javascripts/fullscreenTable.test.js
@@ -112,6 +112,7 @@ describe('FullscreenTable', () => {
 
   afterEach(() => {
 
+    $(window).off('scroll resize');
     document.body.innerHTML = '';
 
   });
@@ -240,18 +241,18 @@ describe('FullscreenTable', () => {
   });
 
   describe("the width of the table should fit the horizontal space available to it", () => {
-    let rowNumberColumnCell;
+    let rowNumberColumnHeader;
 
     beforeEach(() => {
 
-      rowNumberColumnCell = container.querySelector('.table-field-index');
+      rowNumberColumnHeader = container.querySelector('.table-field-heading-first');
 
-      // set main content column width (used as module as gauge for table width)
+      // set main content column width (used by module as gauge for table width)
       screenMock.window.setWidthTo(1024);
-      document.querySelector('main').setAttribute('style', 'width: 742px');
+      document.querySelector('main').setAttribute('style', 'width: 712px');
 
       // set total width of column for row numbers in table to 40px
-      rowNumberColumnCell.setAttribute('style', 'width: 40px');
+      rowNumberColumnHeader.setAttribute('style', 'width: 40px');
 
       // start module
       window.GOVUK.notifyModules.start();
@@ -269,9 +270,8 @@ describe('FullscreenTable', () => {
 
     test("when the page has loaded", () => {
 
-      // table should set its width to be that of `<main>`, minus margin-left for the row numbers column
-      expect(window.getComputedStyle(tableFrame)['width']).toEqual('702px'); // width of content column - numbers column
-      expect(window.getComputedStyle(tableFrame)['margin-left']).toEqual('40px'); // width of numbers column
+      // table should set its width to be that of `<main>`
+      expect(window.getComputedStyle(tableFrame)['width']).toEqual('712px');
 
       // table for number column has 4px extra to allow space for drop shadow
       expect(window.getComputedStyle(numberColumnFrame)['width']).toEqual('44px');
@@ -281,15 +281,51 @@ describe('FullscreenTable', () => {
     test("when the page has resized", () => {
 
       // resize window and content column
-      document.querySelector('main').setAttribute('style', 'width: 720px');
+      document.querySelector('main').setAttribute('style', 'width: 668px');
       screenMock.window.resizeTo({ height: 768, width: 960 });
 
-      // table should set its width to be that of `<main>`, minus margin-left for the row numbers column
-      expect(window.getComputedStyle(tableFrame)['width']).toEqual('680px'); // width of content column - numbers column
-      expect(window.getComputedStyle(tableFrame)['margin-left']).toEqual('40px'); // width of numbers column
+      // table should set its width to be that of `<main>`
+      expect(window.getComputedStyle(tableFrame)['width']).toEqual('668px');
 
       // table for number column has 4px extra to allow space for drop shadow
       expect(window.getComputedStyle(numberColumnFrame)['width']).toEqual('44px');
+
+    });
+
+  });
+
+  // the layout algorithms browsers use can make the first column different between tables so detection and a fix are both requried
+  describe('the first column of both the scrollable table and that with fixed row headers should be the same width', () => {
+
+    afterEach(() => {
+
+      screenMock.reset();
+
+    });
+
+    // table dimensions are set when the module starts and on page resizes
+    // we can't fake the columns being different when it starts so our test needs to run after a resize
+    test('when the page has resized', () => {
+
+      let invisibleScrollableTopLeftCell;
+      let fixedTopLeftHeaderCell;
+
+      // set main content column width (used by module as gauge for table width)
+      screenMock.window.setWidthTo(1024);
+      document.querySelector('main').setAttribute('style', 'width: 712px');
+
+      // start module
+      window.GOVUK.notifyModules.start();
+
+      invisibleScrollableTopLeftCell = document.querySelector('.fullscreen-scrollable-table .table-field-heading-first');
+      fixedTopLeftHeaderCell = document.querySelector('.fullscreen-fixed-table .table-field-heading-first');
+
+      invisibleScrollableTopLeftCell.setAttribute('style', 'width: 30px');
+      fixedTopLeftHeaderCell.setAttribute('style', 'width: 9px');
+
+      screenMock.window.resizeTo({ height: 1000, width: 600 });
+
+      expect(window.getComputedStyle(invisibleScrollableTopLeftCell)['width']).toEqual('9px');
 
     });
 


### PR DESCRIPTION
Bring back in changes from https://github.com/alphagov/notifications-admin/pull/5010 by reverting [the merge that reverted the original changes](alphagov/notifications-admin#5025).