### PR TITLE
Add `exec` to entrypoint to handle shutdowns gracefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ watch-frontend:  ## Build frontend and watch for changes
 run-flask:  ## Run flask
 	. environment.sh && flask run -p 6012
 
+.PHONY: run-flask-with-docker
+run-flask-with-docker: ## Run flask
+	./scripts/run_with_docker.sh web-local
+
 .PHONY: npm-audit
 npm-audit:  ## Check for vulnerabilities in NPM packages
 	source $(HOME)/.nvm/nvm.sh && npm run audit
@@ -63,6 +67,10 @@ test: ## Run tests
 .PHONY: watch-tests
 watch-tests: ## Watch tests and run on change
 	ptw --runner "pytest --testmon -n auto"
+
+.PHONY: test-with-docker
+test-with-docker: ## Run tests in Docker container
+	./scripts/run_with_docker.sh make test
 
 .PHONY: fix-imports
 fix-imports: ## Fix imports using ruff

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,15 +2,14 @@
 
 if [ "$1" == "web" ]
 then
-  gunicorn --error-logfile - -c /home/vcap/app/gunicorn_config.py application
+  exec gunicorn --error-logfile - -c /home/vcap/app/gunicorn_config.py application
 
 elif [ "$1" == "web-local" ]
 then
   npm run build
-  flask run --host 0.0.0.0 --port $PORT
+  exec flask run --host 0.0.0.0 --port $PORT
 
 else
-  echo -e "'\033[31m'FATAL: missing argument'\033[0m'" && exit 1
-  exit 1
-
+  echo "Running custom command"
+  exec $@
 fi

--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -3,12 +3,24 @@ DOCKER_IMAGE_NAME=notifications-admin
 
 source environment.sh
 
+REDIS_URL=${REDIS_URL:-"redis://host.docker.internal:6379"}
+ADMIN_BASE_URL=${ADMIN_BASE_URL:-"http://host.docker.internal:6012"}
+API_HOST_NAME=${API_HOST_NAME:-"http://host.docker.internal:6011"}
+TEMPLATE_PREVIEW_API_HOST=${TEMPLATE_PREVIEW_API_HOST:-"http://host.docker.internal:6013"}
+ANTIVIRUS_API_HOST=${ANTIVIRUS_API_HOST:-"http://host.docker.internal:6016"}
+
 docker run -it --rm \
   -e NOTIFY_ENVIRONMENT=development \
   -e FLASK_DEBUG=${FLASK_DEBUG:-1} \
+  -e WERKZEUG_DEBUG_PIN=${WERKZEUG_DEBUG_PIN:-"off"} \
   -e FLASK_APP=application.py \
   -e STATSD_ENABLED= \
   -e REDIS_ENABLED=${REDIS_ENABLED:-1} \
+  -e REDIS_URL=$REDIS_URL \
+  -e ADMIN_BASE_URL=${ADMIN_BASE_URL:-"http://host.docker.internal:6012"} \
+  -e API_HOST_NAME=${API_HOST_NAME:-"http://host.docker.internal:6011"} \
+  -e TEMPLATE_PREVIEW_API_HOST=${TEMPLATE_PREVIEW_API_HOST:-"http://host.docker.internal:6013"} \
+  -e ANTIVIRUS_API_HOST=${ANTIVIRUS_API_HOST:-"http://host.docker.internal:6016"} \
   -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-$(aws configure get aws_access_key_id)} \
   -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-$(aws configure get aws_secret_access_key)} \
   -e SENTRY_ENABLED=${SENTRY_ENABLED:-0} \

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 import pytest
 import requests
-from flask import Response, g, url_for
+from flask import Response, current_app, g, url_for
 from flask_wtf.csrf import CSRFError
 from notifications_python_client.errors import HTTPError
 
@@ -137,7 +137,9 @@ def test_api_error_response_logging(
     response.status_code = 400
     response.headers["content-type"] = "application/json"
     response.raw = BytesIO(b'{"message": "not found"}')
-    response.url = "http://localhost:6012/user/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/organisations-and-services"
+    response.url = (
+        f"{current_app.config['ADMIN_BASE_URL']}/user/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/organisations-and-services"
+    )
     requests_mock.get(
         "http://you-forgot-to-mock-an-api-call-to/user/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/organisations-and-services",
         exc=requests.HTTPError(response=response),
@@ -149,6 +151,7 @@ def test_api_error_response_logging(
         )
 
     assert (
-        "API http://localhost:6012/user/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/organisations-and-services "
+        f"API {current_app.config['ADMIN_BASE_URL']}"
+        "/user/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/organisations-and-services "
         "failed with status=400, message='not found'"
     ) in caplog.messages

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -1,5 +1,7 @@
 from unittest.mock import ANY
 
+from flask import current_app
+
 from app import invite_api_client
 
 
@@ -41,7 +43,7 @@ def test_client_creates_invite(
             "service": "67890",
             "created_by": ANY,
             "permissions": "send_emails,send_letters,send_texts",
-            "invite_link_host": "http://localhost:6012",
+            "invite_link_host": current_app.config["ADMIN_BASE_URL"],
             "folder_permissions": [fake_uuid],
         },
     )

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -2,6 +2,7 @@ import uuid
 from unittest.mock import Mock, call
 
 import pytest
+from flask import current_app
 from notifications_python_client.errors import HTTPError
 
 from app import invite_api_client, service_api_client, user_api_client
@@ -85,7 +86,7 @@ def test_client_passes_admin_url_when_sending_email_auth(
         f"/user/{fake_uuid}/email-code",
         data={
             "to": "ignored@example.com",
-            "email_auth_link_host": "http://localhost:6012",
+            "email_auth_link_host": current_app.config["ADMIN_BASE_URL"],
         },
     )
 
@@ -315,7 +316,7 @@ def test_reset_password(
         "/user/reset-password",
         data={
             "email": "test@example.com",
-            "admin_base_url": "http://localhost:6012",
+            "admin_base_url": current_app.config["ADMIN_BASE_URL"],
         },
     )
 
@@ -332,6 +333,6 @@ def test_send_registration_email(
         f"/user/{fake_uuid}/email-verification",
         data={
             "to": "test@example.com",
-            "admin_base_url": "http://localhost:6012",
+            "admin_base_url": current_app.config["ADMIN_BASE_URL"],
         },
     )


### PR DESCRIPTION
We are already using the entrypoint for the app, but we want to run the entrypoint commands with `exec` to handle terminations gracefully.

This also adds a few changes to allow the tests to be run with Docker and the app to be run on its own (not as part of notifications-local).