### PR TITLE
Convert headless tables to the summary list component

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -128,12 +128,24 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 
 }
 
-.notify-summary-list__key--one-quarter {
+// carrying over from
+// https://github.com/alphagov/notifications-admin/pull/2931
+.notify-summary-list__key--35-100 {
 
   @include govuk-media-query($from: tablet) {
-    width: 25%;
+    width: 35%;
   }
 
+}
+
+.govuk-summary-list__value--default {
+  color: $govuk-secondary-text-colour;
+}
+
+.govuk-summary-list__value--truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .notify-hint--paragraph {

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -34,3 +34,31 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
     background-color: $notify-secondary-button-hover-colour;
   }
 }
+
+ // remove default focus styles in favour of those for :before pseudo class
+.govuk-summary-list__actions .govuk-link {
+  display: block;
+  position: relative;
+
+  &:focus {
+    box-shadow: none;
+  }
+
+  &:before {
+    content: "";
+    display: block;
+
+    position: absolute;
+
+    top: -1 * govuk-spacing(3);
+    right: 0;
+    bottom: -1 * govuk-spacing(3) + 4px;
+    left: -1 * govuk-spacing(3);
+
+    background: transparent;
+  }
+
+  &:focus:before {
+    box-shadow: inset 0px -4px $govuk-focus-text-colour, inset 0px 15px $govuk-focus-colour, inset 15px 0px $govuk-focus-colour, inset 0px -11px $govuk-focus-colour;
+  }
+}

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -1,5 +1,5 @@
 {% extends "org_template.html" %}
-{% from "components/table.html" import mapping_table, optional_text_field, row, field, text_field, edit_field with context %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% block org_page_title %}
   Settings
@@ -7,185 +7,309 @@
 
 {% block maincolumn_content %}
   <h1 class="heading-medium">Settings</h1>
-  <div class="bottom-gutter-3-2 settings-table body-copy-table">
-    {% call mapping_table(
-      caption='General',
-      field_headings=['Label', 'Value', 'Action'],
-      field_headings_visible=False,
-      caption_visible=False
-    ) %}
-      {% call row() %}
-        {{ text_field('Name') }}
-        {{ text_field(current_org.name) }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_name', org_id=current_org.id),
-            suffix='organisation name'
-          )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Sector') }}
-        {{ optional_text_field(current_org.organisation_type_label) }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_type', org_id=current_org.id),
-            suffix='sector for the organisation'
-          )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Crown organisation') }}
-        {{ optional_text_field(
-            {
-              True: 'Yes',
-              False: 'No',
-            }.get(current_org.crown),
-            default='Not sure'
-        ) }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_crown_status', org_id=current_org.id),
-            suffix='organisation crown status'
-          )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Data processing and financial agreement') }}
-        {{ text_field(
-          {
-            True: 'Signed',
-            False: 'Not signed',
-            None: 'Not signed (but we have some service-specific agreements in place)'
-          }.get(current_org.agreement_signed)
-        ) }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_agreement', org_id=current_org.id),
-            suffix='data processing and financial agreement for the organisation'
-          )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Request to go live notes') }}
-        {{ optional_text_field(current_org.request_to_go_live_notes, default='None') }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_go_live_notes', org_id=current_org.id),
-            suffix='go live notes for the organisation'
-          )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Can approve own go-live requests') }}
-        {{ text_field(current_org.can_approve_own_go_live_requests|format_yes_no) }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_can_approve_own_go_live_requests', org_id=current_org.id),
-            suffix='whether this organisation can approve its own go-live requests'
-          )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Users can ask to join services') }}
-        {{ text_field(current_org.can_ask_to_join_a_service|format_yes_no) }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_can_ask_to_join_a_service', org_id=current_org.id),
-            suffix='whether this users can ask to join services in this organisation'
-          )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Billing details')}}
-        {{ optional_text_field(current_org.billing_details, default="None", wrap=True) }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_billing_details', org_id=current_org.id),
-            suffix='billing details for the organisation'
-          )
-        }}
-      {% endcall %}
+  <div class="bottom-gutter-3-2">
 
-      {% call row() %}
-        {{ text_field('Notes')}}
-        {{ optional_text_field(current_org.notes, default="None", wrap=True) }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_notes', org_id=current_org.id),
-            suffix='the notes for the organisation'
-          )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Email branding options') }}
-        {% set email_branding_html %}
-          <div {% if current_org.email_branding_pool_excluding_default %}class="govuk-!-margin-bottom-3"{% endif %}>
-            {{ current_org.email_branding.name }}
-            <br>
-            <div class="table-field-status-default">
-              Default
-            </div>
-          </div>
-
-          {% for item in current_org.email_branding_pool_excluding_default %}
-            {% if loop.first %}<ul>{% endif %}
-              <li>
-                {{ item.name }}
-              </li>
-            {% if loop.last %}</ul>{% endif %}
+    {% set billing_details_html %}
+      {% if current_org.billing_details is iterable and text is not string %}
+        <ul class="govuk-list">
+          {% for item in current_org.billing_details %}
+            {% if item %}
+              <li>{{ item }}</li>
+            {% endif %}
           {% endfor %}
-        {% endset %}
-        {% call field() %}
-          {{ email_branding_html }}
-        {% endcall %}
-        {{ edit_field(
-            'Manage',
-            url_for('main.organisation_email_branding', org_id=current_org.id),
-            suffix='email branding options for the organisation'
-          )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Letter branding options') }}
-        {% set letter_branding_html %}
-          <div {% if current_org.letter_branding_pool_excluding_default %}class="govuk-!-margin-bottom-3"{% endif %}>
-            {{ current_org.letter_branding.name or "No branding" }}
-            <br>
-            <div class="table-field-status-default">
-              Default
-            </div>
-          </div>
-          {% for item in current_org.letter_branding_pool_excluding_default %}
-            {% if loop.first %}<ul>{% endif %}
-              <li>
-                {{ item.name }}
-              </li>
-            {% if loop.last %}</ul>{% endif %}
-          {% endfor %}
-        {% endset %}
+        </ul>
+      {% else %}
+        None
+      {% endif %}
+    {% endset %}
 
-        {% call field() %}
-          {{ letter_branding_html }}
-        {% endcall %}
-        {{ edit_field(
-            'Manage',
-            url_for('main.organisation_letter_branding', org_id=current_org.id),
-            suffix='letter branding options for the organisation'
-            )
-        }}
-      {% endcall %}
-      {% call row() %}
-        {{ text_field('Known email domains') }}
-        {{ optional_text_field(current_org.domains or None, default='None') }}
-        {{ edit_field(
-            'Change',
-            url_for('main.edit_organisation_domains', org_id=current_org.id),
-            suffix='known email domains for the organisation'
-          )
-        }}
-      {% endcall %}
-    {% endcall %}
+    {% set email_branding_html %}
+      <div {% if current_org.email_branding_pool_excluding_default %}class="govuk-!-margin-bottom-3"{% endif %}>
+        {{ current_org.email_branding.name }}
+        <br>
+        <span class="govuk-hint">
+          Default
+        </span>
+      </div>
+
+      {% for item in current_org.email_branding_pool_excluding_default %}
+        {% if loop.first %}<ul class="govuk-list">{% endif %}
+          <li>
+            {{ item.name }}
+          </li>
+        {% if loop.last %}</ul>{% endif %}
+      {% endfor %}
+    {% endset %}
+
+    {% set letter_branding_html %}
+      <div {% if current_org.letter_branding_pool_excluding_default %}class="govuk-!-margin-bottom-3"{% endif %}>
+        {{ current_org.letter_branding.name or "No branding" }}
+        <br>
+        <span class="govuk-hint">
+          Default
+        </span>
+      </div>
+      {% for item in current_org.letter_branding_pool_excluding_default %}
+        {% if loop.first %}<ul class="govuk-list">{% endif %}
+          <li>
+            {{ item.name }}
+          </li>
+        {% if loop.last %}</ul>{% endif %}
+      {% endfor %}
+    {% endset %}
+
+    {% set known_domains_html %}
+      {% if current_org.domains %}
+        <ul class="govuk-list">
+          {% for item in current_org.domains %}
+            {% if item %}
+              <li>{{ item }}</li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      {% else %}
+        None
+      {% endif %}
+    {% endset %}
+
+    {{ govukSummaryList({
+      "classes": "notify-summary-list organisation-settings",
+      "rows": [
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Name"
+          },
+          "value": {
+            "text": current_org.name
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_organisation_name', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "organisation name",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Sector"
+          },
+          "value": {
+            "text": current_org.organisation_type_label or "Not set"
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_organisation_type', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "sector for the organisation",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Crown organisation"
+          },
+          "value": {
+            "text": "Not sure" if current_org.crown is none else "Yes" if current_org.crown else "No",
+            "classes": "govuk-summary-list__value--default" if current_org.crown is none
+          },
+          "actions": {
+            "items": [
+              {
+                "href":  url_for('main.edit_organisation_crown_status', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "organisation crown status",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Data processing and financial agreement"
+          },
+          "value": {
+            "text": "Not signed (but we have some service-specific agreements in place)" if current_org.agreement_signed is none else "Signed" if current_org.agreement_signed else "Not signed",
+            "classes": "govuk-summary-list__value--truncate" if current_org.agreement_signed is none
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_organisation_agreement', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "data processing and financial agreement for the organisation",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Request to go live notes"
+          },
+          "value": {
+            "text": current_org.request_to_go_live_notes or "None",
+            "classes": "govuk-summary-list__value--default" if current_org.request_to_go_live_notes is none else "govuk-summary-list__value--truncate"
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_organisation_go_live_notes', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "go live notes for the organisation",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Can approve own go-live requests"
+          },
+          "value": {
+            "text": current_org.can_approve_own_go_live_requests|format_yes_no
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_organisation_can_approve_own_go_live_requests', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "whether this organisation can approve its own go-live requests",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Users can ask to join services"
+          },
+          "value": {
+            "text": current_org.can_ask_to_join_a_service|format_yes_no
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_organisation_can_ask_to_join_a_service', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "whether this users can ask to join services in this organisation",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Billing details"
+          },
+          "value": {
+            "text": billing_details_html
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_organisation_billing_details', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "billing details for the organisation",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Notes"
+          },
+          "value": {
+            "text": current_org.notes or "None",
+            "classes": "govuk-summary-list__value--default" if current_org.notes is none
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_organisation_notes', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "the notes for the organisation",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Email branding options"
+          },
+          "value": {
+            "text": email_branding_html
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.organisation_email_branding', org_id=current_org.id),
+                "text": "Manage",
+                "visuallyHiddenText": "email branding options for the organisation",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Letter branding options"
+          },
+          "value": {
+            "text": letter_branding_html
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.organisation_letter_branding', org_id=current_org.id),
+                "text": "Manage",
+                "visuallyHiddenText": "letter branding options for the organisation",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Known email domains"
+          },
+          "value": {
+            "text": known_domains_html,
+            "classes": "govuk-summary-list__value--default" if not current_org.domains
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_organisation_domains', org_id=current_org.id),
+                "text": "Change",
+                "visuallyHiddenText": "known email domains for the organisation",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        }
+      ]
+    }) }}
     {% if current_org.active %}
       <p class="top-gutter-1-2">
         <span class="page-footer-link page-footer-delete-link-without-button">

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -1,304 +1,472 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import mapping_table, row, settings_row, text_field, callable_text_field, optional_text_field, edit_field, field, boolean_field with context %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 {% block service_page_title %}
   Settings
 {% endblock %}
 
 {% block maincolumn_content %}
 
+    {% set service_base_settings %}
+      {% set data_retention_html %}
+        {% if current_service.get_consistent_data_retention_period() %}
+          {{ current_service.get_consistent_data_retention_period()|string + ' days' }}
+        {% else %}
+          <ul class="govuk-list">
+            {% for channel in ['email', 'sms', 'letter'] %}
+            <li>{{ channel|format_notification_type }} – {{ current_service.get_days_of_retention(channel) }} days</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      {% endset %}
+
+      {{ govukSummaryList({
+        "classes": "notify-summary-list service-base-settings",
+        "rows": [
+           {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Service name"
+            },
+            "value": {
+              "text": current_service.name,
+              "classes": "govuk-summary-list__value--truncate"
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_name_change', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "service name",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Sign-in method"
+            },
+            "value": {
+              "text": ("Email link or text message code" if 'email_auth' in current_service.permissions else "Text message code")
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_set_auth_type', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "sign-in method",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Data retention period"
+            },
+            "value": {
+              "text": data_retention_html
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_data_retention', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "data retention",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          }
+        ]
+      }) }}
+    {% endset %}
+
+    {% set service_email_settings %}
+      {% set email_sender_html %}
+        {% with email_sender_name = current_service.custom_email_sender_name or current_service.name %}
+          {% include "partials/preview-email-sender-name.html" %}
+        {% endwith %}
+      {% endset %}
+
+      {% set reply_to_email_addresses_html %}
+        {{ current_service.default_email_reply_to_address or 'Not set' }}
+        {% if current_service.count_email_reply_to_addresses > 1 %}
+          <div class="govuk-hint">
+            {{ '…and %d more' | format(current_service.count_email_reply_to_addresses - 1) }}
+          </div>
+        {% endif %}
+      {% endset %}
+
+      {% set base_email_settings_row = [
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Send emails"
+          },
+          "value": {
+            "text": "On" if 'email' in current_service.permissions else "Off"
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('.service_set_channel', channel='email', service_id=current_service.id),
+                "text": "Change",
+                "visuallyHiddenText": "your settings for sending emails",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        }
+      ]%}
+
+      {% if 'email' in current_service.permissions %}
+        {% set restricted_email_settings_rows = [
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Email sender name"
+            },
+            "value": {
+              "html": email_sender_html,
+              "classes": "govuk-summary-list__value--truncate"
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_email_sender_change', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "email sender name",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Reply-to email addresses"
+            },
+            "value": {
+              "classes": "govuk-summary-list__value--default" if current_service.default_email_reply_to_address is none else "govuk-summary-list__value--truncate",
+              "html": reply_to_email_addresses_html
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_email_reply_to', service_id=current_service.id),
+                  "text": "Manage",
+                  "visuallyHiddenText": "reply-to email addresses",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Email branding"
+            },
+            "value": {
+              "text": current_service.email_branding.name
+            },
+            "actions": {
+              "items": [
+                {
+                  "href":  url_for('main.email_branding_options', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "email branding",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Send files by email"
+            },
+            "value": {
+              "text": current_service.contact_link or 'Not set up',
+              "classes": "govuk-summary-list__value--default" if current_service.contact_link is none else "govuk-summary-list__value--truncate"
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.send_files_by_email_contact_details', service_id=current_service.id),
+                  "text": "Manage",
+                  "visuallyHiddenText": "sending files by email",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          }
+        ]%}
+      {% endif %}
+
+      {% set email_settings_rows = base_email_settings_row + restricted_email_settings_rows if restricted_email_settings_rows else base_email_settings_row %}
+
+      {{ govukSummaryList({
+        "classes": "notify-summary-list service-email-settings",
+        "rows": email_settings_rows
+      }) }}
+
+    {% endset %}
+
+    {% set service_text_message_settings %}
+      {% set text_message_sender_ids_html %}
+        {{ current_service.default_sms_sender | nl2br if current_service.default_sms_sender else 'None'}}
+        {% if current_service.count_sms_senders > 1 %}
+          <div class="govuk-hint">
+            {{ '…and %d more' | format(current_service.count_sms_senders - 1) }}
+          </div>
+        {% endif %}
+      {% endset %}
+
+      {% set base_text_message_setting_row = [
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Send text messages"
+          },
+          "value": {
+            "text": "On" if 'sms' in current_service.permissions else "Off"
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for(
+                    '.service_set_channel',
+                    service_id=current_service.id,
+                    channel='sms'
+                  ),
+                "text": "Change",
+                "visuallyHiddenText": "your settings for sending text messages",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        }
+      ]%}
+
+      {% if 'sms' in current_service.permissions %}
+        {% set restricted_text_message_settings_rows = [
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Text message sender IDs"
+            },
+            "value": {
+              "text": text_message_sender_ids_html,
+              "classes": "govuk-summary-list__value--truncate"
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_sms_senders', service_id=current_service.id),
+                  "text": "Manage",
+                  "visuallyHiddenText": "text message sender IDs",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Start text messages with service name"
+            },
+            "value": {
+              "text": "On" if current_service.prefix_sms else "Off"
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_set_sms_prefix', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "your settings for starting text messages with service name",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Send international text messages"
+            },
+            "value": {
+              "text": "On" if 'international_sms' in current_service.permissions else "Off"
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_set_international_sms', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "your settings for sending international text messages",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Receive text messages"
+            },
+            "value": {
+              "text": "On" if 'inbound_sms' in current_service.permissions else "Off"
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_receive_text_messages', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "your settings for receiving text messages",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          }
+        ]%}
+      {% endif %}
+
+      {% set text_message_settings_rows = base_text_message_setting_row + restricted_text_message_settings_rows  if restricted_text_message_settings_rows else base_text_message_setting_row %}
+
+      {{ govukSummaryList({
+        "classes": "notify-summary-list service-sms-settings",
+        "rows": text_message_settings_rows
+      }) }}
+    {% endset %}
+
+    {% set service_letter_settings %}
+      {% set base_letter_settings_row = [
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Send letters"
+          },
+          "value": {
+            "text": "On" if 'letter' in current_service.permissions else "Off"
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for(
+                  '.service_set_channel',
+                  channel='letter',
+                  service_id=current_service.id
+                ),
+                "text": "Change",
+                "visuallyHiddenText": "your settings for sending letters",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        }
+      ]%}
+
+      {% if 'letter' in current_service.permissions %}
+
+        {% set sender_addresses_html %}
+          {% if current_service.default_letter_contact_block %}
+            {{ current_service.default_letter_contact_block.contact_block | nl2br }}
+          {% elif current_service.count_letter_contact_details %}
+            Blank
+          {% else %}
+            Not set
+          {% endif %}
+          {% if current_service.count_letter_contact_details > 1 %}
+            <div class="govuk-hint">
+              {{ '…and %d more' | format(current_service.count_letter_contact_details - 1) }}
+            </div>
+          {% endif %}
+        {% endset %}
+        {% set restricted_letter_settings_rows = [
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Send international letters"
+            },
+            "value": {
+              "text": "On" if current_service.has_permission('international_letters') else "Off"
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_set_international_letters', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "your settings for sending international letters",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Sender addresses"
+            },
+            "value": {
+              "html": sender_addresses_html,
+              "classes": "govuk-summary-list__value--default" if current_service.count_letter_contact_details == 0 else "govuk-summary-list__value--truncate"
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.service_letter_contact_details', service_id=current_service.id),
+                  "text": "Manage",
+                  "visuallyHiddenText": "sender addresses",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          },
+          {
+            "key": {
+              "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+              "text": "Letter branding"
+            },
+            "value": {
+              "text": current_service.letter_branding.name or "Not set",
+              "classes": "govuk-summary-list__value--default" if not current_service.letter_branding.name
+            },
+            "actions": {
+              "items": [
+                {
+                  "href": url_for('main.letter_branding_options', service_id=current_service.id),
+                  "text": "Change",
+                  "visuallyHiddenText": "letter branding",
+                  "classes": "govuk-link--no-visited-state"
+                }
+              ]
+            }
+          }
+        ] %}
+      {% endif %}
+
+      {% set letter_settings_rows = base_letter_settings_row + restricted_letter_settings_rows  if restricted_letter_settings_rows else base_letter_settings_row %}
+
+      {{ govukSummaryList({
+        "classes": "notify-summary-list service-letter-settings",
+        "rows": letter_settings_rows
+      }) }}
+
+    {% endset %}
+
     <h1 class="heading-medium">Settings</h1>
+    <div class="bottom-gutter-3-2">
+      <h2 class="heading-medium govuk-visually-hidden">General</h2>
+      {{ service_base_settings }}
+      <h2 class="heading-medium">Email settings</h2>
+      {{ service_email_settings }}
+      <h2 class="heading-medium">Text message settings</h2>
+      {{ service_text_message_settings }}
+      <h2 class="heading-medium">Letter settings</h2>
+      {{ service_letter_settings }}
 
-    <div class="bottom-gutter-3-2 settings-table body-copy-table">
-
-      {% call mapping_table(
-        caption='General',
-        field_headings=['Label', 'Value', 'Action'],
-        field_headings_visible=False,
-        caption_visible=False
-      ) %}
-
-        {% call row() %}
-          {{ text_field('Service name') }}
-          {{ text_field(current_service.name) }}
-          {{ edit_field(
-              'Change',
-              url_for('main.service_name_change', service_id=current_service.id),
-              permissions=['manage_service'],
-              suffix='service name',
-            )
-          }}
-        {% endcall %}
-
-        {% call row() %}
-          {{ text_field('Sign-in method') }}
-          {{ text_field(
-            'Email link or text message code'
-            if 'email_auth' in current_service.permissions
-            else 'Text message code'
-          ) }}
-          {{ edit_field(
-              'Change',
-              url_for('main.service_set_auth_type', service_id=current_service.id),
-              permissions=['manage_service'],
-              suffix='sign-in method',
-            )
-          }}
-        {% endcall %}
-          {% call row() %}
-            {{ text_field('Data retention period') }}
-            {% if current_service.get_consistent_data_retention_period() %}
-              {{ text_field(current_service.get_consistent_data_retention_period()|string + ' days') }}
-            {% else %}
-              {% call field() %}
-                  <ul>
-                    {% for channel in ['email', 'sms', 'letter'] %}
-                    <li>{{ channel|format_notification_type }} – {{ current_service.get_days_of_retention(channel) }} days</li>
-                    {% endfor %}
-                  </ul>
-              {% endcall %}
-            {% endif %}
-            {{ edit_field(
-              'Change',
-              url_for('main.service_data_retention', service_id=current_service.id),
-              permissions=['manage_service'],
-              suffix='data retention'
-              )
-            }}
-          {% endcall %}
-      {% endcall %}
-
-      {% call mapping_table(
-        caption='Email settings',
-        field_headings=['Label', 'Value', 'Action'],
-        field_headings_visible=False,
-        caption_visible=True
-      ) %}
-
-        {% call row() %}
-          {{ text_field('Send emails') }}
-          {{ boolean_field('email' in current_service.permissions) }}
-          {{ edit_field(
-            'Change',
-            url_for(
-              '.service_set_channel',
-              channel='email',
-              service_id=current_service.id
-            ),
-            permissions=['manage_service'],
-            suffix='your settings for sending emails',
-          )}}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='email') %}
-          {{ text_field('Email sender name') }}
-          {% call callable_text_field() %}
-            {% with email_sender_name = current_service.custom_email_sender_name or current_service.name %}
-              {% include "partials/preview-email-sender-name.html" %}
-            {% endwith %}
-          {% endcall %}
-          {{ edit_field(
-              'Change',
-              url_for('main.service_email_sender_change', service_id=current_service.id),
-              permissions=['manage_service'],
-              suffix='email sender name',
-            )
-          }}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='email') %}
-          {{ text_field('Reply-to email addresses') }}
-          {% call field(status='default' if current_service.count_email_reply_to_addresses == 0 else '') %}
-            {{ current_service.default_email_reply_to_address or 'Not set' }}
-            {% if current_service.count_email_reply_to_addresses > 1 %}
-              <div class="hint">
-                {{ '…and %d more' | format(current_service.count_email_reply_to_addresses - 1) }}
-              </div>
-            {% endif %}
-          {% endcall %}
-          {{ edit_field(
-              'Manage',
-              url_for('main.service_email_reply_to', service_id=current_service.id),
-              permissions=['manage_service','manage_api_keys'],
-              suffix='reply-to email addresses',
-            )
-          }}
-        {% endcall %}
-
-        {% set email_options_url = url_for('main.email_branding_options', service_id=current_service.id) %}
-
-        {% call settings_row(if_has_permission='email') %}
-          {{ text_field('Email branding') }}
-          {{ text_field(current_service.email_branding.name) }}
-          {{ edit_field(
-            'Change',
-            email_options_url,
-            permissions=['manage_service'],
-            suffix='email branding',
-          )}}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='email') %}
-          {{ text_field('Send files by email') }}
-          {{ optional_text_field(current_service.contact_link, default="Not set up", truncate=true) }}
-          {{ edit_field(
-            'Manage',
-            url_for('main.send_files_by_email_contact_details', service_id=current_service.id),
-            permissions=['manage_service'],
-            suffix='sending files by email',
-          )}}
-        {% endcall %}
-
-      {% endcall %}
-
-      {% call mapping_table(
-        caption='Text message settings',
-        field_headings=['Label', 'Value', 'Action'],
-        field_headings_visible=False,
-        caption_visible=True
-      ) %}
-
-        {% call row() %}
-          {{ text_field('Send text messages') }}
-          {{ boolean_field('sms' in current_service.permissions) }}
-          {{ edit_field(
-            'Change',
-            url_for(
-              '.service_set_channel',
-              service_id=current_service.id,
-              channel='sms'
-            ),
-            permissions=['manage_service'],
-            suffix='your settings for sending text messages',
-          )}}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='sms') %}
-          {{ text_field('Text message sender IDs') }}
-          {% call field(status='default' if current_service.default_sms_sender == "None" else '') %}
-            {{ current_service.default_sms_sender | nl2br if current_service.default_sms_sender else 'None'}}
-            {% if current_service.count_sms_senders > 1 %}
-              <div class="hint">
-                {{ '…and %d more' | format(current_service.count_sms_senders - 1) }}
-              </div>
-            {% endif %}
-          {% endcall %}
-          {{ edit_field(
-              'Manage',
-              url_for('main.service_sms_senders', service_id=current_service.id),
-              permissions=['manage_service','manage_api_keys'],
-              suffix='text message sender IDs',
-          )
-          }}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='sms') %}
-          {{ text_field('Start text messages with service name') }}
-          {{ boolean_field(current_service.prefix_sms) }}
-          {{ edit_field(
-              'Change',
-              url_for('main.service_set_sms_prefix', service_id=current_service.id),
-              permissions=['manage_service'],
-              suffix='your settings for starting text messages with service name',
-          )
-          }}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='sms') %}
-          {{ text_field('Send international text messages') }}
-          {{ boolean_field('international_sms' in current_service.permissions) }}
-          {{ edit_field(
-              'Change',
-              url_for('main.service_set_international_sms', service_id=current_service.id),
-              permissions=['manage_service'],
-              suffix='your settings for sending international text messages',
-          )
-          }}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='sms') %}
-          {{ text_field('Receive text messages') }}
-          {{ boolean_field('inbound_sms' in current_service.permissions) }}
-          {{ edit_field(
-              'Change',
-              url_for('main.service_receive_text_messages', service_id=current_service.id),
-              permissions=['manage_service'],
-              suffix='your settings for receiving text messages',
-          )
-          }}
-        {% endcall %}
-
-      {% endcall %}
-
-      {% call mapping_table(
-        caption='Letter settings',
-        field_headings=['Label', 'Value', 'Action'],
-        field_headings_visible=False,
-        caption_visible=True
-      ) %}
-
-        {% call row() %}
-          {{ text_field('Send letters') }}
-          {{ boolean_field('letter' in current_service.permissions) }}
-          {{ edit_field(
-            'Change',
-            url_for(
-              '.service_set_channel',
-              channel='letter',
-              service_id=current_service.id
-            ),
-            permissions=['manage_service'],
-            suffix='your settings for sending letters',
-          )}}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='letter') %}
-          {{ text_field('Send international letters') }}
-          {{ boolean_field(current_service.has_permission('international_letters')) }}
-          {{ edit_field(
-            'Change',
-            url_for('main.service_set_international_letters', service_id=current_service.id),
-            permissions=['manage_service'],
-            suffix='your settings for sending international letters',
-          )}}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='letter') %}
-          {{ text_field('Sender addresses') }}
-          {% call field(status='' if current_service.count_letter_contact_details else 'default') %}
-            {% if current_service.default_letter_contact_block %}
-              {{ current_service.default_letter_contact_block.contact_block | nl2br }}
-            {% elif current_service.count_letter_contact_details %}
-              Blank
-            {% else %}
-              Not set
-            {% endif %}
-            {% if current_service.count_letter_contact_details > 1 %}
-              <div class="hint">
-                {{ '…and %d more' | format(current_service.count_letter_contact_details - 1) }}
-              </div>
-            {% endif %}
-          {% endcall %}
-          {{ edit_field(
-              'Manage',
-              url_for('main.service_letter_contact_details', service_id=current_service.id),
-              permissions=['manage_service','manage_api_keys'],
-              suffix='sender addresses',
-          )
-          }}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='letter') %}
-          {{ text_field('Letter branding') }}
-          {{ optional_text_field(current_service.letter_branding.name) }}
-          {{ edit_field(
-            'Change',
-            url_for('main.letter_branding_options', service_id=current_service.id),
-            permissions=['manage_service'],
-            suffix='letter branding',
-          )}}
-        {% endcall %}
-
-      {% endcall %}
     </div>
 
     {% if current_service.trial_mode %}
@@ -342,139 +510,354 @@
 
     {% if current_user.platform_admin %}
 
-      <div class="settings-table body-copy-table">
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-4 govuk-!-margin-top-8">Platform admin settings</h2>
 
-        <h2 class="govuk-heading-l govuk-!-margin-bottom-4 govuk-!-margin-top-8">Platform admin settings</h2>
+      {% set has_change_action = {} %}
+      {% set admin_org_live_status_html %}
+        {% if current_service.trial_mode and not current_service.organisation_id %}
+            No
+            <div class="govuk-hint">Organisation must be set first</div>
+        {% elif current_service.trial_mode and current_service.organisation.agreement_signed is false %}
+            No
+            <div class="govuk-hint">Organisation must accept the data processing and financial agreement first</div>
+        {% else %}
+          {{ "On" if not current_service.trial_mode else "Off" }}
 
-        {% call mapping_table(
-          caption='Settings',
-          field_headings=['Label', 'Value', 'Action'],
-          field_headings_visible=False,
-          caption_visible=False
-        ) %}
+          {% do has_change_action.update({
+            "items": [
+              {
+                "href": url_for('main.service_switch_live', service_id=current_service.id),
+                "text": "Change",
+                "visuallyHiddenText": "service status",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }) %}
+        {% endif %}
+      {% endset %}
 
-          {% call row() %}
-            {{ text_field('Live')}}
-            {% if current_service.trial_mode and not current_service.organisation_id %}
-              {% call field() %}
-                No
-                <div class="hint">Organisation must be set first</div>
-              {% endcall %}
-              {{ text_field('') }}
-            {% elif current_service.trial_mode and current_service.organisation.agreement_signed is false %}
-              {% call field(wrap=True) %}
-                No
-                <div class="hint">Organisation must accept the data processing and financial agreement first</div>
-              {% endcall %}
-              {{ text_field('') }}
-            {% else %}
-              {{ boolean_field(not current_service.trial_mode) }}
-              {{ edit_field('Change', url_for('main.service_switch_live', service_id=current_service.id), suffix='service status') }}
-            {% endif %}
-          {% endcall %}
-
-          {% call row() %}
-            {{ text_field('Count in list of live services')}}
-            {{ text_field(current_service.count_as_live|format_yes_no) }}
-            {{ edit_field('Change', url_for('main.service_switch_count_as_live', service_id=current_service.id), suffix='if service is counted in list of live services') }}
-          {% endcall %}
-          {% call row() %}
-            {{ text_field('Billing details')}}
-            {{ optional_text_field(current_service.billing_details, default="None", wrap=True) }}
-            {{ edit_field('Change', url_for('main.edit_service_billing_details', service_id=current_service.id), suffix='billing details for service') }}
-          {% endcall %}
-
-          {% call row() %}
-            {{ text_field('Notes')}}
-            {{ optional_text_field(current_service.notes, default="None", wrap=True) }}
-            {{ edit_field('Change', url_for('main.edit_service_notes', service_id=current_service.id), suffix='the notes for the service') }}
-          {% endcall %}
-
-          {% call row() %}
-            {{ text_field('Organisation')}}
-            {% call field() %}
-              {% if current_service.organisation_id %}
-                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.organisation_dashboard', org_id=current_service.organisation_id) }}">
-                  {{ current_service.organisation_name }}
-                </a>
-              {% else %}
-                <span class="table-field-status-default">Not set</span>
+      {% set admin_service_billing_details_html %}
+        {% if current_service.billing_details %}
+          <ul class="govuk-list">
+            {% for item in current_service.billing_details %}
+              {% if item %}
+                <li>{{ item }}</li>
               {% endif %}
-              {% if current_service.organisation_type %}
-                <div class="hint">
-                  {{ current_service.organisation_type_label }}
-                </div>
-              {% endif %}
-            {% endcall %}
-            {{ edit_field('Change', url_for('main.link_service_to_organisation', service_id=current_service.id), suffix='organisation for service') }}
-          {% endcall %}
+            {% endfor %}
+          </ul>
+        {% else %}
+          None
+        {% endif %}
+      {% endset %}
 
-          {% call row() %}
-            {{ text_field('Rate limit')}}
-            {{ text_field('{:,} per minute'.format(current_service.rate_limit)) }}
-            {{ edit_field('Change', url_for('main.set_per_minute_rate_limit', service_id=current_service.id), suffix='rate limit') }}
-          {% endcall %}
-          {% for channel in ('email', 'sms', 'letter') %}
-            {% call row() %}
-              {{ text_field('{} limit'.format(channel|format_notification_type)) }}
-              {{ text_field('{:,} per day'.format(current_service.get_message_limit(channel))) }}
-              {{ edit_field('Change', url_for('main.set_per_day_message_limit', service_id=current_service.id, notification_type=channel), suffix='daily {} limit'.format(channel|format_notification_type|lower)) }}
-            {% endcall %}
-          {% endfor %}
-          {% call row() %}
-            {{ text_field('Free text message allowance')}}
-            {{ text_field('{:,} per year'.format(current_service.free_sms_fragment_limit)) }}
-            {{ edit_field('Change', url_for('main.set_free_sms_allowance', service_id=current_service.id), suffix='free text message allowance') }}
-          {% endcall %}
-          {% call row() %}
-            {{ text_field('Email branding' )}}
-            {{ text_field(current_service.email_branding.name) }}
-            {{ edit_field('Change', url_for('main.service_set_branding', service_id=current_service.id, branding_type='email'), suffix='email branding (admin view)') }}
-          {% endcall %}
-          {% call row() %}
-            {{ text_field('Letter branding')}}
-            {{ optional_text_field(current_service.letter_branding.name) }}
-            {{ edit_field('Change', url_for('main.service_set_branding', service_id=current_service.id, branding_type='letter'), suffix='letter branding (admin view)') }}
-          {% endcall %}
-          {% call row() %}
-            {{ text_field('Custom data retention')}}
-            {% call field() %}
-              {% for channel in current_service.data_retention %}
-                {% if loop.first %}
-                  <ul>
-                {% endif %}
-                  <li>{{ channel.notification_type|format_notification_type }} – {{ channel.days_of_retention }} days</li>
-                {% if loop.last %}
-                  </ul>
-                {% endif %}
-              {% else %}
-                <div class="table-field-status-default">Not set</div>
-              {% endfor %}
-            {% endcall %}
-            {{ edit_field('Change', url_for('main.data_retention', service_id=current_service.id), suffix='data retention') }}
-          {% endcall %}
+      {% set admin_service_parent_org_html %}
+        {% if current_service.organisation_id %}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.organisation_dashboard', org_id=current_service.organisation_id) }}">
+            {{ current_service.organisation_name }}
+          </a>
+        {% else %}
+          <span class="govuk-hint">Not set</span>
+        {% endif %}
+        {% if current_service.organisation_type %}
+          <div class="govuk-hint">
+            {{ current_service.organisation_type_label }}
+          </div>
+        {% endif %}
+      {% endset %}
 
-          {% for permission in service_permissions %}
-            {% if not service_permissions[permission].requires or current_service.has_permission(service_permissions[permission].requires) %}
-              {% call row() %}
-                {{ text_field(service_permissions[permission].title)}}
-                {{ boolean_field(current_service.has_permission(permission)) }}
-                {{ edit_field(
-                    'Change',
-                    url_for(
+      {% set admin_service_data_retention_html %}
+        {% for channel in current_service.data_retention %}
+          {% if loop.first %}
+            <ul class="govuk-list">
+          {% endif %}
+            <li>{{ channel.notification_type|format_notification_type }} – {{ channel.days_of_retention }} days</li>
+          {% if loop.last %}
+            </ul>
+          {% endif %}
+        {% else %}
+          Not set
+        {% endfor %}
+      {% endset %}
+
+      {% set admin_settings_rows = [
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Live"
+          },
+          "value": {
+            "html": admin_org_live_status_html,
+          },
+          "actions": has_change_action
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Count in list of live services"
+          },
+          "value": {
+            "text": current_service.count_as_live|format_yes_no
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.service_switch_count_as_live', service_id=current_service.id),
+                "text": "Change",
+                "visuallyHiddenText": "if service is counted in list of live services",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Billing details"
+          },
+          "value": {
+            "text": admin_service_billing_details_html,
+            "classes": "govuk-summary-list__value--default" if not current_service.billing_details
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_service_billing_details', service_id=current_service.id),
+                "text": "Change",
+                "visuallyHiddenText": "billing details for service",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Notes"
+          },
+          "value": {
+            "text": current_service.notes or "None",
+            "classes": "govuk-summary-list__value--default" if not current_service.notes
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_service_notes', service_id=current_service.id),
+                "text": "Change",
+                "visuallyHiddenText": "the notes for the service",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Organisation"
+          },
+          "value": {
+            "html": admin_service_parent_org_html
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.link_service_to_organisation', service_id=current_service.id),
+                "text": "Change",
+                "visuallyHiddenText": "organisation for service",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Rate limit"
+          },
+          "value": {
+            "text": "{:,} per minute".format(current_service.rate_limit)
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.set_per_minute_rate_limit', service_id=current_service.id),
+                "text": "Change",
+                "visuallyHiddenText": "rate limit",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "{} limit".format('email'|format_notification_type)
+          },
+          "value": {
+            "text": "{:,} per day".format(current_service.get_message_limit('email'))
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.set_per_day_message_limit', service_id=current_service.id, notification_type='email'),
+                "text": "Change",
+                "visuallyHiddenText": "daily {} limit".format('email'|format_notification_type|lower),
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "{} limit".format('sms'|format_notification_type)
+          },
+          "value": {
+            "text": "{:,} per day".format(current_service.get_message_limit('sms'))
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.set_per_day_message_limit', service_id=current_service.id, notification_type='sms'),
+                "text": "Change",
+                "visuallyHiddenText": "daily {} limit".format('sms'|format_notification_type|lower),
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "{} limit".format('letter'|format_notification_type)
+          },
+          "value": {
+            "text": "{:,} per day".format(current_service.get_message_limit('letter'))
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.set_per_day_message_limit', service_id=current_service.id, notification_type='letter'),
+                "text": "Change",
+                "visuallyHiddenText": "daily {} limit".format('letter'|format_notification_type|lower),
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Free text message allowance"
+          },
+          "value": {
+            "text": "{:,} per year".format(current_service.free_sms_fragment_limit)
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.set_free_sms_allowance', service_id=current_service.id),
+                "text": "Change",
+                "visuallyHiddenText": "free text message allowance",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Email branding"
+          },
+          "value": {
+            "text": current_service.email_branding.name
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.service_set_branding', service_id=current_service.id, branding_type='email'),
+                "text": "Change",
+                "visuallyHiddenText": "email branding (admin view)",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Letter branding"
+          },
+          "value": {
+            "text": current_service.letter_branding.name or "Not set",
+            "classes": "govuk-summary-list__value--default" if not current_service.letter_branding.name
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.service_set_branding', service_id=current_service.id, branding_type='letter'),
+                "text": "Change",
+                "visuallyHiddenText": "letter branding (admin view)",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": "Custom data retention"
+          },
+          "value": {
+            "text": admin_service_data_retention_html,
+            "classes": "govuk-summary-list__value--default" if not current_service.data_retention
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.data_retention', service_id=current_service.id),
+                "text": "Change",
+                "visuallyHiddenText": "data retention",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        },
+      ] %}
+
+      {% for permission in service_permissions %}
+        {% if not service_permissions[permission].requires or current_service.has_permission(service_permissions[permission].requires) %}
+          {% do admin_settings_rows.append(
+            {
+              "key": {
+                "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+                "text": service_permissions[permission].title
+              },
+              "value": {
+                "text": "On" if current_service.has_permission(permission) else "Off"
+              },
+              "actions": {
+                "items": [
+                  {
+                    "href": url_for(
                       service_permissions[permission].endpoint or '.service_set_permission',
                       service_id=current_service.id,
                       permission=permission if not service_permissions[permission].endpoint else None
                     ),
-                    suffix='your settings for ' + service_permissions[permission].title,
-                  ) }}
-              {% endcall %}
-            {% endif %}
-          {% endfor %}
+                    "text": "Change",
+                    "visuallyHiddenText": "your settings for " + service_permissions[permission].title,
+                    "classes": "govuk-link--no-visited-state"
+                  }
+                ]
+              }
+            }
+          ) %}
+        {% endif %}
+      {% endfor %}
 
-        {% endcall %}
-
-      </div>
+      {{ govukSummaryList({
+        "classes": "notify-summary-list platform-admin-settings",
+        "rows": admin_settings_rows
+      }) }}
 
     {% endif %}
 
@@ -501,4 +884,3 @@
       {% endif %}
     </p>
 {% endblock %}
-

--- a/app/templates/views/service-settings/data-retention.html
+++ b/app/templates/views/service-settings/data-retention.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, with context %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% block service_page_title %}
   Data retention
@@ -40,21 +40,34 @@
       </div>
     </div>
   {% else %}
-     {% call mapping_table(
-      caption='Data retention',
-      field_headings=['Label', 'Value', 'Action'],
-      field_headings_visible=False,
-      caption_visible=False
-    ) %}
-      {% for item in current_service.data_retention %}
-          {% call row() %}
-            {{ text_field(item.notification_type | format_notification_type)}}
-            {{ text_field(item.days_of_retention|string + ' days') }}
-            {{ edit_field('Change', url_for('main.edit_data_retention', service_id=current_service.id, data_retention_id=item.id)) }}
-          {% endcall %}
-
-      {% endfor %}
-    {% endcall %}
+    {% set data_retention_settings = [] %}
+    {% for item in current_service.data_retention %}
+      {% do data_retention_settings.append(
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+            "text": item.notification_type | format_notification_type
+          },
+          "value": {
+            "text": item.days_of_retention|string + " days"
+          },
+          "actions": {
+            "items": [
+              {
+                "href": url_for('main.edit_data_retention', service_id=current_service.id, data_retention_id=item.id),
+                "text": "Change",
+                "visuallyHiddenText": item.notification_type | format_notification_type | lower + " data retention setting",
+                "classes": "govuk-link--no-visited-state"
+              }
+            ]
+          }
+        }
+      ) %}
+    {% endfor %}
+    {{ govukSummaryList({
+      "classes": "notify-summary-list",
+      "rows": data_retention_settings
+    }) }}
   {% endif %}
 
 {% endblock %}

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -13,7 +13,7 @@
     {% set email_address_row =
       {
         "key": {
-          "classes": "notify-summary-list__key notify-summary-list__key",
+          "classes": "notify-summary-list__key notify-summary-list__key--35-100",
           "text": "Email address"
         },
         "value": {
@@ -34,7 +34,7 @@
       {
         "classes": "govuk-summary-list__row--no-actions",
         "key": {
-          "classes": "notify-summary-list__key notify-summary-list__key",
+          "classes": "notify-summary-list__key notify-summary-list__key--35-100",
           "text": "Email address"
         },
         "value": {
@@ -47,7 +47,7 @@
   {% set rows = [
     {
       "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key",
+        "classes": "notify-summary-list__key notify-summary-list__key--35-100",
         "text": "Name"
       },
       "value": {
@@ -67,7 +67,7 @@
     email_address_row,
     {
       "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key",
+        "classes": "notify-summary-list__key notify-summary-list__key--35-100",
         "text": "Mobile number"
       },
       "value": {
@@ -88,7 +88,7 @@
     },
     {
       "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key",
+        "classes": "notify-summary-list__key notify-summary-list__key--35-100",
         "text": "Password"
       },
       "value": {
@@ -107,7 +107,7 @@
     },
     {
       "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key",
+        "classes": "notify-summary-list__key notify-summary-list__key--35-100",
         "text": "Take part in user research"
       },
       "value": {
@@ -126,7 +126,7 @@
     },
     {
       "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key",
+        "classes": "notify-summary-list__key notify-summary-list__key--35-100",
         "text": "Get emails about new features"
       },
       "value": {
@@ -149,7 +149,7 @@
   {% do rows.append(
     {
       "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key",
+        "classes": "notify-summary-list__key notify-summary-list__key--35-100",
         "text": "Security keys"
       },
       "value": {
@@ -174,7 +174,7 @@
   {% do rows.append(
     {
       "key": {
-        "classes": "notify-summary-list__key notify-summary-list__key",
+        "classes": "notify-summary-list__key notify-summary-list__key--35-100",
         "text": "Use platform admin view"
       },
       "value": {

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1030,7 +1030,6 @@ def test_organisation_settings_for_platform_admin(
     organisation_one,
 ):
     expected_rows = [
-        "Label Value Action",
         "Name Test organisation Change organisation name",
         "Sector Central government Change sector for the organisation",
         "Crown organisation Yes Change organisation crown status",
@@ -1052,7 +1051,7 @@ def test_organisation_settings_for_platform_admin(
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
 
     assert page.select_one("h1").text == "Settings"
-    rows = page.select("tr")
+    rows = page.select(".govuk-summary-list__row")
     assert len(rows) == len(expected_rows)
     for index, row in enumerate(expected_rows):
         assert row == " ".join(rows[index].text.split())
@@ -1070,7 +1069,7 @@ def test_organisation_settings_table_shows_email_branding_pool(
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
 
-    email_branding_options_row = page.select("tr")[10]
+    email_branding_options_row = page.select(".govuk-summary-list__row")[9]
 
     assert normalize_spaces(email_branding_options_row.text) == (
         "Email branding options "
@@ -1092,7 +1091,9 @@ def test_organisation_settings_table_shows_letter_branding_pool(
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
 
-    letter_branding_options_row = find_element_by_tag_and_partial_text(page, "tr", "Letter branding options")
+    letter_branding_options_row = find_element_by_tag_and_partial_text(
+        page, ".govuk-summary-list__row", "Letter branding options"
+    )
 
     assert normalize_spaces(letter_branding_options_row.text) == (
         "Letter branding options "
@@ -1128,7 +1129,9 @@ def test_organisation_settings_table_shows_letter_branding_pool_with_brand_as_de
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
 
-    letter_branding_options_row = find_element_by_tag_and_partial_text(page, "tr", "Letter branding options")
+    letter_branding_options_row = find_element_by_tag_and_partial_text(
+        page, ".govuk-summary-list__row", "Letter branding options"
+    )
 
     assert normalize_spaces(letter_branding_options_row.text) == (
         "Letter branding options "
@@ -1169,7 +1172,7 @@ def test_organisation_settings_table_shows_email_branding_pool_non_govuk_default
         client_request.login(platform_admin_user)
         page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
 
-    email_branding_options_row = page.select("tr")[10]
+    email_branding_options_row = page.select(".govuk-summary-list__row")[9]
 
     assert normalize_spaces(email_branding_options_row.text) == (
         "Email branding options "
@@ -1190,7 +1193,7 @@ def test_organisation_settings_table_shows_email_branding_pool_govuk_default(
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
 
-    email_branding_options_row = page.select("tr")[10]
+    email_branding_options_row = page.select(".govuk-summary-list__row")[9]
 
     assert normalize_spaces(email_branding_options_row.text) == (
         "Email branding options GOV.UK Default Manage email branding options for the organisation"
@@ -1896,7 +1899,7 @@ def test_organisation_settings_links_to_edit_organisation_notes_page(
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
 
-    assert page.select(".table-field-right-aligned a")[4]["href"] == url_for(
+    assert page.select(".govuk-summary-list__actions a")[4]["href"] == url_for(
         ".edit_organisation_go_live_notes",
         org_id=organisation_one["id"],
     )
@@ -1964,7 +1967,7 @@ def test_organisation_settings_links_to_edit_can_approve_own_go_live_request(
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
 
-    assert page.select(".table-field-right-aligned a")[5]["href"] == url_for(
+    assert page.select(".govuk-summary-list__actions a")[5]["href"] == url_for(
         ".edit_organisation_can_approve_own_go_live_requests",
         org_id=organisation_one["id"],
     )
@@ -1982,7 +1985,7 @@ def test_organisation_settings_links_to_edit_can_ask_to_join_a_service(
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
 
-    assert page.select(".table-field-right-aligned a")[6]["href"] == url_for(
+    assert page.select(".govuk-summary-list__actions a")[6]["href"] == url_for(
         ".edit_organisation_can_ask_to_join_a_service",
         org_id=organisation_one["id"],
     )

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -180,7 +180,12 @@ def test_service_setting_toggles_show(
     link_url = url_for(endpoint, **kwargs, service_id=service_one["id"])
     service_one.update(service_fields)
     page = get_service_settings_page()
-    assert normalize_spaces(page.select_one(f'a[href="{link_url}"]').find_parent("tr").text.strip()) == text
+    assert (
+        normalize_spaces(
+            page.select_one(f'a[href="{link_url}"]').find_parent("div", class_="govuk-summary-list__row").text.strip()
+        )
+        == text
+    )
 
 
 @pytest.mark.parametrize(
@@ -232,7 +237,7 @@ def test_service_settings_doesnt_show_option_if_parent_permission_disabled(
 ):
     service_one["permissions"] = [permissions]
     page = get_service_settings_page()
-    cells = page.select("td")
+    cells = page.select("dd")
     assert any(cell for cell in cells if permissions_text in cell.text) is visible
 
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -64,23 +64,19 @@ def mock_get_service_settings_page_common(
             create_active_user_with_permissions(),
             ["sms", "email"],
             [
-                "Label Value Action",
                 "Service name Test Service Change service name",
                 "Sign-in method Text message code Change sign-in method",
                 "Data retention period 7 days Change data retention",
-                "Label Value Action",
                 "Send emails On Change your settings for sending emails",
                 "Email sender name Test Service test.service@notifications.service.gov.uk Change email sender name",
                 "Reply-to email addresses Not set Manage reply-to email addresses",
                 "Email branding GOV.UK Change email branding",
                 "Send files by email contact_us@gov.uk Manage sending files by email",
-                "Label Value Action",
                 "Send text messages On Change your settings for sending text messages",
                 "Text message sender IDs GOVUK Manage text message sender IDs",
                 "Start text messages with service name On Change your settings for starting text messages with service name",  # noqa
                 "Send international text messages Off Change your settings for sending international text messages",
                 "Receive text messages Off Change your settings for receiving text messages",
-                "Label Value Action",
                 "Send letters Off Change your settings for sending letters",
             ],
         ),
@@ -88,15 +84,11 @@ def mock_get_service_settings_page_common(
             create_active_user_with_permissions(),
             ["letter"],
             [
-                "Label Value Action",
                 "Service name Test Service Change service name",
                 "Sign-in method Text message code Change sign-in method",
                 "Data retention period 7 days Change data retention",
-                "Label Value Action",
                 "Send emails Off Change your settings for sending emails",
-                "Label Value Action",
                 "Send text messages Off Change your settings for sending text messages",
-                "Label Value Action",
                 "Send letters On Change your settings for sending letters",
                 "Send international letters Off Change your settings for sending international letters",
                 "Sender addresses Not set Manage sender addresses",
@@ -107,25 +99,20 @@ def mock_get_service_settings_page_common(
             create_platform_admin_user(),
             ["sms", "email"],
             [
-                "Label Value Action",
                 "Service name Test Service Change service name",
                 "Sign-in method Text message code Change sign-in method",
                 "Data retention period 7 days Change data retention",
-                "Label Value Action",
                 "Send emails On Change your settings for sending emails",
                 "Email sender name Test Service test.service@notifications.service.gov.uk Change email sender name",
                 "Reply-to email addresses Not set Manage reply-to email addresses",
                 "Email branding GOV.UK Change email branding",
                 "Send files by email contact_us@gov.uk Manage sending files by email",
-                "Label Value Action",
                 "Send text messages On Change your settings for sending text messages",
                 "Text message sender IDs GOVUK Manage text message sender IDs",
                 "Start text messages with service name On Change your settings for starting text messages with service name",  # noqa
                 "Send international text messages Off Change your settings for sending international text messages",
                 "Receive text messages Off Change your settings for receiving text messages",
-                "Label Value Action",
                 "Send letters Off Change your settings for sending letters",
-                "Label Value Action",
                 "Live No Organisation must accept the data processing and financial agreement first",
                 "Count in list of live services Yes Change if service is counted in list of live services",
                 "Billing details None Change billing details for service",
@@ -149,20 +136,15 @@ def mock_get_service_settings_page_common(
             create_platform_admin_user(),
             ["letter"],
             [
-                "Label Value Action",
                 "Service name Test Service Change service name",
                 "Sign-in method Text message code Change sign-in method",
                 "Data retention period 7 days Change data retention",
-                "Label Value Action",
                 "Send emails Off Change your settings for sending emails",
-                "Label Value Action",
                 "Send text messages Off Change your settings for sending text messages",
-                "Label Value Action",
                 "Send letters On Change your settings for sending letters",
                 "Send international letters Off Change your settings for sending international letters",
                 "Sender addresses Not set Manage sender addresses",
                 "Letter branding Not set Change letter branding",
-                "Label Value Action",
                 "Live No Organisation must accept the data processing and financial agreement first",
                 "Count in list of live services Yes Change if service is counted in list of live services",
                 "Billing details None Change billing details for service",
@@ -208,7 +190,7 @@ def test_should_show_overview(
     page = client_request.get("main.service_settings", service_id=SERVICE_ONE_ID)
 
     assert page.select_one("h1").text == "Settings"
-    rows = page.select("tr")
+    rows = page.select(".govuk-summary-list__row")
     assert len(rows) == len(expected_rows)
     assert [" ".join(row.text.split()) for row in rows] == expected_rows
     app.service_api_client.get_service.assert_called_with(SERVICE_ONE_ID)
@@ -271,10 +253,10 @@ def test_no_go_live_link_for_service_without_organisation(
 
     assert page.select_one("h1").text == "Settings"
 
-    is_live = find_element_by_tag_and_partial_text(page, tag="td", string="Live")
+    is_live = find_element_by_tag_and_partial_text(page, tag="dt", string="Live")
     assert normalize_spaces(is_live.find_next_sibling().text) == "No Organisation must be set first"
 
-    organisation = find_element_by_tag_and_partial_text(page, tag="td:first-child", string="Organisation")
+    organisation = find_element_by_tag_and_partial_text(page, tag="dt", string="Organisation")
     assert normalize_spaces(organisation.find_next_siblings()[0].text) == "Not set Central government"
     assert normalize_spaces(organisation.find_next_siblings()[1].text) == "Change organisation for service"
 
@@ -294,7 +276,7 @@ def test_organisation_name_links_to_org_dashboard(
     client_request.login(platform_admin_user, service_one)
     response = client_request.get("main.service_settings", service_id=SERVICE_ONE_ID)
 
-    org_row = find_element_by_tag_and_partial_text(response, tag="td:first-child", string="Organisation").parent
+    org_row = find_element_by_tag_and_partial_text(response, tag="dt", string="Organisation").parent
     assert org_row.find("a")["href"] == url_for("main.organisation_dashboard", org_id=ORGANISATION_ID)
     assert normalize_spaces(org_row.find("a").text) == "Test organisation"
 
@@ -326,7 +308,9 @@ def test_send_files_by_email_row_on_settings_page(
     client_request.login(platform_admin_user, service_one)
     response = client_request.get("main.service_settings", service_id=SERVICE_ONE_ID)
 
-    org_row = find_element_by_tag_and_partial_text(response, tag="tr", string="Send files by email")
+    org_row = find_element_by_tag_and_partial_text(
+        response, tag=".govuk-summary-list__row", string="Send files by email"
+    )
     assert normalize_spaces(org_row.get_text()) == expected_text
 
 
@@ -339,19 +323,16 @@ def test_send_files_by_email_row_on_settings_page(
                 "Service name service one Change service name",
                 "Sign-in method Text message code Change sign-in method",
                 "Data retention period 7 days Change data retention",
-                "Label Value Action",
                 "Send emails On Change your settings for sending emails",
                 "Email sender name service one service.one@notifications.service.gov.uk Change email sender name",
                 "Reply-to email addresses test@example.com Manage reply-to email addresses",
                 "Email branding Organisation name Change email branding",
                 "Send files by email Not set up Manage sending files by email",
-                "Label Value Action",
                 "Send text messages On Change your settings for sending text messages",
                 "Text message sender IDs GOVUK Manage text message sender IDs",
                 "Start text messages with service name On Change your settings for starting text messages with service name",  # noqa
                 "Send international text messages On Change your settings for sending international text messages",
                 "Receive text messages On Change your settings for receiving text messages",
-                "Label Value Action",
                 "Send letters Off Change your settings for sending letters",
             ],
         ),
@@ -361,19 +342,16 @@ def test_send_files_by_email_row_on_settings_page(
                 "Service name service one Change service name",
                 "Sign-in method Email link or text message code Change sign-in method",
                 "Data retention period 7 days Change data retention",
-                "Label Value Action",
                 "Send emails On Change your settings for sending emails",
                 "Email sender name service one service.one@notifications.service.gov.uk Change email sender name",
                 "Reply-to email addresses test@example.com Manage reply-to email addresses",
                 "Email branding Organisation name Change email branding",
                 "Send files by email Not set up Manage sending files by email",
-                "Label Value Action",
                 "Send text messages On Change your settings for sending text messages",
                 "Text message sender IDs GOVUK Manage text message sender IDs",
                 "Start text messages with service name On Change your settings for starting text messages with service name",  # noqa
                 "Send international text messages Off Change your settings for sending international text messages",
                 "Receive text messages Off Change your settings for receiving text messages",
-                "Label Value Action",
                 "Send letters Off Change your settings for sending letters",
             ],
         ),
@@ -383,11 +361,8 @@ def test_send_files_by_email_row_on_settings_page(
                 "Service name service one Change service name",
                 "Sign-in method Text message code Change sign-in method",
                 "Data retention period 7 days Change data retention",
-                "Label Value Action",
                 "Send emails Off Change your settings for sending emails",
-                "Label Value Action",
                 "Send text messages Off Change your settings for sending text messages",
-                "Label Value Action",
                 "Send letters On Change your settings for sending letters",
                 "Send international letters Off Change your settings for sending international letters",
                 "Sender addresses 1 Example Street Manage sender addresses",
@@ -413,7 +388,9 @@ def test_should_show_overview_for_service_with_more_things_set(
     service_one["permissions"] = permissions
     service_one["email_branding"] = uuid4()
     page = client_request.get("main.service_settings", service_id=service_one["id"])
-    assert [" ".join(row.text.split()) for row in page.select("tr")[1:]] == expected_rows
+    assert [
+        " ".join(row.text.split()) for row in page.select(".notify-summary-list .govuk-summary-list__row")[0:]
+    ] == expected_rows
 
 
 def test_if_cant_send_letters_then_cant_see_letter_contact_block(
@@ -442,9 +419,9 @@ def test_letter_contact_block_shows_none_if_not_set(
         service_id=SERVICE_ONE_ID,
     )
 
-    div = page.select("tr")[11].select("td")[1].div
+    div = page.select(".service-letter-settings .govuk-summary-list__value")[2]
     assert div.text.strip() == "Not set"
-    assert "default" in div.attrs["class"][0]
+    assert "govuk-summary-list__value--default" in div.attrs["class"][1]
 
 
 def test_escapes_letter_contact_block(
@@ -461,8 +438,7 @@ def test_escapes_letter_contact_block(
         "main.service_settings",
         service_id=SERVICE_ONE_ID,
     )
-
-    div = str(page.select("tr")[11].select("td")[1].div)
+    div = str(page.select(".service-letter-settings .govuk-summary-list__value")[2])
     assert "foo<br/>bar" in div
     assert "<script>" not in div
 
@@ -603,7 +579,7 @@ def test_show_restricted_service(
     )
 
     assert page.select_one("h1").text == "Settings"
-    assert page.select("main h2")[0].text == "Your service is in trial mode"
+    assert page.select("main > h2")[0].text == "Your service is in trial mode"
 
     assert [normalize_spaces(li.text) for li in page.select("main ul li")] == [
         "send messages to yourself and other people in your team",
@@ -641,7 +617,7 @@ def test_show_limits_for_live_service(
         service_id=SERVICE_ONE_ID,
     )
 
-    assert page.select_one("main h2").text == "Your service is live"
+    assert page.select_one("main > h2").text == "Your service is live"
     assert normalize_spaces(page.select_one("main p").text) == "You can send up to:"
     assert [normalize_spaces(li.text) for li in page.select("main ul li")] == [
         "1,000 emails per day",
@@ -2554,7 +2530,9 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
     page = client_request.get("main.service_settings", service_id=service_one["id"])
 
     def get_row(page, label):
-        return normalize_spaces(find_element_by_tag_and_partial_text(page, tag="tr", string=label).text)
+        return normalize_spaces(
+            find_element_by_tag_and_partial_text(page, tag=".govuk-summary-list__row", string=label).text
+        )
 
     assert (
         get_row(page, "Reply-to email addresses")
@@ -5773,9 +5751,9 @@ def test_show_service_data_retention(
         service_id=service_one["id"],
     )
 
-    rows = page.select("tbody tr")
+    rows = page.select(".govuk-summary-list__row")
     assert len(rows) == 1
-    assert normalize_spaces(rows[0].text) == "Email 5 days Change"
+    assert normalize_spaces(rows[0].text) == "Email 5 days Change email data retention setting"
 
     assert page.select_one(".govuk-back-link")["href"] == url_for(
         "main.service_settings",


### PR DESCRIPTION
Migrate headless tables to a govuk-summary-list component as that's the more accessible way of presenting it to the user for interaction.

See individual commits for details. Fixes https://trello.com/c/7I9xjoqU/740-change-tables-without-column-headers-to-use-the-govuk-frontend-summary-list-pattern

Related: https://github.com/alphagov/notifications-functional-tests/pull/505

<details>
  <summary>Service settings</summary>

**Before**
![service-settings-before](https://github.com/alphagov/notifications-admin/assets/3758555/4a77d827-2658-4a36-927f-95f980264de5)

**After**
![service-settings-after](https://github.com/alphagov/notifications-admin/assets/3758555/414eb591-788d-412e-adae-169dfbf492f2)

**Mobile before**
![service-seetings-mobile-before](https://github.com/alphagov/notifications-admin/assets/3758555/f12981bc-4f6f-445b-bfcf-c724a872239d)

**Mobile after**
![service-settings-mobile](https://github.com/alphagov/notifications-admin/assets/3758555/dd0fd2c9-8230-4511-bec8-fd66f1e5a1a8)

</details>

<details>
  <summary>Organisation settings</summary>

**Before**
![org-settings-before](https://github.com/alphagov/notifications-admin/assets/3758555/9b3a59df-5081-4b99-9676-ff02f340f029)

**After**
![org-settings-after](https://github.com/alphagov/notifications-admin/assets/3758555/c670c8a8-1314-4c90-b2bf-ba60c202e514)

**Mobile before**
![org-settings-before-mobile](https://github.com/alphagov/notifications-admin/assets/3758555/789fbc90-6f80-4902-b607-37a5dc08246b)

**Mobile after**
![org-settings-mobile](https://github.com/alphagov/notifications-admin/assets/3758555/816d0cd7-9cf8-44b8-86f1-604826039a9d)

</details>

<details>
  <summary>Data retention settings</summary>

**Before**
![data-retention-before](https://github.com/alphagov/notifications-admin/assets/3758555/73620411-5c8b-40be-b0ee-75407e5f82ef)

**After**
![data-retention-after](https://github.com/alphagov/notifications-admin/assets/3758555/30a88d90-f1e3-447d-aed2-708b8723cedb)

**Mobile before**
![data-retention-mobile-before](https://github.com/alphagov/notifications-admin/assets/3758555/eb7b1e76-22ea-4369-ab3d-2f4edc60c2cc)

**Mobile after**
![data-retention-mobile](https://github.com/alphagov/notifications-admin/assets/3758555/69dfaf52-fbc0-4cff-9ded-9b2d9411937d)

</details>
