### PR TITLE
Make callout to callback documentation consistent

### DIFF
--- a/app/templates/views/api/callbacks/received-text-messages-callback.html
+++ b/app/templates/views/api/callbacks/received-text-messages-callback.html
@@ -18,7 +18,7 @@
     <div class="govuk-grid-column-five-sixths">
       <p class="govuk-body">
         When you receive a text message in Notify, we can forward it to your system.
-        Check the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}"> callback documentation </a> for more information.
+        Read the Callbacks section of our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a> for more information.
       </p>
 
       {% call form_wrapper() %}


### PR DESCRIPTION
The callout for delivery status callbacks and inbound text message callbacks was different, for no obvious reason. I've made these consistent, picking what I thought is the better and clearer message of the 2 ways we do it.

Will need review of a content designer please.

## Before

![image](https://github.com/alphagov/notifications-admin/assets/7228605/117b5863-053c-4d99-b965-37d5dcbd9f43)
![image](https://github.com/alphagov/notifications-admin/assets/7228605/e1ee362e-8383-46f9-af3a-0be37cc626f2)

## After
![image](https://github.com/alphagov/notifications-admin/assets/7228605/c1c0c8dc-eae9-45fe-89b6-292ae965247b)
