### PR TITLE
fix(forms): enforce character length validation in template name

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1348,8 +1348,8 @@ class TemplateNameMixin:
     name = GovukTextInputField(
         "Template name",
         validators=[
-            NotifyDataRequired(thing="a name for this template"),
-            Length(max=255, thing="a name for this template"),
+            NotifyDataRequired(thing="Template name"),
+            Length(max=255, thing="Template name"),
         ],
     )
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1345,7 +1345,10 @@ class ConfirmPasswordForm(StripWhitespaceForm):
 
 
 class TemplateNameMixin:
-    name = GovukTextInputField("Template name", validators=[NotifyDataRequired(thing="a name for this template")])
+    name = GovukTextInputField("Template name", validators=[
+        NotifyDataRequired(thing="a name for this template"),
+        Length(max=255, thing="a name for this template"),
+    ])
 
 
 class RenameTemplateForm(StripWhitespaceForm, TemplateNameMixin):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1345,10 +1345,13 @@ class ConfirmPasswordForm(StripWhitespaceForm):
 
 
 class TemplateNameMixin:
-    name = GovukTextInputField("Template name", validators=[
-        NotifyDataRequired(thing="a name for this template"),
-        Length(max=255, thing="a name for this template"),
-    ])
+    name = GovukTextInputField(
+        "Template name",
+        validators=[
+            NotifyDataRequired(thing="a name for this template"),
+            Length(max=255, thing="a name for this template"),
+        ],
+    )
 
 
 class RenameTemplateForm(StripWhitespaceForm, TemplateNameMixin):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -3078,7 +3078,7 @@ def test_name_required_to_rename_template(
         },
         _expected_status=200,
     )
-    assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Enter a name for this template"
+    assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Enter Template name"
 
 
 @pytest.mark.parametrize("template_type", ("email", "sms"))


### PR DESCRIPTION
## PR Summary
- form validation for template name set to 255 characters.
- we were enforcing this validation on the database but not at the form level


### How was this tested?
-  all templates now have validation for that field
- top error message has a link that takes to the error field

**before**:

FIELD REQUIRED VALIDATION

![Screenshot 2024-07-08 at 10 37 51](https://github.com/alphagov/notifications-admin/assets/171517790/8f97d28d-684f-4e63-b020-fce2784034f3)

**after**:
LENGTH VALIDATION

![Screenshot 2024-07-08 at 10 35 54](https://github.com/alphagov/notifications-admin/assets/171517790/3a8aca1d-9f11-47bf-ab3c-c4aab9f7ad5d)

FIELD REQUIRED VALIDATION

![Screenshot 2024-07-08 at 10 36 06](https://github.com/alphagov/notifications-admin/assets/171517790/ed8283ea-d09b-42bb-bf46-0ce76b0ba9f6)


### Related ticket:
[Add max length validation to the template name field in the admin app](https://trello.com/c/7v4l6uri/795-add-max-length-validation-to-the-template-name-field-in-the-admin-app)