### PR TITLE
Enable error summary for platform admin letter branding edit

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1958,7 +1958,7 @@ class AdminEditEmailBrandingForm(StripWhitespaceForm):
         "Alt text", param_extensions={"hint": {"text": "Text for people who cannot see the logo"}}
     )
     colour = HexColourCodeField("Colour")
-    file = VirusScannedFileField("Upload a PNG logo", validators=[FileAllowed(["png"], "PNG Images only!")])
+    file = VirusScannedFileField("Upload a PNG logo", validators=[FileAllowed(["png"], "The logo must be a PNG file")])
     brand_type = GovukRadiosField(
         "Brand type",
         choices=[
@@ -2050,7 +2050,7 @@ class AdminEditLetterBrandingSVGUploadForm(StripWhitespaceForm):
     file = VirusScannedFileField(
         "Upload an SVG logo",
         validators=[
-            FileAllowed(["svg"], "SVG Images only!"),
+            FileAllowed(["svg"], "The logo must be an SVG file"),
             DataRequired(message="You need to upload a file to submit"),
             NoEmbeddedImagesInSVG(),
             NoTextInSVG(),

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -106,6 +106,7 @@ def update_letter_branding(branding_id):
         cdn_url=current_app.config["LOGO_CDN_DOMAIN"],
         logo=logo_key,
         is_update=True,
+        error_summary_enabled=True,
     )
 
 

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -247,7 +247,7 @@ def test_update_letter_branding_when_uploading_invalid_file(
     )
 
     assert page.select_one("h1").text == "Update letter branding"
-    assert page.select_one(".error-message").text.strip() == "SVG Images only!"
+    assert page.select_one(".error-message").text.strip() == "The logo must be an SVG file"
 
 
 def test_update_letter_branding_with_original_file_and_new_details(
@@ -542,7 +542,7 @@ def test_create_letter_branding_when_uploading_invalid_file(
         _follow_redirects=True,
     )
     assert page.select_one("h1").text == "Add letter branding"
-    assert page.select_one(".error-message").text.strip() == "SVG Images only!"
+    assert page.select_one(".error-message").text.strip() == "The logo must be an SVG file"
 
 
 def test_create_new_letter_branding_shows_preview_of_logo(client_request, platform_admin_user, fake_uuid, logo_client):

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -106,7 +106,7 @@ describe('File upload', () => {
 
     var buttonLabel;
 
-    uploadLabel.innerHTML += '<span class="error-message">PNG images only!</span>';
+    uploadLabel.innerHTML += '<span class="error-message">The logo must be a PNG file</span>';
 
     // start module
     window.GOVUK.notifyModules.start();
@@ -116,7 +116,7 @@ describe('File upload', () => {
     expect(buttonLabel).not.toBeNull();
 
     // The button's label should include its existing text and the validation errors added together
-    expect(buttonLabel.textContent.trim().replace(/\s{2,}/g, ' ')).toEqual("Upload logo PNG images only!");
+    expect(buttonLabel.textContent.trim().replace(/\s{2,}/g, ' ')).toEqual("Upload logo The logo must be a PNG file");
 
   });
 


### PR DESCRIPTION
https://trello.com/c/Uu9YoBkj/710-make-forms-for-uploading-files-meet-validation-requirements

This is the first page to be fixed for that trello ticket. On an error with the file upload, it:

- adds ‘Error: ’ to the beginning of the page <title> so screen readers read it out as soon as possible
- shows an error summary at the top of the page, and move keyboard focus to it
- shows error messages next to fields with errors

I'm less sure on the criteria 'show them the page again, with the form fields as the user filled them in' as we don't show them the bad logo they uploaded. Should we be?

I used my initiative to change the error message to something more consistent and less informal. I copied the pattern from the form below which we show to our users which uses 'Branding must be an SVG file'. It may not be perfect, but I think it is a bit better than what we had before.

To trigger the below screenshots, I hacked the HTML code on the page to remove the SVG upload restriction so I could submit a JPG file.

## Before

<img width="1790" alt="image" src="https://github.com/alphagov/notifications-admin/assets/7228605/d5f32089-5778-4098-9572-6a63b2612a14">

## After

<img width="1789" alt="image" src="https://github.com/alphagov/notifications-admin/assets/7228605/f09cc2ee-bec2-421f-aa7f-e0a2ed951f3f">
