### PR TITLE
Fix unsubscribe request count singular or plural content

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -377,8 +377,8 @@ def message_count_noun(count, message_type):
     if message_type == "letter":
         return "letter" if singular else "letters"
 
-    if message_type == "unsubscribe request":
-        return "unsubscribe request" if singular else "unsubscribe requests"
+    if message_type and message_type.endswith("request"):
+        return message_type if singular else message_type + "s"
 
     return "message" if singular else "messages"
 

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -26,7 +26,7 @@
 
 {% if not report.completed %}
     <p class="govuk-body" id="report-unsubscribe-requests-count">
-     {{ report.count|format_thousands}} new requests to unsubscribe
+     {{ report.count|format_thousands}} new {{ report.count | message_count_label('request', suffix='') }} to unsubscribe
     </p>
 
     <p class="govuk-body">You must: </p>

--- a/tests/app/test_formatters.py
+++ b/tests/app/test_formatters.py
@@ -1,4 +1,4 @@
-from app.formatters import sentence_case
+from app.formatters import message_count_label, sentence_case
 
 
 def test_sentence_case():
@@ -7,3 +7,10 @@ def test_sentence_case():
         sentence_case("mobile number 2 does not look like a UK mobile number")
         == "Mobile number 2 does not look like a UK mobile number"
     )
+
+
+def test_message_count_label_for_unsubscribe_requests():
+    assert message_count_label(count=1, message_type="unsubscribe request", suffix="") == "unsubscribe request"
+    assert message_count_label(count=2, message_type="unsubscribe request", suffix="") == "unsubscribe requests"
+    assert message_count_label(count=1, message_type="request", suffix="") == "request"
+    assert message_count_label(count=2, message_type="request", suffix="") == "requests"


### PR DESCRIPTION
Presently the content of an individual unsubscribe request report page does not make a distinction between single or  multiple requests ie the message for a single request is "1 new requests to unsubscribe".

This PR corrects this issue:

**before:**
<img width="1173" alt="Screenshot 2024-08-12 at 12 40 11" src="https://github.com/user-attachments/assets/e703838b-92aa-4fcc-9ed0-a95e71ade92d">

**after**
<img width="1125" alt="Screenshot 2024-08-12 at 16 54 02" src="https://github.com/user-attachments/assets/bf5ade1c-725b-4e69-b621-65dc6a6f0740">
