### PR TITLE
Add pricing information for receiving text messages

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -35,6 +35,8 @@ Text message pricing
     <li>send text messages to <a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">international numbers</a></li>
   </ul>
 
+  <p class="govuk-body">It does not cost you anything to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_receive_text_messages') }}">receive text messages</a>.</p>
+
   <h2 class="heading-medium" id="free-text-message-allowance">Free text message allowance</h2>
 
 


### PR DESCRIPTION
It does not cost anything to receive text messages. Because of this we never used to mention it on our Text message pricing page. However, it does feel like an omission on our part.

We’ve had an enquiry from a user who was looking for the cost of inbound SMS on the pricing page – they did not find the ‘Receive text messages’ guidance page.

To avoid similar enquiries in the future, this PR adds:

* the fact that inbound SMS does not cost anything
* a link to the inbound SMS guidance page