### PR TITLE
Replace ‘Clinical Commissioning Group’ with ‘Integrated Care Board’

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1182,8 +1182,8 @@ class AddNHSLocalOrganisationForm(StripWhitespaceForm):
         self.organisations.choices = organisation_choices
 
     organisations = GovukRadiosField(
-        "Which NHS Trust or Clinical Commissioning Group do you work for?",
-        thing="an NHS Trust or Clinical Commissioning Group",
+        "Which NHS Trust or Integrated Care Board do you work for?",
+        thing="an NHS Trust or Integrated Care Board",
     )
 
 

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -34,7 +34,7 @@ class Organisation(JSONModel):
         TYPE_CENTRAL: "Central government",
         TYPE_LOCAL: "Local government",
         TYPE_NHS_CENTRAL: "NHS – central government agency or public body",
-        TYPE_NHS_LOCAL: "NHS Trust or Clinical Commissioning Group",
+        TYPE_NHS_LOCAL: "NHS Trust or Integrated Care Board",
         TYPE_NHS_GP: "GP surgery",
         TYPE_EMERGENCY_SERVICE: "Emergency service",
         TYPE_SCHOOL_OR_COLLEGE: "School or college",

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -276,7 +276,7 @@ def test_nhs_local_can_create_own_organisations(
         return
 
     assert normalize_spaces(page.select_one("main p").text) == (
-        "Which NHS Trust or Clinical Commissioning Group do you work for?"
+        "Which NHS Trust or Integrated Care Board do you work for?"
     )
     assert page.select_one("[data-notify-module=live-search]")["data-targets"] == ".govuk-radios__item"
     assert [

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1352,7 +1352,7 @@ def test_archive_organisation_does_not_allow_orgs_with_team_members_or_services_
                 {"value": "central", "label": "Central government"},
                 {"value": "local", "label": "Local government"},
                 {"value": "nhs_central", "label": "NHS – central government agency or public body"},
-                {"value": "nhs_local", "label": "NHS Trust or Clinical Commissioning Group"},
+                {"value": "nhs_local", "label": "NHS Trust or Integrated Care Board"},
                 {"value": "nhs_gp", "label": "GP surgery"},
                 {"value": "emergency_service", "label": "Emergency service"},
                 {"value": "school_or_college", "label": "School or college"},

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -45,7 +45,7 @@ def test_get_should_render_add_service_template(
         "Central government",
         "Local government",
         "NHS – central government agency or public body",
-        "NHS Trust or Clinical Commissioning Group",
+        "NHS Trust or Integrated Care Board",
         "GP surgery",
         "Emergency service",
         "School or college",

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -243,7 +243,7 @@ def test_get_should_only_show_nhs_org_types_radios_if_user_has_nhs_email(
     assert page.select_one("input[name=name]").get("value") is None
     assert [label.text.strip() for label in page.select(".govuk-radios__item label")] == [
         "NHS – central government agency or public body",
-        "NHS Trust or Clinical Commissioning Group",
+        "NHS Trust or Integrated Care Board",
         "GP surgery",
     ]
     assert [radio["value"] for radio in page.select(".govuk-radios__item input")] == [


### PR DESCRIPTION
NHS Clinical Commissioning Groups were replaced with Integrated Care Boards.

This PR updates our content to reflect this organisational change.