### PR TITLE
Use report `title` for confirmation message 

### DIFF
--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -1,6 +1,6 @@
 from flask import flash, redirect, render_template, url_for
 
-from app import current_service, format_date_normal, format_date_numeric, service_api_client
+from app import current_service, format_date_numeric, service_api_client
 from app.main import main
 from app.main.forms import ProcessUnsubscribeRequestForm
 from app.models.spreadsheet import Spreadsheet
@@ -31,10 +31,10 @@ def unsubscribe_request_report(service_id, batch_id=None):
         report_has_been_processed = form.data["report_has_been_processed"]
         data = {"report_has_been_processed": report_has_been_processed}
         service_api_client.process_unsubscribe_request_report(service_id, batch_id=batch_id, data=data)
-        message = f"""Report for {format_date_normal(report.earliest_timestamp)} until  \
-                  {format_date_normal(report.latest_timestamp)} has been marked as \
-                  {'Completed' if report_has_been_processed else 'not completed.'}"""
-        flash(message, "default_with_tick")
+        flash(
+            f"Report for {report.title} marked as {'completed' if report_has_been_processed else 'not completed'}",
+            "default_with_tick",
+        )
         return redirect(url_for("main.unsubscribe_request_reports_summary", service_id=service_id, batch_id=batch_id))
     return render_template(
         "views/unsubscribe-request-report.html",

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from flask import abort
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 
-from app.formatters import format_date_human, format_datetime_human, sentence_case
+from app.formatters import format_date_human, format_datetime_human
 from app.models import JSONModel, ModelList
 from app.notify_client.service_api_client import service_api_client
 
@@ -100,9 +100,9 @@ class UnsubscribeRequestsReport(JSONModel):
     @property
     def title(self):
         if self.earliest == self.latest:
-            return sentence_case(self.latest)
+            return self.latest
 
-        return f"{sentence_case(self.earliest)} to {self.latest}"
+        return f"{self.earliest} to {self.latest}"
 
 
 class UnsubscribeRequestsReports(ModelList):

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -5,7 +5,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
 {% block service_page_title %}
-    {{ report.title }}
+    {{ report.title|sentence_case }}
 {% endblock %}
 
 
@@ -15,7 +15,7 @@
 
 {% block maincolumn_content %}
 
-    {{ page_header(report.title) }}
+    {{ page_header(report.title|sentence_case) }}
 
 
 {% if not report.completed %}

--- a/app/templates/views/unsubscribe-request-reports-summary.html
+++ b/app/templates/views/unsubscribe-request-reports-summary.html
@@ -28,7 +28,7 @@
 
       <a class="govuk-link govuk-link--no-visited-state file-list-filename"
          href="{{url_for('main.unsubscribe_request_report', service_id=current_service.id, batch_id=item.batch_id)}}" >
-          {{ item.title }}
+          {{ item.title|sentence_case }}
         </a>
        <p class="file-list-hint">
 

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -341,7 +341,7 @@ def test_mark_report_as_completed(client_request, mocker, fake_uuid):
         data={"report_has_been_processed": True},
     )
     assert normalize_spaces(page.select_one("main .banner-default-with-tick")) == (
-        "Report for Yesterday to today marked as completed"
+        "Report for yesterday to today marked as completed"
     )
 
 

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -309,6 +309,42 @@ def test_non_existing_unsubscribe_request_report_batch_id_returns_404(client_req
     assert normalize_spaces(page.select("h1")[0].text) == "Page not found"
 
 
+@freeze_time("2024-08-07")
+def test_mark_report_as_completed(client_request, mocker, fake_uuid):
+    mocker.patch.object(
+        UnsubscribeRequestsReports,
+        "client_method",
+        return_value=[
+            {
+                "count": 321,
+                "earliest_timestamp": "2024-08-06",
+                "latest_timestamp": "2024-08-07",
+                "processed_by_service_at": None,
+                "batch_id": fake_uuid,
+                "is_a_batched_report": True,
+            },
+        ],
+    )
+    mock_batch_report = mocker.patch.object(service_api_client, "process_unsubscribe_request_report")
+    page = client_request.post(
+        "main.unsubscribe_request_report",
+        service_id=SERVICE_ONE_ID,
+        batch_id=fake_uuid,
+        _data={
+            "report_has_been_processed": True,
+        },
+        _follow_redirects=True,
+    )
+    mock_batch_report.assert_called_once_with(
+        SERVICE_ONE_ID,
+        batch_id=fake_uuid,
+        data={"report_has_been_processed": True},
+    )
+    assert normalize_spaces(page.select_one("main .banner-default-with-tick")) == (
+        "Report for Yesterday to today marked as completed"
+    )
+
+
 def test_download_unsubscribe_request_report_redirects_to_batch_unsubscribe_request_report_endpoint_no_batch_id(
     client_request,
 ):


### PR DESCRIPTION
Rather than hand-crafting the to/from dates here we can use the `title` property introduced in 
 https://github.com/alphagov/notifications-admin/pull/5160 to give a more context-dependent title for the report. It will also match the title shown later down the page.

This also rewords the message slightly to be less verbose and passive.