### PR TITLE
Add guidance for team members on support

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -19,6 +19,13 @@ from app.utils import hide_from_search_engines
 
 bank_holidays = BankHolidays(use_cached_holidays=True)
 
+ZENDESK_USER_LOGGED_OUT_NOTE = (
+    "The requester is not signed in to GOV.UK Notify.\n\n"
+    "To confirm they have access to the email address they entered in the support form:\n\n"
+    "1. Submit a public reply to this ticket.\n"
+    "2. Wait for the requester to reply."
+)
+
 
 @main.route("/support", methods=["GET", "POST"])
 @hide_from_search_engines
@@ -140,7 +147,7 @@ def feedback(ticket_type):
         if zendesk_ticket_id and not current_user.is_authenticated:
             zendesk_client.update_ticket(
                 zendesk_ticket_id,
-                comment=NotifySupportTicketComment(body="Requester not logged in", public=False),
+                comment=NotifySupportTicketComment(body=ZENDESK_USER_LOGGED_OUT_NOTE, public=False),
             )
 
         return redirect(

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -10,7 +10,7 @@ from notifications_utils.clients.zendesk.zendesk_client import (
     ZendeskError,
 )
 
-from app.main.views.feedback import in_business_hours
+from app.main.views.feedback import ZENDESK_USER_LOGGED_OUT_NOTE, in_business_hours
 from app.models.feedback import (
     GENERAL_TICKET_TYPE,
     PROBLEM_TICKET_TYPE,
@@ -165,7 +165,7 @@ def test_passed_non_logged_in_user_details_through_flow(client_request, mocker):
     mock_send_ticket_to_zendesk.assert_called_once()
     mock_update_ticket_with_internal_note.assert_called_once_with(
         1234,
-        comment=NotifySupportTicketComment(body="Requester not logged in", attachments=(), public=False),
+        comment=NotifySupportTicketComment(body=ZENDESK_USER_LOGGED_OUT_NOTE, attachments=(), public=False),
     )
 
 


### PR DESCRIPTION
We just did some work to [warn our team when a Zendesk ticket has come from a user who’s not signed in to Notify](https://trello.com/c/bPywVnSY/825-reduce-chance-of-impersonation-on-our-support-form-for-unauthenticated-users).

Now we need to provide some practical guidance for team members on support to know how to check a user is who they say they are.