### PR TITLE
Adding validator for potentially malicious sender IDS

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -72,6 +72,7 @@ from app.main.validators import (
     FileIsVirusFree,
     IsAUKMobileNumberOrShortCode,
     IsNotAGenericSenderID,
+    IsNotAPotentiallyMaliciousSenderID,
     Length,
     MustContainAlphanumericCharacters,
     NoCommasInPlaceHolders,
@@ -1793,6 +1794,7 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
             ),
             DoesNotStartWithDoubleZero(),
             IsNotAGenericSenderID(),
+            IsNotAPotentiallyMaliciousSenderID(),
             IsAUKMobileNumberOrShortCode(),
         ],
     )

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -165,7 +165,7 @@ class IsNotAPotentiallyMaliciousSenderID:
         if field.data and field.data.lower() in self.potentially_malicious_sender_ids:
             current_app.logger.warning("User tried to set sender id to potentially malicious one: %s", field.data)
             raise ValidationError(
-                f"Text message sender ID cannot be ‘{field.data}’ - this is to protect recipients " f"from phishing"
+                f"Text message sender ID cannot be ‘{field.data}’ - this is to protect recipients " f"from phishing scams"
             )
 
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -165,7 +165,7 @@ class IsNotAPotentiallyMaliciousSenderID:
         if field.data and field.data.lower() in self.potentially_malicious_sender_ids:
             current_app.logger.warning("User tried to set sender id to potentially malicious one: %s", field.data)
             raise ValidationError(
-                f"Text message sender ID cannot be ‘{field.data}’ - this is to protect recipients " f"from phishing scams"
+                f"Text message sender ID cannot be ‘{field.data}’ - this is to protect recipients from phishing scams"
             )
 
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -146,6 +146,29 @@ class IsNotAGenericSenderID:
             raise ValidationError(self.message)
 
 
+class IsNotAPotentiallyMaliciousSenderID:
+    potentially_malicious_sender_ids = [
+        "amazon",
+        "evri",
+        "lloydsbank",
+        "coinbase",
+        "fromnab",
+        "nab",
+        "hsbc",
+        "natwest",
+        "tsb",
+        "barclays",
+        "nationwide",
+    ]
+
+    def __call__(self, form, field):
+        if field.data and field.data.lower() in self.potentially_malicious_sender_ids:
+            current_app.logger.warning("User tried to set sender id to potentially malicious one: %s", field.data)
+            raise ValidationError(
+                f"Text message sender ID cannot be ‘{field.data}’ - this is to protect recipients " f"from phishing"
+            )
+
+
 class IsAUKMobileNumberOrShortCode:
     number_regex = re.compile(r"^[0-9\.]+$")
     mobile_regex = re.compile(r"^07[0-9]{9}$")

--- a/tests/app/main/forms/test_service_sms_senders_form.py
+++ b/tests/app/main/forms/test_service_sms_senders_form.py
@@ -34,7 +34,7 @@ from app.main.forms import ServiceSmsSenderForm
         (
             "Evri",
             True,
-            "Text message sender ID cannot be ‘Evri’ - this is to protect recipients from phishing",
+            "Text message sender ID cannot be ‘Evri’ - this is to protect recipients from phishing scams",
         ),
         pytest.param("'UC'", False, None, marks=pytest.mark.xfail),  # Apostrophes can cause SMS delivery issues
     ],

--- a/tests/app/main/forms/test_service_sms_senders_form.py
+++ b/tests/app/main/forms/test_service_sms_senders_form.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from app.main.forms import ServiceSmsSenderForm
@@ -29,6 +31,11 @@ from app.main.forms import ServiceSmsSenderForm
         ("UK-GOV", False, None),  # Simple dashes are allowed
         ("UK.GOV", False, None),  # Full stops are allowed
         ("UK&GOV", False, None),  # Ampersands are allowed
+        (
+            "Evri",
+            True,
+            "Text message sender ID cannot be ‘Evri’ - this is to protect recipients from phishing",
+        ),
         pytest.param("'UC'", False, None, marks=pytest.mark.xfail),  # Apostrophes can cause SMS delivery issues
     ],
 )
@@ -43,3 +50,28 @@ def test_sms_sender_form_validation(client_request, mock_get_user_by_email, sms_
         assert error_message == form.errors["sms_sender"][0]
     else:
         assert not form.errors
+
+
+@pytest.mark.parametrize(
+    "sms_sender,log_expected,log_message",
+    [
+        ("UK&GOV", False, None),  # No warning log on valid senderID
+        (
+            "Evri",
+            True,
+            "User tried to set sender id to potentially malicious one: Evri",
+        ),
+    ],
+)
+def test_sms_validation_logs(caplog, sms_sender, log_expected, log_message):
+
+    form = ServiceSmsSenderForm()
+    form.sms_sender.data = sms_sender
+    with caplog.at_level(logging.WARNING):
+        form.validate()
+
+    if log_expected:
+        assert log_message in caplog.messages
+
+    else:
+        assert len(caplog.messages) == 0


### PR DESCRIPTION
Following on from an incident, it was identified that we could block senderids that were for companies, such as Evri etc.

This work is the initial effort in this regard, we will look at expanding this list of companies and perhaps keeping it in the database in later work.

The work is case insensitive for the sender IDs involved in the incident as well as some banks.

The error looks like 

![Screenshot 2024-04-26 at 16 22 18](https://github.com/alphagov/notifications-admin/assets/10772338/9a11e943-cfaf-4da2-aa43-a57831363d10)

@karlchillmaid when you have a moment could you review the error message?

