### PR TITLE
SPIKE: Upgrade to govuk frontend v5

### DIFF
--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -26,7 +26,7 @@
   </head>
   <body class="govuk-template__body ">
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-    <header class="govuk-header " role="banner" data-module="header">
+    <header class="govuk-header " data-module="header">
       <div class="govuk-header__container govuk-width-container">
 
         <div class="govuk-header__logo">
@@ -65,7 +65,7 @@
     </header>
 
     <div class="govuk-width-container">
-      <main class="govuk-main-wrapper govuk-!-padding-top-0 govuk-!-padding-bottom-12" id="main-content" role="main">
+      <main class="govuk-main-wrapper govuk-!-padding-top-0 govuk-!-padding-bottom-12" id="main-content">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-l govuk-!-padding-top-7">
@@ -81,7 +81,7 @@
       </main>
     </div>
 
-    <footer class="govuk-footer " role="contentinfo">
+    <footer class="govuk-footer ">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -9,13 +9,19 @@
     <meta name="theme-color" content="#0b0c0c" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/static/images/favicon.ico?de7abc5226925203ac10b0a4a94af949" type="image/x-icon" />
+    <!-- <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/static/images/favicon.ico?de7abc5226925203ac10b0a4a94af949" type="image/x-icon" />
     <link rel="mask-icon" href="/static/images/govuk-mask-icon.svg?2afd125b1db96109388d4a0727312f3e" color="#0b0c0c">
     <link rel="apple-touch-icon" sizes="180x180" href="/static/images/govuk-apple-touch-icon-180x180.png?a0f7e1b728a42016b247dc54ee40d055">
     <link rel="apple-touch-icon" sizes="167x167" href="/static/images/govuk-apple-touch-icon-167x167.png?f636cb7d471fc6239d2241d75cbdabcb">
     <link rel="apple-touch-icon" sizes="152x152" href="/static/images/govuk-apple-touch-icon-152x152.png?40846d46aa37232e2b35065769ce567c">
-    <link rel="apple-touch-icon" href="/static/images/govuk-apple-touch-icon.png?3c45daa1f1e716458e4da954b973002e">
-
+    <link rel="apple-touch-icon" href="/static/images/govuk-apple-touch-icon.png?3c45daa1f1e716458e4da954b973002e"> -->
+    <!-- check with Tom about fingerprint values -->
+    <link rel="icon" sizes="48x48" href="/static/images/favicon.ico">
+    <link rel="icon" sizes="any" href="/static/images/favicon.svg" type="image/svg+xml">
+    <link rel="mask-icon" href="/static/images/govuk-icon-mask.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" href="/static/images/govuk-icon-180.png">
+    <!-- probs don't need -->
+    <!-- <link rel="manifest" href="{{ asset_url('manifest.json') }}"> -->
     <link rel="stylesheet" media="screen" href="/static/stylesheets/main.css?d077f86473501ab244de0b30600536ee" />
     <link rel="stylesheet" media="print" href="/static/stylesheets/print.css?28010888ca5719dc83d7c2c80f6ed2b2" />
     <style>

--- a/app/assets/javascripts/esm/all.mjs
+++ b/app/assets/javascripts/esm/all.mjs
@@ -8,78 +8,17 @@
 // For example, `export { Frontend }` will assign `Frontend` to `window.Frontend`
 
 // GOVUK Frontend modules
-import { Header, Button, Radios, ErrorSummary, SkipLink, Tabs } from 'govuk-frontend';
+
 
 // Modules from 3rd party vendors
 import morphdom from 'morphdom';
 
-// Copy of the initAll function from https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/all.js
-// except it only includes, and initialises, the components used by this application.
-function initAll (options) {
-  // Set the options to an empty object by default if no options are passed.
-  options = typeof options !== 'undefined' ? options : {}
-
-  // Allow the user to initialise GOV.UK Frontend in only certain sections of the page
-  // Defaults to the entire document if nothing is set.
-  var scope = typeof options.scope !== 'undefined' ? options.scope : document
-
-  // Find all buttons with [role=button] on the scope to enhance.
-  var $buttons = scope.querySelectorAll('[data-module="govuk-button"]')
-  if ($buttons) {
-    $buttons.forEach(($button) => {
-      new Button($button)
-    })
-  }
-
-  // Find first header module to enhance.
-  var $toggleButton = scope.querySelector('[data-module="govuk-header"]')
-  new Header($toggleButton)
-
-  var $radios = scope.querySelectorAll('[data-module="govuk-radios"]')
-  if ($radios) {
-    $radios.forEach(($radio) => {
-      new Radios($radio)
-    })
-  }
-
-  var $skipLinks = scope.querySelectorAll('[data-module="govuk-skip-link"]')
-  if ($skipLinks) {
-    $skipLinks.forEach(($skipLink) => {
-      new SkipLink($skipLink)
-    })
-  }
-
-  var $tabs = scope.querySelectorAll('[data-module="govuk-tabs"]')
-  if ($tabs) {
-    $tabs.forEach(($tabs) => {
-      new Tabs($tabs)
-    })
-  }
-
-  // There will only every be one error-summary per page
-  var $errorSummary = scope.querySelector('[data-module="govuk-error-summary"]');
-  if ($errorSummary) {
-    new ErrorSummary($errorSummary);
-  }
-}
-
-// Create separate namespace for GOVUK Frontend.
-var Frontend = {
-  "Header": Header,
-  "Button": Button,
-  "Radios": Radios,
-  "ErrorSummary": ErrorSummary,
-  "SkipLink": SkipLink,
-  "initAll": initAll
-}
-
 var vendor = {
-  "morphdom": morphdom
+  "morphdom": morphdom,
 }
 
 // The exported object will be assigned to window.GOVUK in our production code
 // (bundled into an IIFE by RollupJS)
 export {
-  Frontend,
   vendor
 }

--- a/app/assets/javascripts/esm/all.mjs
+++ b/app/assets/javascripts/esm/all.mjs
@@ -8,24 +8,10 @@
 // For example, `export { Frontend }` will assign `Frontend` to `window.Frontend`
 
 // GOVUK Frontend modules
-import { Header, Details, Button, Radios, ErrorSummary, SkipLink, Tabs } from 'govuk-frontend';
+import { Header, Button, Radios, ErrorSummary, SkipLink, Tabs } from 'govuk-frontend';
 
 // Modules from 3rd party vendors
 import morphdom from 'morphdom';
-
-/**
- * TODO: Ideally this would be a NodeList.prototype.forEach polyfill
- * This seems to fail in IE8, requires more investigation.
- * See: https://github.com/imagitama/nodelist-foreach-polyfill
- */
-function nodeListForEach (nodes, callback) {
-  if (window.NodeList.prototype.forEach) {
-    return nodes.forEach(callback)
-  }
-  for (var i = 0; i < nodes.length; i++) {
-    callback.call(window, nodes[i], i, nodes);
-  }
-}
 
 // Copy of the initAll function from https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/all.js
 // except it only includes, and initialises, the components used by this application.
@@ -38,42 +24,48 @@ function initAll (options) {
   var scope = typeof options.scope !== 'undefined' ? options.scope : document
 
   // Find all buttons with [role=button] on the scope to enhance.
-  new Button(scope).init()
-
-  // Find all global details elements to enhance.
-  var $details = scope.querySelectorAll('[data-module="govuk-details"]')
-  nodeListForEach($details, function ($detail) {
-    new Details($detail).init()
-  })
+  var $buttons = scope.querySelectorAll('[data-module="govuk-button"]')
+  if ($buttons) {
+    $buttons.forEach(($button) => {
+      new Button($button)
+    })
+  }
 
   // Find first header module to enhance.
   var $toggleButton = scope.querySelector('[data-module="govuk-header"]')
-  new Header($toggleButton).init()
+  new Header($toggleButton)
 
   var $radios = scope.querySelectorAll('[data-module="govuk-radios"]')
-  nodeListForEach($radios, function ($radio) {
-    new Radios($radio).init()
-  })
+  if ($radios) {
+    $radios.forEach(($radio) => {
+      new Radios($radio)
+    })
+  }
 
   var $skipLinks = scope.querySelectorAll('[data-module="govuk-skip-link"]')
-  nodeListForEach($skipLinks, function ($skipLink) {
-    new SkipLink($skipLink).init()
-  })
+  if ($skipLinks) {
+    $skipLinks.forEach(($skipLink) => {
+      new SkipLink($skipLink)
+    })
+  }
 
   var $tabs = scope.querySelectorAll('[data-module="govuk-tabs"]')
-  nodeListForEach($tabs, function ($tabs) {
-    new Tabs($tabs).init()
-  })
+  if ($tabs) {
+    $tabs.forEach(($tabs) => {
+      new Tabs($tabs)
+    })
+  }
 
   // There will only every be one error-summary per page
-  var $errorSummary = scope.querySelector('[data-module="govuk-error-summary"]')
-  new ErrorSummary($errorSummary).init()
+  var $errorSummary = scope.querySelector('[data-module="govuk-error-summary"]');
+  if ($errorSummary) {
+    new ErrorSummary($errorSummary);
+  }
 }
 
 // Create separate namespace for GOVUK Frontend.
 var Frontend = {
   "Header": Header,
-  "Details": Details,
   "Button": Button,
   "Radios": Radios,
   "ErrorSummary": ErrorSummary,

--- a/app/assets/javascripts/esm/frontend.mjs
+++ b/app/assets/javascripts/esm/frontend.mjs
@@ -1,0 +1,44 @@
+import { Header, Button, Radios, ErrorSummary, SkipLink, Tabs } from 'govuk-frontend';
+
+var options = typeof options !== 'undefined' ? options : {}
+
+var scope = typeof options.scope !== 'undefined' ? options.scope : document
+
+  // Find all buttons with [role=button] on the scope to enhance.
+  var $buttons = scope.querySelectorAll('[data-module="govuk-button"]')
+  if ($buttons) {
+    $buttons.forEach(($button) => {
+      new Button($button)
+    })
+  }
+
+  // Find first header module to enhance.
+  var $toggleButton = scope.querySelector('[data-module="govuk-header"]')
+  new Header($toggleButton)
+
+  var $radios = scope.querySelectorAll('[data-module="govuk-radios"]')
+  if ($radios) {
+    $radios.forEach(($radio) => {
+      new Radios($radio)
+    })
+  }
+
+  var $skipLinks = scope.querySelectorAll('[data-module="govuk-skip-link"]')
+  if ($skipLinks) {
+    $skipLinks.forEach(($skipLink) => {
+      new SkipLink($skipLink)
+    })
+  }
+
+  var $tabs = scope.querySelectorAll('[data-module="govuk-tabs"]')
+  if ($tabs) {
+    $tabs.forEach(($tabs) => {
+      new Tabs($tabs)
+    })
+  }
+
+  // There will only every be one error-summary per page
+  var $errorSummary = scope.querySelector('[data-module="govuk-error-summary"]');
+  if ($errorSummary) {
+    new ErrorSummary($errorSummary);
+  }

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,4 +1,4 @@
-window.GOVUK.Frontend.initAll();
+
 
 $(() => $("time.timeago").timeago());
 

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -6,8 +6,8 @@
 $govuk-assets-path: "/static/";
 
 @import "govuk/base";
-@import "govuk/core/all";
-@import "govuk/objects/all";
+@import "govuk/core/index";
+@import "govuk/objects/index";
 
 // section replacing @import "components/all", specifying which components to include
 @import "govuk/components/skip-link/index";
@@ -25,8 +25,8 @@ $govuk-assets-path: "/static/";
 @import "govuk/components/textarea/index";
 @import "govuk/components/summary-list/index";
 
-@import "govuk/utilities/all";
-@import "govuk/overrides/all";
+@import "govuk/utilities/index";
+@import "govuk/overrides/index";
 
 // Styles extending those from GOV.UK Frontend
 @import "./extensions";

--- a/app/assets/stylesheets/local/_typography.scss
+++ b/app/assets/stylesheets/local/_typography.scss
@@ -1,5 +1,5 @@
-@import 'govuk/settings/all';
-@import 'govuk/helpers/all';
+@import 'govuk/settings/index';
+@import 'govuk/helpers/index';
 
 @mixin destructive-link-style-default {
   &:link {

--- a/app/assets/stylesheets/local/_typography.scss
+++ b/app/assets/stylesheets/local/_typography.scss
@@ -63,6 +63,6 @@
 
 // Font override classes
 .extended-gsm-characters {
-  font-family: $govuk-font-family-tabular;
+  @include govuk-font-tabular-numbers;
   letter-spacing: 0.5em;
 }

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -2,12 +2,12 @@
 // set asset URL root to match that of application
 $govuk-assets-path: "/static/";
 
-@import "govuk/settings/all";
-@import "govuk/tools/all";
-@import "govuk/helpers/all";
+@import "govuk/settings/index";
+@import "govuk/tools/index";
+@import "govuk/helpers/index";
 
-@import "govuk/core/all";
-@import "govuk/objects/all";
+@import "govuk/core/index";
+@import "govuk/objects/index";
 
 * {
   background: transparent;

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -18,7 +18,7 @@ $govuk-assets-path: "/static/";
 }
 
 body {
-  @include govuk-font($size: 14);
+  @include govuk-font($size: 16);
   margin: 0;
   padding: 0;
   width: 100%;

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -132,5 +132,7 @@
 {% block bodyEnd %}
   {% block extra_javascripts %}
   {% endblock %}
+  <script type="module" src="{{ asset_url('javascripts/frontend.mjs') }}"></script>
   <script type="text/javascript" src="{{ asset_url('javascripts/all.js') }}"></script>
+  
 {% endblock %}

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -47,8 +47,7 @@
     "productName": "Notify",
     "navigation": header_navigation.visible_header_nav(),
     "navigationClasses": "govuk-header__navigation--end",
-    "assetsPath": asset_path + "images",
-    "useTudorCrown": True
+    "assetsPath": asset_path + "images"
   }) }}
 {% endblock %}
 

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -1,12 +1,11 @@
 {% extends "govuk_frontend_jinja/template.html"%}
 
 {% block headIcons %}
-  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ asset_url('images/favicon.ico') }}" type="image/x-icon" />
-  <link rel="mask-icon" href="{{ asset_url('images/govuk-mask-icon.svg') }}" color="{{ themeColor | default('#0b0c0c') }}"> {# Hardcoded value of $govuk-black #}
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ asset_url('images/govuk-apple-touch-icon-180x180.png') }}">
-  <link rel="apple-touch-icon" sizes="167x167" href="{{ asset_url('images/govuk-apple-touch-icon-167x167.png') }}">
-  <link rel="apple-touch-icon" sizes="152x152" href="{{ asset_url('images/govuk-apple-touch-icon-152x152.png') }}">
-  <link rel="apple-touch-icon" href="{{ asset_url('images/govuk-apple-touch-icon.png') }}">
+  <link rel="icon" sizes="48x48" href="{{ asset_url('images/favicon.ico') }}">
+  <link rel="icon" sizes="any" href="{{ asset_url('images/favicon.svg') }}" type="image/svg+xml">
+  <link rel="mask-icon" href="{{ asset_url('images/govuk-icon-mask.svg') }}" color="#0b0c0c">
+  <link rel="apple-touch-icon" href="{{ asset_url('images/govuk-icon-180.png') }}">
+  <link rel="manifest" href="{{ asset_url('manifest.json') }}">
 {% endblock %}
 
 {% block head %}

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -132,7 +132,5 @@
 {% block bodyEnd %}
   {% block extra_javascripts %}
   {% endblock %}
-  <!--[if gt IE 8]><!-->
   <script type="text/javascript" src="{{ asset_url('javascripts/all.js') }}"></script>
-  <!--<![endif]-->
 {% endblock %}

--- a/app/templates/components/previous-next-navigation.html
+++ b/app/templates/components/previous-next-navigation.html
@@ -1,6 +1,6 @@
 {% macro previous_next_navigation(previous_page, next_page) %}
   {% if previous_page or next_page %}
-    <nav class="govuk-previous-and-next-navigation" role="navigation" aria-label="Pagination">
+    <nav class="govuk-previous-and-next-navigation" aria-label="Pagination">
       <ul class="group">
         {% if previous_page %}
           <li class="previous-page">

--- a/app/templates/fullwidth_template.html
+++ b/app/templates/fullwidth_template.html
@@ -4,7 +4,7 @@
 
 {% block main %}
   {% block beforeContent %}{% endblock %}
-  <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main">
+  <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content">
     {% block content %}{% endblock %}
   </main>
 {% endblock %}

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -25,7 +25,7 @@
         {% block beforeContent %}
           {% block backLink %}{% endblock %}
         {% endblock %}
-        <main class="govuk-main-wrapper column-main govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main" >
+        <main class="govuk-main-wrapper column-main govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" >
           {% block content %}
             {% include 'flash_messages.html' %}
             {% block errorSummary %}

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -40,7 +40,7 @@
       </div>
       <div class="govuk-grid-column-three-quarters">
       {% block backLink %}{% endblock %}
-        <main class="govuk-main-wrapper column-main govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main">
+        <main class="govuk-main-wrapper column-main govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content">
           {% block content %}
             {% include 'flash_messages.html' %}
             {% block errorSummary %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -28,7 +28,7 @@
         {% block beforeContent %}
           {% block backLink %}{% endblock %}
         {% endblock %}
-        <main class="govuk-main-wrapper column-main {{ mainClasses }}" id="main-content" role="main">
+        <main class="govuk-main-wrapper column-main {{ mainClasses }}" id="main-content">
         {% block content %}
           {% include 'flash_messages.html' %}
           {% block errorSummary %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,6 +132,24 @@ const javascripts = () => {
     presets: ['@babel/preset-env']
   }));
 
+  const frontend = src(
+    paths.src + 'javascripts/esm/frontend.mjs',
+  )
+  .pipe(plugins.rollup(
+    {
+      plugins: [
+        // determine module entry points from either 'module' or 'main' fields in package.json
+        rollupPluginNodeResolve({
+          mainFields: ['module', 'main']
+        })
+      ]
+    },
+    {
+      format: 'esm',
+    }
+  ))
+  .pipe(dest(paths.dist + 'javascripts/'))
+
   // return single stream of all vinyl objects piped from the end of the vendored stream, then
   // those from the end of the local stream
   return streamqueue({ objectMode: true }, vendored, local)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,6 +53,10 @@ const copy = {
       return src(paths.govuk_frontend + 'govuk/assets/fonts/**/*')
         .pipe(dest(paths.dist + 'fonts/'));
     },
+    header_icon_manifest: () => {
+      return src(paths.govuk_frontend + 'govuk/assets/manifest.json')
+        .pipe(dest(paths.dist));
+    },
   }
 };
 
@@ -234,6 +238,7 @@ const defaultTask = series(
   clean.everything,
   parallel(
     copy.govuk_frontend.fonts,
+    copy.govuk_frontend.header_icon_manifest,
     copy.error_pages,
     images,
     javascripts,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ const paths = {
   src: 'app/assets/',
   dist: 'app/static/',
   npm: 'node_modules/',
-  govuk_frontend: 'node_modules/govuk-frontend/'
+  govuk_frontend: 'node_modules/govuk-frontend/dist/'
 };
 // Rewrite /static prefix for URLs in CSS files
 let staticPathMatcher = new RegExp('^\/static\/');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cbor-js": "0.1.0",
-        "govuk-frontend": "4.8.0",
+        "govuk-frontend": "5.4.0",
         "hogan": "1.0.2",
         "jquery": "3.5.0",
         "morphdom": "2.6.1",
@@ -6578,9 +6578,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -20583,7 +20583,7 @@
           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.6"
+            "minimist": "1.2.6"
           }
         },
         "ms": {
@@ -21645,13 +21645,13 @@
       "integrity": "sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=",
       "dev": true,
       "requires": {
-        "minimist": "1.1.x"
+        "minimist": "1.2.6"
       }
     },
     "govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw=="
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -29336,7 +29336,7 @@
           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.6"
+            "minimist": "1.2.6"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4056,7 +4056,7 @@
     "node_modules/cbor-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz",
-      "integrity": "sha1-yAzmEg84fo+qdDcN/aIdlluPx/k="
+      "integrity": "sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw=="
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -19580,7 +19580,7 @@
     "cbor-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz",
-      "integrity": "sha1-yAzmEg84fo+qdDcN/aIdlluPx/k="
+      "integrity": "sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw=="
     },
     "chalk": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor-js": "0.1.0",
-    "govuk-frontend": "4.8.0",
+    "govuk-frontend": "5.4.0",
     "hogan": "1.0.2",
     "jquery": "3.5.0",
     "morphdom": "2.6.1",

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ fido2==1.1.0
 
 itsdangerous==2.1.2
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
-govuk-frontend-jinja==2.8.0
+govuk-frontend-jinja==3.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 govuk-bank-holidays==0.14
     # via notifications-utils
-govuk-frontend-jinja==2.8.0
+govuk-frontend-jinja==3.1.0
     # via -r requirements.in
 greenlet==3.0.3
     # via eventlet

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -724,7 +724,7 @@ describe("Stick to top/bottom of window when scrolling", () => {
     beforeEach(() => {
 
       document.body.innerHTML = `
-        <main role="main" class="govuk-grid-column-three-quarters column-main">
+        <main class="govuk-grid-column-three-quarters column-main">
           <a class="govuk-back-link" href="">Back</a>
           <h1 class="heading-large js-header">
             Preview of ‘Content email’


### PR DESCRIPTION
working, but things to resolve


We could use `createAll` but difficulty with scope

might be an issue with `new window.GOVUK.Frontend.Button(this.$form[0]).init();` in fileUpload.js

some of our code relies implicitly on polyfills that were in govuk-frontend < 5:
- classList (copyToClipboard.js)
- dataset (removeInPresenceOf.js)
- nextElementSibling & previousElementSibling (radioSelect.js)
- String.trim()


<img width="1285" alt="Screenshot 2024-06-28 at 20 17 48" src="https://github.com/alphagov/notifications-admin/assets/3758555/9ef327ec-7cb7-4bca-bf54-025a82622cde">
