### PR TITLE
Remove `process_type` from API client

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -191,7 +191,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "template_type": type_,
             "content": content,
             "service": service_id,
-            "process_type": "normal",
         }
         if subject:
             data.update({"subject": subject})

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -336,7 +336,6 @@ def template_json(
         "version": version,
         "updated_at": updated_at or datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f"),
         "archived": archived,
-        "process_type": "normal",
         "service_letter_contact": service_letter_contact,
         "reply_to": reply_to,
         "reply_to_text": reply_to_text,


### PR DESCRIPTION
This is cleaning up a property we have removed. Follow up to
- https://github.com/alphagov/notifications-admin/pull/4567
- https://github.com/alphagov/notifications-api/pull/3711