### PR TITLE
Remove use of `permission in current_service.permissions`

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -66,7 +66,6 @@ from app.s3_client.s3_letter_upload_client import (
 )
 from app.template_previews import TemplatePreview
 from app.utils import (
-    NOTIFICATION_TYPES,
     should_skip_template_page,
 )
 from app.utils.letters import (
@@ -165,7 +164,7 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
     )
 
     single_notification_channel = None
-    notification_channels = list(set(current_service.permissions).intersection(NOTIFICATION_TYPES))
+    notification_channels = current_service.available_template_types
     if len(notification_channels) == 1:
         single_notification_channel = notification_channels[0]
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -75,8 +75,12 @@ class Service(JSONModel):
         return cls(service_api_client.get_service(service_id)["data"])
 
     @property
-    def permissions(self):
+    def _permissions(self):
         return self._dict.get("permissions", self.TEMPLATE_TYPES)
+
+    @property
+    def permissions(self):
+        return self._permissions
 
     @property
     def billing_details(self):
@@ -107,7 +111,7 @@ class Service(JSONModel):
         )
 
     def force_permission(self, permission, on=False):
-        permissions, permission = set(self.permissions), {permission}
+        permissions, permission = set(self._permissions), {permission}
 
         return self.update_permissions(
             permissions | permission if on else permissions - permission,
@@ -127,7 +131,7 @@ class Service(JSONModel):
     def has_permission(self, permission):
         if permission not in self.ALL_PERMISSIONS:
             raise KeyError(f"{permission} is not a service permission")
-        return permission in self.permissions
+        return permission in self._permissions
 
     def get_page_of_jobs(self, page):
         return PaginatedJobs(self.id, page=page)
@@ -605,7 +609,7 @@ class Service(JSONModel):
 
     @property
     def sign_in_method(self) -> str:
-        if "email_auth" in self.permissions:
+        if "email_auth" in self._permissions:
             return SIGN_IN_METHOD_TEXT_OR_EMAIL
 
         return SIGN_IN_METHOD_TEXT

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -80,7 +80,7 @@ class Service(JSONModel):
 
     @property
     def permissions(self):
-        return self._permissions
+        raise NotImplementedError('Use Service.has_permission("…") instead')
 
     @property
     def billing_details(self):
@@ -609,7 +609,7 @@ class Service(JSONModel):
 
     @property
     def sign_in_method(self) -> str:
-        if "email_auth" in self._permissions:
+        if self.has_permission("email_auth"):
             return SIGN_IN_METHOD_TEXT_OR_EMAIL
 
         return SIGN_IN_METHOD_TEXT

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -60,7 +60,7 @@
 
 {% macro settings_row(if_has_permission='') -%}
   {% set parent_caller = caller %}
-  {% if if_has_permission in current_service.permissions %}
+  {% if current_service.has_permission(if_has_permission) %}
     {% call row() %}
       {{ parent_caller() }}
     {% endcall %}

--- a/app/templates/views/dashboard/write-first-messages.html
+++ b/app/templates/views/dashboard/write-first-messages.html
@@ -2,7 +2,7 @@
 
 <nav>
   <a class="govuk-link govuk-link--inverse pill-separate-item" href="{{ url_for('main.choose_template', service_id=current_service.id) }}">
-    {% if 'letter' in current_service.permissions %}
+    {% if current_service.has_permission('letter') %}
       Write an email, text message or letter
     {% else %}
       Write an email or text message

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -48,7 +48,7 @@
               "text": "Sign-in method"
             },
             "value": {
-              "text": ("Email link or text message code" if 'email_auth' in current_service.permissions else "Text message code")
+              "text": ("Email link or text message code" if current_service.has_permission("email_auth") else "Text message code")
             },
             "actions": {
               "items": [
@@ -107,7 +107,7 @@
             "text": "Send emails"
           },
           "value": {
-            "text": "On" if 'email' in current_service.permissions else "Off"
+            "text": "On" if current_service.has_permission("email") else "Off"
           },
           "actions": {
             "items": [
@@ -122,7 +122,7 @@
         }
       ]%}
 
-      {% if 'email' in current_service.permissions %}
+      {% if current_service.has_permission("email") %}
         {% set restricted_email_settings_rows = [
           {
             "key": {
@@ -232,7 +232,7 @@
             "text": "Send text messages"
           },
           "value": {
-            "text": "On" if 'sms' in current_service.permissions else "Off"
+            "text": "On" if current_service.has_permission("sms") else "Off"
           },
           "actions": {
             "items": [
@@ -251,7 +251,7 @@
         }
       ]%}
 
-      {% if 'sms' in current_service.permissions %}
+      {% if current_service.has_permission("sms") %}
         {% set restricted_text_message_settings_rows = [
           {
             "key": {
@@ -298,7 +298,7 @@
               "text": "Send international text messages"
             },
             "value": {
-              "text": "On" if 'international_sms' in current_service.permissions else "Off"
+              "text": "On" if current_service.has_permission("international_sms") else "Off"
             },
             "actions": {
               "items": [
@@ -317,7 +317,7 @@
               "text": "Receive text messages"
             },
             "value": {
-              "text": "On" if 'inbound_sms' in current_service.permissions else "Off"
+              "text": "On" if current_service.has_permission("inbound_sms") else "Off"
             },
             "actions": {
               "items": [
@@ -349,7 +349,7 @@
             "text": "Send letters"
           },
           "value": {
-            "text": "On" if 'letter' in current_service.permissions else "Off"
+            "text": "On" if current_service.has_permission("letter") else "Off"
           },
           "actions": {
             "items": [
@@ -368,7 +368,7 @@
         }
       ]%}
 
-      {% if 'letter' in current_service.permissions %}
+      {% if current_service.has_permission("letter") %}
 
         {% set sender_addresses_html %}
           {% if current_service.default_letter_contact_block %}

--- a/app/templates/views/service-settings/receive-text-messages.html
+++ b/app/templates/views/service-settings/receive-text-messages.html
@@ -19,7 +19,7 @@
     <div class="govuk-grid-column-five-sixths">
       {{ page_header('Receive text messages') }}
 
-      {% if 'inbound_sms' in current_service.permissions %}
+      {% if current_service.has_permission("inbound_sms") %}
         <p class="govuk-body">
           Your service will receive text messages sent to:
         </p>


### PR DESCRIPTION
In our code we use have 2 ways to determine whether a `Service` instance has a given permission:

1. `service.has_permission(permission)`
2. `permission in service.permissions`

This pull request settles on 1. as the canonical way of doing things because:
- it is already more common throughout the codebase
- it doesn’t rely on knowledge of the internals/type of the `permissions` field returned by the API

It means if we want to change how we check permissions in the future it will be an easier refactor<sup>1</sup>

*** 

1. I don’t actually think we need to do this. We already check that a given string is a valid permission anyway:
    https://github.com/alphagov/notifications-admin/blob/669f92fbe73cb3d8add73f66e32471094eb85406/app/models/service.py#L128-L129