### PR TITLE
Utils Bump to 86.2.0 - adding allow landline flag

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -103,7 +103,11 @@ class ValidPhoneNumber:
         try:
             if field.data:
                 if self.allow_sms_to_uk_landlines:
-                    PhoneNumber(field.data, allow_international=self.allow_international_sms)
+                    number = PhoneNumber(field.data)
+                    number.validate(
+                        allow_international_number=self.allow_international_sms,
+                        allow_uk_landline=self.allow_sms_to_uk_landlines,
+                    )
                 else:
                     validate_phone_number(field.data, international=self.allow_international_sms)
         except InvalidPhoneError as e:

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==8.0.1
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@85.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.2.0
 
 govuk-frontend-jinja==3.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@85.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.2.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@85.0.0
+# This file is automatically copied from notifications-utils@86.2.0
 
 beautifulsoup4==4.11.1
 pytest==7.2.0

--- a/tests/app/main/forms/test_placeholder_form.py
+++ b/tests/app/main/forms/test_placeholder_form.py
@@ -16,10 +16,11 @@ def test_form_class_not_mutated(notify_admin):
 
 
 @pytest.mark.parametrize(
-    "service_can_send_international_sms, placeholder_name, template_type, value, expected_error",
+    "service_can_send_international_sms, send_to_uk_landlines, placeholder_name, template_type, value, expected_error",
     [
-        (False, "email address", "email", "", "Enter an email address"),
+        (False, False, "email address", "email", "", "Enter an email address"),
         (
+            False,
             False,
             "email address",
             "email",
@@ -28,32 +29,35 @@ def test_form_class_not_mutated(notify_admin):
         ),
         (
             False,
+            False,
             "email address",
             "email",
             "“bad”@email-address.com",
             "Enter an email address in the correct format, like name@example.gov.uk",
         ),
-        (False, "email address", "email", "test@example.com", None),
-        (False, "email address", "email", "test@example.gov.uk", None),
-        (False, "phone number", "sms", "", "Cannot be empty"),
+        (False, False, "email address", "email", "test@example.com", None),
+        (False, False, "email address", "email", "test@example.gov.uk", None),
+        (False, False, "phone number", "sms", "", "Cannot be empty"),
         (
+            False,
             False,
             "phone number",
             "sms",
             "+1-2345-678890",
             "This does not look like a UK mobile number – double check the mobile number you entered",
         ),
-        (False, "phone number", "sms", "07900900123", None),
-        (False, "phone number", "sms", "+44(0)7900 900-123", None),
-        (True, "phone number", "sms", "+123", "Mobile number is too short"),
-        (True, "phone number", "sms", "+44(0)7900 900-123", None),
-        (True, "phone number", "sms", "+1-2345-678890", None),
-        (False, "anything else", "sms", "", "Cannot be empty"),
-        (False, "anything else", "email", "", "Cannot be empty"),
-        (True, "phone number", "sms", "invalid", "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"),
-        (True, "phone number", "email", "invalid", None),
-        (True, "phone number", "letter", "invalid", None),
-        (True, "email address", "sms", "invalid", None),
+        (False, False, "phone number", "sms", "07900900123", None),
+        (False, False, "phone number", "sms", "+44(0)7900 900-123", None),
+        (True, False, "phone number", "sms", "+123", "Mobile number is too short"),
+        (True, False, "phone number", "sms", "+44(0)7900 900-123", None),
+        (True, False, "phone number", "sms", "+1-2345-678890", None),
+        (False, False, "anything else", "sms", "", "Cannot be empty"),
+        (False, False, "anything else", "email", "", "Cannot be empty"),
+        (True, False, "phone number", "sms", "invalid", "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -"),
+        (True, False, "phone number", "email", "invalid", None),
+        (True, False, "phone number", "letter", "invalid", None),
+        (True, False, "email address", "sms", "invalid", None),
+        (False, True, "phone number", "sms", "02030024300", None),
     ],
 )
 def test_validates_recipients(
@@ -62,6 +66,7 @@ def test_validates_recipients(
     template_type,
     value,
     service_can_send_international_sms,
+    send_to_uk_landlines,
     expected_error,
 ):
     with notify_admin.test_request_context(method="POST", data={"placeholder_value": value}):
@@ -70,6 +75,7 @@ def test_validates_recipients(
             {},
             template_type,
             allow_international_phone_numbers=service_can_send_international_sms,
+            allow_sms_to_uk_landline=send_to_uk_landlines,
         )
         if expected_error:
             assert not form.validate_on_submit()


### PR DESCRIPTION
Updated phonenumber validation code to use allow_landline flag
In order to migrate phonenumber validation code to use the PhoneNumber utils class
    we need to support passing the SMS_TO_UK_LANDLINES permissions as an attribute to
    instances of the class so that it can correctly validate depending on the permissions
    service has. This is also required to fully migrate all phonenumebe validation logic
    away to PhoneNumber objects.