### PR TITLE
Change ‘Your profile’ to ‘Your account’

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -965,7 +965,7 @@ class PermissionsForm(StripWhitespaceForm):
                     {
                         "hint": {
                             "text": "Not available because this team member has not added a "
-                            "phone number to their profile"
+                            "phone number to their account"
                         },
                         "disabled": True,
                     },

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -175,7 +175,7 @@ class HeaderNavigation(Navigation):
             nav_items.append(
                 {
                     "href": url_for("main.user_profile"),
-                    "text": "Your profile",
+                    "text": "Your account",
                     "active": self.is_selected("user-profile"),
                 }
             )

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -2,12 +2,12 @@
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% block per_page_title %}
-  Your profile
+  Your account
 {% endblock %}
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Your profile</h1>
+  <h1 class="heading-large">Your account</h1>
 
   {% if can_see_edit %}
     {% set email_address_row =

--- a/tests/app/main/views/test_header_navigation.py
+++ b/tests/app/main/views/test_header_navigation.py
@@ -26,7 +26,7 @@ from tests.conftest import normalize_spaces
                 ("Features", ".guidance_features"),
                 ("Pricing", ".guidance_pricing"),
                 ("Using Notify", ".guidance_using_notify"),
-                ("Your profile", ".user_profile"),
+                ("Your account", ".user_profile"),
             ),
         ),
         (
@@ -38,7 +38,7 @@ from tests.conftest import normalize_spaces
                 ("Pricing", ".guidance_pricing"),
                 ("Using Notify", ".guidance_using_notify"),
                 ("Platform admin", ".platform_admin_search"),
-                ("Your profile", ".user_profile"),
+                ("Your account", ".user_profile"),
             ),
         ),
     ),


### PR DESCRIPTION
We use the terms ‘profile’ and ‘account’ inconsistently.

This PR replaces the less common ‘Your profile’ with ‘Your account’.

This is only a superficial change to the public-facing content. We still use ‘profile’ a lot in the code. And it looks like we use ‘account’ to mean ‘service’ in the code too. We’ll need to tackle this as part of our attempts to be clear and consistent about the meaning of ‘account’ and ‘service’.