### PR TITLE
Fix timestamps when batching unsubscribe request report

### DIFF
--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -77,18 +77,12 @@ def download_unsubscribe_request_report(service_id, batch_id=None):
 @main.route("/services/<uuid:service_id>/unsubscribe-requests/reports/batch-report")
 @user_has_permissions("view_activity")
 def create_unsubscribe_request_report(service_id):
-    unbatched_report = current_service.unsubscribe_request_reports_summary.get_unbatched_report()
-    unbatched_report_data = {
-        "count": unbatched_report.count,
-        "earliest_timestamp": unbatched_report.earliest_timestamp.isoformat(),
-        "latest_timestamp": unbatched_report.latest_timestamp.isoformat(),
-    }
-    created_report_data = service_api_client.create_unsubscribe_request_report(service_id, unbatched_report_data)
+    created_report_id = current_service.unsubscribe_request_reports_summary.batch_unbatched(service_id)
     return redirect(
         url_for(
             "main.unsubscribe_request_report",
             service_id=service_id,
-            batch_id=created_report_data["report_id"],
+            batch_id=created_report_id,
             force_download="true",
         )
     )

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -80,8 +80,8 @@ def create_unsubscribe_request_report(service_id):
     unbatched_report = current_service.unsubscribe_request_reports_summary.get_unbatched_report()
     unbatched_report_data = {
         "count": unbatched_report.count,
-        "earliest_timestamp": unbatched_report.earliest_timestamp,
-        "latest_timestamp": unbatched_report.latest_timestamp,
+        "earliest_timestamp": unbatched_report.earliest_timestamp.isoformat(),
+        "latest_timestamp": unbatched_report.latest_timestamp.isoformat(),
     }
     created_report_data = service_api_client.create_unsubscribe_request_report(service_id, unbatched_report_data)
     return redirect(

--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -82,7 +82,6 @@ def create_unsubscribe_request_report(service_id):
         "count": unbatched_report.count,
         "earliest_timestamp": unbatched_report.earliest_timestamp,
         "latest_timestamp": unbatched_report.latest_timestamp,
-        "processed_by_service_at": unbatched_report.processed_by_service_at,
     }
     created_report_data = service_api_client.create_unsubscribe_request_report(service_id, unbatched_report_data)
     return redirect(

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -125,3 +125,15 @@ class UnsubscribeRequestsReports(ModelList):
             if not report.is_a_batched_report:
                 return report
         abort(404)
+
+    def batch_unbatched(self, service_id):
+        unbatched = self.get_unbatched_report()
+        created = service_api_client.create_unsubscribe_request_report(
+            service_id,
+            {
+                "count": unbatched.count,
+                "earliest_timestamp": unbatched.earliest_timestamp.isoformat(),
+                "latest_timestamp": unbatched.latest_timestamp.isoformat(),
+            },
+        )
+        return created["report_id"]

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -6,6 +6,7 @@ from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 from app.formatters import format_date_human, format_datetime_human
 from app.models import JSONModel, ModelList
 from app.notify_client.service_api_client import service_api_client
+from app.utils.time import to_utc_string
 
 
 class UnsubscribeRequestsReport(JSONModel):
@@ -132,8 +133,8 @@ class UnsubscribeRequestsReports(ModelList):
             service_id,
             {
                 "count": unbatched.count,
-                "earliest_timestamp": unbatched.earliest_timestamp.isoformat(),
-                "latest_timestamp": unbatched.latest_timestamp.isoformat(),
+                "earliest_timestamp": to_utc_string(unbatched.earliest_timestamp),
+                "latest_timestamp": to_utc_string(unbatched.latest_timestamp),
             },
         )
         return created["report_id"]

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -515,6 +515,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def get_unsubscribe_request_statistics(self, service_id):
         return self.get(f"service/{service_id}/unsubscribe-request-statistics")
 
+    @cache.delete("service-{service_id}-unsubscribe-request-reports-summary")
     def create_unsubscribe_request_report(self, service_id, data):
         return self.post(f"service/{service_id}/create-unsubscribe-request-report", data)
 

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -31,7 +31,7 @@
 
     <p class="govuk-body">You must: </p>
       <ol class="govuk-list govuk-list--number">
-        <li class="bottom-gutter"><a download href="{{ url_for('main.download_unsubscribe_request_report', service_id=current_service.id, batch_id=report.batch_id) }}" class="govuk-link heading-small">
+        <li class="bottom-gutter"><a href="{{ url_for('main.download_unsubscribe_request_report', service_id=current_service.id, batch_id=report.batch_id) }}" class="govuk-link heading-small">
             Download the report</a>&nbsp;<span id="unsubscribe_report_availability">
             (available until {{report.report_latest_download_date|format_date_normal}})</span></li>
         <li>Remove the email addresses from your mailing list before you send any further emails</li>

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -25,3 +25,8 @@ def percentage_through_current_financial_year():
 
 def is_less_than_days_ago(date_from_db, number_of_days):
     return (datetime.utcnow().astimezone(pytz.utc) - parser.parse(date_from_db)).days < number_of_days
+
+
+def to_utc_string(aware_datetime):
+    # Format matches app.utils.DATETIME_FORMAT in the API codebase
+    return aware_datetime.astimezone(pytz.utc).replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -467,7 +467,6 @@ def test_create_unsubscribe_request_report_creates_batched_report(client_request
             "count": 34,
             "earliest_timestamp": utc_string_to_aware_gmt_datetime("Thu, 18 Jul 2024 15:32:28 GMT"),
             "latest_timestamp": utc_string_to_aware_gmt_datetime("Sat, 20 Jul 2024 18:22:11 GMT"),
-            "processed_by_service_at": None,
         },
     )
 

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -224,11 +224,13 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
     unsubscribe_requests_count_text = page.select("#report-unsubscribe-requests-count")[0].text
     availability_date = page.select("#unsubscribe_report_availability")[0].text
     update_button = page.select("#process_unsubscribe_report")
-    assert page.select_one("li a[download]")["href"] == url_for(
+    download_link = page.select_one("main ol li a")
+    assert download_link["href"] == url_for(
         "main.download_unsubscribe_request_report",
         service_id=SERVICE_ONE_ID,
         batch_id=test_data[0]["batch_id"],
     )
+    assert normalize_spaces(download_link.text) == "Download the report"
     assert "disabled" not in checkbox
     assert normalize_spaces(checkbox_hint) == "I have unsubscribed these recipients from our mailing list"
     assert normalize_spaces(unsubscribe_requests_count_text) == "200 new requests to unsubscribe"
@@ -261,11 +263,13 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
     availability_date = page.select("#unsubscribe_report_availability")[0].text
     update_button = page.select("#process_unsubscribe_report")
     assert page.select("h1")[0].text == "22 June to yesterday"
-    assert page.select_one("li a[download]")["href"] == url_for(
+    download_link = page.select_one("main ol li a")
+    assert download_link["href"] == url_for(
         "main.download_unsubscribe_request_report",
         service_id=SERVICE_ONE_ID,
-        batch_id=None,
+        batch_id=test_data[0]["batch_id"],
     )
+    assert normalize_spaces(download_link.text) == "Download the report"
     assert "disabled" in checkbox
     assert normalize_spaces(checkbox_hint) == "You cannot do this until you’ve downloaded the report"
     assert normalize_spaces(unsubscribe_requests_count_text) == "34 new requests to unsubscribe"

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -1,7 +1,6 @@
 import pytest
 from flask import url_for
 from freezegun import freeze_time
-from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 
 from app import service_api_client
 from app.models.unsubscribe_requests_report import UnsubscribeRequestsReports
@@ -465,8 +464,8 @@ def test_create_unsubscribe_request_report_creates_batched_report(client_request
         SERVICE_ONE_ID,
         {
             "count": 34,
-            "earliest_timestamp": utc_string_to_aware_gmt_datetime("Thu, 18 Jul 2024 15:32:28 GMT"),
-            "latest_timestamp": utc_string_to_aware_gmt_datetime("Sat, 20 Jul 2024 18:22:11 GMT"),
+            "earliest_timestamp": "2024-07-18T16:32:28+01:00",
+            "latest_timestamp": "2024-07-20T19:22:11+01:00",
         },
     )
 

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -438,8 +438,8 @@ def test_create_unsubscribe_request_report_creates_batched_report(client_request
     summary_data = [
         {
             "count": 34,
-            "earliest_timestamp": "Thu, 18 Jul 2024 15:32:28 GMT",
-            "latest_timestamp": "Sat, 20 Jul 2024 18:22:11 GMT",
+            "earliest_timestamp": "2024-07-18T16:32:28.000000Z",
+            "latest_timestamp": "2024-07-20T19:22:11.000000Z",
             "processed_by_service_at": None,
             "batch_id": None,
             "is_a_batched_report": False,
@@ -464,8 +464,8 @@ def test_create_unsubscribe_request_report_creates_batched_report(client_request
         SERVICE_ONE_ID,
         {
             "count": 34,
-            "earliest_timestamp": "2024-07-18T16:32:28+01:00",
-            "latest_timestamp": "2024-07-20T19:22:11+01:00",
+            "earliest_timestamp": "2024-07-18T17:32:28+01:00",
+            "latest_timestamp": "2024-07-20T20:22:11+01:00",
         },
     )
 

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -468,8 +468,8 @@ def test_create_unsubscribe_request_report_creates_batched_report(client_request
         SERVICE_ONE_ID,
         {
             "count": 34,
-            "earliest_timestamp": "2024-07-18T17:32:28+01:00",
-            "latest_timestamp": "2024-07-20T20:22:11+01:00",
+            "earliest_timestamp": "2024-07-18T16:32:28.000000Z",
+            "latest_timestamp": "2024-07-20T19:22:11.000000Z",
         },
     )
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -595,3 +595,18 @@ def test_client_parsing_service_name_errors(err_data, expected_message):
     error_message = client.parse_edit_service_http_error(error)
 
     assert error_message == expected_message
+
+
+def test_deletes_unsubscribe_request_summary_when_batching(
+    notify_admin,
+    mock_get_user,
+    mocker,
+    fake_uuid,
+):
+    mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
+    mock_request = mocker.patch("notifications_python_client.base.BaseAPIClient.request")
+
+    service_api_client.create_unsubscribe_request_report(fake_uuid, data={})
+
+    mock_redis_delete.assert_called_with_subset_of_args(f"service-{fake_uuid}-unsubscribe-request-reports-summary")
+    assert len(mock_request.call_args_list) == 1


### PR DESCRIPTION
The API client was getting called with a `datetime` object here, which it can’t serialise to JSON. Instead, let’s serialise the `datetime` into the same string format as the API uses. This means the dates being passed between the apps aren’t ambiguous with respect to timezone.

Couple of other small cleanups in separate commits.