### PR TITLE
Make branding journeys remember the radio button choices

### DIFF
--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -401,7 +401,7 @@ def email_branding_set_alt_text(service_id):
 
 
 def _email_branding_flow_query_params(request, **kwargs):
-    """Return a dictionary containing values for the new email branding flow.
+    """Return a dictionary containing values for the email branding flow.
 
     In order to create a new email branding for a user we need to collect and remember a series of information:
     - what kind of brand they want
@@ -519,7 +519,7 @@ def branding_option_preview(service_id, branding_type):
         back_link_query_params = _email_branding_flow_query_params(request)
     else:
         branding_pool = current_service.letter_branding_pool
-        back_link_query_params = _letter_branding_flow_query_params()
+        back_link_query_params = _letter_branding_flow_query_params(request)
     try:
         chosen_branding = branding_pool.get_item_by_id(request.args.get("branding_choice"))
     except branding_pool.NotFound:
@@ -552,7 +552,7 @@ def branding_nhs(service_id, branding_type):
         back_link_query_params = _email_branding_flow_query_params(request)
     else:
         branding = LetterBranding.NHS_ID
-        back_link_query_params = _letter_branding_flow_query_params()
+        back_link_query_params = _letter_branding_flow_query_params(request)
 
     check_branding_allowed_for_service(branding, branding_type=branding_type)
 
@@ -577,7 +577,7 @@ def branding_nhs(service_id, branding_type):
 # ================= LETTER BRANDING ===================
 
 
-def _letter_branding_flow_query_params(**kwargs):
+def _letter_branding_flow_query_params(request, **kwargs):
     """Return a dictionary containing values for the letter branding flow.
 
     We've got a variety of query parameters we want to pass around between pages. Any params that are passed in, we
@@ -627,7 +627,7 @@ def letter_branding_options(service_id):
                 url_for(
                     ".letter_branding_upload_branding",
                     service_id=current_service.id,
-                    **_letter_branding_flow_query_params(branding_choice=branding_choice),
+                    **_letter_branding_flow_query_params(request, branding_choice=branding_choice),
                 )
             )
 
@@ -643,7 +643,7 @@ def letter_branding_options(service_id):
 @user_has_permissions("manage_service")
 def letter_branding_request(service_id):
     form = BrandingRequestForm()
-    from_template = _letter_branding_flow_query_params()["from_template"]
+    from_template = _letter_branding_flow_query_params(request)["from_template"]
 
     if form.validate_on_submit():
         ticket_message = render_template(
@@ -679,7 +679,7 @@ def letter_branding_request(service_id):
         back_link=url_for(
             ".letter_branding_upload_branding",
             service_id=current_service.id,
-            **_letter_branding_flow_query_params(),
+            **_letter_branding_flow_query_params(request),
         ),
         error_summary_enabled=True,
     )
@@ -698,7 +698,7 @@ def letter_branding_upload_branding(service_id):
             url_for(
                 "main.letter_branding_set_name",
                 service_id=current_service.id,
-                **_letter_branding_flow_query_params(temp_filename=temporary_logo_key),
+                **_letter_branding_flow_query_params(request, temp_filename=temporary_logo_key),
             )
         )
 
@@ -709,7 +709,7 @@ def letter_branding_upload_branding(service_id):
         back_link=url_for(
             ".letter_branding_options",
             service_id=current_service.id,
-            **_letter_branding_flow_query_params(),
+            **_letter_branding_flow_query_params(request),
         ),
         # TODO: Create branding-specific zendesk flow that creates branding ticket (see .letter_branding_request)
         abandon_flow_link=url_for(".letter_branding_request", service_id=current_service.id),
@@ -733,7 +733,7 @@ def _should_set_default_org_letter_branding(branding_choice):
 @main.route("/services/<uuid:service_id>/service-settings/letter-branding/set-name", methods=["GET", "POST"])
 @user_has_permissions("manage_service")
 def letter_branding_set_name(service_id):
-    letter_branding_data = _letter_branding_flow_query_params()
+    letter_branding_data = _letter_branding_flow_query_params(request)
     temporary_logo_key = letter_branding_data["temp_filename"]
 
     if not temporary_logo_key:
@@ -776,7 +776,7 @@ def letter_branding_set_name(service_id):
         back_link=url_for(
             ".letter_branding_upload_branding",
             service_id=service_id,
-            **_letter_branding_flow_query_params(temp_filename=None),
+            **_letter_branding_flow_query_params(request, temp_filename=None),
         ),
         temp_filename=letter_filename_for_db_from_logo_key(temporary_logo_key),
         form=form,

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -173,11 +173,18 @@ def email_branding_request(service_id):
 @service_belongs_to_org_type("central")
 def email_branding_request_government_identity_logo(service_id):
     branding_choice = request.args.get("branding_choice")
+    logo_type = request.args.get("logo_type")
+
     return render_template(
         "views/service-settings/branding/new/email-branding-create-government-identity-logo.html",
         service_id=service_id,
-        back_link=url_for(".email_branding_choose_logo", service_id=service_id, branding_choice=branding_choice),
+        back_link=url_for(
+            ".email_branding_choose_logo",
+            service_id=service_id,
+            **_email_branding_flow_query_params(request),
+        ),
         branding_choice=branding_choice,
+        logo_type=logo_type,
         example=AllEmailBranding().example_government_identity_branding,
     )
 
@@ -218,7 +225,9 @@ def email_branding_enter_government_identity_logo_text(service_id):
         "views/service-settings/branding/new/email-branding-enter-government-identity-logo-text.html",
         form=form,
         back_link=url_for(
-            ".email_branding_request_government_identity_logo", service_id=service_id, branding_choice=branding_choice
+            ".email_branding_request_government_identity_logo",
+            service_id=service_id,
+            **_email_branding_flow_query_params(request),
         ),
         error_summary_enabled=True,
     )
@@ -230,6 +239,7 @@ def email_branding_enter_government_identity_logo_text(service_id):
 def email_branding_choose_logo(service_id):
     form = EmailBrandingChooseLogoForm()
     branding_choice = request.args.get("branding_choice")
+    form.branding_options.data = form.branding_options.data or request.args.get("logo_type")
 
     if form.validate_on_submit():
         if form.branding_options.data == "org":
@@ -238,9 +248,8 @@ def email_branding_choose_logo(service_id):
                     url_for(
                         ".email_branding_upload_logo",
                         service_id=current_service.id,
-                        branding_choice=branding_choice,
-                        brand_type="both",
                         back_link=".email_branding_choose_logo",
+                        **_email_branding_flow_query_params(request, brand_type="both", logo_type="org"),
                     )
                 )
 
@@ -249,7 +258,7 @@ def email_branding_choose_logo(service_id):
                     ".email_branding_choose_banner_type",
                     service_id=current_service.id,
                     back_link=".email_branding_choose_logo",
-                    **_email_branding_flow_query_params(request),
+                    **_email_branding_flow_query_params(request, logo_type="org"),
                 )
             )
         elif form.branding_options.data == "single_identity":
@@ -257,7 +266,7 @@ def email_branding_choose_logo(service_id):
                 url_for(
                     ".email_branding_request_government_identity_logo",
                     service_id=current_service.id,
-                    **_email_branding_flow_query_params(request),
+                    **_email_branding_flow_query_params(request, logo_type="single_identity"),
                 )
             )
 
@@ -270,7 +279,7 @@ def email_branding_choose_logo(service_id):
             back_link=url_for(
                 "main.email_branding_options",
                 service_id=current_service.id,
-                **_email_branding_flow_query_params(request),
+                **_email_branding_flow_query_params(request, logo_type=None),
             ),
         ),
         400 if form.errors else 200,
@@ -361,8 +370,9 @@ def email_branding_set_alt_text(service_id):
     form = EmailBrandingAltTextForm()
 
     if form.validate_on_submit():
-        # we use this key to keep track of user choices through the journey but we don't use it to save the branding
+        # we use these keys to keep track of user choices through the journey but we don't use them to save the branding
         branding_choice = email_branding_data.pop("branding_choice")
+        email_branding_data.pop("logo_type", None)
 
         # Copy the temporary logo to its permanent location in S3 and overwrite the temporary logo key in the
         # email data to use in creating the logo in the DB.
@@ -425,7 +435,9 @@ def _email_branding_flow_query_params(request, **kwargs):
 
     These values can get passed to the `/_email` endpoint to generate a preview of a new brand.
     """
-    return {k: kwargs.get(k, request.args.get(k)) for k in ("brand_type", "branding_choice", "colour", "logo")}
+    return {
+        k: kwargs.get(k, request.args.get(k)) for k in ("brand_type", "branding_choice", "colour", "logo", "logo_type")
+    }
 
 
 @main.route("/services/<uuid:service_id>/service-settings/email-branding/add-banner", methods=["GET", "POST"])

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -315,7 +315,7 @@ def email_branding_upload_logo(service_id):
         back_link = url_for(
             ".email_branding_choose_banner_type",
             service_id=service_id,
-            **_email_branding_flow_query_params(request, brand_type=None),
+            **_email_branding_flow_query_params(request),
         )
 
     return (
@@ -432,6 +432,7 @@ def _email_branding_flow_query_params(request, **kwargs):
 @user_has_permissions("manage_service")
 def email_branding_choose_banner_type(service_id):
     form = EmailBrandingChooseBanner()
+    form.banner.data = form.banner.data or request.args.get("brand_type")
 
     if form.validate_on_submit():
         if form.banner.data == "org":
@@ -467,7 +468,7 @@ def email_branding_choose_banner_type(service_id):
             back_link=url_for(
                 back_view,
                 service_id=current_service.id,
-                **_email_branding_flow_query_params(request),
+                **_email_branding_flow_query_params(request, brand_type=None),
             ),
             error_summary_enabled=True,
         ),

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -731,7 +731,9 @@ def letter_branding_upload_branding(service_id):
             **_letter_branding_flow_query_params(request),
         ),
         # TODO: Create branding-specific zendesk flow that creates branding ticket (see .letter_branding_request)
-        abandon_flow_link=url_for(".letter_branding_request", service_id=current_service.id),
+        abandon_flow_link=url_for(
+            ".letter_branding_request", service_id=current_service.id, **_letter_branding_flow_query_params(request)
+        ),
         error_summary_enabled=True,
     )
 

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -305,6 +305,12 @@ def email_branding_upload_logo(service_id):
             service_id=service_id,
             **_email_branding_flow_query_params(request, colour=None),
         )
+    elif request.args.get("brand_type") == "both":
+        back_link = url_for(
+            ".email_branding_choose_logo",
+            service_id=service_id,
+            **_email_branding_flow_query_params(request),
+        )
     else:
         back_link = url_for(
             ".email_branding_choose_banner_type",

--- a/app/templates/views/service-settings/branding/new/email-branding-create-government-identity-logo.html
+++ b/app/templates/views/service-settings/branding/new/email-branding-create-government-identity-logo.html
@@ -46,7 +46,8 @@
     "href": url_for(
       '.email_branding_enter_government_identity_logo_text',
       service_id=service_id,
-      branding_choice=branding_choice
+      branding_choice=branding_choice,
+      logo_type=logo_type
     )
   }) }}
 

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -1073,6 +1073,22 @@ def test_email_branding_choose_logo_page_shows_not_setup_message(
     else:
         assert not hint
 
+    assert not page.select(".govuk-radios__item input[checked]")
+
+
+@pytest.mark.parametrize("logo_type", ["single_identity", "org"])
+def test_email_branding_choose_logo_page_shows_form_prefilled(client_request, service_one, logo_type):
+    page = client_request.get(
+        "main.email_branding_choose_logo",
+        service_id=SERVICE_ONE_ID,
+        logo_type=logo_type,
+    )
+
+    checked_radio_button = page.select(".govuk-radios__item input[checked]")
+
+    assert len(checked_radio_button) == 1
+    assert checked_radio_button[0]["value"] == logo_type
+
 
 def test_email_branding_choose_logo_page_prevents_xss_attacks(
     mocker,
@@ -1115,32 +1131,42 @@ def test_only_central_org_services_can_see_email_branding_choose_logo_page(clien
             "something_else",
             "org",
             ".email_branding_choose_banner_type",
-            {"back_link": ".email_branding_choose_logo", "branding_choice": "something_else"},
+            {"back_link": ".email_branding_choose_logo", "branding_choice": "something_else", "logo_type": "org"},
         ),
         (
             "something_else",
             "single_identity",
             ".email_branding_request_government_identity_logo",
-            {"branding_choice": "something_else"},
+            {"branding_choice": "something_else", "logo_type": "single_identity"},
         ),
         (
             "org",
             "org",
             ".email_branding_choose_banner_type",
-            {"back_link": ".email_branding_choose_logo", "branding_choice": "org"},
+            {"back_link": ".email_branding_choose_logo", "branding_choice": "org", "logo_type": "org"},
         ),
-        ("org", "single_identity", ".email_branding_request_government_identity_logo", {"branding_choice": "org"}),
+        (
+            "org",
+            "single_identity",
+            ".email_branding_request_government_identity_logo",
+            {"branding_choice": "org", "logo_type": "single_identity"},
+        ),
         (
             "govuk_and_org",
             "org",
             ".email_branding_upload_logo",
-            {"back_link": ".email_branding_choose_logo", "branding_choice": "govuk_and_org", "brand_type": "both"},
+            {
+                "back_link": ".email_branding_choose_logo",
+                "branding_choice": "govuk_and_org",
+                "brand_type": "both",
+                "logo_type": "org",
+            },
         ),
         (
             "govuk_and_org",
             "single_identity",
             ".email_branding_request_government_identity_logo",
-            {"branding_choice": "govuk_and_org"},
+            {"branding_choice": "govuk_and_org", "logo_type": "single_identity"},
         ),
     ],
 )

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -1170,7 +1170,7 @@ def test_email_branding_choose_logo_redirects_to_right_page(
         ),
         (
             {"brand_type": "org"},
-            "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/add-banner",
+            "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/add-banner?brand_type=org",
             (
                 "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/request"
                 "?back_link=.email_branding_upload_logo&brand_type=org"
@@ -1655,6 +1655,7 @@ def test_email_branding_choose_banner_type_page(
     assert form["method"] == "post"
     assert "Continue" in submit_button.text
     assert [radio["value"] for radio in page.select("input[type=radio]")] == ["org_banner", "org"]
+    assert not page.select(".govuk-radios__item input[checked]")
 
     assert back_button["href"] == url_for(back_button_url, service_id=SERVICE_ONE_ID)
 
@@ -1709,6 +1710,16 @@ def test_any_org_type_can_see_email_branding_choose_banner_type_page(
         service_id=SERVICE_ONE_ID,
         _expected_status=expected_status,
     )
+
+
+@pytest.mark.parametrize("banner_type", ["org", "org_banner"])
+def test_email_branding_choose_banner_type_shows_banner_type_form_prefilled(client_request, service_one, banner_type):
+    page = client_request.get(".email_branding_choose_banner_type", service_id=SERVICE_ONE_ID, brand_type=banner_type)
+
+    checked_radio_button = page.select(".govuk-radios__item input[checked]")
+
+    assert len(checked_radio_button) == 1
+    assert checked_radio_button[0]["value"] == banner_type
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -1184,6 +1184,14 @@ def test_email_branding_choose_logo_redirects_to_right_page(
                 "?back_link=.email_branding_upload_logo&brand_type=org_banner"
             ),
         ),
+        (
+            {"brand_type": "both"},
+            "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/choose-logo?brand_type=both",  # noqa
+            (
+                "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/request"
+                "?back_link=.email_branding_upload_logo&brand_type=both"
+            ),
+        ),
     ),
 )
 def test_GET_email_branding_upload_logo(

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -372,7 +372,9 @@ def test_GET_letter_branding_upload_branding_renders_form(
     assert file_input["name"] == "branding"
 
     assert abandon_flow_link is not None
-    assert abandon_flow_link["href"] == url_for("main.letter_branding_request", service_id=SERVICE_ONE_ID)
+    assert abandon_flow_link["href"] == url_for(
+        "main.letter_branding_request", service_id=SERVICE_ONE_ID, branding_choice="something_else"
+    )
     assert abandon_flow_link.text == "I do not have a file to upload"
 
 


### PR DESCRIPTION
https://trello.com/c/vgGPEQav/853-branding-journeys-dont-remember-your-choices

Best reviewed commit by commit. This change ensures we always remember the radio buttons selected when going through the flow to select branding. We had previously done this for the initial radio buttons you see, but the email branding journey has two more pages with radio buttons and we weren't remembering the selection made there.

To do this, we pass query params with the choices on the forms made through the requests, using the helper methods (`_email_branding_flow_query_params` and `_letter_branding_flow_query_params`) to do this.

* The choice made on the `ChooseEmailBrandingForm` is stored in the `branding_choice` query param
* The choice made on the `EmailBrandingChooseLogoForm` is stored in the `logo_type` query param
* The choice made on the `EmailBrandingChooseBanner` is stored in the `logo_type` query brand_type