### PR TITLE
Remove unused branding query param

### DIFF
--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -85,7 +85,6 @@ def email_branding_options(service_id):
                 url_for(
                     ".branding_option_preview",
                     service_id=current_service.id,
-                    branding_option=branding_choice,
                     branding_choice=branding_choice,
                     branding_type="email",
                 )
@@ -522,9 +521,7 @@ def branding_option_preview(service_id, branding_type):
         branding_pool = current_service.letter_branding_pool
         back_link_query_params = _letter_branding_flow_query_params()
     try:
-        chosen_branding = branding_pool.get_item_by_id(
-            request.args.get("branding_choice", request.args.get("branding_option"))
-        )
+        chosen_branding = branding_pool.get_item_by_id(request.args.get("branding_choice"))
     except branding_pool.NotFound:
         flash("No branding found for this id.")
         return redirect(url_for(f".{branding_type}_branding_options", service_id=current_service.id))
@@ -621,7 +618,6 @@ def letter_branding_options(service_id):
                 url_for(
                     ".branding_option_preview",
                     service_id=current_service.id,
-                    branding_option=branding_choice,
                     branding_choice=branding_choice,
                     branding_type="letter",
                 )

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -482,7 +482,6 @@ def test_email_branding_options_redirects_to_branding_preview_for_a_branding_poo
         _expected_redirect=url_for(
             "main.branding_option_preview",
             service_id=SERVICE_ONE_ID,
-            branding_option="email-branding-1-id",
             branding_choice="email-branding-1-id",
             branding_type="email",
         ),
@@ -503,7 +502,7 @@ def test_email_branding_option_preview_page_displays_preview_of_chosen_branding(
     page = client_request.get(
         ".branding_option_preview",
         service_id=SERVICE_ONE_ID,
-        branding_option="email-branding-1-id",
+        branding_choice="email-branding-1-id",
         branding_type="email",
     )
 
@@ -529,7 +528,7 @@ def test_email_branding_option_preview_page_redirects_to_branding_request_page_i
     client_request.get(
         ".branding_option_preview",
         service_id=SERVICE_ONE_ID,
-        branding_option="some-unknown-branding-id",
+        branding_choice="some-unknown-branding-id",
         branding_type="email",
         _expected_status=302,
         _expected_redirect=url_for("main.email_branding_options", service_id=SERVICE_ONE_ID),
@@ -558,7 +557,7 @@ def test_email_branding_option_preview_changes_email_branding_when_user_confirms
     page = client_request.post(
         ".branding_option_preview",
         service_id=SERVICE_ONE_ID,
-        branding_option="email-branding-1-id",
+        branding_choice="email-branding-1-id",
         branding_type="email",
         _follow_redirects=True,
     )

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -178,7 +178,6 @@ def test_letter_branding_options_redirects_to_branding_preview_for_a_branding_po
         _expected_redirect=url_for(
             "main.branding_option_preview",
             service_id=SERVICE_ONE_ID,
-            branding_option="1234",
             branding_choice="1234",
             branding_type="letter",
         ),
@@ -734,7 +733,7 @@ def test_letter_branding_option_preview_page_displays_preview_of_chosen_branding
     )
 
     page = client_request.get(
-        ".branding_option_preview", service_id=SERVICE_ONE_ID, branding_option="1234", branding_type="letter"
+        ".branding_option_preview", service_id=SERVICE_ONE_ID, branding_choice="1234", branding_type="letter"
     )
 
     assert page.select_one("main img")["src"] == url_for(
@@ -758,7 +757,7 @@ def test_letter_branding_option_preview_page_redirects_to_branding_options_page_
     client_request.get(
         ".branding_option_preview",
         service_id=SERVICE_ONE_ID,
-        branding_option="some-unknown-branding-id",
+        branding_choice="some-unknown-branding-id",
         branding_type="letter",
         _expected_status=302,
         _expected_redirect=url_for("main.letter_branding_options", service_id=SERVICE_ONE_ID),
@@ -787,7 +786,7 @@ def test_letter_branding_option_preview_changes_letter_branding_when_user_confir
     page = client_request.post(
         ".branding_option_preview",
         service_id=SERVICE_ONE_ID,
-        branding_option="1234",
+        branding_choice="1234",
         branding_type="letter",
         _follow_redirects=True,
     )
@@ -833,7 +832,7 @@ def test_letter_branding_nhs_page_returns_404_if_service_not_nhs(
         ".branding_nhs",
         service_id=SERVICE_ONE_ID,
         branding_type="letter",
-        branding_option="some-unknown-branding-id",
+        branding_choice="some-unknown-branding-id",
         _expected_status=404,
     )
 


### PR DESCRIPTION
In order to rename the branding query parameter `branding_option` to `branding_choice`, we first added `branding_choice` which had the same value of `branding_option` and wrote the code to check both https://github.com/alphagov/notifications-admin/pull/5076. This was done so that the existing journey didn't break if someone was in the middle of using it when the change was deployed.

Now that the change has been deployed for some days, `branding_option` should not be being used so can be removed.