### PR TITLE
Form validation messages on register form

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -586,7 +586,7 @@ class LoginForm(StripWhitespaceForm):
 
 class RegisterUserForm(StripWhitespaceForm):
     name = GovukTextInputField("Full name", validators=[NotifyDataRequired(thing="your full name")])
-    email_address = make_email_address_field(gov_user=True)
+    email_address = make_email_address_field(gov_user=True, thing="your email address")
     mobile_number = international_phone_number()
     password = make_password_field(thing="your password")
     # always register as sms type

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -25,7 +25,7 @@ def register():
         _do_registration(form, send_sms=False)
         return redirect(url_for("main.registration_continue"))
 
-    return render_template("views/register.html", form=form)
+    return render_template("views/register.html", form=form, error_summary_enabled=True)
 
 
 @main.route("/register-from-invite", methods=["GET", "POST"])

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -10,7 +10,7 @@ Create an account
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="heading-large">Create an account</h1>
+    <h1 class="govuk-heading-l">Create an account</h1>
     {% call form_wrapper(autocomplete=True) %}
       {{ form.name(param_extensions={"classes": "govuk-!-width-three-quarters"}) }}
       {{ form.email_address(


### PR DESCRIPTION
## What 
Update /register form error messaging to:
- user error summary
- display an error message for empty email field that is consistent with the rest of the site

## Before

![Screenshot 2024-07-08 at 13 23 19](https://github.com/alphagov/notifications-admin/assets/3758555/3b422e69-0bae-4a73-99c5-0dbfc5f1f08e)
![Screenshot 2024-07-08 at 13 23 33](https://github.com/alphagov/notifications-admin/assets/3758555/9ea13948-d2ba-4746-ab91-0d2b3d015639)

## After

![Screenshot 2024-07-08 at 13 23 50](https://github.com/alphagov/notifications-admin/assets/3758555/a745ade7-4e9a-412f-bdd5-2d9aef2e44f3)
![Screenshot 2024-07-08 at 13 24 07](https://github.com/alphagov/notifications-admin/assets/3758555/f893d7ad-1892-453d-a674-f9027f9f919c)
