### PR TITLE
Add a checkbox to mark a template as unsubscribeable

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1375,6 +1375,9 @@ class BaseTemplateForm(StripWhitespaceForm):
         if hasattr(self, "name"):
             new_template_data["name"] = self.name.data
 
+        if hasattr(self, "has_unsubscribe_link"):
+            new_template_data["has_unsubscribe_link"] = self.has_unsubscribe_link.data
+
         return new_template_data
 
 
@@ -1423,6 +1426,7 @@ class LetterAddressForm(StripWhitespaceForm):
 
 class EmailTemplateForm(BaseTemplateForm, TemplateNameMixin):
     subject = GovukTextareaField("Subject", validators=[NotifyDataRequired(thing="the subject of the email")])
+    has_unsubscribe_link = GovukCheckboxField("Allow users to unsubscribe")
 
 
 class LetterTemplateForm(BaseTemplateForm, TemplateNameMixin):

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -37,10 +37,10 @@ def _create_service(service_name, organisation_type, form):
 
 def _create_example_template(service_id):
     example_sms_template = service_api_client.create_service_template(
-        "Example text message template",
-        "sms",
-        "Hey ((name)), I’m trying out Notify. Today is ((day of week)) and my favourite colour is ((colour)).",
-        service_id,
+        name="Example text message template",
+        type_="sms",
+        content="Hey ((name)), I’m trying out Notify. Today is ((day of week)) and my favourite colour is ((colour)).",
+        service_id=service_id,
     )
     return example_sms_template
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -466,6 +466,7 @@ def copy_template(service_id, template_id):
             letter_languages=template.get_raw("letter_languages"),
             letter_welsh_subject=template.get_raw("letter_welsh_subject"),
             letter_welsh_content=template.get_raw("letter_welsh_content"),
+            has_unsubscribe_link=template.get_raw("has_unsubscribe_link"),
         )["data"]
         if template.template_type == "letter" and template.get_raw("letter_attachment"):
             _copy_letter_attachment(from_template=template, to_template=new_template)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -636,6 +636,7 @@ def add_service_template(service_id, template_type, template_folder_id=None):
                 service_id,
                 form.subject.data if hasattr(form, "subject") else None,
                 template_folder_id,
+                form.has_unsubscribe_link.data if hasattr(form, "has_unsubscribe_link") else None,
             )
         except HTTPError as e:
             if (

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -630,13 +630,13 @@ def add_service_template(service_id, template_type, template_folder_id=None):
     if form.validate_on_submit():
         try:
             new_template = service_api_client.create_service_template(
-                form.name.data,
-                template_type,
-                form.template_content.data,
-                service_id,
-                form.subject.data if hasattr(form, "subject") else None,
-                template_folder_id,
-                form.has_unsubscribe_link.data if hasattr(form, "has_unsubscribe_link") else None,
+                name=form.name.data,
+                type_=template_type,
+                content=form.template_content.data,
+                service_id=service_id,
+                subject=form.subject.data if hasattr(form, "subject") else None,
+                parent_folder_id=template_folder_id,
+                has_unsubscribe_link=form.has_unsubscribe_link.data if hasattr(form, "has_unsubscribe_link") else None,
             )
         except HTTPError as e:
             if (

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -230,7 +230,6 @@ class Service(JSONModel):
 
     def get_template_with_user_permission_or_403(self, template_id, user, **kwargs):
         template = self.get_template(template_id, **kwargs)
-
         self.get_template_folder_with_user_permission_or_403(template.get_raw("folder"), user)
 
         return template

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -15,6 +15,7 @@ ALLOWED_TEMPLATE_ATTRIBUTES = {
     "subject",
     "letter_welsh_subject",
     "letter_welsh_content",
+    "has_unsubscribe_link",
 }
 
 
@@ -182,6 +183,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         letter_languages: Optional[LetterLanguageOptions] = None,
         letter_welsh_subject: str = None,
         letter_welsh_content: str = None,
+        has_unsubscribe_link: Optional[bool] = None,
     ):
         """
         Create a service template.
@@ -191,6 +193,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "template_type": type_,
             "content": content,
             "service": service_id,
+            "has_unsubscribe_link": has_unsubscribe_link,
         }
         if subject:
             data.update({"subject": subject})
@@ -201,6 +204,10 @@ class ServiceAPIClient(NotifyAdminAPIClient):
                 "letter_languages": letter_languages,
                 "letter_welsh_subject": letter_welsh_subject,
                 "letter_welsh_content": letter_welsh_content,
+            }
+        if has_unsubscribe_link is not None:
+            data |= {
+                "has_unsubscribe_link": has_unsubscribe_link,
             }
         data = _attach_current_user(data)
         endpoint = f"/service/{service_id}/template"

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -174,6 +174,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     @cache.delete("service-{service_id}-templates")
     def create_service_template(
         self,
+        *,
         name,
         type_,
         content,

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -37,6 +37,10 @@
             }
           }) }}
 
+          {% if current_user.platform_admin %}
+            {{ form.has_unsubscribe_link }}
+          {% endif %}
+
           {{ form.template_content(param_extensions={
             "classes": "govuk-!-width-full govuk-textarea-highlight__textbox",
             "attributes": {

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -326,6 +326,7 @@ def template_json(
     letter_welsh_subject=None,
     letter_welsh_content=None,
     updated_at=None,
+    has_unsubscribe_link=None,
 ):
     template = {
         "id": id_,
@@ -346,6 +347,7 @@ def template_json(
         "letter_languages": letter_languages or "english" if type_ == "letter" else None,
         "letter_welsh_subject": letter_welsh_subject,
         "letter_welsh_content": letter_welsh_content,
+        "has_unsubscribe_link": has_unsubscribe_link,
     }
     if content is None:
         template["content"] = "template content"

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -181,10 +181,12 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
         user_id=api_user_active["id"],
     )
     mock_create_service_template.assert_called_once_with(
-        "Example text message template",
-        "sms",
-        ("Hey ((name)), I’m trying out Notify. Today is " "((day of week)) and my favourite colour is ((colour))."),
-        101,
+        name="Example text message template",
+        type_="sms",
+        content=(
+            "Hey ((name)), I’m trying out Notify. Today is " "((day of week)) and my favourite colour is ((colour))."
+        ),
+        service_id=101,
     )
     with client_request.session_transaction() as session:
         assert session["service_id"] == 101

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -558,13 +558,13 @@ def test_can_create_email_template_with_parent_folder(client_request, mock_creat
         ),
     )
     mock_create_service_template.assert_called_once_with(
-        data["name"],
-        data["template_type"],
-        data["template_content"],
-        SERVICE_ONE_ID,
-        data["subject"],
-        data["parent_folder_id"],
-        False,
+        name=data["name"],
+        type_=data["template_type"],
+        content=data["template_content"],
+        service_id=SERVICE_ONE_ID,
+        subject=data["subject"],
+        parent_folder_id=data["parent_folder_id"],
+        has_unsubscribe_link=False,
     )
 
 

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -564,6 +564,7 @@ def test_can_create_email_template_with_parent_folder(client_request, mock_creat
         SERVICE_ONE_ID,
         data["subject"],
         data["parent_folder_id"],
+        False,
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -652,7 +652,15 @@ def test_add_email_template_should_add_unsubscribe(
             "template_content": "baz",
         },
     )
-    mock_create_service_template.assert_called_once_with("foo", "email", "baz", SERVICE_ONE_ID, "bar", None, True)
+    mock_create_service_template.assert_called_once_with(
+        type_="email",
+        name="foo",
+        subject="bar",
+        content="baz",
+        service_id=SERVICE_ONE_ID,
+        parent_folder_id=None,
+        has_unsubscribe_link=True,
+    )
 
 
 def test_editing_letter_template_should_have_hidden_name_field(
@@ -4077,13 +4085,13 @@ def test_should_create_sms_template_without_downgrading_unicode_characters(
     )
 
     mock_create_service_template.assert_called_with(
-        ANY,  # name
-        ANY,  # type
-        msg,  # content
-        ANY,  # service_id
-        ANY,  # subject
-        ANY,  # parent_folder_id
-        ANY,  # is_unsubcribeable
+        name=ANY,
+        type_=ANY,
+        content=msg,
+        service_id=ANY,
+        subject=ANY,
+        parent_folder_id=ANY,
+        has_unsubscribe_link=ANY,
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2718,6 +2718,7 @@ def test_post_copy_template(
             letter_languages=None,
             letter_welsh_subject=None,
             letter_welsh_content=None,
+            has_unsubscribe_link=None,
         )
     ]
 
@@ -2760,6 +2761,7 @@ def test_post_copy_template_into_folder(
             letter_languages=None,
             letter_welsh_subject=None,
             letter_welsh_content=None,
+            has_unsubscribe_link=None,
         )
     ]
 
@@ -2798,6 +2800,7 @@ def test_post_copy_letter_template(
             letter_languages="english",
             letter_welsh_subject=None,
             letter_welsh_content=None,
+            has_unsubscribe_link=None,
         )
     ]
 
@@ -2844,6 +2847,7 @@ def test_copy_letter_template_with_letter_attachment(
             letter_languages="english",
             letter_welsh_subject=None,
             letter_welsh_content=None,
+            has_unsubscribe_link=None,
         )
     ]
     assert mock_upload.call_args_list == [

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -408,8 +408,13 @@ def test_deletes_service_cache(
     [
         (
             "create_service_template",
-            ["name", "type_", "content", SERVICE_ONE_ID],
-            {},
+            [],
+            {
+                "name": "name",
+                "type_": "type_",
+                "content": "content",
+                "service_id": SERVICE_ONE_ID,
+            },
             [f"service-{SERVICE_ONE_ID}-templates"],
             [],
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -959,9 +959,16 @@ def mock_create_service_template(mocker, fake_uuid):
         letter_languages: Optional[LetterLanguageOptions] = None,
         letter_welsh_subject: str = None,
         letter_welsh_content: str = None,
+        has_unsubscribe_link: Optional[bool] = None,
     ):
         template = template_json(
-            service_id=service_id, id_=fake_uuid, name=name, type_=type_, content=content, folder=parent_folder_id
+            service_id=service_id,
+            id_=fake_uuid,
+            name=name,
+            type_=type_,
+            content=content,
+            folder=parent_folder_id,
+            has_unsubscribe_link=has_unsubscribe_link,
         )
         return {"data": template}
 
@@ -979,6 +986,7 @@ def mock_update_service_template(mocker):
         subject=None,
         letter_welsh_subject=None,
         letter_welsh_content=None,
+        has_unsubscribe_link=False,
     ):
         template = template_json(
             service_id=service_id,
@@ -988,6 +996,7 @@ def mock_update_service_template(mocker):
             subject=subject,
             letter_welsh_subject=None,
             letter_welsh_content=None,
+            has_unsubscribe_link=has_unsubscribe_link,
         )
         return {"data": template}
 
@@ -996,7 +1005,7 @@ def mock_update_service_template(mocker):
 
 @pytest.fixture(scope="function")
 def mock_create_service_template_content_too_big(mocker):
-    def _create(name, type_, content, service, subject=None, parent_folder_id=None):
+    def _create(name, type_, content, service, subject=None, parent_folder_id=None, has_unsubscribe_link=None):
         json_mock = Mock(
             return_value={
                 "message": {"content": ["Content has a character count greater than the limit of 459"]},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -950,6 +950,7 @@ def mock_get_service_letter_template_with_qr_placeholder(mocker):
 @pytest.fixture(scope="function")
 def mock_create_service_template(mocker, fake_uuid):
     def _create(
+        *,
         name,
         type_,
         content,
@@ -1005,7 +1006,16 @@ def mock_update_service_template(mocker):
 
 @pytest.fixture(scope="function")
 def mock_create_service_template_content_too_big(mocker):
-    def _create(name, type_, content, service, subject=None, parent_folder_id=None, has_unsubscribe_link=None):
+    def _create(
+        *,
+        name,
+        type_,
+        content,
+        service_id,
+        subject=None,
+        parent_folder_id=None,
+        has_unsubscribe_link=None,
+    ):
         json_mock = Mock(
             return_value={
                 "message": {"content": ["Content has a character count greater than the limit of 459"]},


### PR DESCRIPTION
This is platform-admin-only for now until we are ready to launch the feature.

Won’t do anything until the API and database are updated but also won’t break anything if merged as-is.

Content TBC but we can merge this first and update it later.

Property name matches:
https://github.com/alphagov/notifications-api/pull/4090/commits/1be1fdf7e15bbe74731b430cfcf0f2da19eb8124#diff-90c680eba43456b516da8b4c2573d467ae17d1b0ed4373549f2a593ced3616d5R1050

<img width="784" alt="image" src="https://github.com/alphagov/notifications-admin/assets/355079/c08fd962-5985-43e2-9b0a-90d8c464113d">
