### PR TITLE
fix: if users are login via sms auth we do not want to show sms-specific message when they do not receive the email

### DIFF
--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -5,7 +5,6 @@ from app.main import main
 from app.main.forms import TextNotReceivedForm
 from app.models.user import User
 from app.utils.login import (
-    email_needs_revalidating,
     redirect_to_sign_in,
 )
 
@@ -54,7 +53,7 @@ def check_and_resend_verification_code():
 def email_not_received():
     # user login from two-factor-sms refactor does not need to see the two-factor-sms details on page
     user = User.from_email_address(session["user_details"]["email"])
-    login_via_sms = email_needs_revalidating(user)
+    login_via_sms = user.sms_auth
 
     redirect_url = request.args.get("next")
     return render_template("views/email-not-received.html", redirect_url=redirect_url, login_via_sms=login_via_sms)

--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -4,7 +4,10 @@ from app import user_api_client
 from app.main import main
 from app.main.forms import TextNotReceivedForm
 from app.models.user import User
-from app.utils.login import redirect_to_sign_in
+from app.utils.login import (
+    email_needs_revalidating,
+    redirect_to_sign_in,
+)
 
 
 @main.route("/resend-email-verification")
@@ -49,8 +52,12 @@ def check_and_resend_verification_code():
 @main.route("/email-not-received", methods=["GET"])
 @redirect_to_sign_in
 def email_not_received():
+    # user login from two-factor-sms refactor does not need to see the two-factor-sms details on page
+    user = User.from_email_address(session["user_details"]["email"])
+    login_via_sms = email_needs_revalidating(user)
+
     redirect_url = request.args.get("next")
-    return render_template("views/email-not-received.html", redirect_url=redirect_url)
+    return render_template("views/email-not-received.html", redirect_url=redirect_url, login_via_sms=login_via_sms)
 
 
 @main.route("/send-new-email-token", methods=["GET"])

--- a/app/templates/views/email-not-received.html
+++ b/app/templates/views/email-not-received.html
@@ -46,14 +46,16 @@
       "html": change_email
     }) }}
 
-    {% set text_message_code %}
-        <p class="govuk-body">Ask a member of your team with the ‘Manage settings, team and usage’ permission to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">change your sign-in method</a>.</p>
-    {% endset %}
+    {% if not login_via_sms %}
+        {% set text_message_code %}
+            <p class="govuk-body">Ask a member of your team with the ‘Manage settings, team and usage’ permission to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_sign_in_method') }}">change your sign-in method</a>.</p>
+        {% endset %}
 
-    {{ govukDetails({
-      "summaryText": "If you want to sign in with a text message code instead",
-      "html": text_message_code
-    }) }}
+        {{ govukDetails({
+          "summaryText": "If you want to sign in with a text message code instead",
+          "html": text_message_code
+        }) }}
+    {% endif %}
   </div>
 </div>
 

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -43,7 +43,7 @@ def redirect_when_logged_in(platform_admin):
     return redirect(url_for("main.show_accounts_or_dashboard"))
 
 
-def email_needs_revalidating(user):
+def email_needs_revalidating(user) -> bool:
     return not is_less_than_days_ago(user.email_access_validated_at, 90)
 
 

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -43,7 +43,7 @@ def redirect_when_logged_in(platform_admin):
     return redirect(url_for("main.show_accounts_or_dashboard"))
 
 
-def email_needs_revalidating(user) -> bool:
+def email_needs_revalidating(user):
     return not is_less_than_days_ago(user.email_access_validated_at, 90)
 
 

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -1,6 +1,5 @@
 import pytest
 from flask import url_for
-from freezegun import freeze_time
 
 from tests.conftest import SERVICE_ONE_ID
 
@@ -179,12 +178,11 @@ def test_redirect_to_sign_in_if_not_logged_in(
     )
 
 
-@freeze_time("2020-11-27T12:00:00")
 @pytest.mark.parametrize(
-    ("redirect_url", "email_access_validated_at"),
+    ("redirect_url", "sms_auth"),
     [
-        (None, "2020-11-23T11:35:21.726132Z"),  # login_via_sms = False
-        (f"/services/{SERVICE_ONE_ID}/templates", "2020-11-23T11:35:21.726132Z"),
+        (None, False),
+        (f"/services/{SERVICE_ONE_ID}/templates", False),
     ],
 )
 def test_should_render_correct_email_not_received_template_for_active_user(
@@ -193,12 +191,12 @@ def test_should_render_correct_email_not_received_template_for_active_user(
     mock_get_user_by_email,
     mock_send_verify_code,
     redirect_url,
-    email_access_validated_at,
+    sms_auth,
 ):
     client_request.logout()
     with client_request.session_transaction() as session:
         session["user_details"] = {"id": api_user_active["id"], "email": api_user_active["email_address"]}
-    api_user_active["email_access_validated_at"] = email_access_validated_at
+    api_user_active["sms_auth"] = sms_auth
 
     page = client_request.get("main.email_not_received", next=redirect_url)
 


### PR DESCRIPTION
## Summary
- when users login via text message AND have not verified their email for more than 90 days, we force them to verify their email address prior to login by sending them an email link
- In the case that they do not receive that email link, they can click on `Not received an email?` and it will take you to this page:
![Screenshot 2024-07-24 at 17 26 42](https://github.com/user-attachments/assets/53461f03-5ee6-4e19-8aa3-10ccf0262afb)

**Issue to resolve**: Since the user started their journey via sms-verification, showcasing text regarding 'If you want to sign in with a text message code instead' can be quite confusing

**Expectation**: do not show that section if the user came from a text-message verification journey.

**After fix**:
![Screenshot 2024-07-24 at 17 13 06](https://github.com/user-attachments/assets/bfbfec4e-9f23-4236-8d9d-e8260d7fd216)

### Related task
[Fix  login journey for users who authenticate via sms and have not logged in a while](https://trello.com/c/KHF3gK7N/882-fix-login-journey-for-users-who-authenticate-via-sms-and-have-not-logged-in-a-while)