### PR TITLE
Enable Design System error-summary validation pattern on tour pages

### DIFF
--- a/app/main/views/tour.py
+++ b/app/main/views/tour.py
@@ -91,6 +91,7 @@ def tour_step(service_id, template_id, step_index):
         form=form,
         back_link=back_link,
         help="2",
+        error_summary_enabled=True,
     )
 
 

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -18,7 +18,7 @@
 
   {% call form_wrapper(
     class='js-stick-at-top-when-scrolling send-one-off-form' if template.template_type != 'sms' else 'send-one-off-form',
-    module="autofocus" if form.placeholder_value.label.text not in ['email address', 'phone number'] else None,
+    module="autofocus" if not form.errors else None,
     data_kwargs={'force-focus': True}
   ) %}
     <div class="govuk-grid-row">

--- a/tests/app/main/views/test_tour.py
+++ b/tests/app/main/views/test_tour.py
@@ -151,7 +151,7 @@ def test_should_show_empty_text_box(
 
     page = client_request.get("main.tour_step", service_id=SERVICE_ONE_ID, template_id=fake_uuid, step_index=1)
 
-    textbox = page.select_one("[data-notify-module=autofocus][data-force-focus=True] .govuk-input")
+    textbox = page.select_one("[data-notify-module=autofocus] .govuk-input")
     assert "value" not in textbox
     assert textbox["name"] == "placeholder_value"
     assert textbox["class"] == [
@@ -360,6 +360,9 @@ def test_post_tour_step_raises_validation_error_for_form_error(
         _data={"placeholder_value": ""},
         _expected_status=200,  # should this be 400
     )
+
+    error_summary = page.select_one(".govuk-error-summary")
+    assert "There is a problem" in error_summary.text
 
     assert normalize_spaces(page.select(".govuk-error-message")[0].text) == "Error: Cannot be empty"
 


### PR DESCRIPTION
Enable error-summary Design System validation pattern on tour pages to match the rest of the admin.

![Screenshot 2024-08-08 at 12 55 24](https://github.com/user-attachments/assets/a79da3b0-34fd-4a4f-93a6-b8981ce76307)

Fixes: https://trello.com/c/D5EEpWDV/689-tour-pages-validation-doesnt-have-meet-design-system-requirements

As field's auto focus interferes with the required error-summary autofocus logic was added to only autofucs when there's to form error.

Additionally, this also fixes the bug on one-off-send journey where autofocus should be set, but it isn't working

Before

![Screenshot 2024-08-08 at 12 44 47](https://github.com/user-attachments/assets/240f6ad5-1148-4c02-aca7-761684dcb596)
![Screenshot 2024-08-08 at 12 46 36](https://github.com/user-attachments/assets/53440ab8-6ea3-4110-b0ce-b33591f9ea98)

After

![Screenshot 2024-08-08 at 12 43 10](https://github.com/user-attachments/assets/a918458b-6d0f-4317-aec6-79e9f2d1763e)
![Screenshot 2024-08-08 at 12 43 17](https://github.com/user-attachments/assets/9d9e6d4a-e9ea-4726-af28-7e22373e4852)
