### PR TITLE
Bring in the cookie banner CSS

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -10,6 +10,7 @@ $govuk-assets-path: "/static/";
 @import "govuk/objects/all";
 
 // section replacing @import "components/all", specifying which components to include
+@import "govuk/components/cookie-banner/index";
 @import "govuk/components/skip-link/index";
 @import "govuk/components/header/index";
 @import "govuk/components/footer/index";

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -34,8 +34,3 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
     background-color: $notify-secondary-button-hover-colour;
   }
 }
-
-// by default the cookie banner component has no top padding
-.govuk-cookie-banner {
-  @include govuk-responsive-padding(4, "top");
-}


### PR DESCRIPTION
It's so minimal[^1] that it not being there wasn't spotted during visual testing because it doesn't make much of a difference.

<img width="988" alt="image" src="https://github.com/alphagov/notifications-admin/assets/87140/345e437a-8164-4b56-bb1d-9192291438f8">

This also removes some CSS we wrote that isn't needed now.

[^1]: see [the cookie banner CSS this pulls in](https://github.com/alphagov/govuk-frontend/blob/f706252d274f5c46e9ae8dc8d81d021aa4af45c9/src/govuk/components/cookie-banner/_index.scss)