### PR TITLE
Improve the ‘security code not received’ guidance 

### DIFF
--- a/app/templates/views/text-not-received.html
+++ b/app/templates/views/text-not-received.html
@@ -12,14 +12,12 @@ If you do not receive a security code
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">If you do not receive a security code</h1>
 
-    <p class="govuk-body">
-      <ol class="govuk-list govuk-list--number">
-         <li>Check that you can receive text messages from other numbers.</li>
-         <li>Switch your phone off and then back on again.</li>
-         <li>Check the mobile phone number you entered is correct.</li>
-         <li>Request a new security code.</li>
-       </ol>
-    </p>       
+    <ol class="govuk-list govuk-list--number">
+      <li>Check that you can receive text messages from other numbers.</li>
+      <li>Switch your phone off and then back on again.</li>
+      <li>Check the mobile phone number you entered is correct.</li>
+      <li>Request a new security code.</li>
+    </ol>
 
       {% call form_wrapper() %}
         {{ form.mobile_number }}

--- a/app/templates/views/text-not-received.html
+++ b/app/templates/views/text-not-received.html
@@ -14,8 +14,9 @@ If you do not receive a security code
 
     <ol class="govuk-list govuk-list--number">
       <li>Check that you can receive text messages from other numbers.</li>
-      <li>Switch your phone off and then back on to try and reset your mobile phone connection.</li>
-      <li>Check the mobile phone number you entered is correct and then resend the security code.</li>
+      <li>Switch your phone off and then back on again.</li>
+      <li>Check the mobile phone number you entered is correct.</li>
+      <li>If you still do not receive a security code, we can send you a new one.</li>
     </ol>    
 
       {% call form_wrapper() %}

--- a/app/templates/views/text-not-received.html
+++ b/app/templates/views/text-not-received.html
@@ -12,12 +12,14 @@ If you do not receive a security code
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">If you do not receive a security code</h1>
 
-    <ol class="govuk-list govuk-list--number">
-      <li>Check that you can receive text messages from other numbers.</li>
-      <li>Switch your phone off and then back on again.</li>
-      <li>Check the mobile phone number you entered is correct.</li>
-      <li>If you still do not receive a security code, we can send you a new one.</li>
-    </ol>    
+    <p class="govuk-body">
+      <ol class="govuk-list govuk-list--number">
+         <li>Check that you can receive text messages from other numbers.</li>
+         <li>Switch your phone off and then back on again.</li>
+         <li>Check the mobile phone number you entered is correct.</li>
+         <li>Request a new security code.</li>
+       </ol>
+    </p>       
 
       {% call form_wrapper() %}
         {{ form.mobile_number }}

--- a/app/templates/views/text-not-received.html
+++ b/app/templates/views/text-not-received.html
@@ -3,16 +3,20 @@
 {% from "components/form.html" import form_wrapper %}
 
 {% block per_page_title %}
-Check your mobile number
+If you do not receive a security code
 {% endblock %}
 
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="heading-large">Check your mobile number</h1>
+    <h1 class="heading-large">If you do not receive a security code</h1>
 
-    <p class="govuk-body">Check your mobile phone number is correct and then resend the security code.</p>
+    <ol class="govuk-list govuk-list--number">
+      <li>Check that you can receive text messages from other numbers.</li>
+      <li>Switch your phone off and then back on to try and reset your mobile phone connection.</li>
+      <li>Check the mobile phone number you entered is correct and then resend the security code.</li>
+    </ol>    
 
       {% call form_wrapper() %}
         {{ form.mobile_number }}

--- a/app/templates/views/two-factor-sms.html
+++ b/app/templates/views/two-factor-sms.html
@@ -15,7 +15,7 @@
 
     <p class="govuk-body">We’ve sent you a text message with a security code.</p>
 
-    <p class="govuk-body">Text messages can sometimes take a few minutes to arrive.</p>
+    <p class="govuk-body">Text messages can take a few minutes to arrive.</p>
     
     {% call form_wrapper(class="extra-tracking") %}
       {{ form.sms_code(param_extensions={

--- a/app/templates/views/two-factor-sms.html
+++ b/app/templates/views/two-factor-sms.html
@@ -15,6 +15,8 @@
 
     <p class="govuk-body">We’ve sent you a text message with a security code.</p>
 
+    <p class="govuk-body">Text messages can sometimes take a few minutes to arrive.</p>
+    
     {% call form_wrapper(class="extra-tracking") %}
       {{ form.sms_code(param_extensions={
           "classes": "govuk-input govuk-input--width-5",

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -1,15 +1,16 @@
 {% extends "withoutnav_template.html" %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {% block per_page_title %}
-  If you have not received your security code
+  If you do not receive a security code
 {% endblock %}
 
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="heading-large">If you have not received your security code</h1>
+    <h1 class="heading-large">If you do not receive a security code</h1>
 
     <p class="govuk-body">Wait a few minutes. Text messages sometimes take a while to arrive.</p>
 
@@ -31,24 +32,36 @@
 
     <p class="govuk-body">If this does not work, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.</p>
 
-    <h2 class="heading-medium">If your phone number has changed</h2>
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          If your phone number has changed
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <p class="govuk-body">Find a member of your team with the ‘Manage settings, team and usage’ permission. Ask them to:</p>
 
-    <p class="govuk-body">Find a member of your team with the ‘Manage settings, team and usage’ permission. Ask them to:</p>
-
-    <ol class="govuk-list govuk-list--number">
-      <li>Sign in to GOV.UK Notify.</li>
-      <li>Go to the <span class="govuk-body govuk-!-font-weight-bold">Team members</span> page.</li>
-      <li>Find your name and select <span class="govuk-body govuk-!-font-weight-bold">Change details</span>.</li>
-      <li>Select <span class="govuk-body govuk-!-font-weight-bold">Change</span> next to your phone number.</li>
-      <li>Enter your new phone number and select <span class="govuk-body govuk-!-font-weight-bold">Save</span>.</li>
-      <li>Select <span class="govuk-body govuk-!-font-weight-bold">Save</span> again.</li>
-    </ol>
+        <ol class="govuk-list govuk-list--number">
+          <li>Sign in to GOV.UK Notify.</li>
+          <li>Go to the <span class="govuk-body govuk-!-font-weight-bold">Team members</span> page.</li>
+          <li>Find your name and select <span class="govuk-body govuk-!-font-weight-bold">Change details</span>.</li>
+          <li>Select <span class="govuk-body govuk-!-font-weight-bold">Change</span> next to your phone number.</li>
+        </ol>
     
-    <p class="govuk-body">Now try to sign in again.</p>
+        <p class="govuk-body">Now try to sign in again.</p>
+      </div>
+    </details>
 
-    <h2 class="heading-medium">If you want to sign in with an email link instead</h2>
-    
-    <p class="govuk-body">Ask a member of your team with the ‘Manage settings, team and usage’ permission to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">change your sign-in method</a>.</p>
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          If you want to sign in with an email link instead
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <p class="govuk-body">Ask a member of your team with the ‘Manage settings, team and usage’ permission to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">change your sign-in method</a>.</p>
+      </div>
+    </details>
 
   </div>
 </div>

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -14,7 +14,7 @@
     
     <ol class="govuk-list govuk-list--number">
       <li>Check that you can receive text messages from other numbers.</li>
-      <li>Switch your phone off and then back on to try and reset your mobile phone connection.</li>
+      <li>Switch your phone off and then back on again.</li>
       <li>If you still do not receive a security code, we can send you a new one.</li>
     </ol>
 

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -11,10 +11,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">If you do not receive a security code</h1>
-
-    <p class="govuk-body">Wait a few minutes. Text messages sometimes take a while to arrive.</p>
-
-    <p class="govuk-body">If this does not work:</p>
     
     <ol class="govuk-list govuk-list--number">
       <li>Check that you can receive text messages from other numbers.</li>

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -47,7 +47,6 @@
           <li>Select <span class="govuk-body govuk-!-font-weight-bold">Change</span> next to your phone number.</li>
         </ol>
     
-        <p class="govuk-body">Now try to sign in again.</p>
       </div>
     </details>
 

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -2,16 +2,25 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
 {% block per_page_title %}
-  Resend security code
+  If you have not received your security code
 {% endblock %}
 
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="heading-large">Resend security code</h1>
+    <h1 class="heading-large">If you have not received your security code</h1>
 
-    <p class="govuk-body">Text messages sometimes take a few minutes to arrive. If you do not receive a security code, Notify can send you a new one.</p>
+    <p class="govuk-body">Wait a few minutes. Text messages sometimes take a while to arrive.</p>
+
+    <p class="govuk-body">If this does not work:</p>
+    
+    <ol class="govuk-list govuk-list--number">
+      <li>Check that you can receive text messages from other numbers.</li>
+      <li>Switch your phone off and then back on to try and reset your mobile phone connection.</li>
+      <li>If you still do not receive a security code, we can send you a new one.</li>
+    </ol>
+
     <p class="govuk-body">
       {{ govukButton({
         "element": "a",
@@ -20,13 +29,27 @@
       }) }}
     </p>
 
-    <h2 class="heading-medium">If your mobile number has changed</h2>
-    <p class="govuk-body">You’ll need to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>find a member of your team who has permission to manage settings, team and usage</li>
-      <li>ask them to change the mobile number for your account</li>
-      <li>select <span class="govuk-body govuk-!-font-weight-bold">Resend security code</span></li>
-    </ul>
+    <p class="govuk-body">If this does not work, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.</p>
+
+    <h2 class="heading-medium">If your phone number has changed</h2>
+
+    <p class="govuk-body">Find a member of your team with the ‘Manage settings, team and usage’ permission. Ask them to:</p>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>Sign in to GOV.UK Notify.</li>
+      <li>Go to the <span class="govuk-body govuk-!-font-weight-bold">Team members</span> page.</li>
+      <li>Find your name and select <span class="govuk-body govuk-!-font-weight-bold">Change details</span>.</li>
+      <li>Select <span class="govuk-body govuk-!-font-weight-bold">Change</span> next to your phone number.</li>
+      <li>Enter your new phone number and select <span class="govuk-body govuk-!-font-weight-bold">Save</span>.</li>
+      <li>Select <span class="govuk-body govuk-!-font-weight-bold">Save</span> again.</li>
+    </ol>
+    
+    <p class="govuk-body">Now try to sign in again.</p>
+
+    <h2 class="heading-medium">If you want to sign in with an email link instead</h2>
+    
+    <p class="govuk-body">Ask a member of your team with the ‘Manage settings, team and usage’ permission to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">change your sign-in method</a>.</p>
+
   </div>
 </div>
 

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -28,13 +28,7 @@
 
     <p class="govuk-body">If this does not work, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.</p>
 
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          If your phone number has changed
-        </span>
-      </summary>
-      <div class="govuk-details__text">
+    {% set change_number %}
         <p class="govuk-body">Ask a member of your team with the ‘Manage settings, team and usage’ permission to update your phone number.</p>
         
         <p class="govuk-body">To do this, they should:</p>
@@ -46,20 +40,21 @@
           <li>Find your name and select <span class="govuk-body govuk-!-font-weight-bold">Change details</span>.</li>
           <li>Select <span class="govuk-body govuk-!-font-weight-bold">Change</span> next to your phone number.</li>
         </ol>
-    
-      </div>
-    </details>
+    {% endset %}
 
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          If you want to sign in with an email link instead
-        </span>
-      </summary>
-      <div class="govuk-details__text">
+    {{ govukDetails({
+      "summaryText": "If your phone number has changed",
+      "html": change_number
+    }) }}
+
+    {% set email_link %}
         <p class="govuk-body">Ask a member of your team with the ‘Manage settings, team and usage’ permission to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">change your sign-in method</a>.</p>
-      </div>
-    </details>
+    {% endset %}
+
+    {{ govukDetails({
+      "summaryText": "If you want to sign in with an email link instead",
+      "html": email_link
+    }) }}
 
   </div>
 </div>

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -35,7 +35,10 @@
         </span>
       </summary>
       <div class="govuk-details__text">
-        <p class="govuk-body">Find a member of your team with the ‘Manage settings, team and usage’ permission. Ask them to:</p>
+        <p class="govuk-body">Ask a member of your team with the ‘Manage settings, team and usage’ permission to update your phone number.</p>
+        
+        <p class="govuk-body">To do this, they should:</p>
+
 
         <ol class="govuk-list govuk-list--number">
           <li>Sign in to GOV.UK Notify.</li>

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -39,7 +39,7 @@ def test_should_render_correct_resend_template_for_active_user(
         session["user_details"] = {"id": api_user_active["id"], "email": api_user_active["email_address"]}
     page = client_request.get("main.check_and_resend_text_code", next=redirect_url)
 
-    assert page.select_one("h1").string == "Resend security code"
+    assert page.select_one("h1").string == "If you do not receive a security code"
     # there shouldn't be a form for updating mobile number
     assert page.select_one("form") is None
     assert page.select_one("a.govuk-button")["href"] == url_for(
@@ -60,7 +60,7 @@ def test_should_render_correct_resend_template_for_pending_user(
         session["user_details"] = {"id": api_user_pending["id"], "email": api_user_pending["email_address"]}
     page = client_request.get("main.check_and_resend_text_code")
 
-    assert page.select_one("h1").string == "Check your mobile number"
+    assert page.select_one("h1").string == "If you do not receive a security code"
 
     expected = "Check your mobile phone number is correct and then resend the security code."
     message = page.select("main p")[0].text

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -62,8 +62,8 @@ def test_should_render_correct_resend_template_for_pending_user(
 
     assert page.select_one("h1").string == "If you do not receive a security code"
 
-    expected = "Check your mobile phone number is correct and then resend the security code."
-    message = page.select("main p")[0].text
+    expected = "Check that you can receive text messages from other numbers."
+    message = page.select("main li")[0].text
     assert message == expected
     assert page.select_one("form").input["value"] == api_user_pending["mobile_number"]
 


### PR DESCRIPTION
When users do not receive their security code text message, they contact support.

To help users troubleshoot the possible causes of this issue before they have to contact us, we’re going to publish some of the information we usually send through support on our website.