### PR TITLE
Fix validation for pages with list entry form fields

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -77,6 +77,7 @@ from app.formatters import (
     recipient_count,
     recipient_count_label,
     redact_mobile_number,
+    sentence_case,
     valid_phone_number,
 )
 from app.models.organisation import Organisation
@@ -578,6 +579,7 @@ def add_template_filters(application):
         format_yes_no,
         make_string_safe_for_email_local_part,
         extract_path_from_url,
+        sentence_case,
     ]:
         application.add_template_filter(fn)
 

--- a/app/assets/javascripts/listEntry.js
+++ b/app/assets/javascripts/listEntry.js
@@ -43,6 +43,7 @@
         ' id="{{id}}"' +
         ' {{#value}}value="{{value}}{{/value}}"' +
         ' class="{{{sharedInputClasses}}}{{#customClasses}} {{{customClasses}}}{{/customClasses}}"' +
+        ' {{#error}}aria-describedby="{{{id}}}-error"{{/error}}' +
         ' {{{sharedAttributes}}}' +
         '/>' +
         '{{#button}}' +
@@ -59,7 +60,7 @@
   ListEntry.prototype.getSharedAttributes = function () {
     var $inputs = this.$wrapper.find('input'),
         attributeTemplate = Hogan.compile(' {{name}}="{{value}}"'),
-        protectedAttributes = ['id', 'name', 'value', 'class'],
+        protectedAttributes = ['id', 'name', 'value', 'class', 'aria-describedby'],
         attributes = [],
         attrIdx,
         elmAttributes,

--- a/app/assets/javascripts/listEntry.js
+++ b/app/assets/javascripts/listEntry.js
@@ -42,7 +42,7 @@
         ' name="{{name}}"' +
         ' id="{{id}}"' +
         ' {{#value}}value="{{value}}{{/value}}"' +
-        ' class="{{{sharedInputClasses}}}{{#customClasses}} {{{customClasses}}}{{/customClasses}}"' +
+        ' class="{{{sharedInputClasses}}}{{#customClasses}} {{{customClasses}}}{{/customClasses}}{{#error}} govuk-input--error{{/error}}"' +
         ' {{#error}}aria-describedby="{{{id}}}-error"{{/error}}' +
         ' {{{sharedAttributes}}}' +
         '/>' +
@@ -111,7 +111,7 @@
       var customClassesForElm = [];
 
       elm.classList.forEach(token => {
-        if ($.inArray(token, this.sharedInputClasses) === -1) {
+        if (($.inArray(token, this.sharedInputClasses) === -1) && (token !== 'govuk-input--error')) {
           customClassesForElm.push(token);
         }
       });

--- a/app/assets/javascripts/listEntry.js
+++ b/app/assets/javascripts/listEntry.js
@@ -27,20 +27,22 @@
   ListEntry.optionalAttributes = ['aria-describedby'];
   ListEntry.prototype.entryTemplate = Hogan.compile(
     '<div class="list-entry">' +
-      '<label for="{{{id}}}" class="govuk-input--numbered__label">' +
-        '<span class="govuk-visually-hidden">{{listItemName}} number </span>{{number}}.' +
-      '</label>' +
-      '<input' +
+      '<div class="govuk-form-group{{#error}} govuk-form-group--error{{/error}}">' +
+        '<label for="{{{id}}}" class="govuk-input--numbered__label">' +
+          '<span class="govuk-visually-hidden">{{listItemName}} number </span>{{number}}.' +
+        '</label>' +
+        '<input' +
         ' name="{{name}}"' +
         ' id="{{id}}"' +
         ' {{#value}}value="{{value}}{{/value}}"' +
         ' {{{sharedAttributes}}}' +
-      '/>' +
-      '{{#button}}' +
+        '/>' +
+        '{{#button}}' +
         '<button type="button" class="govuk-button govuk-button--secondary input-list__button--remove">' +
-          'Remove<span class="govuk-visually-hidden"> {{listItemName}} number {{number}}</span>' +
+        'Remove<span class="govuk-visually-hidden"> {{listItemName}} number {{number}}</span>' +
         '</button>' +
-      '{{/button}}' +
+        '{{/button}}' +
+      '</div>' +
     '</div>'
   );
   ListEntry.prototype.addButtonTemplate = Hogan.compile(

--- a/app/assets/javascripts/listEntry.js
+++ b/app/assets/javascripts/listEntry.js
@@ -28,9 +28,14 @@
   ListEntry.prototype.entryTemplate = Hogan.compile(
     '<div class="list-entry">' +
       '<div class="govuk-form-group{{#error}} govuk-form-group--error{{/error}}">' +
-        '<label for="{{{id}}}" class="govuk-input--numbered__label">' +
+        '<label for="{{{id}}}" class="govuk-label govuk-input--numbered__label{{#error}} govuk-input--numbered__label--error{{/error}}">' +
           '<span class="govuk-visually-hidden">{{listItemName}} number </span>{{number}}.' +
         '</label>' +
+        '{{#error}}' +
+        '<p id="{{{id}}}-error" class="govuk-error-message" data-notify-module="track-error" data-error-type="{{{error}}}" data-error-label="{{{name}}}">' +
+          '<span class="govuk-visually-hidden">Error: </span>{{{error}}}' +
+        '</p>' +
+        '{{/error}}' +
         '<input' +
         ' name="{{name}}"' +
         ' id="{{id}}"' +

--- a/app/assets/stylesheets/components/list-entry.scss
+++ b/app/assets/stylesheets/components/list-entry.scss
@@ -16,12 +16,20 @@
   }
 
   .govuk-input--numbered__label--error {
-    // - button padding bottom and top (17px)
+    // - button padding bottom and top and 2px border (7px + 8px + 2px + 2px)
     // - button line-height (1.1875em)
     // - button margin-top (5px)
     // - text input border and padding (2px + 5px = 7px)
-    // - half of difference in line-height with text input (0.3125em)
-    bottom: calc(17px + 1.1875em + 5px + 7px + 0.3125em);
+    // - half of difference in line-height with text input (0.1875em)
+    bottom: calc(19px + 1.1875em + 5px + 7px + 0.1875em);
+
+    @include govuk-media-query($from: tablet) {
+      bottom: 7px;
+    }
+  }
+
+  .list-entry:first-of-type .govuk-input--numbered__label--error {
+    bottom: calc(7px + 0.1875em); // the first input doesn't have a 'remove' button
 
     @include govuk-media-query($from: tablet) {
       bottom: 7px;

--- a/app/assets/stylesheets/components/list-entry.scss
+++ b/app/assets/stylesheets/components/list-entry.scss
@@ -2,12 +2,29 @@
 
   .list-entry {
     vertical-align: middle;
-    margin-bottom: 15px;
+    margin-bottom: 20px;
     position: relative;
+
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: 15px;
+    }
 
     // move the left border, signifying the error, out of the main column
     .govuk-form-group--error {
       margin-left: ($govuk-border-width + $govuk-gutter-half) * -1;
+    }
+  }
+
+  .govuk-input--numbered__label--error {
+    // - button padding bottom and top (17px)
+    // - button line-height (1.1875em)
+    // - button margin-top (5px)
+    // - text input border and padding (2px + 5px = 7px)
+    // - half of difference in line-height with text input (0.3125em)
+    bottom: calc(17px + 1.1875em + 5px + 7px + 0.3125em);
+
+    @include govuk-media-query($from: tablet) {
+      bottom: 7px;
     }
   }
 
@@ -17,7 +34,6 @@
   }
 
   &__button--remove {
-    margin-bottom: 15px;
     margin-top: 5px;
     position: static;
     overflow: hidden;
@@ -27,6 +43,11 @@
       position: absolute;
       top: 0;
       left: 100%;
+
+      .govuk-form-group--error & {
+        top: auto;
+        bottom: 2px; // 2px to match the box shadow at the bottom
+      }
     }
   }
 

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -87,12 +87,16 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 .govuk-input--numbered__label {
   float: left;
   width: 1.6em;
-  margin: 8px -1.6em 0 0;
+  margin: 10px -1.6em 0 0;
   position: relative;
   left: 10px;
   color: $govuk-secondary-text-colour;
   font-weight: bold;
   pointer-events: none;
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: 8px;
+  }
 }
 
 .govuk-input--numbered__label--error {

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -17,7 +17,7 @@ from notifications_utils.formatters import strip_all_whitespace
 from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.recipient_validation.email_address import validate_email_address
 from notifications_utils.recipient_validation.errors import InvalidEmailError, InvalidPhoneError
-from notifications_utils.recipient_validation.phone_number import normalise_phone_number, validate_phone_number
+from notifications_utils.recipient_validation.phone_number import normalise_phone_number
 from notifications_utils.recipient_validation.postal_address import PostalAddress
 from notifications_utils.safe_string import make_string_safe_for_email_local_part
 from ordered_set import OrderedSet
@@ -81,6 +81,8 @@ from app.main.validators import (
     StringsNotAllowed,
     ValidEmail,
     ValidGovEmail,
+    ValidInternationalPhoneNumber,
+    ValidUKMobileNumber,
 )
 from app.models.branding import (
     GOVERNMENT_IDENTITY_SYSTEM_COLOURS,
@@ -233,31 +235,16 @@ class GovukTextInputFieldMixin(GovukFrontendWidgetMixin):
         return params
 
 
-class UKMobileNumber(GovukTextInputFieldMixin, TelField):
+class PhoneNumber(GovukTextInputFieldMixin, TelField):
     input_type = "tel"
-
-    def pre_validate(self, form):
-        try:
-            validate_phone_number(self.data)
-        except InvalidPhoneError as e:
-            raise ValidationError(str(e)) from e
-
-
-class InternationalPhoneNumber(UKMobileNumber, GovukTextInputFieldMixin, TelField):
-    def pre_validate(self, form):
-        try:
-            if self.data:
-                validate_phone_number(self.data, international=True)
-        except InvalidPhoneError as e:
-            raise ValidationError(str(e)) from e
 
 
 def uk_mobile_number(label="Mobile number"):
-    return UKMobileNumber(label, validators=[DataRequired(message="Cannot be empty")])
+    return PhoneNumber(label, validators=[DataRequired(message="Cannot be empty"), ValidUKMobileNumber()])
 
 
 def international_phone_number(label="Mobile number"):
-    return InternationalPhoneNumber(label, validators=[NotifyDataRequired(thing="a mobile number")])
+    return PhoneNumber(label, validators=[NotifyDataRequired(thing="a mobile number"), ValidInternationalPhoneNumber()])
 
 
 def make_password_field(label="Password", thing="a password", validate_length=True):
@@ -611,7 +598,7 @@ class RegisterUserFromInviteForm(RegisterUserForm):
             name=guess_name_from_email_address(invited_user.email_address),
         )
 
-    mobile_number = InternationalPhoneNumber("Mobile number")
+    mobile_number = PhoneNumber("Mobile number", validators=[ValidInternationalPhoneNumber()])
     service = HiddenField("service")
     email_address = HiddenField("email_address")
     auth_type = HiddenField("auth_type", validators=[DataRequired()])
@@ -630,8 +617,8 @@ class RegisterUserFromOrgInviteForm(StripWhitespaceForm):
 
     name = GovukTextInputField("Full name", validators=[NotifyDataRequired(thing="your full name")])
 
-    mobile_number = InternationalPhoneNumber(
-        "Mobile number", validators=[NotifyDataRequired(thing="your mobile number")]
+    mobile_number = PhoneNumber(
+        "Mobile number", validators=[NotifyDataRequired(thing="your mobile number"), ValidInternationalPhoneNumber()]
     )
     password = make_password_field(thing="your password")
     organisation = HiddenField("organisation")
@@ -919,6 +906,12 @@ class GovukRadiosFieldWithRequiredMessage(GovukRadiosField):
             return super().pre_validate(form)
         except ValueError as e:
             raise ValidationError(self.required_message) from e
+
+
+class ListEntryFieldList(FieldList):
+    def __init__(self, *args, thing="item", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.thing = thing
 
 
 # guard against data entries that aren't a known permission
@@ -1229,13 +1222,19 @@ class OrganisationAgreementSignedForm(StripWhitespaceForm):
     )
 
 
+class StripWhitespaceStringFieldInListEntry(StripWhitespaceStringField):
+    def pre_validate(self, form):
+        self.error_summary_messages = []
+        super().pre_validate(form)
+
+
 class AdminOrganisationDomainsForm(StripWhitespaceForm):
     def populate(self, domains_list):
         for index, value in enumerate(domains_list):
             self.domains[index].data = value
 
-    domains = FieldList(
-        StripWhitespaceStringField(
+    domains = ListEntryFieldList(
+        StripWhitespaceStringFieldInListEntry(
             "",
             validators=[
                 CharactersNotAllowed("@"),
@@ -2126,11 +2125,11 @@ class PDFUploadForm(StripWhitespaceForm):
     )
 
 
-class EmailFieldInGuestList(GovukEmailField, StripWhitespaceStringField):
+class EmailFieldInGuestList(GovukEmailField, StripWhitespaceStringFieldInListEntry):
     pass
 
 
-class InternationalPhoneNumberInGuestList(InternationalPhoneNumber, StripWhitespaceStringField):
+class PhoneNumberInGuestList(PhoneNumber, StripWhitespaceStringFieldInListEntry):
     pass
 
 
@@ -2143,15 +2142,15 @@ class GuestList(StripWhitespaceForm):
             for index, value in enumerate(existing_guest_list):
                 form_field[index].data = value
 
-    email_addresses = FieldList(
+    email_addresses = ListEntryFieldList(
         EmailFieldInGuestList("", validators=[Optional(), ValidEmail()], default=""),
         min_entries=5,
         max_entries=5,
         label="Email addresses",
     )
 
-    phone_numbers = FieldList(
-        InternationalPhoneNumberInGuestList("", validators=[Optional()], default=""),
+    phone_numbers = ListEntryFieldList(
+        PhoneNumberInGuestList("", validators=[Optional(), ValidInternationalPhoneNumber()], default=""),
         min_entries=5,
         max_entries=5,
         label="Mobile numbers",

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1246,6 +1246,7 @@ class AdminOrganisationDomainsForm(StripWhitespaceForm):
         min_entries=20,
         max_entries=20,
         label="Domain names",
+        thing="domain name",
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2147,6 +2147,7 @@ class GuestList(StripWhitespaceForm):
         min_entries=5,
         max_entries=5,
         label="Email addresses",
+        thing="email address",
     )
 
     phone_numbers = ListEntryFieldList(
@@ -2154,6 +2155,7 @@ class GuestList(StripWhitespaceForm):
         min_entries=5,
         max_entries=5,
         label="Mobile numbers",
+        thing="mobile number",
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -909,7 +909,7 @@ class GovukRadiosFieldWithRequiredMessage(GovukRadiosField):
 
 
 class ListEntryFieldList(FieldList):
-    def __init__(self, *args, thing="item", **kwargs):
+    def __init__(self, *args, thing, **kwargs):
         super().__init__(*args, **kwargs)
         self.thing = thing
 
@@ -1222,10 +1222,14 @@ class OrganisationAgreementSignedForm(StripWhitespaceForm):
     )
 
 
-class StripWhitespaceStringFieldInListEntry(StripWhitespaceStringField):
+class FieldInListEntry:
     def pre_validate(self, form):
         self.error_summary_messages = []
         super().pre_validate(form)
+
+
+class StripWhitespaceStringFieldInListEntry(FieldInListEntry, StripWhitespaceStringField):
+    pass
 
 
 class AdminOrganisationDomainsForm(StripWhitespaceForm):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -85,18 +85,12 @@ class ValidPhoneNumber:
     is_international = False
     message = None
 
-    TOO_SHORT = "Mobile number is too short"
-    TOO_LONG = "Mobile number is too long"
-    NOT_UK = "This does not look like a UK mobile number – double check the mobile number you entered"
-    NO_COUNTRY_CODE = "Country code not found - double check the mobile number you entered"
-    INVALID_CHARS = "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"
-
     _error_summary_messages_map = {
-        TOO_SHORT: "%s is too short",
-        TOO_LONG: "%s is too long",
-        NOT_UK: "%s does not look like a UK mobile number",
-        NO_COUNTRY_CODE: "Country code for %s not found",
-        INVALID_CHARS: "%s can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -",
+        InvalidPhoneError.Codes.TOO_SHORT: "%s is too short",
+        InvalidPhoneError.Codes.TOO_LONG: "%s is too long",
+        InvalidPhoneError.Codes.NOT_A_UK_MOBILE: "%s does not look like a UK mobile number",
+        InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE: "Country code for %s not found",
+        InvalidPhoneError.Codes.UNKNOWN_CHARACTER: "%s can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -",
     }
 
     def __call__(self, form, field):
@@ -106,7 +100,7 @@ class ValidPhoneNumber:
         except InvalidPhoneError as e:
             error_message = str(e)
             if hasattr(field, "error_summary_messages"):
-                error_summary_message = self._error_summary_messages_map[error_message]
+                error_summary_message = self._error_summary_messages_map[e.code]
 
                 field.error_summary_messages.append(error_summary_message)
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -64,7 +64,7 @@ class ValidEmail:
     def __init__(
         self,
         message="Enter an email address in the correct format, like name@example.gov.uk",
-        error_summary_message="Enter %s in the correct format, like name@example.gov.uk",
+        error_summary_message="Enter %s in the correct format",
     ):
         self.message = message
         self.error_summary_message = error_summary_message
@@ -94,8 +94,8 @@ class ValidPhoneNumber(ABC):
     _error_summary_messages_map = {
         TOO_SHORT: "%s is too short",
         TOO_LONG: "%s is too long",
-        NOT_UK: "%s does not look like a UK mobile number - double check the mobile number you entered",
-        NO_COUNTRY_CODE: "Country code for %s not found - double check the mobile number you entered",
+        NOT_UK: "%s does not look like a UK mobile number",
+        NO_COUNTRY_CODE: "Country code for %s not found",
         INVALID_CHARS: "%s can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -",
     }
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -81,7 +81,7 @@ class ValidEmail:
             raise ValidationError(self.message) from e
 
 
-class ValidPhoneNumber(ABC):
+class ValidPhoneNumber:
     is_international = False
     message = None
 
@@ -106,10 +106,7 @@ class ValidPhoneNumber(ABC):
         except InvalidPhoneError as e:
             error_message = str(e)
             if hasattr(field, "error_summary_messages"):
-                if error_message in self._error_summary_messages_map:
-                    error_summary_message = self._error_summary_messages_map[error_message]
-                else:
-                    error_summary_message = f"%s: {error_message}"
+                error_summary_message = self._error_summary_messages_map[error_message]
 
                 field.error_summary_messages.append(error_summary_message)
 

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -55,7 +55,7 @@ def guest_list(service_id):
         return redirect(url_for(".api_integration", service_id=service_id))
     if not form.errors:
         form.populate(**service_api_client.get_guest_list(service_id))
-    return render_template("views/api/guest-list.html", form=form)
+    return render_template("views/api/guest-list.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/services/<uuid:service_id>/api/keys")

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -409,6 +409,7 @@ def edit_organisation_domains(org_id):
                 return render_template(
                     "views/organisations/organisation/settings/edit-domains.html",
                     form=form,
+                    error_summary_enabled=True,
                 )
             else:
                 raise e
@@ -420,6 +421,7 @@ def edit_organisation_domains(org_id):
     return render_template(
         "views/organisations/organisation/settings/edit-domains.html",
         form=form,
+        error_summary_enabled=True,
     )
 
 

--- a/app/templates/components/error-summary.html
+++ b/app/templates/components/error-summary.html
@@ -1,17 +1,35 @@
 {% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
+{%- macro addErrorsForFieldList(field, errors) -%}
+  {%- for entry in field.entries -%}
+    {%- if entry.errors -%}
+      {% set entryNum = loop.index | string %}
+      {%- do errors.append(
+        {
+          "href": "#" + field.id + '-' + entryNum,
+          "text": entry.error_summary_messages[0] | format((field.thing + ' ' + entryNum)) | capitalize()
+        }
+      ) -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endmacro -%}
+
 {% macro errorSummary(form) %}
   {% if form.errors %}
     {% set errors = [] %}
     {% for field_name, error_list in form.errors.items() %}
       {% if field_name %}
-        {% do errors.append(
-          {
-            "href": "#" + (form[field_name].error_summary_id if form[field_name].error_summary_id != undefined else form[field_name].id),
-            "text": error_list[0] | striptags
-          }
-        ) %}
-      {% else %}
+        {%- if form[field_name].entries -%} {# field is a FieldList #}
+          {{- addErrorsForFieldList(form[field_name], errors) -}}
+        {%- else -%}
+          {% do errors.append(
+            {
+              "href": "#" + (form[field_name].error_summary_id if form[field_name].error_summary_id != undefined else form[field_name].id),
+              "text": error_list[0] | striptags
+            }
+          ) %}
+        {%- endif -%}
+      {%- else -%}
         {# field_name is None for form level errors #}
         {% do errors.append({"text": error_list[0]}) %}
       {% endif %}

--- a/app/templates/components/error-summary.html
+++ b/app/templates/components/error-summary.html
@@ -7,7 +7,7 @@
       {%- do errors.append(
         {
           "href": "#" + field.id + '-' + entryNum,
-          "text": entry.error_summary_messages[0] | format((field.thing + ' ' + entryNum)) | capitalize()
+          "text": entry.error_summary_messages[0] | format((field.thing + ' ' + entryNum)) | sentence_case()
         }
       ) -%}
     {%- endif -%}

--- a/app/templates/components/list-entry.html
+++ b/app/templates/components/list-entry.html
@@ -41,7 +41,7 @@
           {% endif %}
           {% set field_name = field.name + "-" + loop.index|string %}
           {% set html -%}
-            <span class="govuk-visually-hidden">{{ item_name }} number </span> + {{ loop.index }}.
+            <span class="govuk-visually-hidden">{{ item_name }} number </span> {{ loop.index }}.
           {%- endset%}
           {{ entry(param_extensions={
             "id": "input-" + field_name,

--- a/app/templates/components/list-entry.html
+++ b/app/templates/components/list-entry.html
@@ -44,7 +44,7 @@
             <span class="govuk-visually-hidden">{{ item_name }} number </span> {{ loop.index }}.
           {%- endset%}
           {{ entry(param_extensions={
-            "id": "input-" + field_name,
+            "id": field_name,
             "name": field_name,
             "label": {
               "html": html,

--- a/app/templates/views/api/guest-list.html
+++ b/app/templates/views/api/guest-list.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/list-entry.html" import list_entry %}
@@ -16,28 +15,7 @@
 
 {% block maincolumn_content %}
 
-  {% if form.email_addresses.errors or form.phone_numbers.errors %}
-    {% call banner_wrapper(type='dangerous') %}
-      <h1 class='banner-title'>
-        There was a problem with your guest list
-      </h1>
-      <p class="govuk-body">Fix these errors:</p>
-      <ul class="govuk-list govuk-!-margin-bottom-0">
-        {% if form.email_addresses.errors %}
-          <li>
-            <a class="govuk-link govuk-link--destructive" href="#{{ form.email_addresses.name }}">Enter valid email addresses</a>
-          </li>
-        {% endif %}
-        {% if form.phone_numbers.errors %}
-          <li>
-            <a class="govuk-link govuk-link--destructive" href="#{{ form.phone_numbers.name }}">Enter valid phone numbers</a>
-          </li>
-        {% endif %}
-      </ul>
-    {% endcall %}
-  {% else %}
-    {{ page_header('Guest list') }}
-  {% endif %}
+  {{ page_header('Guest list') }}
 
   <p class="govuk-body">
     You can use a team and guest list key to send real messages to your team and up to 5 other email addresses or phone numbers.

--- a/app/templates/views/organisations/organisation/settings/edit-domains.html
+++ b/app/templates/views/organisations/organisation/settings/edit-domains.html
@@ -4,7 +4,6 @@
 {% from "components/list-entry.html" import list_entry %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/banner.html" import banner_wrapper %}
 
 {% block org_page_title %}
   Known email domains
@@ -15,25 +14,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-
-  {% if form.domains.errors %}
-    {% call banner_wrapper(type='dangerous') %}
-
-      <h1 class='banner-title'>
-        There is a problem
-      </h1>
-
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-        {% for field_errors in form.domains.errors %}
-          {% if field_errors %}
-            <li>Item {{ loop.index }}: {{ field_errors[0] }}</li>
-          {% endif %}
-        {% endfor %}
-      </ul>
-
-    {% endcall %}
-  {% endif %}
-
   {{ page_header("Known email domains") }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -92,12 +92,12 @@ def test_uk_mobile_number_validation_messages_match(mocker):
     mock_field = _gen_mock_field("notanumber", error_summary_messages=[])
     mocker.patch(
         "app.main.validators.validate_phone_number",
-        side_effect=InvalidPhoneError("Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"),
+        side_effect=InvalidPhoneError(code=InvalidPhoneError.Codes.UNKNOWN_CHARACTER),
     )
     with pytest.raises(ValidationError) as error:
         ValidUKMobileNumber()(None, mock_field)
 
-    assert str(error.value) == "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"
+    assert str(error.value) == InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNKNOWN_CHARACTER]
     assert mock_field.error_summary_messages == ["%s can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"]
 
 

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -101,19 +101,6 @@ def test_uk_mobile_number_validation_messages_match(mocker):
     assert mock_field.error_summary_messages == ["%s can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"]
 
 
-def test_uk_mobile_number_validation_messages_fallback(mocker):
-    mock_field = _gen_mock_field("notanumber", error_summary_messages=[])
-    mocker.patch(
-        "app.main.validators.validate_phone_number",
-        side_effect=InvalidPhoneError("Phone numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"),
-    )
-    with pytest.raises(ValidationError) as error:
-        ValidUKMobileNumber()(None, mock_field)
-
-    assert str(error.value) == "Phone numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"
-    assert mock_field.error_summary_messages == ["%s: Phone numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"]
-
-
 def test_for_commas_in_placeholders(
     client_request,
 ):

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from notifications_utils.recipient_validation.errors import InvalidPhoneError
 from wtforms import ValidationError
 
 from app.main.validators import (
@@ -10,11 +11,12 @@ from app.main.validators import (
     OnlySMSCharacters,
     StringsNotAllowed,
     ValidGovEmail,
+    ValidUKMobileNumber,
 )
 
 
-def _gen_mock_field(x):
-    return Mock(data=x)
+def _gen_mock_field(x, **kwargs):
+    return Mock(data=x, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -86,6 +88,32 @@ def test_invalid_list_of_white_list_email_domains(
         email_domain_validators(None, _gen_mock_field(email))
 
 
+def test_uk_mobile_number_validation_messages_match(mocker):
+    mock_field = _gen_mock_field("notanumber", error_summary_messages=[])
+    mocker.patch(
+        "app.main.validators.validate_phone_number",
+        side_effect=InvalidPhoneError("Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"),
+    )
+    with pytest.raises(ValidationError) as error:
+        ValidUKMobileNumber()(None, mock_field)
+
+    assert str(error.value) == "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"
+    assert mock_field.error_summary_messages == ["%s can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"]
+
+
+def test_uk_mobile_number_validation_messages_fallback(mocker):
+    mock_field = _gen_mock_field("notanumber", error_summary_messages=[])
+    mocker.patch(
+        "app.main.validators.validate_phone_number",
+        side_effect=InvalidPhoneError("Phone numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"),
+    )
+    with pytest.raises(ValidationError) as error:
+        ValidUKMobileNumber()(None, mock_field)
+
+    assert str(error.value) == "Phone numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"
+    assert mock_field.error_summary_messages == ["%s: Phone numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"]
+
+
 def test_for_commas_in_placeholders(
     client_request,
 ):
@@ -131,59 +159,74 @@ def test_if_string_contains_alphanumeric_characters_does_not_raise(string):
 
 
 def test_string_cannot_contain_characters():
+    mock_field = _gen_mock_field("abc", error_summary_messages=[])
     with pytest.raises(ValidationError) as error:
-        CharactersNotAllowed("abcdef")(None, _gen_mock_field("abc"))
+        CharactersNotAllowed("abcdef")(None, mock_field)
 
     assert str(error.value) == "Cannot contain a, b or c"
+    assert mock_field.error_summary_messages == ["%s cannot contain a, b or c"]
 
 
 def test_string_cannot_contain_characters_with_custom_error_message():
+    mock_field = _gen_mock_field("abc", error_summary_messages=[])
     with pytest.raises(ValidationError) as error:
-        CharactersNotAllowed("abcdef", message="Cannot use first 3 letters of the alphabet")(
-            None, _gen_mock_field("abc")
-        )
+        CharactersNotAllowed(
+            "abcdef",
+            message="Cannot use first 3 letters of the alphabet",
+            error_summary_message="%s cannot use first 3 letters of the alphabet",
+        )(None, mock_field)
 
     assert str(error.value) == "Cannot use first 3 letters of the alphabet"
+    assert mock_field.error_summary_messages == ["%s cannot use first 3 letters of the alphabet"]
 
 
 @pytest.mark.parametrize(
-    "field_value, expected_error",
+    "field_value, expected_error, expected_error_summary_messages",
     (
-        ("abc", "Cannot be ‘abc’"),
-        ("ABC", "Cannot be ‘abc’"),
-        ("123", "Cannot be ‘123’"),
+        ("abc", "Cannot be ‘abc’", ["%s cannot be ‘abc’"]),
+        ("ABC", "Cannot be ‘abc’", ["%s cannot be ‘abc’"]),
+        ("123", "Cannot be ‘123’", ["%s cannot be ‘123’"]),
         pytest.param(
             "abc123",
             "Cannot be ‘abc’",
+            ["%s cannot be ‘abc’"],
             marks=pytest.mark.xfail(reason="Shouldn’t match on substrings"),
         ),
     ),
 )
-def test_string_cannot_contain_string(field_value, expected_error):
+def test_string_cannot_contain_string(field_value, expected_error, expected_error_summary_messages):
+    mock_field = _gen_mock_field(field_value, error_summary_messages=[])
     with pytest.raises(ValidationError) as error:
-        StringsNotAllowed("abc", "123")(None, _gen_mock_field(field_value))
+        StringsNotAllowed("abc", "123")(None, mock_field)
 
     assert str(error.value) == expected_error
+    assert mock_field.error_summary_messages == expected_error_summary_messages
 
 
 @pytest.mark.parametrize(
-    "field_value, expected_error",
+    "field_value, expected_error, expected_error_summary_messages",
     (
-        ("abc", "Cannot contain ‘abc’"),
-        ("ABC", "Cannot contain ‘abc’"),
-        ("123", "Cannot contain ‘123’"),
-        ("abc123", "Cannot contain ‘abc’"),
+        ("abc", "Cannot contain ‘abc’", ["%s cannot contain ‘abc’"]),
+        ("ABC", "Cannot contain ‘abc’", ["%s cannot contain ‘abc’"]),
+        ("123", "Cannot contain ‘123’", ["%s cannot contain ‘123’"]),
+        ("abc123", "Cannot contain ‘abc’", ["%s cannot contain ‘abc’"]),
     ),
 )
-def test_string_cannot_contain_substrings(field_value, expected_error):
+def test_string_cannot_contain_substrings(field_value, expected_error, expected_error_summary_messages):
+    mock_field = _gen_mock_field(field_value, error_summary_messages=[])
     with pytest.raises(ValidationError) as error:
-        StringsNotAllowed("abc", "123", match_on_substrings=True)(None, _gen_mock_field(field_value))
+        StringsNotAllowed("abc", "123", match_on_substrings=True)(None, mock_field)
 
     assert str(error.value) == expected_error
+    assert mock_field.error_summary_messages == expected_error_summary_messages
 
 
 def test_string_cannot_contain_string_with_custom_error_message():
+    mock_field = _gen_mock_field("abc", error_summary_messages=[])
     with pytest.raises(ValidationError) as error:
-        StringsNotAllowed("abc", "123", message="No sequences please")(None, _gen_mock_field("abc"))
+        StringsNotAllowed(
+            "abc", "123", message="No sequences please", error_summary_message="No sequences in %s please"
+        )(None, mock_field)
 
     assert str(error.value) == "No sequences please"
+    assert mock_field.error_summary_messages == ["No sequences in %s please"]

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -626,14 +626,14 @@ def test_should_validate_guestlist_items(
         _expected_status=200,
     )
 
-    assert page.select_one("h1").string.strip() == "There was a problem with your guest list"
-    jump_links = page.select(".banner-dangerous a")
+    assert page.select_one(".govuk-error-summary__title").string.strip() == "There is a problem"
+    jump_links = page.select(".govuk-error-summary__list a")
 
-    assert jump_links[0].string.strip() == "Enter valid email addresses"
-    assert jump_links[0]["href"] == "#email_addresses"
+    assert jump_links[0].string.strip() == "Enter email address 1 in the correct format"
+    assert jump_links[0]["href"] == "#email_addresses-1"
 
-    assert jump_links[1].string.strip() == "Enter valid phone numbers"
-    assert jump_links[1]["href"] == "#phone_numbers"
+    assert jump_links[1].string.strip() == "Mobile number 1 is too short"
+    assert jump_links[1]["href"] == "#phone_numbers-1"
 
     assert mock_update_guest_list.called is False
 

--- a/tests/app/test_formatters.py
+++ b/tests/app/test_formatters.py
@@ -1,0 +1,9 @@
+from app.formatters import sentence_case
+
+
+def test_sentence_case():
+    assert sentence_case("domain 1 cannot contain @") == "Domain 1 cannot contain @"
+    assert (
+        sentence_case("mobile number 2 does not look like a UK mobile number")
+        == "Mobile number 2 does not look like a UK mobile number"
+    )

--- a/tests/javascripts/listEntry.test.js
+++ b/tests/javascripts/listEntry.test.js
@@ -71,7 +71,7 @@ describe("List entry", () => {
           For example cabinet-office.gov.uk
         </span>
         <div class="input-list" data-notify-module="list-entry" data-list-item-name="domain" id="list-entry-domains">
-          ${entries()} }
+          ${entries()}
         </div>
       </fieldset>`;
 

--- a/tests/javascripts/listEntry.test.js
+++ b/tests/javascripts/listEntry.test.js
@@ -224,6 +224,82 @@ describe("List entry", () => {
       expect(fields[0].getAttribute('aria-describedby')).toEqual('hint1');
       expect(fields[0].classList.contains('top-level-domain')).toBe(true);
     });
+
+    describe("If there are validation errors in the page", () => {
+
+      function markFieldAsInvalid(field) {
+
+        const formGroup = field.querySelector('.govuk-form-group');
+        const label = field.querySelector('.govuk-label');
+        const input = field.querySelector('.govuk-input');
+        const errorMessage = document.createElement('p');
+
+        errorMessageText = 'Enter an email address in the correct format, like name@example.gov.uk';
+        errorMessage.setAttribute('id', `${input.id}-error`);
+        errorMessage.setAttribute('data-notify-module', 'track-error');
+        errorMessage.setAttribute('data-error-label', input.id.replace(/^input-/, ''));
+        errorMessage.setAttribute('data-error-type', errorMessageText);
+        errorMessage.classList.add('govuk-error-message');
+        errorMessage.innerHTML = `<span class="govuk-visually-hidden">Error:</span> ${errorMessageText}`;
+
+        formGroup.classList.add('.govuk-form-group--error');
+        label.classList.add('govuk-input--numbered__label--error');
+        input.classList.add('govuk-input--error');
+        input.setAttribute('aria-describedby', errorMessage.id);
+
+        label.insertAdjacentElement('afterend', errorMessage);
+
+      };
+
+      const invalidFields = [0, 2, 5];
+
+      beforeEach(() => {
+
+        inputList.querySelectorAll('.list-entry').forEach((field, idx) => {
+
+          if (invalidFields.includes(idx)) { markFieldAsInvalid(field); }
+
+        });
+
+        // start module
+        window.GOVUK.notifyModules.start();
+
+      });
+
+      test("only textboxes with errors should have their HTML changed", () => {
+
+        document.querySelectorAll('.list-entry').forEach((field, idx) => {
+
+          const formGroup = field.querySelector('.govuk-form-group');
+          const label = field.querySelector('.govuk-label');
+          const input = field.querySelector('.govuk-input');
+          const errorMessage = field.querySelector('.govuk-error-message');
+
+          if (invalidFields.includes(idx)) {
+
+            expect(formGroup.classList.contains('govuk-form-group--error')).toBe(true);
+            expect(label.classList.contains('govuk-input--numbered__label')).toBe(true);
+            expect(input.classList.contains('govuk-input--error')).toBe(true);
+            expect(errorMessage.matches('[data-notify-module][data-error-label][data-error-type]')).toBe(true);
+            expect(errorMessage.innerHTML.trim()).toEqual(
+              `<span class="govuk-visually-hidden">Error:</span> ${errorMessage.dataset.errorLabel}`);
+
+          } else {
+
+            expect(formGroup.classList.contains('govuk-form-group--error')).toBe(false);
+            expect(label.classList.contains('govuk-input--numbered__label')).toBe(false);
+            expect(input.classList.contains('govuk-input--error')).toBe(false);
+            expect(errorMessage.matches('[data-notify-module][data-error-label][data-error-type]')).toBe(false);
+            expect(errorMessage.innerHTML.trim()).not.toEqual(
+              `<span class="govuk-visually-hidden">Error:</span> ${errorMessage.dataset.errorLabel}`);
+
+          }
+
+        });
+
+      });
+
+    });
   });
 
   describe("When the 'remove' button is clicked", () => {
@@ -267,7 +343,7 @@ describe("List entry", () => {
       // the items have their values set to the 10 domains
       const expectedValues = domains.slice(0, -1);
       const itemValues = Array.from(
-                          inputList.querySelectorAll('.list-entry input[type=text]')
+                           inputList.querySelectorAll('.list-entry input[type=text]')
                          )
                          .map(item => item.getAttribute('value'));
 
@@ -283,7 +359,7 @@ describe("List entry", () => {
       // the items have their values set to the 10 domains
       const expectedValues = domains.slice();
       const itemValues = Array.from(
-                          inputList.querySelectorAll('.list-entry input[type=text]')
+                           inputList.querySelectorAll('.list-entry input[type=text]')
                          )
                          .map(item => item.getAttribute('value'));
 

--- a/tests/javascripts/listEntry.test.js
+++ b/tests/javascripts/listEntry.test.js
@@ -232,22 +232,19 @@ describe("List entry", () => {
         const formGroup = field.querySelector('.govuk-form-group');
         const label = field.querySelector('.govuk-label');
         const input = field.querySelector('.govuk-input');
-        const errorMessage = document.createElement('p');
+        const errorMessageText = 'Enter an email address in the correct format, like name@example.gov.uk';
+        const errorMessageId = `${input.id}-error`;
 
-        errorMessageText = 'Enter an email address in the correct format, like name@example.gov.uk';
-        errorMessage.setAttribute('id', `${input.id}-error`);
-        errorMessage.setAttribute('data-notify-module', 'track-error');
-        errorMessage.setAttribute('data-error-label', input.id.replace(/^input-/, ''));
-        errorMessage.setAttribute('data-error-type', errorMessageText);
-        errorMessage.classList.add('govuk-error-message');
-        errorMessage.innerHTML = `<span class="govuk-visually-hidden">Error:</span> ${errorMessageText}`;
-
-        formGroup.classList.add('.govuk-form-group--error');
+        formGroup.classList.add('govuk-form-group--error');
         label.classList.add('govuk-input--numbered__label--error');
         input.classList.add('govuk-input--error');
-        input.setAttribute('aria-describedby', errorMessage.id);
+        input.setAttribute('aria-describedby', errorMessageId);
 
-        label.insertAdjacentElement('afterend', errorMessage);
+        label.insertAdjacentHTML('afterend', `
+          <p class="govuk-error-message" id="${errorMessageId}" data-notify-module="track-error" data-error-label="${input.id.replace(/^input-/, '')}" data-error-type="${errorMessageText}">
+            <span class="govuk-visually-hidden">Error:</span> ${errorMessageText}
+          </p>
+        `);
 
       };
 
@@ -278,20 +275,19 @@ describe("List entry", () => {
           if (invalidFields.includes(idx)) {
 
             expect(formGroup.classList.contains('govuk-form-group--error')).toBe(true);
-            expect(label.classList.contains('govuk-input--numbered__label')).toBe(true);
+            expect(label.classList.contains('govuk-input--numbered__label--error')).toBe(true);
             expect(input.classList.contains('govuk-input--error')).toBe(true);
+            expect(errorMessage).not.toBeNull();
             expect(errorMessage.matches('[data-notify-module][data-error-label][data-error-type]')).toBe(true);
             expect(errorMessage.innerHTML.trim()).toEqual(
-              `<span class="govuk-visually-hidden">Error:</span> ${errorMessage.dataset.errorLabel}`);
+              `<span class="govuk-visually-hidden">Error: </span>${errorMessage.dataset.errorType}`);
 
           } else {
 
             expect(formGroup.classList.contains('govuk-form-group--error')).toBe(false);
-            expect(label.classList.contains('govuk-input--numbered__label')).toBe(false);
+            expect(label.classList.contains('govuk-input--numbered__label--error')).toBe(false);
             expect(input.classList.contains('govuk-input--error')).toBe(false);
-            expect(errorMessage.matches('[data-notify-module][data-error-label][data-error-type]')).toBe(false);
-            expect(errorMessage.innerHTML.trim()).not.toEqual(
-              `<span class="govuk-visually-hidden">Error:</span> ${errorMessage.dataset.errorLabel}`);
+            expect(errorMessage).toBeNull();
 
           }
 

--- a/tests/javascripts/listEntry.test.js
+++ b/tests/javascripts/listEntry.test.js
@@ -241,7 +241,7 @@ describe("List entry", () => {
         input.setAttribute('aria-describedby', errorMessageId);
 
         label.insertAdjacentHTML('afterend', `
-          <p class="govuk-error-message" id="${errorMessageId}" data-notify-module="track-error" data-error-label="${input.id.replace(/^input-/, '')}" data-error-type="${errorMessageText}">
+          <p class="govuk-error-message" id="${errorMessageId}">
             <span class="govuk-visually-hidden">Error:</span> ${errorMessageText}
           </p>
         `);

--- a/tests/javascripts/listEntry.test.js
+++ b/tests/javascripts/listEntry.test.js
@@ -210,7 +210,7 @@ describe("List entry", () => {
 
       inputList.querySelectorAll('.list-entry input[type=text]').forEach((field, idx) => {
 
-        field.setAttribute('aria-describedby', 'hint1');
+        field.setAttribute('pattern', '[\w\.]+');
         field.classList.add('top-level-domain');
 
       });
@@ -221,7 +221,7 @@ describe("List entry", () => {
       // re-select fields, based on updated DOM
       fields = inputList.querySelectorAll('.list-entry input[type=text]');
 
-      expect(fields[0].getAttribute('aria-describedby')).toEqual('hint1');
+      expect(fields[0].getAttribute('pattern')).toEqual('[\w\.]+');
       expect(fields[0].classList.contains('top-level-domain')).toBe(true);
     });
 
@@ -249,8 +249,18 @@ describe("List entry", () => {
       };
 
       const invalidFields = [0, 2, 5];
+      const sixDomains = domains.slice(0, 8);
+
+      sixDomains[0] = 'gov@uk';
+      sixDomains[2] = 'nhs.uk';
+      sixDomains[5] = 'nhs.net';
 
       beforeEach(() => {
+
+        let fields = inputList.querySelectorAll('.list-entry input[type=text]');
+
+        // set values of first 8 fields
+        sixDomains.forEach((domain, idx) => { fields[idx].setAttribute('value', domain) });
 
         inputList.querySelectorAll('.list-entry').forEach((field, idx) => {
 
@@ -281,6 +291,7 @@ describe("List entry", () => {
             expect(errorMessage.matches('[data-notify-module][data-error-label][data-error-type]')).toBe(true);
             expect(errorMessage.innerHTML.trim()).toEqual(
               `<span class="govuk-visually-hidden">Error: </span>${errorMessage.dataset.errorType}`);
+            expect(input.getAttribute('aria-describedby')).toEqual(errorMessage.id);
 
           } else {
 
@@ -296,6 +307,7 @@ describe("List entry", () => {
       });
 
     });
+
   });
 
   describe("When the 'remove' button is clicked", () => {


### PR DESCRIPTION
(List entry is our word for a type of form field that has a variable number of textboxes.)

https://trello.com/c/SH1wQTpD/738-fix-validation-on-pages-with-variable-number-of-fields

## Guestlist page

### Before

<img width="760" alt="guestlist_page_before" src="https://github.com/alphagov/notifications-admin/assets/87140/2b95b96b-952e-4634-b534-160f8f287bc1">

### After

![guestlist_page_after](https://github.com/alphagov/notifications-admin/assets/87140/2730ddf3-133c-4ea1-a327-9ee528094e1d)

## Domains page

### Before

<img width="751" alt="domains_page_before" src="https://github.com/alphagov/notifications-admin/assets/87140/1f50070a-ca56-4171-ba31-9117e11d4ae3">

### After

<img width="780" alt="domains_page_after" src="https://github.com/alphagov/notifications-admin/assets/87140/ace8f5f9-cb17-41fc-b093-11dbd5a2d690">

## Notes for reviewers

There are a lot of changes here and kind of in 2 parts: the ListEntry JS and the WTForms/Python code, so would be better reviewed commit-by-commit.

Also:
- try it without JS
- use the skiplinks

...and please do feel free to comment on the decisions made in the WTForms/Python code. I did what seemed sensible as part of this work but not totally sure I put things in the best places for the wider codebase.