### PR TITLE
Change content for template deletion warning hint

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -866,7 +866,7 @@ def delete_service_template(service_id, template_id):
     try:
         last_used_notification = template_statistics_client.get_last_used_date_for_template(service_id, template.id)
         message = (
-            "This template has never been used."
+            "This template has not been used within the last year."
             if not last_used_notification
             else f"This template was last used {format_delta(last_used_notification)}."
         )

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -3632,11 +3632,15 @@ def test_should_show_delete_template_page_with_time_block_for_empty_notification
             template_id=fake_uuid,
             _test_page_title=False,
         )
-    assert "Are you sure you want to delete ‘Two week reminder’?" in page.select(".banner-dangerous")[0].text
-    assert normalize_spaces(page.select(".banner-dangerous p")[0].text) == "This template has never been used."
-    assert normalize_spaces(page.select(".sms-message-wrapper")[0].text) == (
-        "service one: Template <em>content</em> with & entity"
-    )
+
+    expected_confirmation_question = "Are you sure you want to delete ‘Two week reminder’?"
+    expected_usage_hint = "This template has not been used within the last year."
+    expected_template_content = "service one: Template <em>content</em> with & entity"
+
+    assert expected_confirmation_question in page.select(".banner-dangerous")[0].text
+    assert normalize_spaces(page.select(".banner-dangerous p")[0].text) == expected_usage_hint
+    assert normalize_spaces(page.select(".sms-message-wrapper")[0].text) == expected_template_content
+
     mock_get_service_template.assert_called_with(SERVICE_ONE_ID, fake_uuid, None)
 
 


### PR DESCRIPTION
The query to check when template was last used would often time out (Sentry has record of 10 000 errors this caused - and it's a manual process to delete a template, so it's a lot of users seeing error page :< ).

One measure to prevent that is for us to only search within last year - that should be good enough for the user to be warned if they are deleting a well-used template by mistake.

So in this PR we are changing the content of the warning to match the check we are actually performing in the API
(checking for latest template usage, if any, within last year).

Should go in before this PR: https://github.com/alphagov/notifications-api/pull/4097

Story ticket: https://trello.com/c/RyEMRpQw/719-find-out-why-template-last-use-query-is-slow-and-fails

New content:
<img width="1107" alt="Screenshot 2024-06-04 at 16 52 48" src="https://github.com/alphagov/notifications-admin/assets/20957548/2ddf8f46-3e7b-4045-b6e8-b8a2ee2ba02c">

