### PR TITLE
Update details of who cannot use Notify

### DIFF
--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -41,6 +41,14 @@
     <li>universities</li>
   </ul>
 
+<h2 class="govuk-heading-m" id="suppliers">Suppliers</h2>
+  <p class="govuk-body">
+    If you’re doing work for a public sector organisation you can use GOV.UK&nbsp;Notify.
+  </p>
+  <p class="govuk-body">
+    Someone from the public sector organisation you’re working with needs to set up the account. Then they can invite you as a team member.
+  </p>
+
   <h2 class="govuk-heading-m" id="gp">GP surgeries</h2>
   <p class="govuk-body">
     NHS-funded GP surgeries can use GOV.UK Notify, but they:
@@ -52,14 +60,6 @@
 
   <p class="govuk-body">This is because GP surgeries will be able to use <a class="govuk-link govuk-link--no-visited-state" href="https://digital.nhs.uk/services/nhs-notify">NHS Notify to send messages</a>.</p>
   <p class="govuk-body">NHS Notify should be available to GP surgeries in 2025.</p>
-
-<h2 class="govuk-heading-m" id="suppliers">Suppliers</h2>
-  <p class="govuk-body">
-    If you’re doing work for a public sector organisation you can use GOV.UK&nbsp;Notify.
-  </p>
-  <p class="govuk-body">
-    Someone from the public sector organisation you’re working with needs to set up the account. Then they can invite you as a team member.
-  </p>
 
   <h2 class="govuk-heading-m" id="public">Members of the public</h2>
   <p class="govuk-body">

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -27,12 +27,11 @@
     <li><a class="govuk-link govuk-link--no-visited-state" href="#gp">GP surgeries</a></li>
     <li>state-funded schools</li>
   </ul>
-
-  <p class="govuk-body">GOV.UK Notify is not intended for personal use by individuals working in the public sector.</p>
-
   <p class="govuk-body">
     If you work for one of these organisations but get an error when you try to create an account, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact support</a>.
   </p>
+
+  <p class="govuk-body">GOV.UK Notify is not intended for personal use by individuals working in the public sector.</p>
 
   <p class="govuk-body">
     GOV.UK Notify is not available to:

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -31,6 +31,16 @@
     If you work for one of these organisations but get an error when you try to create an account, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact support</a>.
   </p>
 
+  <p class="govuk-body">
+    GOV.UK Notify is not available to:
+  </p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>charities</li>
+    <li>housing associations</li>
+    <li>members of the public</li>
+    <li>universities</li>
+  </ul>
+
   <h2 class="govuk-heading-m" id="gp">GP surgeries</h2>
   <p class="govuk-body">
     NHS-funded GP surgeries can use GOV.UK Notify, but they:
@@ -49,16 +59,6 @@
   </p>
   <p class="govuk-body">
     Someone from the public sector organisation you’re working with needs to set up the account. Then they can invite you as a team member.
-  </p>
-
-  <h2 class="govuk-heading-m" id="universities">Universities</h2>
-  <p class="govuk-body">
-    GOV.UK Notify is not available to universities.
-  </p>
-
-  <h2 class="govuk-heading-m" id="charities">Charities</h2>
-  <p class="govuk-body">
-    GOV.UK Notify is not currently available to charities.
   </p>
 
   <h2 class="govuk-heading-m" id="public">Members of the public</h2>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -16,17 +16,20 @@
   ) }}
 
   <p class="govuk-body">
-    GOV.UK Notify is available to:
+    GOV.UK Notify is available for teams from:
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>central government departments</li>
     <li>local authorities</li>
     <li>the armed forces</li>
     <li>the NHS</li>
-    <li>emergency services</li>
+    <li>the emergency services</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#gp">GP surgeries</a></li>
     <li>state-funded schools</li>
   </ul>
+
+  <p class="govuk-body">GOV.UK Notify is not intended for personal use by individuals working in the public sector.</p>
+
   <p class="govuk-body">
     If you work for one of these organisations but get an error when you try to create an account, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact support</a>.
   </p>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -16,7 +16,7 @@
   ) }}
 
   <p class="govuk-body">
-    GOV.UK Notify is available for teams from:
+    GOV.UK Notify is available to teams from:
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>central government departments</li>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -20,11 +20,11 @@
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>central government departments</li>
-    <li>emergency services</li>
     <li>local authorities</li>
     <li>the armed forces</li>
     <li>the NHS</li>
-    <li>GP surgeries</li>
+    <li>emergency services</li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#gp">GP surgeries</a></li>
     <li>state-funded schools</li>
   </ul>
   <p class="govuk-body">

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -31,7 +31,7 @@
     If you work for one of these organisations but get an error when you try to create an account, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact support</a>.
   </p>
 
-  <p class="govuk-body">GOV.UK Notify is not intended for personal use by individuals working in the public sector.</p>
+  <p class="govuk-body">GOV.UK Notify is not for personal use.</p>
 
   <p class="govuk-body">
     GOV.UK Notify is not available to:

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -36,6 +36,7 @@
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>charities</li>
+    <li>hospices</li>
     <li>housing associations</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#public">members of the public</a></li>
     <li>universities</li>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -37,7 +37,7 @@
   <ul class="govuk-list govuk-list--bullet">
     <li>charities</li>
     <li>housing associations</li>
-    <li>members of the public</li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#public">members of the public</a></li>
     <li>universities</li>
   </ul>
 


### PR DESCRIPTION
This PR adds `housing associations` and `hospices` to the list of organisations that cannot use GOV.UK Notify.

As this list is getting longer, I've also reformatted the information to stop the page from getting too long and to put the list of ineligible organisations closer to the list of eligible organisations.

I’ve also tried to make clear that Notify is for public sector teams running services – not individuals who happen to work in the public sector.