### PR TITLE
Replace incorrect use of ‘account’

### DIFF
--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -49,7 +49,7 @@
     If you’re doing work for a public sector organisation you can use GOV.UK&nbsp;Notify.
   </p>
   <p class="govuk-body">
-    Someone from the public sector organisation you’re working with needs to set up the account. Then they can invite you as a team member.
+    Someone from the public sector organisation you’re working with needs to set up the service first. Then they can invite you as a team member.
   </p>
 
   <h2 class="govuk-heading-m" id="gp">GP surgeries</h2>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -49,7 +49,7 @@
     If you’re doing work for a public sector organisation you can use GOV.UK&nbsp;Notify.
   </p>
   <p class="govuk-body">
-    Someone from the public sector organisation you’re working with needs to set up the service first. Then they can invite you as a team member.
+    Someone from the public sector organisation you’re working with needs to set up the service. Then they can invite you as a team member.
   </p>
 
   <h2 class="govuk-heading-m" id="gp">GP surgeries</h2>


### PR DESCRIPTION
On the ‘Who can use Notify’ page we incorrectly say ‘account’ when what we mean is ‘service’.

This PR fixes that content error.