### PR TITLE
Make unsubscribe report titles friendlier

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -102,8 +102,8 @@ def format_date_human(date):
     return get_human_day(date)
 
 
-def format_datetime_human(date, date_prefix="on"):
-    return f"{get_human_day(date, date_prefix=date_prefix)} at {format_time(date)}"
+def format_datetime_human(date, date_prefix="on", separator="at"):
+    return f"{get_human_day(date, date_prefix=date_prefix)} {separator} {format_time(date)}"
 
 
 def format_day_of_week(date):

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -102,8 +102,8 @@ def format_date_human(date):
     return get_human_day(date)
 
 
-def format_datetime_human(date, date_prefix=""):
-    return f"{get_human_day(date, date_prefix='on')} at {format_time(date)}"
+def format_datetime_human(date, date_prefix="on"):
+    return f"{get_human_day(date, date_prefix=date_prefix)} at {format_time(date)}"
 
 
 def format_day_of_week(date):

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -5,7 +5,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
 {% block service_page_title %}
-{{ report.earliest_timestamp|format_date_normal }} until {{ report.latest_timestamp|format_date_normal }}
+    {{ report.title }}
 {% endblock %}
 
 
@@ -15,7 +15,7 @@
 
 {% block maincolumn_content %}
 
-    {{ page_header('{} until {}'.format(report.earliest_timestamp|format_date_normal, report.latest_timestamp|format_date_normal)) }}
+    {{ page_header(report.title) }}
 
 
 {% if report.status != "Completed" %}

--- a/app/templates/views/unsubscribe-request-reports-summary.html
+++ b/app/templates/views/unsubscribe-request-reports-summary.html
@@ -28,7 +28,7 @@
 
       <a class="govuk-link govuk-link--no-visited-state file-list-filename"
          href="{{url_for('main.unsubscribe_request_report', service_id=current_service.id, batch_id=item.batch_id)}}" >
-          {{ item.earliest_timestamp | format_date_normal }} to {{ item.latest_timestamp | format_date_normal }}
+          {{ item.title }}
         </a>
        <p class="file-list-hint">
 

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -1,46 +1,188 @@
 import pytest
+from freezegun import freeze_time
 
 from app.models.unsubscribe_requests_report import UnsubscribeRequestsReports
 from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 
 
-def test_unsubscribe_request_reports_summary(client_request, mocker):
-    test_data = [
-        {
-            "count": 34,
-            "earliest_timestamp": "2024-06-22",
-            "latest_timestamp": "2024-07-01",
-            "processed_by_service_at": None,
-            "batch_id": "5e2b05ef-7552-49ef-a77f-96d46ab2b9bb",
-            "is_a_batched_report": False,
-        },
-        {
-            "count": 200,
-            "earliest_timestamp": "2024-06-15",
-            "latest_timestamp": "2024-06-21",
-            "processed_by_service_at": None,
-            "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
-            "is_a_batched_report": True,
-        },
-        {
-            "count": 321,
-            "earliest_timestamp": "2024-06-8",
-            "latest_timestamp": "2024-06-14",
-            "processed_by_service_at": "2024-06-10",
-            "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
-            "is_a_batched_report": True,
-        },
-    ]
+@pytest.mark.parametrize(
+    "test_data, expected_rows",
+    (
+        (
+            # A mixture of reports from different dates
+            [
+                {
+                    "count": 1,
+                    "earliest_timestamp": "2024-06-22 14:00",
+                    "latest_timestamp": "2024-06-22 14:00",
+                    "processed_by_service_at": None,
+                    "batch_id": "1629dada-9777-4d0a-aa5a-a8b6e3c7ff7b",
+                    "is_a_batched_report": False,
+                },
+                {
+                    "count": 1,
+                    "earliest_timestamp": "2024-06-22 10:00",
+                    "latest_timestamp": "2024-06-22 12:17",
+                    "processed_by_service_at": None,
+                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
+                    "is_a_batched_report": False,
+                },
+                {
+                    "count": 34,
+                    "earliest_timestamp": "2024-06-22 09:00",
+                    "latest_timestamp": "2024-06-22 10:00",
+                    "processed_by_service_at": None,
+                    "batch_id": "5e2b05ef-7552-49ef-a77f-96d46ab2b9bb",
+                    "is_a_batched_report": True,
+                },
+                {
+                    "count": 200,
+                    "earliest_timestamp": "2024-06-15 18:00",
+                    "latest_timestamp": "2024-06-21 08:00",
+                    "processed_by_service_at": None,
+                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
+                    "is_a_batched_report": True,
+                },
+                {
+                    "count": 321,
+                    "earliest_timestamp": "2023-12-8",
+                    "latest_timestamp": "2024-01-14",
+                    "processed_by_service_at": "2024-06-10",
+                    "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
+                    "is_a_batched_report": True,
+                },
+            ],
+            [
+                "Report Status",
+                "Today at 4:00pm 1 unsubscribe request Not downloaded",
+                "Today at midday to today at 2:17pm 1 unsubscribe request Not downloaded",
+                "Today until midday 34 unsubscribe requests Downloaded",
+                "15 June to yesterday 200 unsubscribe requests Downloaded",
+                "7 December 2023 to 13 January 321 unsubscribe requests Completed",
+            ],
+        ),
+        (
+            # A single report spanning a long time period
+            [
+                {
+                    "count": 1,
+                    "earliest_timestamp": "2020-01-01 10:00",
+                    "latest_timestamp": "2024-06-01 12:17",
+                    "processed_by_service_at": None,
+                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
+                    "is_a_batched_report": False,
+                },
+            ],
+            [
+                "Report Status",
+                "1 January 2020 to 1 June 1 unsubscribe request Not downloaded",
+            ],
+        ),
+        (
+            # Two reports with overlapping days
+            [
+                {
+                    "count": 1,
+                    "earliest_timestamp": "2024-05-01 10:00",
+                    "latest_timestamp": "2024-05-01 12:17",
+                    "processed_by_service_at": "2024-06-22 13:14",
+                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
+                    "is_a_batched_report": True,
+                },
+                {
+                    "count": 12345678,
+                    "earliest_timestamp": "2024-04-30 02:00",
+                    "latest_timestamp": "2024-05-01 08:00",
+                    "processed_by_service_at": "2024-06-22 13:14",
+                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
+                    "is_a_batched_report": True,
+                },
+            ],
+            [
+                "Report Status",
+                "1 May at midday to 1 May at 2:17pm 1 unsubscribe request Completed",
+                "30 April to 1 May at 10:00am 12,345,678 unsubscribe requests Completed",
+            ],
+        ),
+        (
+            # Three reports on independent, consecutive days
+            [
+                {
+                    "count": 1234,
+                    "earliest_timestamp": "2024-06-22 10:00",
+                    "latest_timestamp": "2024-06-22 12:17",
+                    "processed_by_service_at": None,
+                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
+                    "is_a_batched_report": True,
+                },
+                {
+                    "count": 4567,
+                    "earliest_timestamp": "2024-06-21 10:00",
+                    "latest_timestamp": "2024-06-21 12:17",
+                    "processed_by_service_at": None,
+                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
+                    "is_a_batched_report": True,
+                },
+                {
+                    "count": 7890,
+                    "earliest_timestamp": "2024-06-20 10:00",
+                    "latest_timestamp": "2024-06-20 12:17",
+                    "processed_by_service_at": None,
+                    "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
+                    "is_a_batched_report": True,
+                },
+            ],
+            [
+                "Report Status",
+                "Today 1,234 unsubscribe requests Downloaded",
+                "Yesterday 4,567 unsubscribe requests Downloaded",
+                "20 June 7,890 unsubscribe requests Downloaded",
+            ],
+        ),
+        (
+            # Three reports on the same day
+            [
+                {
+                    "count": 1234,
+                    "earliest_timestamp": "2024-06-01 21:22",
+                    "latest_timestamp": "2024-06-01 22:00",
+                    "processed_by_service_at": None,
+                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
+                    "is_a_batched_report": True,
+                },
+                {
+                    "count": 4567,
+                    "earliest_timestamp": "2024-06-01 12:17",
+                    "latest_timestamp": "2024-06-01 12:18",
+                    "processed_by_service_at": None,
+                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
+                    "is_a_batched_report": True,
+                },
+                {
+                    "count": 7890,
+                    "earliest_timestamp": "2024-06-01 08:00",
+                    "latest_timestamp": "2024-06-01 10:00",
+                    "processed_by_service_at": None,
+                    "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
+                    "is_a_batched_report": True,
+                },
+            ],
+            [
+                "Report Status",
+                "1 June at 11:22pm to 1 June at midnight 1,234 unsubscribe requests Downloaded",
+                "1 June at 2:17pm to 1 June at 2:18pm 4,567 unsubscribe requests Downloaded",
+                "1 June until midday 7,890 unsubscribe requests Downloaded",
+            ],
+        ),
+    ),
+)
+@freeze_time("2024-06-22 22:22:22")
+def test_unsubscribe_request_reports_summary(client_request, mocker, test_data, expected_rows):
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
 
     page = client_request.get("main.unsubscribe_request_reports_summary", service_id=SERVICE_ONE_ID)
 
-    assert [
-        "Report Status",
-        "22 June 2024 to 1 July 2024 34 unsubscribe requests Not downloaded",
-        "15 June 2024 to 21 June 2024 200 unsubscribe requests Downloaded",
-        "8 June 2024 to 14 June 2024 321 unsubscribe requests Completed",
-    ] == [normalize_spaces(row.text) for row in page.select("tr")]
+    assert [normalize_spaces(row.text) for row in page.select("tr")] == expected_rows
 
 
 def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocker):
@@ -54,6 +196,7 @@ def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocke
     ]
 
 
+@freeze_time("2024-06-22")
 def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_request, mocker):
     test_data = [
         {
@@ -73,7 +216,7 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
         service_id=SERVICE_ONE_ID,
         batch_id=test_data[0]["batch_id"],
     )
-    assert page.select("h1")[0].text == "15 June 2024 until 21 June 2024"
+    assert page.select("h1")[0].text == "15 June to yesterday"
     checkbox = page.select("#report_has_been_processed")[0].attrs
     checkbox_hint = page.select("#report_has_been_processed-item-hint")[0].text
     unsubscribe_requests_count_text = page.select("#report-unsubscribe-requests-count")[0].text
@@ -86,12 +229,13 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
     assert normalize_spaces(availability_date) == "(available until 19 September 2024)"
 
 
+@freeze_time("2024-07-02")
 def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker):
     test_data = [
         {
             "count": 34,
-            "earliest_timestamp": "2024-06-22",
-            "latest_timestamp": "2024-07-01",
+            "earliest_timestamp": "2024-06-22 10:00",
+            "latest_timestamp": "2024-07-01 12:00",
             "processed_by_service_at": None,
             "batch_id": None,
             "is_a_batched_report": False,
@@ -109,7 +253,7 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
     unsubscribe_requests_count_text = page.select("#report-unsubscribe-requests-count")[0].text
     availability_date = page.select("#unsubscribe_report_availability")[0].text
     update_button = page.select("#process_unsubscribe_report")
-    assert page.select("h1")[0].text == "22 June 2024 until 1 July 2024"
+    assert page.select("h1")[0].text == "22 June to yesterday"
     assert "disabled" in checkbox
     assert normalize_spaces(checkbox_hint) == "You cannot do this until you’ve downloaded the report"
     assert normalize_spaces(unsubscribe_requests_count_text) == "34 new requests to unsubscribe"
@@ -117,12 +261,13 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
     assert len(update_button) == 0
 
 
+@freeze_time("2024-01-01")
 def test_unsubscribe_request_report_for_processed_batched_reports(client_request, mocker):
     test_data = [
         {
             "count": 321,
-            "earliest_timestamp": "2024-06-8",
-            "latest_timestamp": "2024-06-14",
+            "earliest_timestamp": "2023-06-8",
+            "latest_timestamp": "2023-06-14",
             "processed_by_service_at": "2024-06-10",
             "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
             "is_a_batched_report": True,
@@ -134,7 +279,7 @@ def test_unsubscribe_request_report_for_processed_batched_reports(client_request
         service_id=SERVICE_ONE_ID,
         batch_id=test_data[0]["batch_id"],
     )
-    assert page.select("h1")[0].text == "8 June 2024 until 14 June 2024"
+    assert page.select("h1")[0].text == "8 June 2023 to 14 June 2023"
     checkbox = page.select("#report_has_been_processed")[0].attrs
     checkbox_hint = page.select("#report_has_been_processed-item-hint")[0].text
     main_body_text = page.select("#completed_unsubscribe_report_main_text")[0].text


### PR DESCRIPTION
At the moment the title of our reports follow the same format no matter:
- the range they cover
- how recent they are

This commit makes the titles aware of their context (in other words what time it is now and what other reports exist).

This makes them better in 2 situations especially:
- there are multiple reports on the same day (where we now add the time to help differentiate)
- there are very recent reports (where we now say today or yesterday instead of the numeric date)

The alternative would be to always show the time and year for every report, but this would feel noisy and overly-specific in most cases.

Example from the test cases:

Before | After
---|---
22 June 2024 to 22 June 2024 | Today at 4:00pm
22 June 2024 to 22 June 2024 | Today at midday to today at 2:17pm
22 June 2024 to 22 June 2024 | Today until midday
15 June 2024 to 21 June 2024 | 15 June to yesterday
8 December 2023 to 14 January 2024 | 7 December 2023 to 13 January