### PR TITLE
Re-enable the flake8 print check

### DIFF
--- a/get_zendesk_tickets.py
+++ b/get_zendesk_tickets.py
@@ -40,14 +40,14 @@ def get_tickets():
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
         while next_page:
-            print(next_page)
+            print(next_page)  # noqa
             response = requests.get(
                 next_page,
                 headers={"Content-type": "application/json"},
                 auth=(f"{NOTIFY_ZENDESK_EMAIL}/token", ZENDESK_API_KEY),
             )
             data = response.json()
-            print(data)
+            print(data)  # noqa
             for row in data["results"]:
                 service_url = [
                     x
@@ -84,14 +84,14 @@ def get_tickets_without_service_id():
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
         while next_page:
-            print(next_page)
+            print(next_page)  # noqa
             response = requests.get(
                 next_page,
                 headers={"Content-type": "application/json"},
                 auth=(f"{NOTIFY_ZENDESK_EMAIL}/token", ZENDESK_API_KEY),
             )
             data = response.json()
-            print(data)
+            print(data)  # noqa
             for row in data["results"]:
                 service_url = [
                     x
@@ -128,14 +128,14 @@ def get_tickets_with_description():
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
         while next_page:
-            print(next_page)
+            print(next_page)  # noqa
             response = requests.get(
                 next_page,
                 headers={"Content-type": "application/json"},
                 auth=(f"{NOTIFY_ZENDESK_EMAIL}/token", ZENDESK_API_KEY),
             )
             data = response.json()
-            print(data)
+            print(data)  # noqa
             for row in data["results"]:
                 writer.writerow(
                     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ lint.select = [
     "I",  # isort
     "B",  # flake8-bugbear
     "C90",  # mccabe cyclomatic complexity
-    "G"  # flake8-logging-format
+    "G",  # flake8-logging-format
+    "T20"  # flake8-print
 ]
 lint.ignore = []
 exclude = [


### PR DESCRIPTION
We don’t want print statements in production code – should be using logging instead.

Ruff doesn’t have this check on by default<sup>1</sup> so we need to explicitly include it.

The existing `print` statements in this codebase seem to be there intentionally (they are in a command not a public endpoint) so I’ve marked them as exempt from checking.

***

1. https://docs.astral.sh/ruff/rules/print/