### PR TITLE
Generate asset URLs at request time, not build time

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -889,7 +889,7 @@ class GovukRadiosWithImagesField(GovukRadiosField):
     def get_item_from_option(self, option):
         # deepcopy to avoid mutating the same `dict` multiple times
         image_data = deepcopy(self.image_data[option.data])
-        image_data["url"] = asset_fingerprinter.get_url(image_data["url"])
+        image_data["url"] = asset_fingerprinter.get_url(image_data["path"])
         return {
             "name": option.name,
             "id": option.id,
@@ -2374,7 +2374,7 @@ class EmailBrandingChooseLogoForm(StripWhitespaceForm):
         "single_identity": {
             "label": "Create a government identity logo",
             "image": {
-                "url": "images/branding/single_identity.png",
+                "path": "images/branding/single_identity.png",
                 "alt_text": "An example of an email with a government identity logo,"
                 " including a blue stripe, a crest and department's name",
                 "dimensions": {"width": 606, "height": 404},
@@ -2383,7 +2383,7 @@ class EmailBrandingChooseLogoForm(StripWhitespaceForm):
         "org": {
             "label": "Upload a logo",
             "image": {
-                "url": "images/branding/org.png",
+                "path": "images/branding/org.png",
                 "alt_text": 'An example of an email with the heading "Your logo" in blue text on a white background.',
                 "dimensions": {"width": 606, "height": 404},
             },
@@ -2402,7 +2402,7 @@ class EmailBrandingChooseBanner(OrderableFieldsForm):
         "org_banner": {
             "label": "Yes",
             "image": {
-                "url": "images/branding/org_banner.png",
+                "path": "images/branding/org_banner.png",
                 "alt_text": "An example of an email with a logo on a blue banner.",
                 "dimensions": {"width": 606, "height": 404},
             },
@@ -2410,7 +2410,7 @@ class EmailBrandingChooseBanner(OrderableFieldsForm):
         "org": {
             "label": "No",
             "image": {
-                "url": "images/branding/org.png",
+                "path": "images/branding/org.png",
                 "alt_text": "An example of an email with a logo on a clear background.",
                 "dimensions": {"width": 606, "height": 404},
             },

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,5 +1,6 @@
 import weakref
 from contextlib import suppress
+from copy import deepcopy
 from datetime import datetime, timedelta
 from functools import partial
 from itertools import chain
@@ -886,13 +887,16 @@ class GovukRadiosWithImagesField(GovukRadiosField):
         self.image_data = image_data
 
     def get_item_from_option(self, option):
+        # deepcopy to avoid mutating the same `dict` multiple times
+        image_data = deepcopy(self.image_data[option.data])
+        image_data["url"] = asset_fingerprinter.get_url(image_data["url"])
         return {
             "name": option.name,
             "id": option.id,
             "text": option.label.text,
             "value": str(option.data),  # to protect against non-string types like uuids
             "checked": option.checked,
-            "image": self.image_data[option.data],
+            "image": image_data,
         }
 
 
@@ -2370,7 +2374,7 @@ class EmailBrandingChooseLogoForm(StripWhitespaceForm):
         "single_identity": {
             "label": "Create a government identity logo",
             "image": {
-                "url": asset_fingerprinter.get_url("images/branding/single_identity.png"),
+                "url": "images/branding/single_identity.png",
                 "alt_text": "An example of an email with a government identity logo,"
                 " including a blue stripe, a crest and department's name",
                 "dimensions": {"width": 606, "height": 404},
@@ -2379,7 +2383,7 @@ class EmailBrandingChooseLogoForm(StripWhitespaceForm):
         "org": {
             "label": "Upload a logo",
             "image": {
-                "url": asset_fingerprinter.get_url("images/branding/org.png"),
+                "url": "images/branding/org.png",
                 "alt_text": 'An example of an email with the heading "Your logo" in blue text on a white background.',
                 "dimensions": {"width": 606, "height": 404},
             },
@@ -2398,7 +2402,7 @@ class EmailBrandingChooseBanner(OrderableFieldsForm):
         "org_banner": {
             "label": "Yes",
             "image": {
-                "url": asset_fingerprinter.get_url("images/branding/org_banner.png"),
+                "url": "images/branding/org_banner.png",
                 "alt_text": "An example of an email with a logo on a blue banner.",
                 "dimensions": {"width": 606, "height": 404},
             },
@@ -2406,7 +2410,7 @@ class EmailBrandingChooseBanner(OrderableFieldsForm):
         "org": {
             "label": "No",
             "image": {
-                "url": asset_fingerprinter.get_url("images/branding/org.png"),
+                "url": "images/branding/org.png",
                 "alt_text": "An example of an email with a logo on a clear background.",
                 "dimensions": {"width": 606, "height": 404},
             },

--- a/app/templates/govuk_frontend_jinja_overrides/templates/components/radios-with-images/macro.html
+++ b/app/templates/govuk_frontend_jinja_overrides/templates/components/radios-with-images/macro.html
@@ -66,7 +66,7 @@
         alt="{{ item.image.alt_text }}"
         width="{{ item.image.dimensions.width }}"
         height="{{ item.image.dimensions.height }}"
-        id="{{ id }}-description"
+        id="{{ item.id }}-description"
         class="notify-radios-with-images__image"
         data-notify-module="radios-with-images"
       />


### PR DESCRIPTION
In a small handful of cases – all where we have radio buttons with images – we were generating the cache-busting hashes for images at the time of starting the app.

If the image files were missing (for example because the gulp task had not finished running) this would cause an exception.

This commit changes the radios-with-images component to defer generating the hashes until the `<img>` tags are rendered in the HTML. This is the same way that all other asset URLs are rendered.

This means that the app can start up without the images, but an exception will still be thrown at runtime or while running the (now more robust) tests if the image is missing.