### PR TITLE
Sms to landline validation one shot and csv flows

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -82,7 +82,9 @@ from app.main.validators import (
     StringsNotAllowed,
     ValidEmail,
     ValidGovEmail,
+    ValidInternationalOrUKLandline,
     ValidInternationalPhoneNumber,
+    ValidUKLandlineNumber,
     ValidUKMobileNumber,
 )
 from app.models.branding import (
@@ -244,8 +246,18 @@ def uk_mobile_number(label="Mobile number"):
     return PhoneNumber(label, validators=[DataRequired(message="Cannot be empty"), ValidUKMobileNumber()])
 
 
+def uk_landline_number(label="Mobile number"):
+    return PhoneNumber(label, validators=[NotifyDataRequired(thing="a mobile number"), ValidUKLandlineNumber()])
+
+
 def international_phone_number(label="Mobile number"):
     return PhoneNumber(label, validators=[NotifyDataRequired(thing="a mobile number"), ValidInternationalPhoneNumber()])
+
+
+def international_or_uk_landline_number(label="Mobile number"):
+    return PhoneNumber(
+        label, validators=[NotifyDataRequired(thing="a mobile number"), ValidInternationalOrUKLandline()]
+    )
 
 
 def make_password_field(label="Password", thing="a password", validate_length=True):
@@ -2264,12 +2276,18 @@ def get_placeholder_form_instance(
     dict_to_populate_from,
     template_type,
     allow_international_phone_numbers=False,
+    sms_to_uk_landline=False,
 ):
     if InsensitiveDict.make_key(placeholder_name) == "emailaddress" and template_type == "email":
         field = make_email_address_field(label=placeholder_name, gov_user=False, thing="an email address")
     elif InsensitiveDict.make_key(placeholder_name) == "phonenumber" and template_type == "sms":
-        if allow_international_phone_numbers:
+        if sms_to_uk_landline & allow_international_phone_numbers:
+            field = international_or_uk_landline_number(label=placeholder_name)
+        elif sms_to_uk_landline:
+            field = uk_landline_number(label=placeholder_name)
+        elif allow_international_phone_numbers:
             field = international_phone_number(label=placeholder_name)
+
         else:
             field = uk_mobile_number(label=placeholder_name)
     else:

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -243,14 +243,20 @@ def valid_phone_number(label="Mobile number", international=False, sms_to_uk_lan
     if not (sms_to_uk_landline or international):
         return PhoneNumber(
             label,
-            validators=[DataRequired(message="Cannot be empty"), ValidPhoneNumber(is_international=international)],
+            validators=[
+                DataRequired(message="Cannot be empty"),
+                ValidPhoneNumber(allow_international_sms=international),
+            ],
         )
     else:
         return PhoneNumber(
             label,
             validators=[
                 NotifyDataRequired(thing="a mobile number"),
-                ValidPhoneNumber(sms_to_landline=sms_to_uk_landline, is_international=international),
+                ValidPhoneNumber(
+                    allow_sms_to_uk_landlines=sms_to_uk_landline,
+                    allow_international_sms=international,
+                ),
             ],
         )
 
@@ -606,7 +612,7 @@ class RegisterUserFromInviteForm(RegisterUserForm):
             name=guess_name_from_email_address(invited_user.email_address),
         )
 
-    mobile_number = PhoneNumber("Mobile number", validators=[ValidPhoneNumber(is_international=True)])
+    mobile_number = PhoneNumber("Mobile number", validators=[ValidPhoneNumber(allow_international_sms=True)])
     service = HiddenField("service")
     email_address = HiddenField("email_address")
     auth_type = HiddenField("auth_type", validators=[DataRequired()])
@@ -627,7 +633,10 @@ class RegisterUserFromOrgInviteForm(StripWhitespaceForm):
 
     mobile_number = PhoneNumber(
         "Mobile number",
-        validators=[NotifyDataRequired(thing="your mobile number"), ValidPhoneNumber(is_international=True)],
+        validators=[
+            NotifyDataRequired(thing="your mobile number"),
+            ValidPhoneNumber(allow_international_sms=True),
+        ],
     )
     password = make_password_field(thing="your password")
     organisation = HiddenField("organisation")
@@ -2170,7 +2179,7 @@ class GuestList(StripWhitespaceForm):
     )
 
     phone_numbers = ListEntryFieldList(
-        PhoneNumberInGuestList("", validators=[Optional(), ValidPhoneNumber(is_international=True)], default=""),
+        PhoneNumberInGuestList("", validators=[Optional(), ValidPhoneNumber(allow_international_sms=True)], default=""),
         min_entries=5,
         max_entries=5,
         label="Mobile numbers",

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -82,9 +82,14 @@ class ValidEmail:
 
 
 class ValidPhoneNumber:
-    def __init__(self, is_international=False, sms_to_landline=False, message=None):
-        self.is_international = is_international
-        self.sms_to_landline = sms_to_landline
+    def __init__(
+        self,
+        allow_international_sms=False,
+        allow_sms_to_uk_landlines=False,
+        message=None,
+    ):
+        self.allow_international_sms = allow_international_sms
+        self.allow_sms_to_uk_landlines = allow_sms_to_uk_landlines
         self.message = message
 
     _error_summary_messages_map = {
@@ -98,11 +103,10 @@ class ValidPhoneNumber:
     def __call__(self, form, field):
         try:
             if field.data:
-                if self.sms_to_landline:
-                    PhoneNumber(field.data, allow_international=self.is_international)
+                if self.allow_sms_to_uk_landlines:
+                    PhoneNumber(field.data, allow_international=self.allow_international_sms)
                 else:
-                    validate_phone_number(field.data, international=self.is_international)
-                    # PhoneNumber(field.data, allow_international=self.is_international)
+                    validate_phone_number(field.data, international=self.allow_international_sms)
         except InvalidPhoneError as e:
             error_message = str(e)
             if hasattr(field, "error_summary_messages"):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -82,9 +82,10 @@ class ValidEmail:
 
 
 class ValidPhoneNumber:
-    is_international = False
-    sms_to_landline = False
-    message = None
+    def __init__(self, is_international=False, sms_to_landline=False, message=None):
+        self.is_international = is_international
+        self.sms_to_landline = sms_to_landline
+        self.message = message
 
     _error_summary_messages_map = {
         InvalidPhoneError.Codes.TOO_SHORT: "%s is too short",
@@ -110,23 +111,6 @@ class ValidPhoneNumber:
                 field.error_summary_messages.append(error_summary_message)
 
             raise ValidationError(error_message) from e
-
-
-class ValidUKMobileNumber(ValidPhoneNumber):
-    pass
-
-
-class ValidUKLandlineNumber(ValidPhoneNumber):
-    sms_to_landline = True
-
-
-class ValidInternationalPhoneNumber(ValidPhoneNumber):
-    is_international = True
-
-
-class ValidInternationalOrUKLandline(ValidPhoneNumber):
-    is_international = True
-    sms_to_landline = True
 
 
 class NoCommasInPlaceHolders:

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -454,7 +454,7 @@ def send_one_off_step(service_id, template_id, step_index):  # noqa: C901
         dict_to_populate_from=get_normalised_placeholders_from_session(),
         template_type=template.template_type,
         allow_international_phone_numbers=current_service.has_permission("international_sms"),
-        sms_to_uk_landline=current_service.has_permission("sms_to_uk_landlines"),
+        allow_sms_to_uk_landline=current_service.has_permission("sms_to_uk_landlines"),
     )
 
     template.values = template_values

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -449,12 +449,12 @@ def send_one_off_step(service_id, template_id, step_index):  # noqa: C901
                     step_index=step_index + 1,
                 )
             )
-
     form = get_placeholder_form_instance(
         current_placeholder,
         dict_to_populate_from=get_normalised_placeholders_from_session(),
         template_type=template.template_type,
         allow_international_phone_numbers=current_service.has_permission("international_sms"),
+        sms_to_uk_landline=current_service.has_permission("sms_to_uk_landlines"),
     )
 
     template.values = template_values
@@ -616,6 +616,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row):
         ),
         remaining_messages=remaining_messages,
         allow_international_sms=current_service.has_permission("international_sms"),
+        sms_to_uk_landlines=current_service.has_permission("sms_to_uk_landlines"),
         allow_international_letters=current_service.has_permission("international_letters"),
     )
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -616,7 +616,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row):
         ),
         remaining_messages=remaining_messages,
         allow_international_sms=current_service.has_permission("international_sms"),
-        sms_to_uk_landlines=current_service.has_permission("sms_to_uk_landlines"),
+        allow_sms_to_uk_landline=current_service.has_permission("sms_to_uk_landlines"),
         allow_international_letters=current_service.has_permission("international_letters"),
     )
 

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==8.0.1
 fido2==1.1.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.5.0
 
 govuk-frontend-jinja==3.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.5.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/tests/app/main/forms/test_placeholder_form.py
+++ b/tests/app/main/forms/test_placeholder_form.py
@@ -71,7 +71,6 @@ def test_validates_recipients(
             template_type,
             allow_international_phone_numbers=service_can_send_international_sms,
         )
-
         if expected_error:
             assert not form.validate_on_submit()
             assert form.placeholder_value.errors[0] == expected_error

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -11,7 +11,7 @@ from app.main.validators import (
     OnlySMSCharacters,
     StringsNotAllowed,
     ValidGovEmail,
-    ValidUKMobileNumber,
+    ValidPhoneNumber,
 )
 
 
@@ -95,7 +95,7 @@ def test_uk_mobile_number_validation_messages_match(mocker):
         side_effect=InvalidPhoneError(code=InvalidPhoneError.Codes.UNKNOWN_CHARACTER),
     )
     with pytest.raises(ValidationError) as error:
-        ValidUKMobileNumber()(None, mock_field)
+        ValidPhoneNumber()(None, mock_field)
 
     assert str(error.value) == InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNKNOWN_CHARACTER]
     assert mock_field.error_summary_messages == ["%s can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"]


### PR DESCRIPTION
Adds support on admin for one shot and csv flows to send to UK landlines if the service has the sms_to_uk_landline permission enabled.