### PR TITLE
Fix template checkbox height for Selenium

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -69,7 +69,7 @@ a {
 
       input {
         margin-right: $govuk-checkboxes-label-padding-left-right;
-        height: 0;
+        height: 1px;
       }
     }
 


### PR DESCRIPTION
Selenium errors with `element not interactable`

https://concourse.notify.tools/teams/notify/pipelines/admin/jobs/run-functional-tests-admin-preview/builds/444

Doesn't affect visual display

Before
![Screenshot 2024-08-01 at 10 55 06](https://github.com/user-attachments/assets/ca06a0e7-59d4-45b2-8a0d-ba9125c0673f)

After
![Screenshot 2024-08-01 at 10 56 09](https://github.com/user-attachments/assets/43b527d1-e920-4d3d-a3df-ce7b973fb6bb)

