### PR TITLE
fix: manual csv download without row limit

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -11,3 +11,6 @@ QR_CODE_TOO_LONG = "qr-code-too-long"
 class LetterLanguageOptions(str, enum.Enum):
     english = "english"
     welsh_then_english = "welsh_then_english"
+
+
+MAX_NOTIFICATION_FOR_DOWNLOAD = 250000

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -192,6 +192,15 @@ def view_notifications(service_id, message_type=None):
 
     max_notifications_for_download = 250000
     can_download = notifications_count <= max_notifications_for_download
+    download_link = None
+
+    if can_download:
+        download_link = url_for(
+            ".download_notifications_csv",
+            service_id=current_service.id,
+            message_type=message_type,
+            status=request.args.get("status"),
+        )
 
     return render_template(
         "views/notifications.html",
@@ -215,12 +224,7 @@ def view_notifications(service_id, message_type=None):
             True: ["reference"],
             False: [],
         }.get(bool(current_service.api_keys)),
-        download_link=url_for(
-            ".download_notifications_csv",
-            service_id=current_service.id,
-            message_type=message_type,
-            status=request.args.get("status"),
-        ),
+        download_link=download_link,
         can_download=can_download,
     )
 

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -27,6 +27,7 @@ from app import (
     notification_api_client,
     service_api_client,
 )
+from app.constants import MAX_NOTIFICATION_FOR_DOWNLOAD
 from app.formatters import get_time_left, message_count_noun
 from app.main import json_updates, main
 from app.main.forms import SearchNotificationsForm
@@ -190,8 +191,7 @@ def view_notifications(service_id, message_type=None):
         partials_data["service_data_retention_days"],
     )
 
-    max_notifications_for_download = 250000
-    can_download = notifications_count <= max_notifications_for_download
+    can_download = notifications_count <= MAX_NOTIFICATION_FOR_DOWNLOAD
     download_link = None
 
     if can_download:

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -103,5 +103,15 @@ class NotificationApiClient(NotifyAdminAPIClient):
     def get_notification_count_for_job_id(self, *, service_id, job_id):
         return self.get(url=f"/service/{service_id}/job/{job_id}/notification_count")["count"]
 
+    def get_notifications_count_for_service(self, service_id, template_type, limit_days):
+        params = {
+            "template_type": template_type,
+            "limit_days": limit_days,
+        }
+
+        response = self.get(url=f"/service/{service_id}/notifications/count", params=params)
+
+        return response.get("notifications_sent_count")
+
 
 notification_api_client = NotificationApiClient()

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -68,9 +68,18 @@
 
   {% if current_user.has_permissions('view_activity') %}
     <p class="bottom-gutter">
-      <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
-      &emsp;
-      Data available for {{ partials.service_data_retention_days }} days
+        {% if can_download %}
+            <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">
+                Download this report (<abbr title="Comma separated values">CSV</abbr>)
+            </a>
+            &emsp;
+            Data available for {{ partials.service_data_retention_days }} days
+        {% else %}
+            <span>
+                To download your CSV report get in touch with
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">support</a>
+            </span>
+        {% endif %}
     </p>
   {% endif %}
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -72,14 +72,14 @@
             <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">
                 Download this report (<abbr title="Comma separated values">CSV</abbr>)
             </a>
-            &emsp;
-            Data available for {{ partials.service_data_retention_days }} days
+
         {% else %}
-            <span>
-                To download your CSV report get in touch with
-                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">support</a>
-            </span>
+            <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold" href="{{ url_for('main.feedback', ticket_type='ask-question-give-feedback') }}">
+                Contact support to download this report
+            </a>
         {% endif %}
+        &emsp;
+        Data available for {{ partials.service_data_retention_days }} days
     </p>
   {% endif %}
 

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -99,6 +99,7 @@ def test_can_show_notifications(
     mock_get_service_data_retention,
     mock_has_no_jobs,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     user,
     extra_args,
     expected_update_endpoint,
@@ -131,6 +132,7 @@ def test_can_show_notifications(
             page=page_argument,
             **extra_args,
         )
+
     first_row = page.select_one("tbody tr")
     assert normalize_spaces(first_row.select_one("a.file-list-filename.govuk-link").text) == (
         # Comes from
@@ -202,6 +204,7 @@ def test_can_show_notifications_if_data_retention_not_available(
     mock_get_service_statistics,
     mock_has_no_jobs,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
 ):
     page = client_request.get(
         "main.view_notifications",
@@ -259,6 +262,7 @@ def test_link_to_download_notifications(
     mock_get_service_data_retention,
     mock_has_no_jobs,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     user,
     query_parameters,
     expected_download_link,
@@ -309,6 +313,7 @@ def test_letters_with_status_virus_scan_failed_shows_a_failure_description(
     service_one,
     mock_get_service_statistics,
     mock_get_service_data_retention,
+    mock_get_notifications_count_for_service,
     mock_get_api_keys,
 ):
     notifications = create_notifications(
@@ -338,6 +343,7 @@ def test_should_not_show_preview_link_for_precompiled_letters_in_virus_states(
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     letter_status,
 ):
     notifications = create_notifications(
@@ -360,6 +366,7 @@ def test_shows_message_when_no_notifications(
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_notifications_with_no_notifications,
+    mock_get_notifications_count_for_service,
     mock_get_no_api_keys,
 ):
     page = client_request.get(
@@ -428,6 +435,7 @@ def test_search_recipient_form(
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     initial_query_arguments,
     form_post_data,
     expected_search_box_label,
@@ -475,6 +483,7 @@ def test_api_users_are_told_they_can_search_by_reference_when_service_has_api_ke
     mock_get_notifications,
     mock_get_service_statistics,
     mock_get_service_data_retention,
+    mock_get_notifications_count_for_service,
     message_type,
     expected_search_box_label,
     mock_get_api_keys,
@@ -503,6 +512,7 @@ def test_api_users_are_not_told_they_can_search_by_reference_when_service_has_no
     mock_get_notifications,
     mock_get_service_statistics,
     mock_get_service_data_retention,
+    mock_get_notifications_count_for_service,
     message_type,
     expected_search_box_label,
     mock_get_no_api_keys,
@@ -522,6 +532,7 @@ def test_should_show_notifications_for_a_service_with_next_previous(
     mock_get_notifications_with_previous_next,
     mock_get_service_statistics,
     mock_get_service_data_retention,
+    mock_get_notifications_count_for_service,
     mock_get_no_api_keys,
     mocker,
 ):
@@ -551,6 +562,7 @@ def test_doesnt_show_pagination_with_search_term(
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     mocker,
 ):
     page = client_request.post(
@@ -617,6 +629,7 @@ def test_html_contains_notification_id(
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     mocker,
 ):
     page = client_request.get(
@@ -636,6 +649,7 @@ def test_html_contains_links_for_failed_notifications(
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     mocker,
 ):
     notifications = create_notifications(status="technical-failure")
@@ -672,6 +686,7 @@ def test_redacts_templates_that_should_be_redacted(
     mock_get_service_data_retention,
     mock_get_no_api_keys,
     notification_type,
+    mock_get_notifications_count_for_service,
     expected_row_contents,
 ):
     notifications = create_notifications(
@@ -702,6 +717,7 @@ def test_big_numbers_dont_show_for_letters(
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     message_type,
     nav_visible,
 ):
@@ -751,6 +767,7 @@ def test_sending_status_hint_displays_correctly_on_notifications_page(
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     message_type,
     status,
     expected_hint_status,
@@ -779,6 +796,7 @@ def test_should_show_address_and_hint_for_letters(
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
     mocker,
     is_precompiled_letter,
     expected_address,

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -1,4 +1,5 @@
 import uuid
+from collections import namedtuple
 
 import pytest
 
@@ -149,3 +150,29 @@ def test_get_notification_count_for_job_id(mocker):
     mock_get.assert_called_once_with(
         url="/service/foo/job/bar/notification_count",
     )
+
+
+NotificationCountTestCase = namedtuple("NotificationCountTestCase", ["template_type", "limit_days", "expected_count"])
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        NotificationCountTestCase(template_type="sms", limit_days=7, expected_count=42),
+        NotificationCountTestCase(template_type="email", limit_days=30, expected_count=15),
+        NotificationCountTestCase(template_type="letter", limit_days=1, expected_count=0),
+    ],
+)
+def test_get_notifications_count_for_service(mocker, test_case):
+    mock_get = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.get")
+    mock_get.return_value = {"notifications_sent_count": test_case.expected_count}
+
+    result = NotificationApiClient().get_notifications_count_for_service(
+        service_id="foo", template_type=test_case.template_type, limit_days=test_case.limit_days
+    )
+
+    mock_get.assert_called_once_with(
+        url="/service/foo/notifications/count",
+        params={"template_type": test_case.template_type, "limit_days": test_case.limit_days},
+    )
+    assert result == test_case.expected_count

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4357,3 +4357,11 @@ def mock_onwards_request_headers(mocker):
     mock_gorh = mocker.patch("notifications_utils.request_helper.NotifyRequest.get_onwards_request_headers")
     mock_gorh.return_value = {"some-onwards": "request-headers"}
     return mock_gorh
+
+
+@pytest.fixture(scope="function")
+def mock_get_notifications_count_for_service(mocker):
+    return mocker.patch(
+        "app.notification_api_client.get_notifications_count_for_service",
+        return_value=100,
+    )


### PR DESCRIPTION
## PR Summary
- previously on notifications-api, an endpoint was created to count the notifications_sent by a service within its retention period
- here, this endpoint is used to check notifications_count does not exceed `max_notifications_for_download` which has been set to 250k
- if the number of notifications does exceed this value, we do not want to show the "Download your report" link anymore, instead a message for "Contact support to download this report" is presented which will direct the user to the "ask-question-give-feedback" page


**Default behaviour:**
<img width="595" alt="Screenshot 2024-08-16 at 15 00 42" src="https://github.com/user-attachments/assets/ac6a6d15-ff95-4f99-9b32-2be49a1ce63e">

**Removed button with message for contacting support**
<img width="611" alt="Screenshot 2024-08-19 at 16 40 04" src="https://github.com/user-attachments/assets/d416a53d-d0b6-4c1b-8bcf-31fed117b8d2">

## Related task 
[advise service users to use api instead of using admin page to download notifications if volume is very large](https://trello.com/c/VYDXkKxu/911-advise-service-users-to-use-api-instead-of-using-admin-page-to-download-notifications-if-volume-is-very-large)
