### PR TITLE
Bump utils to 78.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ rtreelib==0.2.0
 fido2==1.1.0
 
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.1.0
 govuk-frontend-jinja==2.8.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.1.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
 ## 78.1.0

* Restrict postcodes to valid UK postcode zones

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/78.0.0...78.1.0