### PR TITLE
Purge Redis cache when unsubscribe report completed

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -507,6 +507,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def get_unsubscribe_reports_summary(self, service_id):
         return self.get(f"service/{service_id}/unsubscribe-request-reports-summary")
 
+    @cache.delete("service-{service_id}-unsubscribe-request-reports-summary")
     def process_unsubscribe_request_report(self, service_id, batch_id, data):
         return self.post(f"service/{service_id}/process-unsubscribe-request-report/{batch_id}", data=data)
 


### PR DESCRIPTION
We also cache a summary of unsubscribe reports that the person running the service has batched up.

When a user marks one of these reports as completed this information is included in the summary. So we need to purge a cache.

Should probably have a test which covers the `POST` route here too