### PR TITLE
Fix text contrast of `disabled` checkboxes

### DIFF
--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -114,3 +114,13 @@ $govuk-checkboxes-size: 40px;
   }
 
 }
+
+.govuk-checkboxes__input:disabled+.govuk-checkboxes__label,
+.govuk-checkboxes__input:disabled~.govuk-hint {
+  opacity: 1;
+  color: $govuk-secondary-text-colour;
+}
+
+.govuk-checkboxes__input:disabled+.govuk-checkboxes__label:before {
+  background: govuk-colour("light-grey");
+}


### PR DESCRIPTION
We have noticed that when checkboxes have the `disabled` attribute set<sup>1</sup>, the text does not meet WCAG standards<sup>2</sup> for colour contrast. This is true for the label<sup>3</sup>, and worse for the hint text<sup>4</sup>.

This is caused by some CSS in GOV.UK Frontend<sup>5</sup>.

I propose:
- using the secondary text colour for
  - the checkbox itself (which is inherited through `currentColor`)
  - the label text
  - the hint text
- using a light grey fill to give an additional visual cue that the choice can’t be filled in by clicking it

***

This is the same thing we did for radio buttons in https://github.com/alphagov/notifications-admin/pull/4744

***

# Before

<img width="767" alt="image" src="https://github.com/user-attachments/assets/8ea2bb11-a8ad-4859-b680-319e46436d9a">

# After

<img width="745" alt="image" src="https://github.com/user-attachments/assets/bd92d948-4269-44d2-9764-8bd7e5fdd789">

***

1. Using `disabled` is not often the best way to do things (and is not documented in the Design System) but sometimes it’s appropriate
2. WCAG 2.0 AA requires a contrast ratio of 4.5:1 for ‘normal text’
3. `$govuk-text-colour` with `opacity: .5` applied computes to a value of  `#858585`, which gives a contrast ratio of 3.69:1 against a white background
4. `$govuk-secondary-text-colour` with `opacity: .5` applied computes to a value of  `#a8acae`, which gives a contrast ratio of 2.28:1 against a white background
5. https://github.com/alphagov/govuk-frontend/blob/6271937e80f6147b7f3f1a248c47eb6d9f5a7061/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss#L138
6. Colour alone isn’t used here to differentiate – there is the semantics of the `disabled` attribute itself, the different cursor behaviour, and the content of the hint text