### PR TITLE
Make upload contact list and upload addresses/phone numbers form meet validation requirements

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1537,7 +1537,7 @@ class CsvUploadForm(StripWhitespaceForm):
     file = FileField(
         "Add recipients",
         validators=[
-            DataRequired(message="Please pick a file"),
+            DataRequired(message="You need to chose a file to upload"),
             CsvFileValidator(),
             FileSize(max_size=10 * 1024 * 1024, message="The file must be smaller than 10MB"),
         ],

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -37,7 +37,7 @@ class CsvFileValidator:
 
     def __call__(self, form, field):
         if not Spreadsheet.can_handle(field.data.filename):
-            raise ValidationError(f"{field.data.filename} is not a spreadsheet that Notify can read")
+            raise ValidationError("The file must be a spreadsheet that Notify can read")
 
 
 class ValidGovEmail:

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -360,24 +360,20 @@ def upload_contact_list(service_id):
                 )
             )
         except (UnicodeDecodeError, BadZipFile, XLRDError):
-            flash(f"Could not read {form.file.data.filename}. Try using a different file format.")
+            form.file.errors = ["Notify cannot read this file - try using a different file type"]
         except XLDateError:
-            flash(
-                (
-                    "{} contains numbers or dates that Notify cannot understand. "
-                    "Try formatting all columns as ‘text’ or export your file as CSV."
-                ).format(form.file.data.filename)
-            )
+            form.file.errors = ["Notify cannot read this file - try saving it as a CSV instead"]
     elif form.errors:
         # just show the first error, as we don't expect the form to have more
         # than one, since it only has one field
         first_field_errors = list(form.errors.values())[0]
-        flash(first_field_errors[0])
+        form.file.errors.append(first_field_errors[0])
 
     return render_template(
         "views/uploads/contact-list/upload.html",
         form=form,
         allowed_file_extensions=Spreadsheet.ALLOWED_FILE_EXTENSIONS,
+        error_summary_enabled=True,
     )
 
 

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -22,7 +22,6 @@
       form.file,
       allowed_file_extensions=allowed_file_extensions,
       button_text='Choose a file',
-      show_errors=False
     )}}
   </div>
 

--- a/app/templates/views/uploads/contact-list/upload.html
+++ b/app/templates/views/uploads/contact-list/upload.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/table.html" import list_table, text_field, index_field %}
@@ -16,32 +15,22 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {% if error %}
-    {% call banner_wrapper(type='dangerous') %}
-      <h1 class="banner-title">{{ error.title }}</h1>
-      {% if error.detail %}
-        <p class="govuk-body">{{ error.detail | safe }}</p>
-      {% endif %}
-    {% endcall %}
-  {% else %}
-    {{ page_header('Upload an emergency contact list') }}
-    <p class="govuk-body">
-      Save a list of staff email addresses or phone numbers in Notify.
-    </p>
-    <p class="govuk-body">
-      In an emergency, you can send a message to everyone on the list.
-    </p>
-    <p class="govuk-body">
-      Do not include contact details for members of the public.
-    </p>
-  {% endif %}
+  {{ page_header('Upload an emergency contact list') }}
+  <p class="govuk-body">
+    Save a list of staff email addresses or phone numbers in Notify.
+  </p>
+  <p class="govuk-body">
+    In an emergency, you can send a message to everyone on the list.
+  </p>
+  <p class="govuk-body">
+    Do not include contact details for members of the public.
+  </p>
 
 <div class="bottom-gutter">
   {{ file_upload(
     form.file,
     allowed_file_extensions=allowed_file_extensions,
     button_text='Choose file',
-    show_errors=False,
   )}}
 </div>
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -365,8 +365,8 @@ def test_upload_files_in_different_formats(
         assert f"Could not read {filename}" not in [r.message for r in caplog.records]
     else:
         assert not mock_s3_upload.called
-        assert normalize_spaces(page.select_one(".banner-dangerous").text) == (
-            f"Could not read {filename}. Try using a different file format."
+        assert normalize_spaces(page.select_one(".govuk-error-summary__body").text) == (
+            "Notify cannot read this file - try using a different file type"
         )
         assert f"{filename} persisted in S3 as {sample_uuid()}" not in [r.message for r in caplog.records]
         assert f"Could not read {filename}" in [r.message for r in caplog.records]
@@ -405,38 +405,14 @@ def test_send_messages_sanitises_and_truncates_file_name_for_metadata(
     [
         (
             partial(UnicodeDecodeError, "codec", b"", 1, 2, "reason"),
-            "Could not read example.xlsx. Try using a different file format.",
+            "Notify cannot read this file - try using a different file type",
         ),
-        (BadZipFile, "Could not read example.xlsx. Try using a different file format."),
-        (XLRDError, "Could not read example.xlsx. Try using a different file format."),
-        (
-            XLDateError,
-            (
-                "example.xlsx contains numbers or dates that Notify cannot understand. "
-                "Try formatting all columns as ‘text’ or export your file as CSV."
-            ),
-        ),
-        (
-            XLDateNegative,
-            (
-                "example.xlsx contains numbers or dates that Notify cannot understand. "
-                "Try formatting all columns as ‘text’ or export your file as CSV."
-            ),
-        ),
-        (
-            XLDateAmbiguous,
-            (
-                "example.xlsx contains numbers or dates that Notify cannot understand. "
-                "Try formatting all columns as ‘text’ or export your file as CSV."
-            ),
-        ),
-        (
-            XLDateTooLarge,
-            (
-                "example.xlsx contains numbers or dates that Notify cannot understand. "
-                "Try formatting all columns as ‘text’ or export your file as CSV."
-            ),
-        ),
+        (BadZipFile, "Notify cannot read this file - try using a different file type"),
+        (XLRDError, "Notify cannot read this file - try using a different file type"),
+        (XLDateError, "Notify cannot read this file - try saving it as a CSV instead"),
+        (XLDateNegative, "Notify cannot read this file - try saving it as a CSV instead"),
+        (XLDateAmbiguous, "Notify cannot read this file - try saving it as a CSV instead"),
+        (XLDateTooLarge, "Notify cannot read this file - try saving it as a CSV instead"),
     ],
 )
 def test_shows_error_if_parsing_exception(
@@ -461,7 +437,7 @@ def test_shows_error_if_parsing_exception(
         _expected_status=200,
     )
 
-    assert normalize_spaces(page.select_one(".banner-dangerous").text) == (expected_error_message)
+    assert normalize_spaces(page.select_one(".govuk-error-summary__body").text) == (expected_error_message)
 
 
 def test_upload_csv_file_with_errors_shows_check_page_with_errors(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -923,7 +923,7 @@ def test_upload_csv_invalid_extension(
         _follow_redirects=True,
     )
 
-    assert "invalid.txt is not a spreadsheet that Notify can read" in page.text
+    assert "The file must be a spreadsheet that Notify can read" in page.text
 
 
 def test_upload_csv_size_too_big(

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -252,8 +252,8 @@ def test_upload_csv_shows_error_with_invalid_extension(
         _follow_redirects=True,
     )
 
-    assert normalize_spaces(page.select_one(".banner-dangerous").text) == (
-        "invalid.txt is not a spreadsheet that Notify can read"
+    assert normalize_spaces(page.select_one(".govuk-error-summary__body").text) == (
+        "The file must be a spreadsheet that Notify can read"
     )
 
 


### PR DESCRIPTION
## What

Update `/services/<service_id>/upload-contact-list` and `/services/<uuid>/send/<uuid>/csv` file upload only validation error messages and display, so that they're displayed in an error summary component.

Addresses https://trello.com/c/exLvftli/772-make-upload-contact-list-form-meet-validation-requirements

_This change only applies to the initial file upload validation messages. Any content validation errors (on the next step) retain the current validation message treatment._

## How to review

Check individual commits to details.

## Visual changes

Some screenshots of visual changes and content updates

### Submit empty form

**Before**
<img width="688" alt="Screenshot 2024-06-10 at 09 41 22" src="https://github.com/alphagov/notifications-admin/assets/3758555/dad058e9-0654-47bc-95f2-3baf1ac40729">
<img width="679" alt="Screenshot 2024-06-10 at 09 39 43" src="https://github.com/alphagov/notifications-admin/assets/3758555/140d1338-ba64-4c6b-b799-c9bbe34022e3">

**After**
<img width="681" alt="Screenshot 2024-06-10 at 09 40 11" src="https://github.com/alphagov/notifications-admin/assets/3758555/1d9369a8-18f5-47ce-adf0-0c3bc0dbf31c">

<img width="675" alt="Screenshot 2024-06-10 at 09 40 40" src="https://github.com/alphagov/notifications-admin/assets/3758555/272d9c31-246d-4178-8c94-e59f523dc693">


### Submit invalid file

**Before**
<img width="685" alt="Screenshot 2024-06-10 at 09 45 38" src="https://github.com/alphagov/notifications-admin/assets/3758555/cd308d2a-dc7b-42e7-9a85-6ca2d45b29c2">

**After**
<img width="677" alt="Screenshot 2024-06-10 at 09 45 11" src="https://github.com/alphagov/notifications-admin/assets/3758555/f23dee0c-ec5e-496a-ac57-98bd416520af">





