### PR TITLE
Remove autofocus from org settings textboxes

### DIFF
--- a/app/templates/views/organisations/organisation/settings/edit-organisation-billing-details.html
+++ b/app/templates/views/organisations/organisation/settings/edit-organisation-billing-details.html
@@ -25,12 +25,7 @@
     </div>
       {{ form.notes(param_extensions={
         "classes": "govuk-!-width-full",
-        "rows": "4",
-        "attributes": {
-          "data-notify-module": "enhanced-textbox",
-          "data-highlight-placeholders": "false",
-          "data-autofocus-textbox": "true"
-        }
+        "rows": "4"
       }) }}
       {{ page_footer('Save') }}
     {% endcall %}

--- a/app/templates/views/organisations/organisation/settings/edit-organisation-notes.html
+++ b/app/templates/views/organisations/organisation/settings/edit-organisation-notes.html
@@ -18,12 +18,7 @@
     {% call form_wrapper() %}
       {{ form.notes(param_extensions={
         "classes": "govuk-!-width-full",
-        "rows": "4",
-        "attributes": {
-          "data-notify-module": "enhanced-textbox",
-          "data-highlight-placeholders": "false",
-          "data-autofocus-textbox": "true"
-        },
+        "rows": "4"
       }) }}
       {{ page_footer('Save') }}
     {% endcall %}


### PR DESCRIPTION
Some textboxes on our organisation settings pages are focused when the page loads. Doing this can be a real problem for screen reader users because it means they don't get the normal announcement when the page loads and so can't tell this has happened.

See [this guidance on autofocus on MDN for details](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus#accessibility_concerns).

Looking at the commits that added these textboxes, I also don't think they were intentionally set up like this. This removes the autofocus functionality.