### PR TITLE
Mark unsubscribe request report processing as completed

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2907,34 +2907,16 @@ class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
         super().__init__(*args, **kwargs)
 
         if is_a_batched_report:
-            if report_completed:
-                self.report_has_been_processed.param_extensions = {
-                    "items": [
-                        {
-                            "hint": {"text": "I have unsubscribed these recipients from our mailing list"},
-                            "disabled": False,
-                            "checked": True,
-                        },
-                    ]
-                }
-            else:
-                self.report_has_been_processed.param_extensions = {
-                    "items": [
-                        {
-                            "hint": {"text": "I have unsubscribed these recipients from our mailing list"},
-                            "disabled": False,
-                        },
-                    ]
-                }
-
-        else:
             self.report_has_been_processed.param_extensions = {
                 "items": [
                     {
-                        "hint": {"text": "You cannot do this until you've downloaded the report"},
-                        "disabled": True,
+                        "hint": {"text": "I have unsubscribed these recipients from our mailing list"},
                     },
                 ]
+            }
+        else:
+            self.report_has_been_processed.param_extensions = {
+                "items": [{"hint": {"text": "You cannot do this until you've downloaded the report"}, "disabled": True}]
             }
 
     def validate_report_has_been_processed(self, field):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2903,8 +2903,8 @@ class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
     report_has_been_processed = GovukCheckboxField("Mark as completed")
 
     def __init__(self, is_a_batched_report, report_status, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self.report_status = report_status
+        super().__init__(*args, **kwargs)
 
         if is_a_batched_report:
             if report_status == "Completed":
@@ -2943,3 +2943,6 @@ class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
                 "There is a problem. "
                 "You must confirm that you have removed the email addresses from your mailing list."
             )
+
+        if field.data and self.report_status == "Completed":
+            raise ValidationError("There is a problem. You have already marked the report as Completed")

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2936,4 +2936,7 @@ class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
                 ]
             }
 
-        # TODO Add logic to allow users to tick the checkbox
+    def validate_report_has_been_processed(self, field):
+        if not field.data:
+            raise ValidationError("There is a problem. "
+                                  "You must confirm that you have removed the email addresses from your mailing list.")

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2902,18 +2902,30 @@ class AddOrJoinServiceForm(StripWhitespaceForm):
 class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
     report_has_been_processed = GovukCheckboxField("Mark as completed")
 
-    def __init__(self, is_a_batched_report, *args, **kwargs):
+    def __init__(self, is_a_batched_report, report_status, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         if is_a_batched_report:
-            self.report_has_been_processed.param_extensions = {
-                "items": [
-                    {
-                        "hint": {"text": "I have unsubscribed these recipients from our mailing list"},
-                        "disabled": False,
-                    },
-                ]
-            }
+            if report_status == "Completed":
+                self.report_has_been_processed.param_extensions = {
+                    "items": [
+                        {
+                            "hint": {"text": "I have unsubscribed these recipients from our mailing list"},
+                            "disabled": False,
+                            "checked": True,
+                        },
+                    ]
+                }
+            else:
+                self.report_has_been_processed.param_extensions = {
+                    "items": [
+                        {
+                            "hint": {"text": "I have unsubscribed these recipients from our mailing list"},
+                            "disabled": False,
+                        },
+                    ]
+                }
+
         else:
             self.report_has_been_processed.param_extensions = {
                 "items": [

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2938,5 +2938,7 @@ class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
 
     def validate_report_has_been_processed(self, field):
         if not field.data:
-            raise ValidationError("There is a problem. "
-                                  "You must confirm that you have removed the email addresses from your mailing list.")
+            raise ValidationError(
+                "There is a problem. "
+                "You must confirm that you have removed the email addresses from your mailing list."
+            )

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2904,6 +2904,7 @@ class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
 
     def __init__(self, is_a_batched_report, report_status, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.report_status = report_status
 
         if is_a_batched_report:
             if report_status == "Completed":
@@ -2937,7 +2938,7 @@ class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
             }
 
     def validate_report_has_been_processed(self, field):
-        if not field.data:
+        if not field.data and self.report_status != "Completed":
             raise ValidationError(
                 "There is a problem. "
                 "You must confirm that you have removed the email addresses from your mailing list."

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2902,12 +2902,12 @@ class AddOrJoinServiceForm(StripWhitespaceForm):
 class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
     report_has_been_processed = GovukCheckboxField("Mark as completed")
 
-    def __init__(self, is_a_batched_report, report_status, *args, **kwargs):
-        self.report_status = report_status
+    def __init__(self, is_a_batched_report, report_completed, *args, **kwargs):
+        self.report_completed = report_completed
         super().__init__(*args, **kwargs)
 
         if is_a_batched_report:
-            if report_status == "Completed":
+            if report_completed:
                 self.report_has_been_processed.param_extensions = {
                     "items": [
                         {
@@ -2938,11 +2938,11 @@ class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
             }
 
     def validate_report_has_been_processed(self, field):
-        if not field.data and self.report_status != "Completed":
+        if not field.data and not self.report_completed:
             raise ValidationError(
                 "There is a problem. "
                 "You must confirm that you have removed the email addresses from your mailing list."
             )
 
-        if field.data and self.report_status == "Completed":
+        if field.data and self.report_completed:
             raise ValidationError("There is a problem. You have already marked the report as Completed")

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -23,17 +23,20 @@ def unsubscribe_request_report(service_id, batch_id=None):
         report = current_service.unsubscribe_request_reports_summary.get_unbatched_report()
     form = ProcessUnsubscribeRequestForm(is_a_batched_report=report.is_a_batched_report,
                                          report_status=report.status)
-
     if form.validate_on_submit():
         try:
             service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=None)
             message = "Report has been marked as Completed"
             flash(message, "default_with_tick")
-            return redirect(url_for('main.unsubscribe_request_report', service_id=service_id))
+            return render_template(
+                                    "views/unsubscribe-request-report.html",
+                                    report=report,
+                                    form=form,
+                                )
         except HTTPError as http_error:
             if http_error.status_code == 400 and http_error.message.get("batch_id"):
                 if http_error.message.get("batch_id"):
-                    error_message = "This report is no longer available for download"
+                    error_message = "This report is not available"
                     form.report_has_been_processed.errors.append(error_message)
             else:
                 raise http_error

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -28,7 +28,7 @@ def unsubscribe_request_report(service_id, batch_id=None):
         service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=data)
         message = f"""Report for {format_date_numeric(report.earliest_timestamp)} until  \
                   {format_date_numeric(report.latest_timestamp)} has been marked as \
-                  {'Completed' if report_has_been_processed else 'not Completed.'}"""
+                  {'Completed' if report_has_been_processed else 'not completed.'}"""
         flash(message, "default_with_tick")
         return redirect(url_for("main.unsubscribe_request_reports_summary", service_id=service_id, batch_id=batch_id))
     return render_template(

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -33,6 +33,7 @@ def unsubscribe_request_report(service_id, batch_id=None):
                                     "views/unsubscribe-request-report.html",
                                     report=report,
                                     form=form,
+                                    error_summary_enabled=True,
                                 )
         except HTTPError as http_error:
             if http_error.status_code == 400 and http_error.message.get("batch_id"):
@@ -45,4 +46,5 @@ def unsubscribe_request_report(service_id, batch_id=None):
         "views/unsubscribe-request-report.html",
         report=report,
         form=form,
+        error_summary_enabled=True,
     )

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -23,6 +23,7 @@ def unsubscribe_request_report(service_id, batch_id=None):
         report = current_service.unsubscribe_request_reports_summary.get_unbatched_report()
     form = ProcessUnsubscribeRequestForm(is_a_batched_report=report.is_a_batched_report,
                                          report_status=report.status)
+
     if form.validate_on_submit():
         try:
             service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=None)

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -23,10 +23,12 @@ def unsubscribe_request_report(service_id, batch_id=None):
     form = ProcessUnsubscribeRequestForm(is_a_batched_report=report.is_a_batched_report, report_status=report.status)
 
     if form.validate_on_submit():
-        data = {"report_has_been_processed": form.data["report_has_been_processed"]}
+        report_has_been_processed = form.data["report_has_been_processed"]
+        data = {"report_has_been_processed": report_has_been_processed}
         service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=data)
         message = f"""Report for {format_date_numeric(report.earliest_timestamp)} until  \
-                  {format_date_numeric(report.latest_timestamp)} has been marked as Completed"""
+                  {format_date_numeric(report.latest_timestamp)} has been marked as \
+                  {'Completed' if report_has_been_processed else 'not Completed.'}"""
         flash(message, "default_with_tick")
         return redirect(url_for("main.unsubscribe_request_reports_summary", service_id=service_id, batch_id=batch_id))
     return render_template(

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -21,7 +21,9 @@ def unsubscribe_request_report(service_id, batch_id=None):
     else:
         report = current_service.unsubscribe_request_reports_summary.get_unbatched_report()
     form = ProcessUnsubscribeRequestForm(
-        is_a_batched_report=report.is_a_batched_report, report_completed=report.completed
+        is_a_batched_report=report.is_a_batched_report,
+        report_completed=report.completed,
+        report_has_been_processed=report.completed,
     )
 
     if form.validate_on_submit():

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -1,6 +1,6 @@
-from flask import render_template, url_for, redirect, flash
+from flask import flash, redirect, render_template, url_for
 
-from app import current_service, service_api_client, format_date_numeric
+from app import current_service, format_date_numeric, service_api_client
 from app.main import main
 from app.main.forms import ProcessUnsubscribeRequestForm
 from app.utils.user import user_has_permissions
@@ -13,23 +13,22 @@ def unsubscribe_request_reports_summary(service_id):
 
 
 @main.route("/services/<uuid:service_id>/unsubscribe-requests/reports/latest")
-@main.route("/services/<uuid:service_id>/unsubscribe-requests/reports/<uuid:batch_id>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/unsubscribe-requests/reports/<uuid:batch_id>", methods=["GET", "POST"])
 @user_has_permissions("view_activity")
 def unsubscribe_request_report(service_id, batch_id=None):
     if batch_id:
         report = current_service.unsubscribe_request_reports_summary.get_by_batch_id(batch_id)
     else:
         report = current_service.unsubscribe_request_reports_summary.get_unbatched_report()
-    form = ProcessUnsubscribeRequestForm(is_a_batched_report=report.is_a_batched_report,
-                                         report_status=report.status)
+    form = ProcessUnsubscribeRequestForm(is_a_batched_report=report.is_a_batched_report, report_status=report.status)
 
     if form.validate_on_submit():
 
         service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=None)
-        message = f"Report for {format_date_numeric(report.earliest_timestamp)} until " \
-                  f"{format_date_numeric(report.latest_timestamp)} has been marked as Completed"
+        message = f"""Report for {format_date_numeric(report.earliest_timestamp)} until  \
+                  {format_date_numeric(report.latest_timestamp)} has been marked as Completed"""
         flash(message, "default_with_tick")
-        return redirect(url_for('main.unsubscribe_request_reports_summary', service_id=service_id, batch_id=batch_id))
+        return redirect(url_for("main.unsubscribe_request_reports_summary", service_id=service_id, batch_id=batch_id))
     return render_template(
         "views/unsubscribe-request-report.html",
         report=report,

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -1,6 +1,7 @@
-from flask import render_template
+from flask import render_template, url_for, redirect, flash
+from notifications_python_client.errors import HTTPError
 
-from app import current_service
+from app import current_service, service_api_client
 from app.main import main
 from app.main.forms import ProcessUnsubscribeRequestForm
 from app.utils.user import user_has_permissions
@@ -13,14 +14,29 @@ def unsubscribe_request_reports_summary(service_id):
 
 
 @main.route("/services/<uuid:service_id>/unsubscribe-requests/reports/latest")
-@main.route("/services/<uuid:service_id>/unsubscribe-requests/reports/<uuid:batch_id>")
+@main.route("/services/<uuid:service_id>/unsubscribe-requests/reports/<uuid:batch_id>", methods=['GET', 'POST'])
 @user_has_permissions("view_activity")
 def unsubscribe_request_report(service_id, batch_id=None):
     if batch_id:
         report = current_service.unsubscribe_request_reports_summary.get_by_batch_id(batch_id)
     else:
         report = current_service.unsubscribe_request_reports_summary.get_unbatched_report()
-    form = ProcessUnsubscribeRequestForm(is_a_batched_report=report.is_a_batched_report)
+    form = ProcessUnsubscribeRequestForm(is_a_batched_report=report.is_a_batched_report,
+                                         report_status=report.status)
+
+    if form.validate_on_submit():
+        try:
+            service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=None)
+            message = "Report has been marked as Completed"
+            flash(message, "default_with_tick")
+            return redirect(url_for('main.unsubscribe_request_report', service_id=service_id))
+        except HTTPError as http_error:
+            if http_error.status_code == 400 and http_error.message.get("batch_id"):
+                if http_error.message.get("batch_id"):
+                    error_message = "This report is no longer available for download"
+                    form.report_has_been_processed.errors.append(error_message)
+            else:
+                raise http_error
     return render_template(
         "views/unsubscribe-request-report.html",
         report=report,

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -23,8 +23,8 @@ def unsubscribe_request_report(service_id, batch_id=None):
     form = ProcessUnsubscribeRequestForm(is_a_batched_report=report.is_a_batched_report, report_status=report.status)
 
     if form.validate_on_submit():
-
-        service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=None)
+        data = {"report_has_been_processed": form.data["report_has_been_processed"]}
+        service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=data)
         message = f"""Report for {format_date_numeric(report.earliest_timestamp)} until  \
                   {format_date_numeric(report.latest_timestamp)} has been marked as Completed"""
         flash(message, "default_with_tick")

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -1,6 +1,6 @@
 from flask import flash, redirect, render_template, url_for
 
-from app import current_service, format_date_numeric, service_api_client
+from app import current_service, format_date_normal, service_api_client
 from app.main import main
 from app.main.forms import ProcessUnsubscribeRequestForm
 from app.utils.user import user_has_permissions
@@ -20,14 +20,16 @@ def unsubscribe_request_report(service_id, batch_id=None):
         report = current_service.unsubscribe_request_reports_summary.get_by_batch_id(batch_id)
     else:
         report = current_service.unsubscribe_request_reports_summary.get_unbatched_report()
-    form = ProcessUnsubscribeRequestForm(is_a_batched_report=report.is_a_batched_report, report_status=report.status)
+    form = ProcessUnsubscribeRequestForm(
+        is_a_batched_report=report.is_a_batched_report, report_completed=report.completed
+    )
 
     if form.validate_on_submit():
         report_has_been_processed = form.data["report_has_been_processed"]
         data = {"report_has_been_processed": report_has_been_processed}
         service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=data)
-        message = f"""Report for {format_date_numeric(report.earliest_timestamp)} until  \
-                  {format_date_numeric(report.latest_timestamp)} has been marked as \
+        message = f"""Report for {format_date_normal(report.earliest_timestamp)} until  \
+                  {format_date_normal(report.latest_timestamp)} has been marked as \
                   {'Completed' if report_has_been_processed else 'not completed.'}"""
         flash(message, "default_with_tick")
         return redirect(url_for("main.unsubscribe_request_reports_summary", service_id=service_id, batch_id=batch_id))

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -27,6 +27,10 @@ class UnsubscribeRequestsReport(JSONModel):
         return "Completed"
 
     @property
+    def completed(self):
+        return self.processed_by_service_at is not None
+
+    @property
     def report_latest_download_date(self):
         if self.status == "Completed":
             limit = 7

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -1,4 +1,8 @@
+from datetime import datetime, UTC, timedelta
+
+from dateutil.parser import parser
 from flask import abort
+from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 
 from app.models import JSONModel, ModelList
 from app.notify_client.service_api_client import service_api_client
@@ -22,6 +26,16 @@ class UnsubscribeRequestsReport(JSONModel):
         if not self.processed_by_service_at:
             return "Downloaded"
         return "Completed"
+
+    @property
+    def report_latest_download_date(self):
+        if self.status == "Completed":
+            limit = 7
+            starting_date = self.processed_by_service_at
+        else:
+            limit = 90
+            starting_date = self.latest_timestamp
+        return utc_string_to_aware_gmt_datetime(starting_date) + timedelta(days=limit)
 
 
 class UnsubscribeRequestsReports(ModelList):

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -1,6 +1,5 @@
-from datetime import datetime, UTC, timedelta
+from datetime import timedelta
 
-from dateutil.parser import parser
 from flask import abort
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -508,7 +508,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.get(f"service/{service_id}/unsubscribe-request-reports-summary")
 
     def process_unsubscribe_request_report(self, service_id, batch_id, data):
-        return self.post(f"service/{service_id}/process-unsubscribe-request-report/{batch_id}", data=None)
+        return self.post(f"service/{service_id}/process-unsubscribe-request-report/{batch_id}", data=data)
 
     @cache.set("service-{service_id}-unsubscribe-request-statistics")
     def get_unsubscribe_request_statistics(self, service_id):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -507,6 +507,9 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def get_unsubscribe_reports_summary(self, service_id):
         return self.get(f"service/{service_id}/unsubscribe-request-reports-summary")
 
+    def process_unsubscribe_request_report(self, service_id, batch_id, data):
+        return self.post(f"service/{service_id}/process-unsubscribe-request-report/{batch_id}", data=None)
+
     @cache.set("service-{service_id}-unsubscribe-request-statistics")
     def get_unsubscribe_request_statistics(self, service_id):
         return self.get(f"service/{service_id}/unsubscribe-request-statistics")

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -25,12 +25,12 @@
 
     <p class="govuk-body">You must: </p>
       <ol class="govuk-list govuk-list--number">
-        <li><span class="bottom-gutter"><a download href="" class="govuk-link heading-small">Download the report</a>&nbsp;(available for 90 days) </span> </li>
+        <li><span class="bottom-gutter"><a download href="" class="govuk-link heading-small">Download the report</a>&nbsp;(available until {{report.report_latest_download_date|format_date_normal}}) </span> </li>
         <li>Remove the email addresses from your mailing list before you send any further emails</li>
       </ol>
 {%  else %}
     <p class="govuk-body" id="completed_unsubscribe_report_main_text"> Report was marked as completed on {{ report.processed_by_service_at | format_date_normal }}</p>
-    <p class="bottom-gutter"><a download href="" class="govuk-link heading-small">Download the report</a>&nbsp;(available for 7 days) </p>
+    <p class="bottom-gutter"><a download href="" class="govuk-link heading-small">Download the report</a>&nbsp;(available until {{report.report_latest_download_date|format_date_normal}}) </p>
 
  {% endif %}
 

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -19,7 +19,7 @@
 
 
 {% if report.status != "Completed" %}
-    <p class="govuk-body">
+    <p class="govuk-body" id="report-unsubscribe-requests-count">
      {{ report.count|format_thousands}} new requests to unsubscribe
     </p>
 
@@ -29,15 +29,16 @@
         <li>Remove the email addresses from your mailing list before you send any further emails</li>
       </ol>
 {%  else %}
-    <p class="govuk-body"> Report was marked as completed on {{ report.processed_by_service_at | format_date_normal }}</p>
+    <p class="govuk-body" id="completed_unsubscribe_report_main_text"> Report was marked as completed on {{ report.processed_by_service_at | format_date_normal }}</p>
     <p class="bottom-gutter"><a download href="" class="govuk-link heading-small">Download the report</a>&nbsp;(available for 7 days) </p>
-     </p>
+
  {% endif %}
+
 {% call form_wrapper() %}
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     {{ form.report_has_been_processed }}
     {% if report.is_a_batched_report %}
-        {{  govukButton({ "text": "Update" }) }}
+        {{  govukButton({ "text": "Update", "id":"process_unsubscribe_report" })}}
     {% endif %}
 
 {% endcall %}

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -17,20 +17,30 @@
 
     {{ page_header('{} until {}'.format(report.earliest_timestamp|format_date_normal, report.latest_timestamp|format_date_normal)) }}
 
- <p class="govuk-body">
+
+{% if report.status != "Completed" %}
+    <p class="govuk-body">
      {{ report.count|format_thousands}} new requests to unsubscribe
- </p>
+    </p>
 
     <p class="govuk-body">You must: </p>
       <ol class="govuk-list govuk-list--number">
         <li><span class="bottom-gutter"><a download href="" class="govuk-link heading-small">Download the report</a>&nbsp;(available for 90 days) </span> </li>
         <li>Remove the email addresses from your mailing list before you send any further emails</li>
       </ol>
-
+{%  else %}
+    <p class="govuk-body"> Report was marked as completed on {{ report.processed_by_service_at | format_date_normal }}</p>
+    <p class="bottom-gutter"><a download href="" class="govuk-link heading-small">Download the report</a>&nbsp;(available for 7 days) </p>
+     </p>
+ {% endif %}
 {% call form_wrapper() %}
-   {{ form.report_has_been_processed }}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    {{ form.report_has_been_processed }}
     {% if report.is_a_batched_report %}
-      {{  govukButton({ "text": "Update" }) }}
+        {{  govukButton({ "text": "Update" }) }}
     {% endif %}
+
 {% endcall %}
+
+
 {% endblock %}

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -25,12 +25,16 @@
 
     <p class="govuk-body">You must: </p>
       <ol class="govuk-list govuk-list--number">
-        <li><span class="bottom-gutter"><a download href="" class="govuk-link heading-small">Download the report</a>&nbsp;(available until {{report.report_latest_download_date|format_date_normal}}) </span> </li>
+        <li class="bottom-gutter"><a download href="" class="govuk-link heading-small">
+            Download the report</a>&nbsp;<span id="unsubscribe_report_availability">
+            (available until {{report.report_latest_download_date|format_date_normal}})</span></li>
         <li>Remove the email addresses from your mailing list before you send any further emails</li>
       </ol>
 {%  else %}
     <p class="govuk-body" id="completed_unsubscribe_report_main_text"> Report was marked as completed on {{ report.processed_by_service_at | format_date_normal }}</p>
-    <p class="bottom-gutter"><a download href="" class="govuk-link heading-small">Download the report</a>&nbsp;(available until {{report.report_latest_download_date|format_date_normal}}) </p>
+    <p class="bottom-gutter"><a download href="" class="govuk-link heading-small" >
+        Download the report</a>&nbsp;<span id="completed_unsubscribe_report_availability">
+        (available until {{report.report_latest_download_date|format_date_normal}})</span> </p>
 
  {% endif %}
 

--- a/tests/app/main/forms/test_process_unubscribe_request_form.py
+++ b/tests/app/main/forms/test_process_unubscribe_request_form.py
@@ -4,7 +4,7 @@ from app.main.forms import ProcessUnsubscribeRequestForm
 def test_should_raise_validation_error_for_reports_whose_status_is_not_completed(
     client_request,
 ):
-    form = ProcessUnsubscribeRequestForm(is_a_batched_report=True, report_status="Downloaded")
+    form = ProcessUnsubscribeRequestForm(is_a_batched_report=True, report_completed=False)
     form.data["report_has_been_processed"] = False
     form.validate()
     assert form.validate() is False
@@ -18,7 +18,7 @@ def test_should_raise_validation_error_for_resubmitting_marked_checkbox_for_an_a
     client_request,
 ):
     form = ProcessUnsubscribeRequestForm(
-        is_a_batched_report=True, report_status="Completed", report_has_been_processed=True
+        is_a_batched_report=True, report_completed=True, report_has_been_processed=True
     )
     form.validate()
     assert form.validate() is False
@@ -36,6 +36,6 @@ def test_should_raise_no_validation_error_for_reports_whose_status_is_being_chan
     from "Completed" to "Downloaded", raises no validation errors.
     """
     form = ProcessUnsubscribeRequestForm(
-        is_a_batched_report=True, report_status="Completed", report_has_been_processed=False
+        is_a_batched_report=True, report_completed=True, report_has_been_processed=False
     )
     assert form.validate() is True

--- a/tests/app/main/forms/test_process_unubscribe_request_form.py
+++ b/tests/app/main/forms/test_process_unubscribe_request_form.py
@@ -14,6 +14,20 @@ def test_should_raise_validation_error_for_reports_whose_status_is_not_completed
     )
 
 
+def test_should_raise_validation_error_for_resubmitting_marked_checkbox_for_an_already_completed_report(
+    client_request,
+):
+    form = ProcessUnsubscribeRequestForm(
+        is_a_batched_report=True, report_status="Completed", report_has_been_processed=True
+    )
+    form.validate()
+    assert form.validate() is False
+    assert (
+        "There is a problem. You have already marked the report as Completed"
+        in form.errors["report_has_been_processed"]
+    )
+
+
 def test_should_raise_no_validation_error_for_reports_whose_status_is_being_changed_from_completed(
     client_request,
 ):
@@ -21,6 +35,7 @@ def test_should_raise_no_validation_error_for_reports_whose_status_is_being_chan
     The test case covered, is that clearing a checkbox for a completed report, ie updating its status
     from "Completed" to "Downloaded", raises no validation errors.
     """
-    form = ProcessUnsubscribeRequestForm(is_a_batched_report=True, report_status="Completed")
-    form.data["report_has_been_processed"] = False
+    form = ProcessUnsubscribeRequestForm(
+        is_a_batched_report=True, report_status="Completed", report_has_been_processed=False
+    )
     assert form.validate() is True

--- a/tests/app/main/forms/test_process_unubscribe_request_form.py
+++ b/tests/app/main/forms/test_process_unubscribe_request_form.py
@@ -1,0 +1,26 @@
+from app.main.forms import ProcessUnsubscribeRequestForm
+
+
+def test_should_raise_validation_error_for_reports_whose_status_is_not_completed(
+    client_request,
+):
+    form = ProcessUnsubscribeRequestForm(is_a_batched_report=True, report_status="Downloaded")
+    form.data["report_has_been_processed"] = False
+    form.validate()
+    assert form.validate() is False
+    assert (
+        "There is a problem. You must confirm that you have removed the email addresses from your mailing list."
+        in form.errors["report_has_been_processed"]
+    )
+
+
+def test_should_raise_no_validation_error_for_reports_whose_status_is_being_changed_from_completed(
+    client_request,
+):
+    """
+    The test case covered, is that clearing a checkbox for a completed report, ie updating its status
+    from "Completed" to "Downloaded", raises no validation errors.
+    """
+    form = ProcessUnsubscribeRequestForm(is_a_batched_report=True, report_status="Completed")
+    form.data["report_has_been_processed"] = False
+    assert form.validate() is True

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -116,3 +116,47 @@ def test_non_existing_unsubscribe_request_report_batch_id_returns_404(client_req
         batch_id=batch_id,
     )
     assert normalize_spaces(page.select("h1")[0].text) == "Page not found"
+
+
+def test_unsubscribe_request_report_checkbox_for_completed_reports_are_checked_by_default(client_request, mocker):
+    test_data = [
+        {
+            "count": 321,
+            "earliest_timestamp": "2024-06-8",
+            "latest_timestamp": "2024-06-14",
+            "processed_by_service_at": None,
+            "batch_id": "b9c28b5b-e442-4e5f-a9c7-c2544502627a",
+            "is_a_batched_report": True,
+        },
+    ]
+
+    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
+    page = client_request.get(
+        "main.unsubscribe_request_report",
+        service_id=SERVICE_ONE_ID,
+        batch_id=test_data[0]["batch_id"],
+    )
+
+    assert "checked" in page.select("#report_has_been_processed")[0].attrs
+
+
+def test_unsubscribe_request_report_checkbox_for_unbatched_reports_are_disabled_checked_by_default(
+        client_request, mocker):
+    test_data = [
+        {
+            "count": 34,
+            "earliest_timestamp": "2024-06-22",
+            "latest_timestamp": "2024-07-01",
+            "processed_by_service_at": None,
+            "batch_id": None,
+            "is_a_batched_report": False,
+        },
+    ]
+
+    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
+    page = client_request.get(
+        "main.unsubscribe_request_report",
+        service_id=SERVICE_ONE_ID,
+        batch_id=test_data[0]["batch_id"],
+    )
+    assert "disabled" in page.select("#report_has_been_processed")[0].attrs

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -136,7 +136,6 @@ def test_unsubscribe_request_report_checkbox_for_completed_reports_are_checked_b
         service_id=SERVICE_ONE_ID,
         batch_id=test_data[0]["batch_id"],
     )
-
     assert "checked" in page.select("#report_has_been_processed")[0].attrs
 
 

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -54,34 +54,32 @@ def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocke
     ]
 
 
-def test_unsubscribe_request_report_for_batched_reports(client_request, mocker):
-    test_data = [
-        {
+def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_request, mocker):
+    test_data = [{
             "count": 200,
             "earliest_timestamp": "2024-06-15",
             "latest_timestamp": "2024-06-21",
             "processed_by_service_at": None,
             "batch_id": "a8a526f9-84be-44a6-b751-62c95c4b9329",
             "is_a_batched_report": True,
-        },
-        {
-            "count": 321,
-            "earliest_timestamp": "2024-06-8",
-            "latest_timestamp": "2024-06-14",
-            "processed_by_service_at": "2024-06-10",
-            "batch_id": "b9c28b5b-e442-4e5f-a9c7-c2544502627a",
-            "is_a_batched_report": True,
-        },
-    ]
+        }]
 
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
 
     page = client_request.get(
         "main.unsubscribe_request_report",
         service_id=SERVICE_ONE_ID,
-        batch_id=test_data[1]["batch_id"],
+        batch_id=test_data[0]["batch_id"],
     )
-    assert page.select("h1")[0].text == "8 June 2024 until 14 June 2024"
+    assert page.select("h1")[0].text == "15 June 2024 until 21 June 2024"
+    checkbox = page.select("#report_has_been_processed")[0].attrs
+    checkbox_hint = page.select("#report_has_been_processed-item-hint")[0].text
+    unsubscribe_requests_count_text = page.select("#report-unsubscribe-requests-count")[0].text
+    update_button = page.select("#process_unsubscribe_report")
+    assert "disabled" not in checkbox
+    assert normalize_spaces(checkbox_hint) == "I have unsubscribed these recipients from our mailing list"
+    assert normalize_spaces(unsubscribe_requests_count_text) == "200 new requests to unsubscribe"
+    assert len(update_button) == 1
 
 
 def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker):
@@ -102,7 +100,43 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
         service_id=SERVICE_ONE_ID,
         batch_id=test_data[0]["batch_id"],
     )
+    checkbox = page.select("#report_has_been_processed")[0].attrs
+    checkbox_hint = page.select("#report_has_been_processed-item-hint")[0].text
+    unsubscribe_requests_count_text = page.select("#report-unsubscribe-requests-count")[0].text
+    update_button = page.select("#process_unsubscribe_report")
     assert page.select("h1")[0].text == "22 June 2024 until 1 July 2024"
+    assert "disabled" in checkbox
+    assert normalize_spaces(checkbox_hint) == "You cannot do this until you've downloaded the report"
+    assert normalize_spaces(unsubscribe_requests_count_text) == "34 new requests to unsubscribe"
+    assert len(update_button) == 0
+
+
+def test_unsubscribe_request_report_for_processed_batched_reports(client_request, mocker):
+    test_data = [{
+            "count": 321,
+            "earliest_timestamp": "2024-06-8",
+            "latest_timestamp": "2024-06-14",
+            "processed_by_service_at": "2024-06-10",
+            "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
+            "is_a_batched_report": True,
+        },
+    ]
+    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
+    page = client_request.get(
+        "main.unsubscribe_request_report",
+        service_id=SERVICE_ONE_ID,
+        batch_id=test_data[0]["batch_id"],
+    )
+    assert page.select("h1")[0].text == "8 June 2024 until 14 June 2024"
+    checkbox = page.select("#report_has_been_processed")[0].attrs
+    checkbox_hint = page.select("#report_has_been_processed-item-hint")[0].text
+    main_body_text = page.select("#completed_unsubscribe_report_main_text")[0].text
+    update_button = page.select("#process_unsubscribe_report")
+    assert "disabled" not in checkbox
+    assert "checked" in checkbox
+    assert normalize_spaces(checkbox_hint) == "I have unsubscribed these recipients from our mailing list"
+    assert normalize_spaces(main_body_text) == "Report was marked as completed on 10 June 2024"
+    assert len(update_button) == 1
 
 
 @pytest.mark.parametrize("batch_id", ["32b4e359-d4df-49b6-a92b-2eaa9343cfdd", None])
@@ -116,46 +150,3 @@ def test_non_existing_unsubscribe_request_report_batch_id_returns_404(client_req
         batch_id=batch_id,
     )
     assert normalize_spaces(page.select("h1")[0].text) == "Page not found"
-
-
-def test_unsubscribe_request_report_checkbox_for_completed_reports_are_checked_by_default(client_request, mocker):
-    test_data = [
-        {
-            "count": 321,
-            "earliest_timestamp": "2024-06-8",
-            "latest_timestamp": "2024-06-14",
-            "processed_by_service_at": None,
-            "batch_id": "b9c28b5b-e442-4e5f-a9c7-c2544502627a",
-            "is_a_batched_report": True,
-        },
-    ]
-
-    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
-    page = client_request.get(
-        "main.unsubscribe_request_report",
-        service_id=SERVICE_ONE_ID,
-        batch_id=test_data[0]["batch_id"],
-    )
-    assert "checked" in page.select("#report_has_been_processed")[0].attrs
-
-
-def test_unsubscribe_request_report_checkbox_for_unbatched_reports_are_disabled_checked_by_default(
-        client_request, mocker):
-    test_data = [
-        {
-            "count": 34,
-            "earliest_timestamp": "2024-06-22",
-            "latest_timestamp": "2024-07-01",
-            "processed_by_service_at": None,
-            "batch_id": None,
-            "is_a_batched_report": False,
-        },
-    ]
-
-    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
-    page = client_request.get(
-        "main.unsubscribe_request_report",
-        service_id=SERVICE_ONE_ID,
-        batch_id=test_data[0]["batch_id"],
-    )
-    assert "disabled" in page.select("#report_has_been_processed")[0].attrs

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -55,14 +55,16 @@ def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocke
 
 
 def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_request, mocker):
-    test_data = [{
+    test_data = [
+        {
             "count": 200,
             "earliest_timestamp": "2024-06-15",
             "latest_timestamp": "2024-06-21",
             "processed_by_service_at": None,
             "batch_id": "a8a526f9-84be-44a6-b751-62c95c4b9329",
             "is_a_batched_report": True,
-        }]
+        }
+    ]
 
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
 
@@ -75,11 +77,13 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
     checkbox = page.select("#report_has_been_processed")[0].attrs
     checkbox_hint = page.select("#report_has_been_processed-item-hint")[0].text
     unsubscribe_requests_count_text = page.select("#report-unsubscribe-requests-count")[0].text
+    availability_date = page.select("#unsubscribe_report_availability")[0].text
     update_button = page.select("#process_unsubscribe_report")
     assert "disabled" not in checkbox
     assert normalize_spaces(checkbox_hint) == "I have unsubscribed these recipients from our mailing list"
     assert normalize_spaces(unsubscribe_requests_count_text) == "200 new requests to unsubscribe"
     assert len(update_button) == 1
+    assert normalize_spaces(availability_date) == "(available until 19 September 2024)"
 
 
 def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker):
@@ -103,16 +107,19 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
     checkbox = page.select("#report_has_been_processed")[0].attrs
     checkbox_hint = page.select("#report_has_been_processed-item-hint")[0].text
     unsubscribe_requests_count_text = page.select("#report-unsubscribe-requests-count")[0].text
+    availability_date = page.select("#unsubscribe_report_availability")[0].text
     update_button = page.select("#process_unsubscribe_report")
     assert page.select("h1")[0].text == "22 June 2024 until 1 July 2024"
     assert "disabled" in checkbox
     assert normalize_spaces(checkbox_hint) == "You cannot do this until you've downloaded the report"
     assert normalize_spaces(unsubscribe_requests_count_text) == "34 new requests to unsubscribe"
+    assert normalize_spaces(availability_date) == "(available until 29 September 2024)"
     assert len(update_button) == 0
 
 
 def test_unsubscribe_request_report_for_processed_batched_reports(client_request, mocker):
-    test_data = [{
+    test_data = [
+        {
             "count": 321,
             "earliest_timestamp": "2024-06-8",
             "latest_timestamp": "2024-06-14",
@@ -131,11 +138,14 @@ def test_unsubscribe_request_report_for_processed_batched_reports(client_request
     checkbox = page.select("#report_has_been_processed")[0].attrs
     checkbox_hint = page.select("#report_has_been_processed-item-hint")[0].text
     main_body_text = page.select("#completed_unsubscribe_report_main_text")[0].text
+    availability_date = page.select("#completed_unsubscribe_report_availability")[0].text
+    "completed_unsubscribe_report_main_text"
     update_button = page.select("#process_unsubscribe_report")
     assert "disabled" not in checkbox
     assert "checked" in checkbox
     assert normalize_spaces(checkbox_hint) == "I have unsubscribed these recipients from our mailing list"
     assert normalize_spaces(main_body_text) == "Report was marked as completed on 10 June 2024"
+    assert normalize_spaces(availability_date) == "(available until 17 June 2024)"
     assert len(update_button) == 1
 
 


### PR DESCRIPTION
This PR enables marking an `unsubscribe-request-report` as "Completed" as described in [this ](https://trello.com/c/5hJS5Oia/54-let-users-mark-email-unsubscribe-requests-as-completed)card.
The `API` end point to support this work is addressed in [this](https://github.com/alphagov/notifications-api/pull/4146) PR.

After marking the checkbox and clicking the update button, the user is redirected to the main reports summary page and a flash confirmation message is displayed:
<img width="996" alt="flash confirmation" src="https://github.com/user-attachments/assets/28764f6b-2720-4a74-b1ff-f958d466ac2f">

Once a report is marked as completed, different content is shown on the report's page. The date the report was marked as completed is displayed and the checkbox is ticked by default.

<img width="1065" alt="detailed" src="https://github.com/user-attachments/assets/5fe0ed03-ed2b-41e6-98c7-96fb2d52fded">

Once a report is marked as completed, it is then only available to download for 7 more days.

For now we are giving users the ability to clear the checkbox and later mark the report as completed, ie updating the `processed_by_service_at`
