### PR TITLE
Conditionally show validation messages in an error-summary for "attach pages to a letter" journey

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1177,7 +1177,7 @@ def _process_letter_attachment_form(service_id, template, form, upload_id):
         current_app.logger.info("Invalid PDF uploaded for service_id: %s", service_id)
         raise LetterAttachmentFormError(
             title="There’s a problem with your file",
-            detail="Notify cannot read this PDF.<br>Save a new copy of your file and try again.",
+            detail="Notify cannot read this PDF - save a new copy and try again",
         ) from None
 
     file_location = get_transient_letter_file_location(service_id, upload_id)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1058,6 +1058,7 @@ def letter_template_attach_pages(service_id, template_id):
     error = {}
     letter_attachment_image_url = None
     attachment_page_count = 0
+    use_error_summary = False
     if form.validate_on_submit():
         upload_id = uuid.uuid4()
         try:
@@ -1073,6 +1074,7 @@ def letter_template_attach_pages(service_id, template_id):
 
     if form.file.errors:
         error = get_error_from_upload_form(form.file.errors[0])
+        use_error_summary = True
 
     if not template.attachment:
         return (
@@ -1083,6 +1085,8 @@ def letter_template_attach_pages(service_id, template_id):
                 error=error,
                 letter_attachment_image_url=letter_attachment_image_url,
                 page_numbers=_get_page_numbers(attachment_page_count),
+                error_summary_enabled=use_error_summary,
+                use_error_summary=use_error_summary,
             ),
             400 if error else 200,
         )

--- a/app/templates/views/templates/attach-pages.html
+++ b/app/templates/views/templates/attach-pages.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-    {% if error %}
+    {% if error and not use_error_summary %}
         <div class="govuk-!-margin-bottom-4">
             {% call banner_wrapper(type='dangerous') %}
                 <h1 class="banner-title">{{ error.title }}</h1>
@@ -57,7 +57,7 @@
         allowed_file_extensions=['pdf'],
         action=url_for('main.letter_template_attach_pages', service_id=current_service.id, template_id=template.id),
         button_text='Upload your file again' if error else 'Choose a file',
-        show_errors=False
+        show_errors=use_error_summary
         )}}
     </div>
 

--- a/app/templates/views/templates/manage-attachment.html
+++ b/app/templates/views/templates/manage-attachment.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-    {% if error %}
+    {% if error and not use_error_summary %}
         <div class="govuk-!-margin-bottom-4">
             {% call banner_wrapper(type='dangerous') %}
                 <h1 class="banner-title">{{ error.title }}</h1>
@@ -53,7 +53,7 @@
         allowed_file_extensions=['pdf'],
         action=url_for('main.letter_template_attach_pages', service_id=current_service.id, template_id=template.id),
         button_text='Upload your file again' if error else 'Choose a different file',
-        show_errors=False,
+        show_errors=use_error_summary,
         alternate_link=url_for('main.letter_template_attach_pages', service_id=current_service.id, template_id=template.id) if error else None,
         alternate_link_text='cancel'
     )}}

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -355,7 +355,7 @@ def test_uploading_a_letter_attachment_shows_error_when_file_is_not_a_pdf(
             _data={"file": file},
             _expected_status=400,
         )
-    assert page.select_one(".banner-dangerous h1").text == "Wrong file type"
+    assert normalize_spaces(page.select_one(".govuk-error-summary__body").text) == "The file must be a PDF"
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
     assert page.select_one("input[type=file]")["accept"] == ".pdf"
 
@@ -370,7 +370,7 @@ def test_uploading_a_letter_attachment_shows_error_when_no_file_uploaded(
         _data={"file": ""},
         _expected_status=400,
     )
-    assert page.select_one(".banner-dangerous p").text == "You need to choose a file to upload"
+    assert normalize_spaces(page.select_one(".govuk-error-summary__body").text) == "You need to choose a file to upload"
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 
 
@@ -388,8 +388,7 @@ def test_uploading_a_letter_attachment_shows_error_when_file_contains_virus(
             _data={"file": file},
             _expected_status=400,
         )
-    assert page.select_one(".banner-dangerous h1").text == "There is a problem"
-    assert page.select_one(".banner-dangerous p").text == "This file contains a virus"
+    assert normalize_spaces(page.select_one(".govuk-error-summary__body").text) == "This file contains a virus"
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
     mock_s3_backup.assert_not_called()
 
@@ -407,8 +406,7 @@ def test_uploading_a_letter_attachment_errors_when_file_is_too_big(
             _data={"file": file},
             _expected_status=400,
         )
-    assert page.select_one(".banner-dangerous h1").text == "There is a problem"
-    assert page.select_one(".banner-dangerous p").text == "The file must be smaller than 2MB"
+    assert normalize_spaces(page.select_one(".govuk-error-summary__body").text) == "The file must be smaller than 2MB"
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 
 
@@ -428,7 +426,7 @@ def test_post_choose_upload_letter_attachment_when_file_is_malformed(
     assert page.select_one("div.banner-dangerous").find("h1").text == "There’s a problem with your file"
     assert (
         page.select_one("div.banner-dangerous").find("p").text
-        == "Notify cannot read this PDF.Save a new copy of your file and try again."
+        == "Notify cannot read this PDF - save a new copy and try again"
     )
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 


### PR DESCRIPTION
## What

Add logic to show for letter attachment file upload error messages in the error summary only for the initial file upload validation if form empty, file not a PDF or file bigger than maximum allowed size.

All content validation error messages remain being shown as they are currently

https://trello.com/c/IWs0jRtA/773-make-attach-a-page-to-a-letter-form-meet-validation-requirements

## Why

We’ve been updating file upload validation to error summary in 
https://trello.com/c/exLvftli/772-make-upload-contact-list-and-upload-addresses-phone-numbers-form-meet-validation-requirements
https://trello.com/c/Uu9YoBkj/710-make-forms-for-uploading-files-meet-validation-requirements

which deal with upload only. We’ve decide to tackle content validation separately in https://trello.com/c/N9RipR7p/590-evaluate-and-update-our-complex-validation-error

## How to review
See individual commits for details

## Visual changes

**New Error summary for upload validation only**

![Screenshot 2024-06-12 at 12 03 21](https://github.com/alphagov/notifications-admin/assets/3758555/62b512a2-7760-437b-9450-11c6d1b40169)

**Current error banner for content validation only**

![Screenshot 2024-06-12 at 12 03 52](https://github.com/alphagov/notifications-admin/assets/3758555/97837e66-6fa1-4b26-8cce-49ef49a40ae6)


