### PR TITLE
Make button positions based on container size

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -5,7 +5,7 @@
 // - the height, calculated from the width, which is made of:
 //   - the width of the image, in container query width units: 100cqw
 //   - the height of the image as a fraction of the width: (1008 / 712)
-@mixin scalable_top($top) {
+@mixin scalable-top($top) {
   $max_height_of_image: 1008;
   $max_width_of_image: 712;
 
@@ -35,13 +35,13 @@
 .edit-template-link-letter-contact {
   @extend %edit-template-link;
 
+  @include scalable-top(285);
   // position underneath contact block
   left: 61.3%;
-  @include scalable_top(285);
 
   &:active {
+    @include scalable-top(285);
     margin-top: -2px;
-    @include scalable_top(285);
   }
 }
 
@@ -59,34 +59,34 @@
 
 .edit-template-link-letter-body {
   @extend %edit-template-link;
-  @include scalable_top(393);
+  @include scalable-top(393);
   left: -20px;
 
   &:active {
+    @include scalable-top(393);
     margin-top: -2px;
-    @include scalable_top(393);
   }
 }
 
 .edit-template-link-letter-postage {
   @extend %edit-template-link;
-  @include scalable_top(51);
+  @include scalable-top(51);
   left: 61.3%; // Aligns left edge to ‘Change sender address’ button
 
   &:active {
+    @include scalable-top(51);
     margin-top: -2px;
-    @include scalable_top(51);
   }
 }
 
 .edit-template-link-letter-branding {
   @extend %edit-template-link;
-  @include scalable_top(51);
+  @include scalable-top(51);
   left: 51px; // Aligns to left of logo area
 
   &:active {
+    @include scalable-top(51);
     margin-top: -2px;
-    @include scalable_top(51);
   }
 }
 
@@ -96,12 +96,12 @@
 
 .edit-template-link-get-ready-to-send {
   @extend %edit-template-link;
-  @include scalable_top(234);
+  @include scalable-top(234);
   left: 51px; // Aligns to left of logo area
 
   &:active {
+    @include scalable-top(234);
     margin-top: -2px;
-    @include scalable_top(234);
   }
 }
 

--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -1,4 +1,22 @@
+// Function to make distance from the top scale when the image of the first page of the letter PDF does
+// We go by the image's largest dimensions, which are: 712px width and 1008px height
+// It has 2 parts:
+// - the fraction of the height of the image (1008) the distance from the top (285) represents: (285 / 1008)
+// - the height, calculated from the width, which is made of:
+//   - the width of the image, in container query width units: 100cqw
+//   - the height of the image as a fraction of the width: (1008 / 712)
+@mixin scalable_top($top) {
+  $max_height_of_image: 1008;
+  $max_width_of_image: 712;
+
+  top: $top * 1px; // for browsers that don't support container queries
+  top: calc((#{$top} / #{$max_height_of_image}) * (100cqw * (#{$max_height_of_image} / #{$max_width_of_image})));
+}
+
 .template-container {
+  container-name: template-container;
+  container-type: inline-size;
+
   position: relative;
 
   &--with-attach-pages-button {
@@ -19,11 +37,11 @@
 
   // position underneath contact block
   left: 61.3%;
-  top: 285px;
+  @include scalable_top(285);
 
   &:active {
     margin-top: -2px;
-    top: 285px;
+    @include scalable_top(285);
   }
 }
 
@@ -41,32 +59,34 @@
 
 .edit-template-link-letter-body {
   @extend %edit-template-link;
-  top: 393px; // aligns to top of subject
+  @include scalable_top(393);
   left: -20px;
+
   &:active {
     margin-top: -2px;
-    top: 393px;
+    @include scalable_top(393);
   }
 }
 
 .edit-template-link-letter-postage {
   @extend %edit-template-link;
-  top: 51px; // aligns bottom edge to bottom of postmark
+  @include scalable_top(51);
   left: 61.3%; // Aligns left edge to ‘Change sender address’ button
 
   &:active {
     margin-top: -2px;
-    top: 51px;
+    @include scalable_top(51);
   }
 }
 
 .edit-template-link-letter-branding {
   @extend %edit-template-link;
-  top: 51px; // aligns with ‘change postage’ link
+  @include scalable_top(51);
   left: 51px; // Aligns to left of logo area
+
   &:active {
     margin-top: -2px;
-    top: 51px;
+    @include scalable_top(51);
   }
 }
 
@@ -76,11 +96,12 @@
 
 .edit-template-link-get-ready-to-send {
   @extend %edit-template-link;
-  top: 234px; // covers MDI barcode and aligns to bottom of contact block
+  @include scalable_top(234);
   left: 51px; // Aligns to left of logo area
+
   &:active {
     margin-top: -2px;
-    top: 234px;
+    @include scalable_top(234);
   }
 }
 


### PR DESCRIPTION
The size of the image for the preview of a letter scales relative to the viewport. This makes the top position of the 'edit' buttons do the same thing, using [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries).

<img width="987" alt="view of the letter preview page, with buttons positioned in different place ontop of an image odf the letter. There are arrows marking the width (with 'A') and height (with 'B') of the image, plus one ('C') for the position of a button relative to the top of the image." src="https://github.com/alphagov/notifications-admin/assets/87140/adebea10-80da-438e-8008-3ca298dafeaf">

# How it works

1. the image keeps its aspect ratio at whatever size so we can always apply it to the width (A) to get the height (B)
2. the image width is set to `100%` so it will always match that of it's container, which scales with the page
3. if we set the image container as the [container context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries#using_container_queries), we can access the image's dimensions in [container query units](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries#container_query_length_units)
4. finally, if we convert the top position of a button (C) to container query units, it will scale with the container (and so, the image).

# Browsers that don't know container queries

We still have some browsers in our support matrix that don't understand container queries:
- [which browsers understand them](https://caniuse.com/css-container-queries)
- [our browser support matrix](https://github.com/alphagov/notifications-manuals/wiki/Support-for-browsers,-email-clients-and-assistive-technologies#browsers)

For them, we just provide a static value, which will get used because CSS engines ignore any code they don't understand.