### PR TITLE
removed nobody on your team can sign in from emergencies

### DIFF
--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -32,7 +32,6 @@
     <h2 class="heading-medium">What counts as an emergency?</h2>
     <p class="govuk-body">A problem is only classed as an emergency if you have a live service and:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>nobody on your team can sign in</li>
       <li>a ‘technical difficulties’ error appears when you try to upload a file</li>
       <li>a 500 response code appears when you try to send messages using the API</li>
     </ul>


### PR DESCRIPTION
Removes "nobody on your team can sign in" as an emergency on the support page.