### PR TITLE
Add permissions decorator to all letter branding endpoints

### DIFF
--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -607,6 +607,7 @@ def letter_branding_options(service_id):
 
 
 @main.route("/services/<uuid:service_id>/service-settings/letter-branding/request", methods=["GET", "POST"])
+@user_has_permissions("manage_service")
 def letter_branding_request(service_id):
     form = BrandingRequestForm()
     from_template = _letter_branding_flow_query_params()["from_template"]
@@ -652,6 +653,7 @@ def letter_branding_request(service_id):
 
 
 @main.route("/services/<uuid:service_id>/service-settings/letter-branding/upload-branding", methods=["GET", "POST"])
+@user_has_permissions("manage_service")
 def letter_branding_upload_branding(service_id):
     form = LetterBrandingUploadBranding()
     if form.validate_on_submit():
@@ -696,6 +698,7 @@ def _should_set_default_org_letter_branding(branding_choice):
 
 
 @main.route("/services/<uuid:service_id>/service-settings/letter-branding/set-name", methods=["GET", "POST"])
+@user_has_permissions("manage_service")
 def letter_branding_set_name(service_id):
     letter_branding_data = _letter_branding_flow_query_params()
     temporary_logo_key = letter_branding_data["temp_filename"]

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -258,7 +258,9 @@ ORGANISATION_ID_ARGUMENT = "org_id"
 def get_routes_and_decorators(argument_name=None):
     import app.main.views as views
 
-    for module_name, module in inspect.getmembers(views) + inspect.getmembers(views.organisations):
+    for module_name, module in (
+        inspect.getmembers(views) + inspect.getmembers(views.organisations) + inspect.getmembers(views.service_settings)
+    ):
         for function_name, function in inspect.getmembers(module):
             if inspect.isfunction(function):
                 decorators = list(get_decorators_for_function(function))
@@ -285,6 +287,10 @@ def test_code_to_extract_decorators_works_with_known_examples():
         "platform_admin.platform_admin",
         ["main.route", "user_is_platform_admin"],
     ) in list(get_routes_and_decorators())
+    assert (
+        "branding.letter_branding_request",
+        ["main.route", "user_has_permissions"],
+    ) in list(get_routes_and_decorators(SERVICE_ID_ARGUMENT))
 
 
 def test_routes_have_permissions_decorators():


### PR DESCRIPTION
Some letter branding endpoints were not checking if a user was logged in, which resulted in a `500` status code when trying to visit these pages and logged out.