### PR TITLE
Bump utils to 82.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==8.0.1
 fido2==1.1.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
 
 govuk-frontend-jinja==3.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
 ## 82.4.0

* Add support for sending SMS to more international numbers. Sending to Eritrea, Wallis and Futuna, Niue, Kiribati, and Tokelau is now supported.

 ## 82.3.0
* Extends the validation logic for the `PhoneNumber` class to disallow premium rate numbers

 ## 82.2.1

* Add fix to recipient_validation/phone_number.py to raise correct error if a service tries to send to an international number without that permission

 ## 82.2.0
* Add `unsubscribe_link` argument to email templates

 ## 82.1.2
* Write updated version number to `requirements.txt` if no `requirements.in` file found

 ## 82.1.1
*  Fix the way we log the request_size. Accessing the data at this point can trigger a validation error early and cause a 500 error

 ## 82.1.0
*  Adds new logging fields to request logging. Namely environment_name, request_size and response_size