### PR TITLE
Switch from internal list of protected sender IDs to api

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -111,6 +111,7 @@ from app.notify_client.performance_dashboard_api_client import (
 )
 from app.notify_client.platform_admin_api_client import admin_api_client
 from app.notify_client.platform_stats_api_client import platform_stats_api_client
+from app.notify_client.protected_sender_id_api_client import protected_sender_id_api_client
 from app.notify_client.provider_client import provider_client
 from app.notify_client.service_api_client import service_api_client
 from app.notify_client.sms_rate_client import sms_rate_api_client
@@ -197,6 +198,7 @@ def create_app(application):
         organisations_client,
         performance_dashboard_api_client,
         platform_stats_api_client,
+        protected_sender_id_api_client,
         provider_client,
         service_api_client,
         sms_rate_api_client,

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -17,6 +17,7 @@ from app import antivirus_client, current_service, zendesk_client
 from app.formatters import sentence_case
 from app.main._commonly_used_passwords import commonly_used_passwords
 from app.models.spreadsheet import Spreadsheet
+from app.notify_client.protected_sender_id_api_client import protected_sender_id_api_client
 from app.utils.user import is_gov_user
 
 
@@ -182,7 +183,8 @@ class IsNotAPotentiallyMaliciousSenderID:
     ]
 
     def __call__(self, form, field):
-        if field.data and field.data.lower() in self.potentially_malicious_sender_ids:
+        if protected_sender_id_api_client.get_check_sender_id(sender_id=field.data):
+
             create_phishing_senderid_zendesk_ticket(senderID=field.data)
             current_app.logger.warning("User tried to set sender id to potentially malicious one: %s", field.data)
             raise ValidationError(

--- a/app/notify_client/protected_sender_id_api_client.py
+++ b/app/notify_client/protected_sender_id_api_client.py
@@ -1,0 +1,10 @@
+from app.notify_client import NotifyAdminAPIClient
+
+
+class ProtectedSenderIDApiClient(NotifyAdminAPIClient):
+
+    def get_check_sender_id(self, sender_id):
+        return self.get(url="/protected-sender-id/check", params={"sender_id": sender_id})
+
+
+protected_sender_id_api_client = ProtectedSenderIDApiClient()

--- a/tests/app/main/forms/test_service_sms_senders_form.py
+++ b/tests/app/main/forms/test_service_sms_senders_form.py
@@ -6,45 +6,62 @@ from app.main.forms import ServiceSmsSenderForm
 
 
 @pytest.mark.parametrize(
-    "sms_sender,error_expected,error_message,sends_zendesk_ticket",
+    "sms_sender,error_expected,error_message,sends_zendesk_ticket,protected_sender_id_return",
     [
-        ("", True, "Enter a text message sender ID", False),
-        ("22", True, "Text message sender ID must be at least 3 characters long", False),
-        ("333", True, "A numeric sender id should be a valid mobile number or short code", False),
-        ("70000", False, None, False),
-        ("07000000000", False, None, False),
+        ("", True, "Enter a text message sender ID", False, False),
+        ("22", True, "Text message sender ID must be at least 3 characters long", False, False),
+        ("333", True, "A numeric sender id should be a valid mobile number or short code", False, False),
+        ("70000", False, None, False, False),
+        ("07000000000", False, None, False, False),
         (
             "Info",
             True,
             "Text message sender ID cannot be Alert, Info or Verify as those are prohibited due to usage by spam",
             False,
+            False,
         ),
-        ("Inform Uk", False, None, False),
-        ("elevenchars", False, None, False),  # 11 chars
-        ("twelvecharas", True, "Text message sender ID cannot be longer than 11 characters", False),  # 12 chars
+        ("Inform Uk", False, None, False, False),
+        ("elevenchars", False, None, False, False),  # 11 chars
+        ("twelvecharas", True, "Text message sender ID cannot be longer than 11 characters", False, False),  # 12 chars
         (
             "###",
             True,
             "Text message sender ID can only include letters, numbers, spaces, and the following characters: & . - _",
             False,
+            False,
         ),
-        ("00111222333", True, "Text message sender ID cannot start with 00", False),
-        ("UK_GOV", False, None, False),  # Underscores are allowed
-        ("UK-GOV", False, None, False),  # Simple dashes are allowed
-        ("UK.GOV", False, None, False),  # Full stops are allowed
-        ("UK&GOV", False, None, False),  # Ampersands are allowed
+        ("00111222333", True, "Text message sender ID cannot start with 00", False, False),
+        ("UK_GOV", False, None, False, False),  # Underscores are allowed
+        ("UK-GOV", False, None, False, False),  # Simple dashes are allowed
+        ("UK.GOV", False, None, False, False),  # Full stops are allowed
+        ("UK&GOV", False, None, False, False),  # Ampersands are allowed
         (
             "Evri",
             True,
             "Text message sender ID cannot be ‘Evri’ - this is to protect recipients from phishing scams",
             True,
-        ),
-        pytest.param("'UC'", False, None, False, marks=pytest.mark.xfail),  # Apostrophes can cause SMS delivery issues
+            True,
+        ),  # Evri is a user id that will be set in the
+        pytest.param(
+            "'UC'", False, None, False, False, marks=pytest.mark.xfail
+        ),  # Apostrophes can cause SMS delivery issues
     ],
 )
 def test_sms_sender_form_validation(
-    client_request, mock_get_user_by_email, sms_sender, error_expected, error_message, sends_zendesk_ticket, mocker
+    client_request,
+    mock_get_user_by_email,
+    sms_sender,
+    error_expected,
+    error_message,
+    sends_zendesk_ticket,
+    protected_sender_id_return,
+    mocker,
 ):
+    mocker.patch(
+        "app.protected_sender_id_api_client.get_check_sender_id",
+        return_value=protected_sender_id_return,
+    )
+
     form = ServiceSmsSenderForm()
     form.sms_sender.data = sms_sender
     mock_create_phishing_zendesk_ticket = mocker.patch(
@@ -63,19 +80,26 @@ def test_sms_sender_form_validation(
 
 
 @pytest.mark.parametrize(
-    "sms_sender,log_expected,log_message,sends_zendesk_ticket",
+    "sms_sender,log_expected,log_message,sends_zendesk_ticket,protected_sender_id_return",
     [
-        ("UK&GOV", False, None, False),  # No warning log on valid senderID
+        ("UK&GOV", False, None, False, False),  # No warning log on valid senderID
         (
             "Evri",
             True,
             "User tried to set sender id to potentially malicious one: Evri",
             True,
+            True,
         ),
     ],
 )
-def test_sms_validation_logs(caplog, sms_sender, log_expected, log_message, sends_zendesk_ticket, mocker):
+def test_sms_validation_logs(
+    caplog, sms_sender, log_expected, log_message, sends_zendesk_ticket, protected_sender_id_return, mocker
+):
 
+    mocker.patch(
+        "app.protected_sender_id_api_client.get_check_sender_id",
+        return_value=protected_sender_id_return,
+    )
     form = ServiceSmsSenderForm()
     form.sms_sender.data = sms_sender
     mock_create_phishing_zendesk_ticket = mocker.patch(

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2742,7 +2742,13 @@ def test_incorrect_sms_sender_input(
     client_request,
     no_sms_senders,
     mock_add_sms_sender,
+    mocker,
 ):
+
+    mocker.patch(
+        "app.protected_sender_id_api_client.get_check_sender_id",
+        return_value=False,
+    )
     page = client_request.post(
         "main.service_add_sms_sender",
         service_id=SERVICE_ONE_ID,
@@ -2761,10 +2767,13 @@ def test_incorrect_sms_sender_input(
 
 
 def test_incorrect_sms_sender_input_with_multiple_errors_only_shows_the_first(
-    client_request,
-    no_sms_senders,
-    mock_add_sms_sender,
+    client_request, no_sms_senders, mock_add_sms_sender, mocker
 ):
+    # Setup protected sender id mock
+    mocker.patch(
+        "app.protected_sender_id_api_client.get_check_sender_id",
+        return_value=False,
+    )
     # There are two errors with the SMS sender - the length and characters used. Only one
     # should be displayed on the page.
     page = client_request.post(
@@ -3004,6 +3013,10 @@ def test_add_letter_contact_when_coming_from_template(
     ],
 )
 def test_add_sms_sender(sms_senders, data, api_default_args, mocker, client_request, mock_add_sms_sender):
+    mocker.patch(
+        "app.protected_sender_id_api_client.get_check_sender_id",
+        return_value=False,
+    )
     mocker.patch("app.service_api_client.get_sms_senders", return_value=sms_senders)
     data["sms_sender"] = "Example"
     client_request.post("main.service_add_sms_sender", service_id=SERVICE_ONE_ID, _data=data)
@@ -3362,6 +3375,11 @@ def test_delete_letter_contact_block(
     ],
 )
 def test_edit_sms_sender(sms_sender, data, api_default_args, mocker, fake_uuid, client_request, mock_update_sms_sender):
+
+    mocker.patch(
+        "app.protected_sender_id_api_client.get_check_sender_id",
+        return_value=False,
+    )
     mocker.patch("app.service_api_client.get_sms_sender", return_value=sms_sender)
 
     client_request.post("main.service_edit_sms_sender", service_id=SERVICE_ONE_ID, sms_sender_id=fake_uuid, _data=data)


### PR DESCRIPTION
This makes admin query api/protected-sender-ids/check?sender_id=$NAME to find out whether an id is in the protected list, rather than in the hardcoded list in admin.

This requires mocking out the client in a bunch of places.