### PR TITLE
Remove redundant section from accessibility statement

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -16,7 +16,7 @@
       "Next review due": "25 June 2024"
     }
     ) }}
-    {# Last non-functional changes: 21 Feb 2024 #}
+    {# Last non-functional changes: 4 June 2024 #}
 
   <p class="govuk-body">
     This accessibility statement applies to the www.notifications.service.gov.uk domain. It does not apply to the <a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk">GOV.UK Notify API documentation subdomain</a>.
@@ -95,16 +95,6 @@
   </p>
 
   <h2 class="heading-medium" id="non-accessible-content">Non-accessible content</h2>
-
-<h3 class="heading-small" id="non-compliance">Non compliance with the accessibility regulations</h3>
-
-  <p class="govuk-body">
-    The following content on the Notify website is not compliant with the WCAG version 2.1 AA standard:
-  </p>
-
-  <p class="govuk-body">
-    The content listed below is non-accessible for the following reasons.
-  </p>
 
   <h3 class="heading-small" id="problems-with-using-the-interface">Problems with using the interface</h3>
 


### PR DESCRIPTION
I removed the last issue from this seciton in https://github.com/alphagov/notifications-admin/pull/5096 but didn't delete the section. This does that.

Example of what it looked like before can be seen [in this version of the statement before that PR](https://github.com/alphagov/notifications-admin/blob/927672d6780faf37bcaaeaa6957b3369ba76f5b5/app/templates/views/accessibility_statement.html#L101)