### PR TITLE
Fix wonky empy state for email unsubscribe request table

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -37,7 +37,7 @@
     {% endfor %}
     {% if not items %}
       {% call row() %}
-        <td class="table-empty-message" colspan="10">
+        <td class="table-empty-message" colspan="{{ field_headings | length }}">
           {{ empty_message }}
         </td>
       {% endcall %}

--- a/app/templates/views/unsubscribe-request-reports-summary.html
+++ b/app/templates/views/unsubscribe-request-reports-summary.html
@@ -20,7 +20,7 @@
         current_service.unsubscribe_request_reports_summary,
         caption="Unsubscribe Request Reports",
         caption_visible=False,
-        empty_message='If you have unsubscribed requests they will be listed here',
+        empty_message='If you have any email unsubscribe requests they will be listed here',
         field_headings=['Report', 'Status'],
         field_headings_visible=False
     ) %}

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -49,7 +49,7 @@ def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocke
 
     page = client_request.get("main.unsubscribe_request_reports_summary", service_id=SERVICE_ONE_ID)
 
-    assert ["Report Status", "If you have unsubscribed requests they will be listed here"] == [
+    assert ["Report Status", "If you have any email unsubscribe requests they will be listed here"] == [
         normalize_spaces(row.text) for row in page.select("tr")
     ]
 


### PR DESCRIPTION
When we show a ‘this table is empty’ message we want it to span the full width of the table.

Previously we were doing this by setting `colspan` to an arbitrary high number (10), which is higher than the number of columns any of our tables have.

At some point this seems to have stopped having the desired effect, in Chrome at least.

This commit fixes the problem by setting `colspan` to exactly the number of columns the table has.

# Before

<img width="797" alt="image" src="https://github.com/user-attachments/assets/1bbcde1e-7968-450e-864c-e9c9a5421616">

# After 

<img width="775" alt="image" src="https://github.com/user-attachments/assets/556fb576-d77c-459d-bb0a-28dacfa8514e">