### PR TITLE
Raise a zendesk ticket if a forbidden senderID is set

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -157,11 +157,9 @@ def create_phishing_senderid_zendesk_ticket(senderID=None):
         subject=f"Possible Phishing sender ID - {current_service.name}",
         message=ticket_message,
         ticket_type=NotifySupportTicket.TYPE_INCIDENT,
-        notify_ticket_type=NotifyTicketType.NON_TECHNICAL,
+        notify_ticket_type=NotifyTicketType.TECHNICAL,
         user_name=current_user.name,
         user_email=current_user.email_address,
-        org_id=current_service.organisation_id,
-        org_type=current_service.organisation_type,
         service_id=current_service.id,
     )
     zendesk_client.send_ticket_to_zendesk(ticket)

--- a/app/templates/support-tickets/phishing-senderid.txt
+++ b/app/templates/support-tickets/phishing-senderid.txt
@@ -1,0 +1,12 @@
+Organisation: {% if current_service.organisation -%}
+  {{ current_service.organisation.name }}
+{%- else -%}
+  Can’t tell (domain is {{ current_user.email_domain }})
+{%- endif %}
+Service: {{ current_service.name }}
+{{ url_for('main.service_dashboard', service_id=current_service.id, _external=True) }}
+
+---
+The user asked for a sender ID that is potentially used for phishing - {{ senderID }}. It has been blocked.
+
+Check whether this is just testing, if not raise a security incident.

--- a/app/templates/support-tickets/phishing-senderid.txt
+++ b/app/templates/support-tickets/phishing-senderid.txt
@@ -1,8 +1,3 @@
-Organisation: {% if current_service.organisation -%}
-  {{ current_service.organisation.name }}
-{%- else -%}
-  Can’t tell (domain is {{ current_user.email_domain }})
-{%- endif %}
 Service: {{ current_service.name }}
 {{ url_for('main.service_dashboard', service_id=current_service.id, _external=True) }}
 

--- a/app/templates/support-tickets/phishing-senderid.txt
+++ b/app/templates/support-tickets/phishing-senderid.txt
@@ -7,6 +7,13 @@ Service: {{ current_service.name }}
 {{ url_for('main.service_dashboard', service_id=current_service.id, _external=True) }}
 
 ---
-The user asked for a sender ID that is potentially used for phishing - {{ senderID }}. It has been blocked.
+The user - {{current_user.email_address}} asked for a sender ID that is potentially used for phishing - {{ senderID }}. It has been blocked.
 
-Check whether this is just testing, if not raise a security incident.
+Check whether this is just testing, if not raise a security incident:
+
+Security Incident runbook: https://github.com/alphagov/notifications-manuals/wiki/What-to-do-during-an-incident#security-incidents-and-data-breaches'
+
+To determine the extent of the problem:
+ - look at sender ids both current and archived : https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#look-at-senderid-history
+ - look at emails: {{url_for("main.view_notifications", service_id=current_service.id, message_type='email', status='delivered', _external=True)}}
+ - look at text messages: {{url_for("main.view_notifications", service_id=current_service.id, message_type='sms', status='delivered', _external=True)}}

--- a/tests/app/main/forms/test_service_sms_senders_form.py
+++ b/tests/app/main/forms/test_service_sms_senders_form.py
@@ -6,67 +6,82 @@ from app.main.forms import ServiceSmsSenderForm
 
 
 @pytest.mark.parametrize(
-    "sms_sender,error_expected,error_message",
+    "sms_sender,error_expected,error_message,sends_zendesk_ticket",
     [
-        ("", True, "Enter a text message sender ID"),
-        ("22", True, "Text message sender ID must be at least 3 characters long"),
-        ("333", True, "A numeric sender id should be a valid mobile number or short code"),
-        ("70000", False, None),
-        ("07000000000", False, None),
+        ("", True, "Enter a text message sender ID", False),
+        ("22", True, "Text message sender ID must be at least 3 characters long", False),
+        ("333", True, "A numeric sender id should be a valid mobile number or short code", False),
+        ("70000", False, None, False),
+        ("07000000000", False, None, False),
         (
             "Info",
             True,
             "Text message sender ID cannot be Alert, Info or Verify as those are prohibited due to usage by spam",
+            False,
         ),
-        ("Inform Uk", False, None),
-        ("elevenchars", False, None),  # 11 chars
-        ("twelvecharas", True, "Text message sender ID cannot be longer than 11 characters"),  # 12 chars
+        ("Inform Uk", False, None, False),
+        ("elevenchars", False, None, False),  # 11 chars
+        ("twelvecharas", True, "Text message sender ID cannot be longer than 11 characters", False),  # 12 chars
         (
             "###",
             True,
             "Text message sender ID can only include letters, numbers, spaces, and the following characters: & . - _",
+            False,
         ),
-        ("00111222333", True, "Text message sender ID cannot start with 00"),
-        ("UK_GOV", False, None),  # Underscores are allowed
-        ("UK-GOV", False, None),  # Simple dashes are allowed
-        ("UK.GOV", False, None),  # Full stops are allowed
-        ("UK&GOV", False, None),  # Ampersands are allowed
+        ("00111222333", True, "Text message sender ID cannot start with 00", False),
+        ("UK_GOV", False, None, False),  # Underscores are allowed
+        ("UK-GOV", False, None, False),  # Simple dashes are allowed
+        ("UK.GOV", False, None, False),  # Full stops are allowed
+        ("UK&GOV", False, None, False),  # Ampersands are allowed
         (
             "Evri",
             True,
             "Text message sender ID cannot be ‘Evri’ - this is to protect recipients from phishing scams",
+            True,
         ),
-        pytest.param("'UC'", False, None, marks=pytest.mark.xfail),  # Apostrophes can cause SMS delivery issues
+        pytest.param("'UC'", False, None, False, marks=pytest.mark.xfail),  # Apostrophes can cause SMS delivery issues
     ],
 )
-def test_sms_sender_form_validation(client_request, mock_get_user_by_email, sms_sender, error_expected, error_message):
+def test_sms_sender_form_validation(
+    client_request, mock_get_user_by_email, sms_sender, error_expected, error_message, sends_zendesk_ticket, mocker
+):
     form = ServiceSmsSenderForm()
     form.sms_sender.data = sms_sender
-
+    mock_create_phishing_zendesk_ticket = mocker.patch(
+        "app.main.validators.create_phishing_senderid_zendesk_ticket",
+        autospec=True,
+    )
     form.validate()
-
     if error_expected:
         assert form.errors
         assert error_message == form.errors["sms_sender"][0]
     else:
         assert not form.errors
 
+    if sends_zendesk_ticket:
+        mock_create_phishing_zendesk_ticket.assert_called_once()
+
 
 @pytest.mark.parametrize(
-    "sms_sender,log_expected,log_message",
+    "sms_sender,log_expected,log_message,sends_zendesk_ticket",
     [
-        ("UK&GOV", False, None),  # No warning log on valid senderID
+        ("UK&GOV", False, None, False),  # No warning log on valid senderID
         (
             "Evri",
             True,
             "User tried to set sender id to potentially malicious one: Evri",
+            True,
         ),
     ],
 )
-def test_sms_validation_logs(caplog, sms_sender, log_expected, log_message):
+def test_sms_validation_logs(caplog, sms_sender, log_expected, log_message, sends_zendesk_ticket, mocker):
 
     form = ServiceSmsSenderForm()
     form.sms_sender.data = sms_sender
+    mock_create_phishing_zendesk_ticket = mocker.patch(
+        "app.main.validators.create_phishing_senderid_zendesk_ticket",
+        autospec=True,
+    )
     with caplog.at_level(logging.WARNING):
         form.validate()
 
@@ -75,3 +90,6 @@ def test_sms_validation_logs(caplog, sms_sender, log_expected, log_message):
 
     else:
         assert len(caplog.messages) == 0
+
+    if sends_zendesk_ticket:
+        mock_create_phishing_zendesk_ticket.assert_called_once_with(senderID=sms_sender)


### PR DESCRIPTION
In order to be alerted to people potentially trying to send a phishing email or other spam email, send a zendesk ticket.

This only triggers with small list of SenderIDS there is a story in the backlog to extend this.

The zendesk email looks like 
![Screenshot 2024-05-20 at 10 58 12](https://github.com/alphagov/notifications-admin/assets/10772338/126c2bf7-9c58-4b8f-a440-a33cdfef1b5a)
