### PR TITLE
Bump utils to 76.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,12 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.275'
+  rev: 'v0.3.7'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/psf/black
-  rev: 24.3.0
+  rev: 24.4.0
   hooks:
     - id: black
       name: black (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length = 120
 
 target-version = "py311"
 
-select = [
+lint.select = [
     "E",  # pycodestyle
     "W",  # pycodestyle
     "F",  # pyflakes
@@ -15,7 +15,7 @@ select = [
     "C90",  # mccabe cyclomatic complexity
     "G"  # flake8-logging-format
 ]
-ignore = []
+lint.ignore = []
 exclude = [
     "venv*",
     "__pycache__",

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ rtreelib==0.2.0
 fido2==1.1.0
 
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.2
 govuk-frontend-jinja==2.8.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.2
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-black==24.3.0  # Also update `.pre-commit-config.yaml` if this changes
-ruff==0.0.275  # Also update `.pre-commit-config.yaml` if this changes
+black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes
 pytest==7.2.0
 pytest-env==0.8.1
 pytest-mock==3.10.0

--- a/tests/app/models/test_webauthn_credential.py
+++ b/tests/app/models/test_webauthn_credential.py
@@ -33,8 +33,8 @@ def test_from_registration_verifies_response(webauthn_dev_server):
     assert credential.registration_response == base64.b64encode(cbor.encode(registration_response)).decode("utf-8")
 
     credential_data = credential.to_credential_data()
-    assert type(credential_data.credential_id) is bytes
-    assert type(credential_data.aaguid) is Aaguid
+    assert isinstance(credential_data.credential_id, bytes)
+    assert isinstance(credential_data.aaguid, Aaguid)
     assert isinstance(credential_data.aaguid, bytes)
     assert credential_data.public_key[3] == ES256.ALGORITHM
 
@@ -49,8 +49,8 @@ def test_from_registration_encodes_as_unicode(webauthn_dev_server):
 
     serialized_credential = credential.serialize()
 
-    assert type(serialized_credential["credential_data"]) == str
-    assert type(serialized_credential["registration_response"]) == str
+    assert isinstance(serialized_credential["credential_data"], str)
+    assert isinstance(serialized_credential["registration_response"], str)
 
 
 def test_from_registration_handles_library_errors(notify_admin):


### PR DESCRIPTION
 ## 76.0.2

* linting changes

 ## 76.0.1

* Reject Gibraltar’s postcode (`GX11 1AA`) when validating postal addresses

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/76.0.0...76.0.2