### PR TITLE
Use hidden attribute instead of pure CSS to hide things in cookies page

### DIFF
--- a/app/assets/javascripts/cookieSettings.js
+++ b/app/assets/javascripts/cookieSettings.js
@@ -5,12 +5,14 @@ window.GOVUK.NotifyModules = window.GOVUK.NotifyModules || {};
   function CookieSettings () {}
 
   CookieSettings.prototype.start = function ($module) {
+    var settingsForm = document.querySelector('form[data-notify-module=cookie-settings]');
+
     this.$module = $module[0];
 
     this.$module.submitSettingsForm = this.submitSettingsForm.bind(this);
 
-    document.querySelector('form[data-notify-module=cookie-settings]')
-      .addEventListener('submit', this.$module.submitSettingsForm);
+    settingsForm.removeAttribute('hidden');
+    settingsForm.addEventListener('submit', this.$module.submitSettingsForm);
 
     this.setInitialFormValues();
   };
@@ -72,7 +74,7 @@ window.GOVUK.NotifyModules = window.GOVUK.NotifyModules || {};
       previousPageLink.style.display = "none";
     }
 
-    confirmationMessage.style.display = "block";
+    confirmationMessage.removeAttribute('hidden');
   };
 
   CookieSettings.prototype.getReferrerLink = function () {
@@ -81,4 +83,3 @@ window.GOVUK.NotifyModules = window.GOVUK.NotifyModules || {};
 
   Modules.CookieSettings = CookieSettings;
 })(window.GOVUK.NotifyModules);
-

--- a/app/assets/stylesheets/views/cookies.scss
+++ b/app/assets/stylesheets/views/cookies.scss
@@ -1,17 +1,10 @@
-.cookie-settings__form-wrapper {
-  display: none;
-
-  .js-enabled & {
-    display: block;
-  }
-}
-
 .cookie-settings__no-js {
   .js-enabled & {
     display: none;
   }
 }
 
-.cookie-settings__confirmation {
+// Override display:block inherited from banner styles
+.cookie-settings__confirmation[hidden] {
   display: none;
 }

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="cookie-settings__confirmation banner banner-with-tick" data-cookie-confirmation="true" role="group" tabindex="-1">
+    <div class="cookie-settings__confirmation banner banner-with-tick" data-cookie-confirmation="true" role="group" tabindex="-1" hidden>
       <h2 class="banner-title">Your cookie settings were saved</h2>
       <a class="govuk_link cookie-settings__prev-page govuk-!-margin-top-1" href="#" data-notify-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
         Go back to the page you were looking at
@@ -119,34 +119,32 @@
         <li>turning on Javascript in your browser</li>
       </ul>
     </div>
-    <div class="cookie-settings__form-wrapper">
-      <form data-notify-module="cookie-settings">
-        <div class="govuk-form-group govuk-!-margin-top-6">
-          <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-              Do you want to accept analytics cookies?
-            </legend>
-            <div class="govuk-radios govuk-radios--inline">
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies-analytics" type="radio" value="on">
-                <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
-                  Yes
-                </label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies-analytics" type="radio" value="off">
-                <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
-                  No
-                </label>
-              </div>
+    <form class="cookie-settings__form" data-notify-module="cookie-settings" hidden>
+      <div class="govuk-form-group govuk-!-margin-top-6">
+        <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            Do you want to accept analytics cookies?
+          </legend>
+          <div class="govuk-radios govuk-radios--inline">
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies-analytics" type="radio" value="on">
+              <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
+                Yes
+              </label>
             </div>
-          </fieldset>
-        </div>
-        {{ govukButton({
-          "text": "Save cookie settings"
-        }) }}
-      </form>
-    </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies-analytics" type="radio" value="off">
+              <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      {{ govukButton({
+        "text": "Save cookie settings"
+      }) }}
+    </form>
   </div>
 </div>
 

--- a/tests/javascripts/cookieSettings.test.js
+++ b/tests/javascripts/cookieSettings.test.js
@@ -32,7 +32,7 @@ describe("Cookie settings", () => {
     jest.spyOn(window.GOVUK, 'initAnalytics');
 
     cookiesPageContent = `
-      <div class="cookie-settings__confirmation banner banner-with-tick" data-cookie-confirmation="true" role="group" tabindex="-1">
+      <div class="cookie-settings__confirmation banner banner-with-tick" data-cookie-confirmation="true" role="group" tabindex="-1" hidden>
         <h2 class="banner-title">Your cookie settings were saved</h2>
         <a class="govuk_link govuk_link--no-visited-state cookie-settings__prev-page" href="#" data-notify-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
           Go back to the page you were looking at
@@ -52,32 +52,30 @@ describe("Cookie settings", () => {
         </ul>
       </div>
       <h2 class="heading-medium">Analytics cookies (optional)</h2>
-      <div class="cookie-settings__form-wrapper">
-        <form data-notify-module="cookie-settings">
-          <div class="govuk-form-group govuk-!-margin-top-6">
-            <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                Do you want to accept analytics cookies?
-              </legend>
-              <div class="govuk-radios govuk-radios--inline">
-                <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies-analytics" type="radio" value="on">
-                  <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
-                    Yes
-                  </label>
-                </div>
-                <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies-analytics" type="radio" value="off">
-                  <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
-                    No
-                  </label>
-                </div>
+      <form class="cookie-settings__form" data-notify-module="cookie-settings" hidden>
+        <div class="govuk-form-group govuk-!-margin-top-6">
+          <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Do you want to accept analytics cookies?
+            </legend>
+            <div class="govuk-radios govuk-radios--inline">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies-analytics" type="radio" value="on">
+                <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
+                  Yes
+                </label>
               </div>
-            </fieldset>
-          </div>
-          <button class="govuk-button" data-module="govuk-button">Save cookie settings</button>
-        </form>
-      </div>`;
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies-analytics" type="radio" value="off">
+                <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
+                  No
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <button class="govuk-button" data-module="govuk-button">Save cookie settings</button>
+      </form>`;
 
     document.body.innerHTML += cookiesPageContent;
 
@@ -112,10 +110,22 @@ describe("Cookie settings", () => {
 
           The message displayed to confirm any selection made is also in the page but hidden on load.
 
-    Both of these work through CSS, based on the presence of the `js-enabled` class on the <body> so are not tested here.
+    Both of these work through CSS. The former based on the presence of the `js-enabled` class on the <body>.
+    The later is hidden by the addition of a `hidden` attribute so are not tested here. Both don't use JS to
+    be hidden on load so that isn't tested here.
   */
 
   describe("When the page loads", () => {
+
+    test("the form to accept or reject analytics should be shown", () => {
+
+      expect(helpers.element(document.querySelector('form.cookie-settings__form')).is('hidden')).toBe(true);
+
+      window.GOVUK.notifyModules.start();
+
+      expect(helpers.element(document.querySelector('form.cookie-settings__form')).is('hidden')).toBe(false);
+
+    })
 
     test("If user has not chosen to accept or reject analytics, the radios for making that choice should be set to unchecked", () => {
 


### PR DESCRIPTION
Using this instead means we make explicit what's hidden when the page loads, in the HTML. It also means users won't see things they shouldn't if the CSS doesn't load, which is often raised as a requirement in accessibility accessments.

Having state represented in the HTML also makes it easier for our Python tests to know what's happening, because they often make assertions based on what's in the HTML of a returned page.