### PR TITLE
Add a warning to support tickets from non-authenticated users

### DIFF
--- a/app/templates/support-tickets/support-ticket.txt
+++ b/app/templates/support-tickets/support-ticket.txt
@@ -1,3 +1,6 @@
+{% if not current_user.is_authenticated -%}
+**This ticket was opened using the public support form and not by a logged in user**
+{% endif %}
 {{ content }}
 {% if current_service -%}
 Service: "{{ current_service.name }}"

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -143,7 +143,7 @@ def test_passed_non_logged_in_user_details_through_flow(client_request, mocker):
     mock_create_ticket.assert_called_once_with(
         ANY,
         subject="[env: test] General Notify Support",
-        message="blah\n",
+        message="**This ticket was opened using the public support form and not by a logged in user**\n\nblah\n",
         ticket_type="question",
         p1=False,
         user_name="Anne Example",
@@ -208,7 +208,7 @@ def test_passes_user_details_through_flow(
 
     assert mock_create_ticket.call_args[1]["message"] == "\n".join(
         [
-            "blah",
+            "\nblah",
             'Service: "service one"',
             url_for(
                 "main.service_dashboard",


### PR DESCRIPTION
This adds a note to the start of support tickets created when a user is logged out of Notify. When someone is logged out, they can enter any email address so this helps make it clear that the user hasn't been verified.

---
Tickets created when not logged in look like this:
<img width="938" alt="Screenshot 2024-06-07 at 15 30 00" src="https://github.com/alphagov/notifications-admin/assets/12881990/4944a966-b176-4b08-a0df-2a5d199e8f03">
