### PR TITLE
Fix nhs local agreement page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1187,6 +1187,7 @@ class AddNHSLocalOrganisationForm(StripWhitespaceForm):
 
     organisations = GovukRadiosField(
         "Which NHS Trust or Integrated Care Board do you work for?",
+        param_extensions={"fieldset": {"legend": {"classes": "govuk-visually-hidden"}}},
         thing="an NHS Trust or Integrated Care Board",
     )
 

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -115,7 +115,7 @@ def add_organisation_from_nhs_local_service(service_id):
         organisation_choices=[
             (organisation.id, organisation.name)
             for organisation in sorted(AllOrganisations())
-            if organisation.organisation_type == Organisation.TYPE_NHS_LOCAL
+            if organisation.organisation_type == Organisation.TYPE_NHS_LOCAL and organisation.active
         ]
     )
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -258,6 +258,7 @@ def test_nhs_local_can_create_own_organisations(
     mocker.patch(
         "app.models.organisation.AllOrganisations.client_method",
         return_value=[
+            organisation_json("t3", "Trust 3", active=False, organisation_type="nhs_local"),
             organisation_json("t2", "Trust 2", organisation_type="nhs_local"),
             organisation_json("t1", "Trust 1", organisation_type="nhs_local"),
             organisation_json("gp1", "GP 1", organisation_type="nhs_gp"),


### PR DESCRIPTION
Small fixes to the page where a user picks which organisation their local NHS services belongs to:

**Stop letting NHS local services select archived orgs**
NHS local services pick which NHS local organisation their service belongs to when signing the agreement. We shouldn't allow them to select archived organisations, so this removes them from the list they see.

**Hide legend on `AddNHSLocalOrganisationForm` form**
We had the form label appearing twice - once above the search box where we display it manually, and once below the search box when the form gets rendered. This hides the form legend so that we only show the text once - above the search box.

| Before      | After |
| ----------- | ----------- |
| <img width="884" alt="Screenshot 2024-08-22 at 15 24 15" src="https://github.com/user-attachments/assets/75e504fa-1738-4f9a-81ff-25beb5d4d67c"> | <img width="871" alt="Screenshot 2024-08-22 at 15 18 40" src="https://github.com/user-attachments/assets/5d17ea46-6af6-4db0-b8b7-45314d8db9c0"> |



