### PR TITLE
Update the `How to pay` page

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -90,10 +90,7 @@ class Config:
         "sort_code": "01-23-45",
         "IBAN": "GB33BUKB20201555555555",
         "swift": "ABCDEF12",
-        "notify_billing_email_addresses": [
-            "generic@digital.cabinet-office.gov.uk",
-            "first.last@digital.cabinet-office.gov.uk",
-        ],
+        "notify_billing_email_address": "generic@digital.cabinet-office.gov.uk",
     }
 
     EMAIL_BRANDING_MIN_LOGO_HEIGHT_PX = 108

--- a/app/main/views/pricing.py
+++ b/app/main/views/pricing.py
@@ -44,6 +44,7 @@ def guidance_pricing_letters():
 def guidance_how_to_pay():
     return render_template(
         "views/guidance/pricing/how-to-pay.html",
+        billing_details=current_app.config["NOTIFY_BILLING_DETAILS"],
         navigation_links=pricing_nav(),
     )
 

--- a/app/templates/views/guidance/pricing/billing-details.html
+++ b/app/templates/views/guidance/pricing/billing-details.html
@@ -41,13 +41,9 @@
       Email address
     </h3>
 
-    <ul class="govuk-list govuk-list--bullet">
-      {% for email in billing_details['notify_billing_email_addresses'] %}
-      <li>
-        {{ email }}
-      </li>
-      {% endfor %}
-    </ul>
+    <p class="govuk-body">
+      {{ billing_details['notify_billing_email_address'] }}
+    </p>
 
     <h3 class="heading-small" id="vat-number">
       <abbr title="Value Added Tax">VAT</abbr> number

--- a/app/templates/views/guidance/pricing/billing-details.html
+++ b/app/templates/views/guidance/pricing/billing-details.html
@@ -38,7 +38,7 @@
     </p>
 
     <h3 class="heading-small" id="email-addresses">
-      Email addresses
+      Email address
     </h3>
 
     <ul class="govuk-list govuk-list--bullet">

--- a/app/templates/views/guidance/pricing/how-to-pay.html
+++ b/app/templates/views/guidance/pricing/how-to-pay.html
@@ -70,7 +70,7 @@
     {% endif %}
 
     <p class="govuk-body">
-      If you do not have a copy of your <abbr title="purchase order">PO</abbr>, send the <abbr title="purchase order">PO</abbr> number and contact details as early as possible. You can then provide <abbr title="Government Digital Service">GDS</abbr> with a copy of the <abbr title="purchase order">PO</abbr> at a later date.
+      If you do not have a copy of your <abbr title="purchase order">PO</abbr> yet, send <abbr title="Government Digital Service">GDS</abbr> the <abbr title="purchase order">PO</abbr> number and contact details. You can then provide a copy of the <abbr title="purchase order">PO</abbr> at a later date.
     </p>
 
     <h2 class="heading-medium" id="invoices">

--- a/app/templates/views/guidance/pricing/how-to-pay.html
+++ b/app/templates/views/guidance/pricing/how-to-pay.html
@@ -26,7 +26,7 @@
     </p>
 
     <p class="govuk-body">
-      If your organisation can process invoices without a <abbr title="purchase order">PO</abbr> reference, <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('main.support')}}">contact us and let us know</a>.
+      If your organisation can process invoices without a <abbr title="purchase order">PO</abbr> number, <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('main.support')}}">contact us and let us know</a>.
     </p>
 
     <h3 class="heading-small" id="billing-details">
@@ -38,11 +38,11 @@
     </p>
 
     <p class="govuk-body">
-      Before you can send us a <abbr title="purchase order">PO</abbr>, your organisation may need to add the Cabinet Office as a supplier.
+      Before you can send us a <abbr title="purchase order">PO</abbr> your organisation may need to add the Cabinet Office as a supplier.
     </p>
 
     <p class="govuk-body">
-      To do this, you’ll need the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">Cabinet Office billing details</a>.
+      To do this, they’ll need the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">Cabinet Office billing details</a>.
     </p>
 
     <h3 class="heading-small" id="where-to-send-your-po">
@@ -50,18 +50,28 @@
     </h3>
 
     <p class="govuk-body">
-      Send your <abbr title="purchase order">PO</abbr> with the name and email address of your finance contact to GDS Business Operations:
+      Send <abbr title="Government Digital Service">GDS</abbr> Business Operations:
     </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your <abbr title="purchase order">PO</abbr> number</li>
+      <li>the name and email address of your finance contact</li>
+      <li>a copy of your <abbr title="purchase order">PO</abbr></li>
+    </ul>
 
     {% if current_user.is_authenticated %}
     <p class="govuk-body">
-      Their email address is {{ billing_details['notify_billing_email_address'] }}
+      The email address is {{ billing_details['notify_billing_email_address'] }}
     </p>
     {% else %}
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in', next=url_for('main.guidance_how_to_pay') )}}">Sign in</a>to see the Business Operations email address.
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in', next=url_for('main.guidance_how_to_pay') )}}">Sign in</a> to see their email address.
     </p>
     {% endif %}
+
+    <p class="govuk-body">
+      If you do not have a copy of your <abbr title="purchase order">PO</abbr>, send the <abbr title="purchase order">PO</abbr> number and contact details. You can then send <abbr title="Government Digital Service">GDS</abbr> a copy of the <abbr title="purchase order">PO</abbr> at a later date.
+    </p>
 
     <h2 class="heading-medium" id="invoices">
       Invoices
@@ -85,7 +95,7 @@
     </p>
 
     <p class="govuk-body">
-      You can pay by BACS, debit card, or credit card.
+      You can pay by <abbr title="Bankers’ automated clearing system">BACS</abbr>, debit card, or credit card.
     </p>
 
     <p class="govuk-body">

--- a/app/templates/views/guidance/pricing/how-to-pay.html
+++ b/app/templates/views/guidance/pricing/how-to-pay.html
@@ -71,7 +71,7 @@
     </ul>
 
     <p class="govuk-body">
-      The invoice will show a breakdown of each service that belongs to your organisation.
+      The invoice will show a breakdown of each service’s spend from your organisation.
     </p>
 
     <p class="govuk-body">

--- a/app/templates/views/guidance/pricing/how-to-pay.html
+++ b/app/templates/views/guidance/pricing/how-to-pay.html
@@ -26,7 +26,7 @@
     </p>
 
     <p class="govuk-body">
-      If your organisation can process invoices without a <abbr title="purchase order">PO</abbr> reference, contact us and let us know.
+      If your organisation can process invoices without a <abbr title="purchase order">PO</abbr> reference, <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('main.support')}}">contact us and let us know</a>.
     </p>
 
     <h3 class="heading-small" id="billing-details">

--- a/app/templates/views/guidance/pricing/how-to-pay.html
+++ b/app/templates/views/guidance/pricing/how-to-pay.html
@@ -42,7 +42,7 @@
     </p>
 
     <p class="govuk-body">
-      To do this, you’ll need the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">Cabinet Office billing details</p>.
+      To do this, you’ll need the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">Cabinet Office billing details</a>.
     </p>
 
     <h3 class="heading-small" id="where-to-send-your-po">
@@ -53,9 +53,15 @@
       Send your <abbr title="purchase order">PO</abbr> with the name and email address of your finance contact to GDS Business Operations:
     </p>
 
+    {% if current_user.is_authenticated %}
     <p class="govuk-body">
-      gdsbusinessops@digital.cabinet-office.gov.uk
+      Their email address is {{ billing_details['notify_billing_email_address'] }}
     </p>
+    {% else %}
+    <p class="govuk-body">
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in', next=url_for('main.guidance_how_to_pay') )}}">Sign in</a>to see the Business Operations email address.
+    </p>
+    {% endif %}
 
     <h2 class="heading-medium" id="invoices">
       Invoices

--- a/app/templates/views/guidance/pricing/how-to-pay.html
+++ b/app/templates/views/guidance/pricing/how-to-pay.html
@@ -17,6 +17,27 @@
       If you use GOV.UK Notify to send text messages or letters, you may need to send us a <a class="govuk-link govuk-link--no-visited-state" href="#purchase-orders">purchase order</a>.
     </p>
 
+    <h2 class="heading-medium" id="purchase-orders">
+      Purchase orders
+    </h2>
+    <p class="govuk-body">Before you exceed the free text message allowance or send letters, we will need either:</p>
+     <ul class="govuk-list govuk-list--bullet">
+       <li>a purchase order (PO) for the financial year</li>
+       <li>confirmation your organisation can receive invoices without a PO reference</li>
+</ul>
+<p class="govuk-body">Use our support form to <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('main.support')}}">send us your PO or confirmation with the name and email address of your finance contact</a>.</p>
+    <p class="govuk-body">
+      If your organisation’s total estimated spend is more than £500 per quarter (before <abbr title="Value Added Tax">VAT</abbr>), you will need to raise a purchase order (PO).
+    </p>
+
+    <p class="govuk-body">
+      Your organisation should raise a single <abbr title="purchase order">PO</abbr> for the estimated cost of all its services. You can update the <abbr title="purchase order">PO</abbr> any time if your usage increases.
+    </p>
+
+    <p class="govuk-body">
+      Your organisation may need to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">add the Cabinet Office as a supplier</a> before you can raise a <abbr title="purchase order">PO</abbr>.
+    </p>
+
     <h2 class="heading-medium" id="invoices">
       Invoices
     </h2>
@@ -48,27 +69,6 @@
 
     <p class="govuk-body">
       Please start your payment reference with the invoice number.
-    </p>
-
-    <h2 class="heading-medium" id="purchase-orders">
-      Purchase orders
-    </h2>
-    <p class="govuk-body">Before you exceed the free text message allowance or send letters, we will need either:</p>
-     <ul class="govuk-list govuk-list--bullet">
-       <li>a purchase order (PO) for the financial year</li>
-       <li>confirmation your organisation can receive invoices without a PO reference</li>
-</ul>
-<p class="govuk-body">Use our support form to <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('main.support')}}">send us your PO or confirmation with the name and email address of your finance contact</a>.</p>
-    <p class="govuk-body">
-      If your organisation’s total estimated spend is more than £500 per quarter (before <abbr title="Value Added Tax">VAT</abbr>), you will need to raise a purchase order (PO).
-    </p>
-
-    <p class="govuk-body">
-      Your organisation should raise a single <abbr title="purchase order">PO</abbr> for the estimated cost of all its services. You can update the <abbr title="purchase order">PO</abbr> any time if your usage increases.
-    </p>
-
-    <p class="govuk-body">
-      Your organisation may need to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">add the Cabinet Office as a supplier</a> before you can raise a <abbr title="purchase order">PO</abbr>.
     </p>
 
 {% endblock %}

--- a/app/templates/views/guidance/pricing/how-to-pay.html
+++ b/app/templates/views/guidance/pricing/how-to-pay.html
@@ -14,37 +14,52 @@
     {{ page_header('How to pay') }}
 
     <p class="govuk-body">
-      If you use GOV.UK Notify to send text messages or letters, you may need to send us a <a class="govuk-link govuk-link--no-visited-state" href="#purchase-orders">purchase order</a>.
+      You must send GOV.UK Notify a purchase order (PO) before you spend any money on text messages or letters.
     </p>
 
     <h2 class="heading-medium" id="purchase-orders">
       Purchase orders
     </h2>
-    <p class="govuk-body">Before you exceed the free text message allowance or send letters, we will need either:</p>
-     <ul class="govuk-list govuk-list--bullet">
-       <li>a purchase order (PO) for the financial year</li>
-       <li>confirmation your organisation can receive invoices without a PO reference</li>
-</ul>
-<p class="govuk-body">Use our support form to <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('main.support')}}">send us your PO or confirmation with the name and email address of your finance contact</a>.</p>
-    <p class="govuk-body">
-      If your organisation’s total estimated spend is more than £500 per quarter (before <abbr title="Value Added Tax">VAT</abbr>), you will need to raise a purchase order (PO).
-    </p>
 
     <p class="govuk-body">
       Your organisation should raise a single <abbr title="purchase order">PO</abbr> for the estimated cost of all its services. You can update the <abbr title="purchase order">PO</abbr> any time if your usage increases.
     </p>
 
     <p class="govuk-body">
-      Your organisation may need to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">add the Cabinet Office as a supplier</a> before you can raise a <abbr title="purchase order">PO</abbr>.
+      If your organisation can process invoices without a <abbr title="purchase order">PO</abbr> reference, contact us and let us know.
+    </p>
+
+    <h3 class="heading-small" id="billing-details">
+      Make sure you have our billing details
+    </h3>
+
+    <p class="govuk-body">
+      GOV.UK Notify is run by the Government Digital Service (GDS), which is part of the Cabinet Office.
+    </p>
+
+    <p class="govuk-body">
+      Before you can send us a <abbr title="purchase order">PO</abbr>, your organisation may need to add the Cabinet Office as a supplier.
+    </p>
+
+    <p class="govuk-body">
+      To do this, you’ll need the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">Cabinet Office billing details</p>.
+    </p>
+
+    <h3 class="heading-small" id="where-to-send-your-po">
+      Where to send your purchase order
+    </h3>
+
+    <p class="govuk-body">
+      Send your <abbr title="purchase order">PO</abbr> with the name and email address of your finance contact to GDS Business Operations:
+    </p>
+
+    <p class="govuk-body">
+      gdsbusinessops@digital.cabinet-office.gov.uk
     </p>
 
     <h2 class="heading-medium" id="invoices">
       Invoices
     </h2>
-
-    <p class="govuk-body">
-      Notify is run by the Government Digital Service (GDS), part of the Cabinet Office.
-    </p>
 
     <p class="govuk-body">
       The Cabinet Office will send your organisation an invoice each quarter if you:
@@ -56,11 +71,11 @@
     </ul>
 
     <p class="govuk-body">
-      If your organisation has more than one Notify service, you’ll see a breakdown of each service on your invoice.
+      The invoice will show a breakdown of each service that belongs to your organisation.
     </p>
 
     <p class="govuk-body">
-      If the value of an invoice is less than £250 (before <abbr title="Value Added Tax">VAT</abbr>), it will be added to the total for the next quarter to save time and effort.
+      If the value of an invoice is less than £500 (before <abbr title="Value Added Tax">VAT</abbr>), we’ll add it to the total for the next quarter to save time and effort.
     </p>
 
     <p class="govuk-body">

--- a/app/templates/views/guidance/pricing/how-to-pay.html
+++ b/app/templates/views/guidance/pricing/how-to-pay.html
@@ -70,7 +70,7 @@
     {% endif %}
 
     <p class="govuk-body">
-      If you do not have a copy of your <abbr title="purchase order">PO</abbr>, send the <abbr title="purchase order">PO</abbr> number and contact details. You can then send <abbr title="Government Digital Service">GDS</abbr> a copy of the <abbr title="purchase order">PO</abbr> at a later date.
+      If you do not have a copy of your <abbr title="purchase order">PO</abbr>, send the <abbr title="purchase order">PO</abbr> number and contact details as early as possible. You can then provide <abbr title="Government Digital Service">GDS</abbr> with a copy of the <abbr title="purchase order">PO</abbr> at a later date.
     </p>
 
     <h2 class="heading-medium" id="invoices">


### PR DESCRIPTION
This PR updates the content on our `How to pay` pricing page.

Based on enquiries from users, we think that the information needs to be reordered to make the process easier to understand.

We also know that some of the current information is out of date, or unclear.