### PR TITLE
Require redirect URL in tests, not just HTTP status

### DIFF
--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -93,7 +93,7 @@ def test_existing_user_with_no_permissions_or_folder_permissions_accept_invite(
     client_request.get(
         "main.accept_invite",
         token="thisisnotarealtoken",
-        _expected_status=302,
+        _expected_redirect=url_for("main.service_dashboard", service_id=service_one["id"]),
     )
     mock_add_user_to_service.assert_called_with(
         expected_service, api_user_active["id"], expected_permissions, expected_folder_permissions
@@ -655,7 +655,7 @@ def test_new_invited_user_is_redirected_to_correct_place(
     client_request.get(
         "main.accept_invite",
         token="thisisnotarealtoken",
-        _expected_status=302,
+        _expected_redirect=url_for("main.register_from_invite"),
     )
 
     with client_request.session_transaction() as session:

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -777,6 +777,10 @@ def test_should_show_redirect_from_template_history(
         "main.template_history",
         service_id=SERVICE_ONE_ID,
         _expected_status=301,
+        _expected_redirect=url_for(
+            "main.template_usage",
+            service_id=SERVICE_ONE_ID,
+        ),
         **extra_args,
     )
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -44,10 +44,11 @@ def test_logged_in_user_redirects_to_choose_account(
 ):
     client_request.get(
         "main.index",
-        _expected_status=302,
+        _expected_redirect=url_for("main.choose_account"),
     )
     client_request.get(
-        "main.sign_in", _expected_status=302, _expected_redirect=url_for("main.show_accounts_or_dashboard")
+        "main.sign_in",
+        _expected_redirect=url_for("main.show_accounts_or_dashboard"),
     )
 
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1800,7 +1800,11 @@ def test_confirm_edit_user_mobile_number_page_redirects_if_session_empty(
         "main.confirm_edit_user_mobile_number",
         service_id=SERVICE_ONE_ID,
         user_id=active_user_with_permissions["id"],
-        _expected_status=302,
+        _expected_redirect=url_for(
+            "main.edit_user_mobile_number",
+            service_id=SERVICE_ONE_ID,
+            user_id=active_user_with_permissions["id"],
+        ),
     )
     assert "Confirm change of mobile number" not in page.text
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -172,8 +172,7 @@ def test_set_sender_redirects_if_no_reply_to_email_addresses(
         ".set_sender",
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
-        _expected_status=302,
-        _expected_url=url_for(
+        _expected_redirect=url_for(
             ".send_one_off",
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
@@ -191,8 +190,7 @@ def test_set_sender_redirects_if_no_sms_senders(
         ".set_sender",
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
-        _expected_status=302,
-        _expected_url=url_for(
+        _expected_redirect=url_for(
             ".send_one_off",
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
@@ -210,8 +208,7 @@ def test_set_sender_redirects_if_one_email_sender(
         ".set_sender",
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
-        _expected_status=302,
-        _expected_url=url_for(
+        _expected_redirect=url_for(
             ".send_one_off",
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
@@ -232,8 +229,7 @@ def test_set_sender_redirects_if_one_sms_sender(
         ".set_sender",
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
-        _expected_status=302,
-        _expected_url=url_for(
+        _expected_redirect=url_for(
             ".send_one_off",
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
@@ -1837,7 +1833,7 @@ def test_send_one_off_sms_message_redirects(
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
         _expected_status=302,
-        _expected_response=url_for(
+        _expected_redirect=url_for(
             "main.send_one_off_step",
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
@@ -2288,7 +2284,12 @@ def test_send_one_off_clears_session(
         "main.send_one_off",
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
-        _expected_status=302,
+        _expected_redirect=url_for(
+            "main.send_one_off_step",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            step_index=0,
+        ),
     )
 
     with client_request.session_transaction() as session:
@@ -4337,8 +4338,7 @@ def test_send_to_myself_sets_placeholder_and_redirects_for_email(
         "main.send_one_off_to_myself",
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
-        _expected_status=302,
-        _expected_url=url_for(
+        _expected_redirect=url_for(
             "main.send_one_off_step",
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
@@ -4363,7 +4363,7 @@ def test_send_to_myself_sets_placeholder_and_redirects_for_sms(
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
         _expected_status=302,
-        _expected_url=url_for(
+        _expected_redirect=url_for(
             "main.send_one_off_step",
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -55,11 +55,11 @@ def test_sign_out_user(
 def test_sign_out_of_two_sessions(client_request):
     client_request.get(
         "main.sign_out",
-        _expected_status=302,
+        _expected_redirect=url_for("main.index"),
     )
     with client_request.session_transaction() as session:
         assert not session
     client_request.get(
         "main.sign_out",
-        _expected_status=302,
+        _expected_redirect=url_for("main.index"),
     )

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -3016,6 +3016,15 @@ def test_should_redirect_to_one_off_if_template_type_is_letter(
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
         _expected_status=expected_status_code,
+        _expected_redirect=(
+            None
+            if expected_status_code == 200
+            else url_for(
+                "main.send_one_off",
+                service_id=SERVICE_ONE_ID,
+                template_id=fake_uuid,
+            )
+        ),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2983,6 +2983,9 @@ def client_request(request, _logged_in_client, mocker, service_one):  # noqa (C9
             if _expected_redirect and _expected_status == 200:
                 _expected_status = 302
 
+            if 300 <= _expected_status <= 399:
+                assert _expected_redirect, "You must specify a redirect URL, not just a status"
+
             assert resp.status_code == _expected_status, resp.location
 
             if _expected_redirect:


### PR DESCRIPTION
When a test asserts that a reponse produces a redirect it should check for both the correct status and the URL.

Checking for just the status (either by omission or by getting the argument name wrong) means that the redirect could change or break and the tests wouldn’t catch it.

We only need to explicitly check the status if it’s not `302`. By default the tests expect a status of `302` if a redirect URL is provided:
https://github.com/alphagov/notifications-admin/blob/e03f026dc4d1f5db011264665f0010d17a18e78e/tests/conftest.py#L2983-L2984