### PR TITLE
Remove notice about upcoming price increase

### DIFF
--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -20,23 +20,6 @@
       }
     ) }}
 
-  <div class="govuk-inset-text">
-    <p class="govuk-body">
-    Royal Mail is increasing its rates.
-    </p>
-    <p class="govuk-body">
-      On 1 July 2024:
-    </p> 
-   
-    <ul class="govuk-list govuk-list--bullet">
-     <li>second class postage will go up by between 5 and 7 pence</li>
-     <li>first class postage will go up by 15 pence</li>
-    </ul>
-    <p class="govuk-body">
-      The exact difference for second class postage will depend on the number of pages in your letter. The changes listed do not include VAT. 
-    </p>  
-  </div>
-
   <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
   <p class="govuk-body">Prices include:</p>


### PR DESCRIPTION
⚠️ **This should not be merged until 1 July** ⚠️

On 1 July 2024, the new prices will be displayed on the page (since the data comes from the api) and we can remove the message about an upcoming increase.