### PR TITLE
Improve display of unsubscribe report status

### DIFF
--- a/app/templates/views/unsubscribe-request-reports-summary.html
+++ b/app/templates/views/unsubscribe-request-reports-summary.html
@@ -35,8 +35,10 @@
          {{ item.count|format_thousands}} {{ item.count | message_count_label('unsubscribe request', suffix='') }}
          </p>
     {% endcall %}
-    {% call field(align='right') %}
+    {% call field(align='right', status='' if item.is_a_batched_report else 'default') %}
+      <span class="align-with-message-body">
         {{ item.status}}
+      </span>
     {% endcall %}
   {% endcall %}
 </div>


### PR DESCRIPTION
This makes the status align to the bottom of the row, same way we do on the received text messages page (this means that the baseline of the small text lines up which is neater).

It also makes the status grey if the report is not downloaded, which feels right as this is an indeterminate state, like ‘sending’ is when sending a message.

# Before

<img width="755" alt="image" src="https://github.com/user-attachments/assets/f8f0190d-3cfb-4901-b36f-bead82791263">

# After 

<img width="759" alt="image" src="https://github.com/user-attachments/assets/8c4b6c6c-8ff3-440c-b113-398f33ae739b">
