### PR TITLE
Remove Emergency Alerts service type indicators

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -28,29 +28,10 @@
     text-transform: uppercase;
     letter-spacing: 0.05em;
 
-    &--training {
-      background: govuk-shade(govuk-colour("light-grey"), 7%);
-      color: mix(govuk-colour("dark-grey"), $govuk-text-colour);
-      box-shadow: 0 -3px 0 0 govuk-shade(govuk-colour("light-grey"), 7%);
-    }
-
     &--suspended {
       background: govuk-shade(govuk-colour("light-grey"), 7%);
       color: mix(govuk-colour("dark-grey"), $govuk-text-colour);
       box-shadow: 0 -3px 0 0 govuk-shade(govuk-colour("light-grey"), 7%);
-    }
-
-    &--live, &--test, &--operator {
-      // This uses new Design System colours to match .govuk-tag--red
-      background: #F6D7D2;
-      color: #942514;
-      box-shadow: 0 -3px 0 0 #F6D7D2;
-    }
-
-    &--government {
-      background: #942514;
-      color: #F6D7D2;
-      box-shadow: 0 -3px 0 0 #942514;
     }
 
   }


### PR DESCRIPTION
The only time we badge the service name now is when a service is suspended:
https://github.com/alphagov/notifications-admin/blob/d94aea6bca2020ba83e6bdb4a5b7c7304214ff20/app/templates/service_navigation.html#L4-L6

The other colours and styles of badges were used for differentiating Emergency Alerts services where it was very important to know which channel and operator an alert was being sent on:

<img width="807" alt="image" src="https://github.com/user-attachments/assets/28db05c1-dcec-44d0-a078-05fb97ca98a7">

Emergency Alerts is no longer part of Notify so we don’t need these in our codebase.