### PR TITLE
Bump utils to 81.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ pyexcel-ods3==0.6.1
 notifications-python-client==8.0.1
 fido2==1.1.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@80.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@81.1.0
 govuk-frontend-jinja==2.8.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@80.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@81.1.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
Brings in changes from these pull requests:
- [Refactor of `InvalidPhoneError` class - breaking change](https://github.com/alphagov/notifications-utils/pull/1125)
- [Introduction of `PhoneNumber` class](https://github.com/alphagov/notifications-utils/pull/1126)

Admin doesn't use any of the bits of the `InvalidPhoneError` API changed by this bump so this doesn't require any further work.

Admin doesn't use `PhoneNumber` anywhere yet. [Leo hinted we will use it as the base of all phone number validation in future](https://github.com/alphagov/notifications-utils/blob/main/CHANGELOG.md#8110) but not yet.

