### PR TITLE
Use older_than to paginate notifications CSV report that services download

### DIFF
--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -8,6 +8,8 @@ class NotificationApiClient(NotifyAdminAPIClient):
         job_id=None,
         template_type=None,
         status=None,
+        paginate_by_older_than=None,
+        older_than=None,
         page=None,
         page_size=None,
         count_pages=None,
@@ -19,6 +21,8 @@ class NotificationApiClient(NotifyAdminAPIClient):
         include_one_off=None,
     ):
         params = {
+            "paginate_by_older_than": paginate_by_older_than,
+            "older_than": older_than,
             "page": page,
             "page_size": page_size,
             "template_type": template_type,

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -11,6 +11,13 @@ from tests import notification_json, single_notification_json
     [
         ({}, {"url": "/service/abcd1234/notifications", "params": {}}),
         ({"page": 99}, {"url": "/service/abcd1234/notifications", "params": {"page": 99}}),
+        (
+            {"page": 99, "paginate_by_older_than": True, "older_than": "5678"},
+            {
+                "url": "/service/abcd1234/notifications",
+                "params": {"page": 99, "paginate_by_older_than": True, "older_than": "5678"},
+            },
+        ),
         ({"include_jobs": False}, {"url": "/service/abcd1234/notifications", "params": {"include_jobs": False}}),
         (
             {"include_from_test_key": True},


### PR DESCRIPTION
Paginating by page numbers made us use offset, which makes large queries quite expensive: https://use-the-index-luke.com/no-offset

This caused issues for notifications CSV reports that services can download. If a service has sent many notifications, the report will be very big - even above 1,000,000 rows.

To prevent it, for this use case we will use older_than parameter to paginate instead - that is - we get our notifications sorted by created_at date. So if we set older_than parameter to the id of the oldest notification in a current page/batch, we know where to start our next batch without using the inefficient offset mechanism.

We still track pages numbers for now - this helps with quick implementation, but we should look at removing them as a refactor in the next PR.

==========

Only merge this PR after API PR is deployed: https://github.com/alphagov/notifications-api/pull/4159