### PR TITLE
Show preferences on the platform admin page for a user

### DIFF
--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -63,14 +63,13 @@
       </nav>
 
       <h2 class="heading-medium">Authentication</h2>
-      <p class="govuk-body">{{ user.auth_type | format_auth_type }}</p>
+      <p class="govuk-body">Signs in with {{ user.auth_type | format_auth_type(with_indefinite_article=True) }}</p>
       {% if user.auth_type != 'webauthn_auth' %}
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.change_user_auth', user_id=user.id) }}">
           Change authentication for this user
         </a>
       {% endif %}
 
-      <h2 class="heading-medium">Last login</h2>
       {% if not user.logged_in_at %}
       <p class="hint">This person has never logged in</p>
       {% else %}
@@ -80,6 +79,15 @@
         </time>
       </p>
       {% endif %}
+
+      <h2 class="heading-medium">Preferences</h2>
+      <p class="govuk-body">
+        {{ "Wants" if user.receives_new_features_email else "Does not want"}} to receive new features email
+      </p>
+      <p class="govuk-body">
+        {{ "Wants" if user.take_part_in_research else "Does not want"}} to take part in user research
+      </p>
+
       {% if user.failed_login_count > 0 %}
       <p style="color:#d4351c;">
         {{ user.failed_login_count }} failed login attempts

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -43,8 +43,10 @@ def test_user_information_page_shows_information_about_user(
     assert [normalize_spaces(p.text) for p in page.select("main p")] == [
         "test@gov.uk",
         "+447700900986",
-        "Text message code",
+        "Signs in with a text message code",
         "Last logged in just now",
+        "Does not want to receive new features email",
+        "Does not want to take part in user research",
     ]
 
     assert "0 failed login attempts" not in page.text
@@ -54,7 +56,7 @@ def test_user_information_page_shows_information_about_user(
         "Live services",
         "Trial mode services",
         "Authentication",
-        "Last login",
+        "Preferences",
     ]
 
     assert [normalize_spaces(a.text) for a in page.select("main li a")] == [


### PR DESCRIPTION
Ia was thinking it would be useful to see this on user profiles in platform admin for recruitment reasons.

I rejigged some of the other info on the page so it fits in nicely.

Before | After 
---|---
<img width="685" alt="image" src="https://github.com/user-attachments/assets/62f9c77e-4bb7-416a-9e7c-65ca483e5789"> | <img width="685" alt="image" src="https://github.com/user-attachments/assets/985911db-baee-4394-8e3e-2f904a28f302">
