### PR TITLE
Ensure Zendesk tickets about phishing senders are not sent to users 

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -2,7 +2,6 @@ import re
 from abc import ABC, abstractmethod
 
 from flask import current_app, render_template
-from flask_login import current_user
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket, NotifyTicketType
 from notifications_utils.field import Field
 from notifications_utils.formatters import formatted_list
@@ -204,28 +203,12 @@ def create_phishing_senderid_zendesk_ticket(senderID=None):
         message=ticket_message,
         ticket_type=NotifySupportTicket.TYPE_TASK,
         notify_ticket_type=NotifyTicketType.TECHNICAL,
-        user_name=current_user.name,
-        user_email=current_user.email_address,
-        service_id=current_service.id,
         notify_task_type="notify_task_blocked_sender",
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 
 
 class IsNotAPotentiallyMaliciousSenderID:
-    potentially_malicious_sender_ids = [
-        "amazon",
-        "evri",
-        "lloydsbank",
-        "coinbase",
-        "fromnab",
-        "nab",
-        "hsbc",
-        "natwest",
-        "tsb",
-        "barclays",
-        "nationwide",
-    ]
 
     def __call__(self, form, field):
         if protected_sender_id_api_client.get_check_sender_id(sender_id=field.data):

--- a/app/templates/views/service-settings/sms-sender/add.html
+++ b/app/templates/views/service-settings/sms-sender/add.html
@@ -14,7 +14,7 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header(service_page_title) }}
+  {{ page_header('Add text message sender ID') }}
 
   {% call form_wrapper() %}
     {{ form.sms_sender(param_extensions={


### PR DESCRIPTION
Setting the user details when creating the creating a Zendesk ticket about potential phishing senders means that the ticket appears to come _from_ them and they also see the ticket. The ticket should be internal only, so this removes the user details from the ticket object. The user and user's service are still visible in the ticket note.

Also fixes the page heading:
**Before**
<img width="500" alt="Screenshot 2024-08-30 at 08 48 17" src="https://github.com/user-attachments/assets/736e0daa-6a80-4ad4-8f71-ffbd09ce78d2">


**After**
<img width="500" alt="Screenshot 2024-08-30 at 08 48 08" src="https://github.com/user-attachments/assets/01254ce8-9cae-4eb0-96b2-11189ec4fae2">
