### PR TITLE
Fix set-letter-branding preview javascript

### DIFF
--- a/app/assets/javascripts/previewPane.js
+++ b/app/assets/javascripts/previewPane.js
@@ -13,7 +13,13 @@
   const $paneWrapper = $('<div class="govuk-grid-column-full"></div>');
   const $form = $('form');
   const previewType = $form.data('previewType');
-  const $previewPane = $(`<iframe src="/_${previewType}?${buildQueryString(['branding_style', branding_style])}" class="branding-preview" scrolling="no"></iframe>`);
+  const letterBrandingPreviewRootPath = `templates/${previewType}-preview-image`;
+  const $iframePreviewPane = $(`<iframe src="/_${previewType}?${buildQueryString(['branding_style', branding_style])}" class="branding-preview" scrolling="no"></iframe>`);
+  const $imagePreviewPane = $(
+    `<div class="branding-preview-image">
+      <img src="/${letterBrandingPreviewRootPath}?${buildQueryString(['branding_style', branding_style])}" alt="Preview of selected letter branding">
+    </div>`
+  );
 
   function buildQueryString () {
     return $.map(arguments, (val, idx) => encodeURI(val[0]) + '=' + encodeURI(val[1])).join('&');
@@ -24,10 +30,20 @@
     if ($target.attr('name') == 'branding_style') {
       branding_style = $target.val();
     }
-    $previewPane.attr('src', `/_${previewType}?${buildQueryString(['branding_style', branding_style])}`);
+
+    if (previewType === 'letter') {
+      $imagePreviewPane.find('img').attr('src', `/${letterBrandingPreviewRootPath}?${buildQueryString(['branding_style', branding_style])}`);
+    } else {
+      $iframePreviewPane.attr('src', `/_${previewType}?${buildQueryString(['branding_style', branding_style])}`);
+    }
   }
 
-  $paneWrapper.append($previewPane);
+  if (previewType === 'letter') {
+    $paneWrapper.append($imagePreviewPane);
+  } else {
+    $paneWrapper.append($iframePreviewPane);
+  }
+
   $form.find('.govuk-grid-row').eq(0).prepend($paneWrapper);
   $form.attr('action', location.pathname.replace(new RegExp(`set-${previewType}-branding$`), `preview-${previewType}-branding`));
   $form.find('button').text('Save');

--- a/tests/javascripts/previewPane.test.js
+++ b/tests/javascripts/previewPane.test.js
@@ -179,7 +179,7 @@ describe('Preview pane', () => {
         // run preview pane script
         require('../../app/assets/javascripts/previewPane.js');
 
-        expect(document.querySelector('iframe')).not.toBeNull();
+        expect(document.querySelector('img')).not.toBeNull();
 
       });
 
@@ -199,7 +199,7 @@ describe('Preview pane', () => {
 
         const selectedValue = Array.from(radios.querySelectorAll('input[type=radio]')).filter(radio => radio.checked)[0].value;
 
-        expect(document.querySelector('iframe').getAttribute('src')).toEqual(`/_letter?branding_style=${selectedValue}`);
+        expect(document.querySelector('img').getAttribute('src')).toEqual(`/templates/letter-preview-image?branding_style=${selectedValue}`);
 
       });
 
@@ -225,7 +225,7 @@ describe('Preview pane', () => {
 
         helpers.moveSelectionToRadio(newSelection);
 
-        expect(document.querySelector('iframe').getAttribute('src')).toEqual(`/_letter?branding_style=${newSelection.value}`);
+        expect(document.querySelector('img').getAttribute('src')).toEqual(`/templates/letter-preview-image?branding_style=${newSelection.value}`);
 
       });
 


### PR DESCRIPTION
As we've changed the way we serve letter branding previews from iframe to image, we need to update
the admin brand preview on `set-letter-branding` platform admin route to serve them in an image as well.

No change to email and sms brand previews

Fixes: https://trello.com/c/egKyrIg1/717-fix-js-for-platform-admin-set-letter-branding-page

As we previously did not make any aria live roles on the iframe, I'm not sure if we want them now either?

**Before**
![image](https://github.com/alphagov/notifications-admin/assets/3758555/32c11066-4935-4590-8756-cee8d372d692)



**After**
![Screenshot 2024-04-30 at 11 49 29](https://github.com/alphagov/notifications-admin/assets/3758555/af13f44b-8e2a-41e6-acd6-06b5dc914b8a)
