### PR TITLE
Save selection when going back to first page in email or letter branding journey

### DIFF
--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -82,6 +82,7 @@ def email_branding_options(service_id):
                     ".branding_option_preview",
                     service_id=current_service.id,
                     branding_option=branding_choice,
+                    branding_choice=branding_choice,
                     branding_type="email",
                 )
             )
@@ -505,7 +506,9 @@ def branding_option_preview(service_id, branding_type):
     else:
         branding_pool = current_service.letter_branding_pool
     try:
-        chosen_branding = branding_pool.get_item_by_id(request.args.get("branding_option"))
+        chosen_branding = branding_pool.get_item_by_id(
+            request.args.get("branding_choice", request.args.get("branding_option"))
+        )
     except branding_pool.NotFound:
         flash("No branding found for this id.")
         return redirect(url_for(f".{branding_type}_branding_options", service_id=current_service.id))
@@ -589,6 +592,7 @@ def letter_branding_options(service_id):
                     ".branding_option_preview",
                     service_id=current_service.id,
                     branding_option=branding_choice,
+                    branding_choice=branding_choice,
                     branding_type="letter",
                 )
             )

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -61,6 +61,7 @@ def create_email_branding_zendesk_ticket(detail=None):
 @user_has_permissions("manage_service")
 def email_branding_options(service_id):
     form = ChooseEmailBrandingForm(current_service)
+    form.options.data = form.options.data or request.args.get("branding_choice")
 
     if form.validate_on_submit():
         branding_choice = form.options.data
@@ -599,6 +600,7 @@ def _letter_branding_flow_query_params(**kwargs):
 @user_has_permissions("manage_service")
 def letter_branding_options(service_id):
     form = ChooseLetterBrandingForm(current_service)
+    form.options.data = form.options.data or request.args.get("branding_choice")
     from_template = request.args.get("from_template")
 
     if form.validate_on_submit():

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -71,10 +71,13 @@ def email_branding_options(service_id):
                     ".branding_nhs",
                     service_id=current_service.id,
                     branding_type="email",
+                    branding_choice=branding_choice,
                 )
             )
         elif branding_choice == "govuk":
-            return redirect(url_for(".email_branding_govuk", service_id=current_service.id))
+            return redirect(
+                url_for(".email_branding_govuk", service_id=current_service.id, branding_choice=branding_choice)
+            )
 
         elif branding_choice in current_service.email_branding_pool.ids:
             return redirect(
@@ -583,6 +586,7 @@ def letter_branding_options(service_id):
                     ".branding_nhs",
                     service_id=current_service.id,
                     branding_type="letter",
+                    branding_choice=branding_choice,
                 )
             )
 

--- a/app/templates/views/service-settings/branding/email-branding-govuk.html
+++ b/app/templates/views/service-settings/branding/email-branding-govuk.html
@@ -13,7 +13,7 @@
 
 {% block backLink %}
   {{ govukBackLink({
-    "href": url_for('main.email_branding_options', service_id=current_service.id)
+    "href": back_link
   }) }}
 {% endblock %}
 

--- a/app/templates/views/service-settings/branding/new/email-branding-choose-logo.html
+++ b/app/templates/views/service-settings/branding/new/email-branding-choose-logo.html
@@ -11,7 +11,7 @@
 
 {% block backLink %}
   {{ govukBackLink({
-    "href": url_for('main.email_branding_options', service_id=current_service.id)
+    "href": back_link
   }) }}
 {% endblock %}
 

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -94,12 +94,31 @@ def test_email_branding_options_page_when_no_branding_is_set(
 
     button_text = normalize_spaces(page.select_one(".page-footer button").text)
 
+    assert not page.select(".govuk-radios__item input[checked]")
     assert [
         (radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip())
         for radio in page.select("input[type=radio]")
     ] == [(EmailBranding.NHS_ID, "NHS"), ("something_else", "Something else")]
 
     assert button_text == "Continue"
+
+
+def test_email_branding_options_shows_query_param_branding_choice_selected(
+    client_request, service_one, organisation_one, mocker, mock_get_email_branding_pool
+):
+    service_one["organisation"] = organisation_one
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_one,
+    )
+    page = client_request.get(
+        ".email_branding_options", service_id=SERVICE_ONE_ID, branding_choice="email-branding-2-id"
+    )
+
+    checked_radio_button = page.select(".govuk-radios__item input[checked]")
+
+    assert len(checked_radio_button) == 1
+    assert checked_radio_button[0]["value"] == "email-branding-2-id"
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -463,6 +463,7 @@ def test_email_branding_options_redirects_to_branding_preview_for_a_branding_poo
             "main.branding_option_preview",
             service_id=SERVICE_ONE_ID,
             branding_option="email-branding-1-id",
+            branding_choice="email-branding-1-id",
             branding_type="email",
         ),
     )

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -283,7 +283,7 @@ def test_email_branding_options_page_shows_preview_if_something_else_is_only_opt
             {"options": "govuk"},
             "central",
             "main.email_branding_govuk",
-            {},
+            {"branding_choice": "govuk"},
         ),
         (
             {"options": "govuk_and_org"},
@@ -319,7 +319,7 @@ def test_email_branding_options_page_shows_preview_if_something_else_is_only_opt
             {"options": EmailBranding.NHS_ID},
             "nhs_local",
             "main.branding_nhs",
-            {"branding_type": "email"},
+            {"branding_type": "email", "branding_choice": EmailBranding.NHS_ID},
         ),
     ),
 )
@@ -433,6 +433,7 @@ def test_email_branding_options_page_redirects_nhs_specific_page(
             "main.branding_nhs",
             service_id=SERVICE_ONE_ID,
             branding_type="email",
+            branding_choice=EmailBranding.NHS_ID,
         ),
     )
 

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -253,6 +253,7 @@ def test_letter_branding_options_redirects_to_nhs_page(
             "main.branding_nhs",
             service_id=SERVICE_ONE_ID,
             branding_type="letter",
+            branding_choice=LetterBranding.NHS_ID,
         ),
     )
 

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -162,6 +162,7 @@ def test_letter_branding_options_redirects_to_branding_preview_for_a_branding_po
             "main.branding_option_preview",
             service_id=SERVICE_ONE_ID,
             branding_option="1234",
+            branding_choice="1234",
             branding_type="letter",
         ),
     )

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -87,6 +87,7 @@ def test_letter_branding_options_page_when_no_branding_is_set(
     button_text = normalize_spaces(page.select_one(".page-footer button").text)
     assert button_text == "Continue"
 
+    assert not page.select(".govuk-radios__item input[checked]")
     assert [
         (radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip())
         for radio in page.select("input[type=radio]")
@@ -108,6 +109,22 @@ def test_letter_branding_options_page_when_branding_is_set_already(
         branding_style=fake_uuid,
     )
     assert page.select_one("main img")["alt"] == "Preview of current letter branding"
+
+
+def test_letter_branding_options_shows_query_param_branding_choice_selected(
+    client_request, service_one, organisation_one, mocker, mock_get_letter_branding_pool
+):
+    service_one["organisation"] = organisation_one
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_one,
+    )
+    page = client_request.get(".letter_branding_options", service_id=SERVICE_ONE_ID, branding_choice="1234")
+
+    checked_radio_button = page.select(".govuk-radios__item input[checked]")
+
+    assert len(checked_radio_button) == 1
+    assert checked_radio_button[0]["value"] == "1234"
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -346,7 +346,11 @@ def test_GET_letter_branding_upload_branding_renders_form(
     file_input = form.select_one("input")
     abandon_flow_link = page.select("main a")[-1]
 
-    assert back_button["href"] == url_for("main.letter_branding_options", service_id=SERVICE_ONE_ID)
+    assert back_button["href"] == url_for(
+        "main.letter_branding_options",
+        service_id=SERVICE_ONE_ID,
+        branding_choice="something_else",
+    )
     assert form["method"] == "post"
     assert "Submit" in submit_button.text
     assert file_input["name"] == "branding"
@@ -380,14 +384,19 @@ def test_GET_letter_branding_upload_branding_renders_form_without_prompt_if_user
     assert "branding is not set up yet" not in normalize_spaces(page.select_one("main").text)
 
 
-@pytest.mark.parametrize("query_params", [{"from_template": "1234-1234-1234"}, {}])
+@pytest.mark.parametrize(
+    "query_params",
+    [
+        {"from_template": "1234-1234-1234", "branding_choice": "something_else"},
+        {"branding_choice": "something_else"},
+    ],
+)
 def test_GET_letter_branding_upload_branding_passes_from_template_through_to_back_link(
     client_request, service_one, query_params
 ):
     page = client_request.get(
         "main.letter_branding_upload_branding",
         service_id=SERVICE_ONE_ID,
-        branding_choice="something_else",
         **query_params,
     )
     back_link = page.select("a.govuk-back-link")


### PR DESCRIPTION
https://trello.com/c/3hU3e6ls/709-going-back-to-first-page-in-email-or-letter-branding-journeys-doesnt-save-your-selection

This change ensures that if you click "back" to return to the first page of the email or letter branding journey, your choice is still selected.

To do this, we ensure that the `branding_choice` query parameter is always passed when leaving or returning to the first page in the journey so that it can be used to pre-populate the form.

