### PR TITLE
Fix cancel button on scheduled jobs

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -11,7 +11,9 @@
       {{ job.scheduled_for|format_datetime_relative }}
     </p>
     <div class="page-footer">
-      {% call form_wrapper() %}
+      {% call form_wrapper(
+        action=url_for("main.cancel_job", service_id=current_service.id, job_id=job.id)
+      ) %}
         {{ page_footer(
           button_text="Cancel sending",
           destructive=True


### PR DESCRIPTION
When AJAX updates the page for a scheduled job the `<form>` is posting to `/services/…/jobs/47a70916-c90f-477c-aac6-263a847321a1.json?status=`

It should be posting to `/services/…/jobs/…` (note no `.json`)

The `.json` endpoint doesn’t accept POST requests therefore is returning `405`.

This was introduced by https://github.com/alphagov/notifications-admin/pull/5068 where we set the `action` of every form to the URL of the current request.

This commit overrides this and forces the `action` to the correct URL.