### PR TITLE
Update code to use new Zendesk form

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -156,11 +156,12 @@ def create_phishing_senderid_zendesk_ticket(senderID=None):
     ticket = NotifySupportTicket(
         subject=f"Possible Phishing sender ID - {current_service.name}",
         message=ticket_message,
-        ticket_type=NotifySupportTicket.TYPE_INCIDENT,
+        ticket_type=NotifySupportTicket.TYPE_TASK,
         notify_ticket_type=NotifyTicketType.TECHNICAL,
         user_name=current_user.name,
         user_email=current_user.email_address,
         service_id=current_service.id,
+        notify_task_type="notify_task_blocked_sender",
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -45,14 +45,14 @@ def create_email_branding_zendesk_ticket(detail=None):
     ticket = NotifySupportTicket(
         subject=f"Email branding request - {current_service.name}",
         message=ticket_message,
-        ticket_type=NotifySupportTicket.TYPE_QUESTION,
+        ticket_type=NotifySupportTicket.TYPE_TASK,
         notify_ticket_type=NotifyTicketType.NON_TECHNICAL,
         user_name=current_user.name,
         user_email=current_user.email_address,
         org_id=current_service.organisation_id,
         org_type=current_service.organisation_type,
         service_id=current_service.id,
-        ticket_categories=["notify_email_letter_branding"],
+        notify_task_type="notify_task_email_branding",
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 
@@ -208,7 +208,7 @@ def email_branding_enter_government_identity_logo_text(service_id):
             org_id=current_service.organisation_id,
             org_type=current_service.organisation_type,
             service_id=current_service.id,
-            ticket_categories=["notify_email_letter_branding"],
+            notify_task_type="notify_task_email_branding_gov",
         )
         zendesk_client.send_ticket_to_zendesk(ticket)
         flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")
@@ -654,14 +654,14 @@ def letter_branding_request(service_id):
         ticket = NotifySupportTicket(
             subject=f"Letter branding request - {current_service.name}",
             message=ticket_message,
-            ticket_type=NotifySupportTicket.TYPE_QUESTION,
+            ticket_type=NotifySupportTicket.TYPE_TASK,
             notify_ticket_type=NotifyTicketType.NON_TECHNICAL,
             user_name=current_user.name,
             user_email=current_user.email_address,
             org_id=current_service.organisation_id,
             org_type=current_service.organisation_type,
             service_id=current_service.id,
-            ticket_categories=["notify_email_letter_branding"],
+            notify_task_type="notify_task_letter_branding",
         )
         zendesk_client.send_ticket_to_zendesk(ticket)
         flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -233,13 +233,15 @@ def submit_request_to_go_live(service_id):
 
     if current_service.organisation.can_approve_own_go_live_requests:
         subject = f"Self approve go live request - {current_service.name}"
+        notify_task_type = "notify_task_go_live_request_self_approve"
     else:
         subject = f"Request to go live - {current_service.name}"
+        notify_task_type = "notify_task_go_live_request"
 
     ticket = NotifySupportTicket(
         subject=subject,
         message=ticket_message,
-        ticket_type=NotifySupportTicket.TYPE_QUESTION,
+        ticket_type=NotifySupportTicket.TYPE_TASK,
         notify_ticket_type=NotifyTicketType.NON_TECHNICAL,
         user_name=current_user.name,
         user_email=current_user.email_address,
@@ -247,7 +249,7 @@ def submit_request_to_go_live(service_id):
         org_id=current_service.organisation_id,
         org_type=current_service.organisation_type,
         service_id=current_service.id,
-        ticket_categories=["notify_go_live_request"],
+        notify_task_type=notify_task_type,
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ rtreelib==0.2.0
 fido2==1.1.0
 
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.0.0
 govuk-frontend-jinja==2.8.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.0.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -815,14 +815,14 @@ def test_email_branding_request_submit(
             ]
         ),
         subject="Email branding request - service one",
-        ticket_type="question",
+        ticket_type="task",
         notify_ticket_type=NotifyTicketType.NON_TECHNICAL,
         user_name="Test User",
         user_email="test@user.gov.uk",
         org_id=None,
         org_type="nhs_local",
         service_id=SERVICE_ONE_ID,
-        ticket_categories=["notify_email_letter_branding"],
+        notify_task_type="notify_task_email_branding",
     )
     mock_send_ticket_to_zendesk.assert_called_once()
     assert normalize_spaces(page.select_one(".banner-default").text) == (

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -338,13 +338,13 @@ def test_POST_letter_branding_request_creates_zendesk_ticket(
         "Homer Simpson",
     ]
     assert zendesk_ticket.subject == "Letter branding request - service one"
-    assert zendesk_ticket.ticket_type == "question"
+    assert zendesk_ticket.ticket_type == "task"
     assert zendesk_ticket.user_name == "Test User"
     assert zendesk_ticket.user_email == "test@user.gov.uk"
     assert zendesk_ticket.org_id == org_id
     assert zendesk_ticket.org_type == "central"
     assert zendesk_ticket.service_id == SERVICE_ONE_ID
-    assert zendesk_ticket.ticket_categories == ["notify_email_letter_branding"]
+    assert zendesk_ticket.notify_task_type == "notify_task_letter_branding"
 
 
 def test_GET_letter_branding_upload_branding_renders_form(

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2038,7 +2038,7 @@ def test_should_redirect_after_request_to_go_live(
         ANY,
         subject="Request to go live - service one",
         message=expected_message,
-        ticket_type="question",
+        ticket_type="task",
         notify_ticket_type=NotifyTicketType.NON_TECHNICAL,
         user_name=active_user_with_permissions["name"],
         user_email=active_user_with_permissions["email_address"],
@@ -2046,7 +2046,7 @@ def test_should_redirect_after_request_to_go_live(
         org_id=None,
         org_type="central",
         service_id=SERVICE_ONE_ID,
-        ticket_categories=["notify_go_live_request"],
+        notify_task_type="notify_task_go_live_request",
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 
@@ -2062,12 +2062,13 @@ def test_should_redirect_after_request_to_go_live(
 
 
 @pytest.mark.parametrize(
-    "can_approve_own_go_live_requests, expected_subject, expected_go_live_notes",
+    "can_approve_own_go_live_requests, expected_subject, expected_go_live_notes, expected_zendesk_task_type",
     (
         (
             False,
             "Request to go live - service one",
             "This service is not allowed to go live",
+            "notify_task_go_live_request",
         ),
         (
             True,
@@ -2077,6 +2078,7 @@ def test_should_redirect_after_request_to_go_live(
                 "No action should be needed from us. "
                 "This service is not allowed to go live"
             ),
+            "notify_task_go_live_request_self_approve",
         ),
     ),
 )
@@ -2098,6 +2100,7 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
     can_approve_own_go_live_requests,
     expected_go_live_notes,
     expected_subject,
+    expected_zendesk_task_type,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -2138,7 +2141,7 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
         ANY,
         subject=expected_subject,
         message=expected_message,
-        ticket_type="question",
+        ticket_type="task",
         notify_ticket_type=NotifyTicketType.NON_TECHNICAL,
         user_name=active_user_with_permissions["name"],
         user_email=active_user_with_permissions["email_address"],
@@ -2146,7 +2149,7 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
         org_id=ORGANISATION_ID,
         org_type="central",
         service_id=SERVICE_ONE_ID,
-        ticket_categories=["notify_go_live_request"],
+        notify_task_type=expected_zendesk_task_type,
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 


### PR DESCRIPTION
Every ticket type is now a "task" and should have the `notify_task_type`
drop down menu populated instead of the `ticket_categories` dropdown,
which has been removed.

The exception to this is the tickets that get opened using the support
form - these haven't changed.

Needs https://github.com/alphagov/notifications-utils/pull/1121 to be merged first 