### PR TITLE
Rejig dates for completed and deleted

### DIFF
--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -163,14 +163,14 @@ $govuk-touch-target-size: ($govuk-checkboxes-size + $govuk-touch-target-gutter);
 
 .govuk-checkboxes__item--single-with-hint {
 
-  margin-top: -10px;
+  margin-top: -1 * govuk-spacing(2);
 
   .govuk-checkboxes__label::before {
-    margin-top: 10px;
+    top: govuk-spacing(2) + 2px;  // 2px is existing top position
   }
 
   .govuk-checkboxes__label::after {
-    margin-top: 10px;
+    top: govuk-spacing(2) + 13px;  // 13px is existing top position
   }
 
 }

--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -136,7 +136,7 @@ $govuk-touch-target-size: ($govuk-checkboxes-size + $govuk-touch-target-gutter);
   display: inline-block;
   position: relative;
   margin-left: govuk-spacing(3);
-  
+
 
   // inner chevron arrow
   &::before {
@@ -159,4 +159,18 @@ $govuk-touch-target-size: ($govuk-checkboxes-size + $govuk-touch-target-gutter);
   &::before {
     transform:translateY(1px) rotate(225deg) scale(1);
   }
+}
+
+.govuk-checkboxes__item--single-with-hint {
+
+  margin-top: -10px;
+
+  .govuk-checkboxes__label::before {
+    margin-top: 10px;
+  }
+
+  .govuk-checkboxes__label::after {
+    margin-top: 10px;
+  }
+
 }

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2933,12 +2933,19 @@ class ProcessUnsubscribeRequestForm(StripWhitespaceForm):
                 "items": [
                     {
                         "hint": {"text": "I have unsubscribed these recipients from our mailing list"},
+                        "classes": "govuk-checkboxes__item--single-with-hint",
                     },
                 ]
             }
         else:
             self.report_has_been_processed.param_extensions = {
-                "items": [{"hint": {"text": "You cannot do this until you’ve downloaded the report"}, "disabled": True}]
+                "items": [
+                    {
+                        "hint": {"text": "You cannot do this until you’ve downloaded the report"},
+                        "disabled": True,
+                        "classes": "govuk-checkboxes__item--single-with-hint",
+                    },
+                ]
             }
 
     def validate_report_has_been_processed(self, field):

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from flask import abort
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
@@ -14,6 +14,7 @@ class UnsubscribeRequestsReport(JSONModel):
         "count",
         "batch_id",
         "is_a_batched_report",
+        "created_at",
     }
     __sort_attribute__ = "earliest_timestamp"
 
@@ -30,14 +31,9 @@ class UnsubscribeRequestsReport(JSONModel):
         return self.processed_by_service_at is not None
 
     @property
-    def report_latest_download_date(self):
-        if self.status == "Completed":
-            limit = 7
-            starting_date = self.processed_by_service_at
-        else:
-            limit = 90
-            starting_date = self.latest_timestamp
-        return starting_date + timedelta(days=limit)
+    def will_be_archived_at(self):
+        # Not all reports have a created_at date currently
+        return datetime.utcnow() + timedelta(days=7)
 
     @property
     def earliest_timestamp(self):

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timedelta
-
 from flask import abort
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 
@@ -14,7 +12,6 @@ class UnsubscribeRequestsReport(JSONModel):
         "count",
         "batch_id",
         "is_a_batched_report",
-        "created_at",
     }
     __sort_attribute__ = "earliest_timestamp"
 
@@ -32,8 +29,7 @@ class UnsubscribeRequestsReport(JSONModel):
 
     @property
     def will_be_archived_at(self):
-        # Not all reports have a created_at date currently
-        return datetime.utcnow() + timedelta(days=7)
+        return utc_string_to_aware_gmt_datetime(self._dict["will_be_archived_at"])
 
     @property
     def earliest_timestamp(self):

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -26,7 +26,7 @@
 
 {% if not report.completed %}
     <p class="govuk-body" id="report-unsubscribe-requests-count">
-     {{ report.count|format_thousands}} new {{ report.count | message_count_label('request', suffix='') }} to unsubscribe
+     {{ report.count|format_thousands}} new unsubscribe {{ report.count | message_count_label('request', suffix='') }}
     </p>
 
     <p class="govuk-body govuk-!-margin-bottom-2">You must: </p>

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -29,22 +29,24 @@
      {{ report.count|format_thousands}} new {{ report.count | message_count_label('request', suffix='') }} to unsubscribe
     </p>
 
-    <p class="govuk-body">You must: </p>
-      <ol class="govuk-list govuk-list--number">
+    <p class="govuk-body govuk-!-margin-bottom-2">You must: </p>
+      <ol class="govuk-list govuk-list--number govuk-!-margin-bottom-6">
         <li class="bottom-gutter"><a href="{{ url_for('main.download_unsubscribe_request_report', service_id=current_service.id, batch_id=report.batch_id) }}" class="govuk-link heading-small">
-            Download the report</a>&nbsp;<span id="unsubscribe_report_availability">
-            (available until {{report.report_latest_download_date|format_date_normal}})</span></li>
+            Download the report</a>
+        </li>
         <li>Remove the email addresses from your mailing list before you send any further emails</li>
       </ol>
 {%  else %}
-    <p class="govuk-body" id="completed_unsubscribe_report_main_text"> Report was marked as completed on {{ report.processed_by_service_at | format_date_normal }}</p>
+    <p class="govuk-body" id="report-unsubscribe-requests-count">
+        {{ report.count|format_thousands}} unsubscribe {{ report.count | message_count_label('request', suffix='') }}
+    </p>
     <p class="bottom-gutter"><a download href="{{ url_for('main.download_unsubscribe_request_report', service_id=current_service.id, batch_id=report.batch_id) }}" class="govuk-link heading-small" >
-        Download the report</a>&nbsp;<span id="completed_unsubscribe_report_availability">
-        (available until {{report.report_latest_download_date|format_date_normal}})</span> </p>
+        Download the report</a>
+    </p>
 
  {% endif %}
 
-{% call form_wrapper() %}
+{% call form_wrapper(class="govuk-!-margin-bottom-6") %}
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     {{ form.report_has_been_processed }}
     {% if report.is_a_batched_report %}
@@ -52,6 +54,19 @@
     {% endif %}
 
 {% endcall %}
-
+<div id="unsubscribe_report_availability">
+    {% if report.is_a_batched_report %}
+        This <span id="unsubscribe_report_availability">
+            report will be deleted in {{ report.will_be_archived_at|format_delta_days}}.
+        </span>
+    {% else %}
+        <p class="govuk-body">
+            Once downloaded, reports are available for 7 days.
+        </p>
+        <p class="govuk-body">
+            Requests which have not been downloaded will be deleted after 90 days.
+        </p>
+    {% endif %}
+</div>
 
 {% endblock %}

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -256,7 +256,7 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
     assert normalize_spaces(download_link.text) == "Download the report"
     assert "disabled" not in checkbox
     assert normalize_spaces(checkbox_hint) == "I have unsubscribed these recipients from our mailing list"
-    assert normalize_spaces(unsubscribe_requests_count_text) == "200 new requests to unsubscribe"
+    assert normalize_spaces(unsubscribe_requests_count_text) == "200 new unsubscribe requests"
     assert len(update_button) == 1
     assert normalize_spaces(availability_date) == "This report will be deleted in 7 days from now."
 
@@ -295,7 +295,7 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
     assert normalize_spaces(download_link.text) == "Download the report"
     assert "disabled" in checkbox
     assert normalize_spaces(checkbox_hint) == "You cannot do this until you’ve downloaded the report"
-    assert normalize_spaces(unsubscribe_requests_count_text) == "34 new requests to unsubscribe"
+    assert normalize_spaces(unsubscribe_requests_count_text) == "34 new unsubscribe requests"
     assert normalize_spaces(availability_date) == (
         "Once downloaded, reports are available for 7 days. "
         "Requests which have not been downloaded will be deleted after 90 days."

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -258,7 +258,7 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
     assert normalize_spaces(checkbox_hint) == "I have unsubscribed these recipients from our mailing list"
     assert normalize_spaces(unsubscribe_requests_count_text) == "200 new requests to unsubscribe"
     assert len(update_button) == 1
-    assert normalize_spaces(availability_date) == "(available until 19 September 2024)"
+    assert normalize_spaces(availability_date) == "This report will be deleted in 7 days from now."
 
 
 @freeze_time("2024-07-02")
@@ -296,7 +296,10 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
     assert "disabled" in checkbox
     assert normalize_spaces(checkbox_hint) == "You cannot do this until you’ve downloaded the report"
     assert normalize_spaces(unsubscribe_requests_count_text) == "34 new requests to unsubscribe"
-    assert normalize_spaces(availability_date) == "(available until 29 September 2024)"
+    assert normalize_spaces(availability_date) == (
+        "Once downloaded, reports are available for 7 days. "
+        "Requests which have not been downloaded will be deleted after 90 days."
+    )
     assert len(update_button) == 0
 
 
@@ -321,8 +324,7 @@ def test_unsubscribe_request_report_for_processed_batched_reports(client_request
     assert page.select("h1")[0].text == "8 June 2023 to 14 June 2023"
     checkbox = page.select("#report_has_been_processed")[0].attrs
     checkbox_hint = page.select("#report_has_been_processed-item-hint")[0].text
-    main_body_text = page.select("#completed_unsubscribe_report_main_text")[0].text
-    availability_date = page.select("#completed_unsubscribe_report_availability")[0].text
+    availability_date = page.select("#unsubscribe_report_availability")[0].text
     "completed_unsubscribe_report_main_text"
     update_button = page.select("#process_unsubscribe_report")
     assert page.select_one("p a[download]")["href"] == url_for(
@@ -333,8 +335,7 @@ def test_unsubscribe_request_report_for_processed_batched_reports(client_request
     assert "disabled" not in checkbox
     assert "checked" in checkbox
     assert normalize_spaces(checkbox_hint) == "I have unsubscribed these recipients from our mailing list"
-    assert normalize_spaces(main_body_text) == "Report was marked as completed on 10 June 2024"
-    assert normalize_spaces(availability_date) == "(available until 17 June 2024)"
+    assert normalize_spaces(availability_date) == "This report will be deleted in 7 days from now."
     assert len(update_button) == 1
 
 

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -221,7 +221,7 @@ def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocke
     ]
 
 
-@freeze_time("2024-06-22")
+@freeze_time("2024-06-22 12:00")
 def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_request, mocker):
     test_data = [
         {
@@ -231,6 +231,7 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
             "processed_by_service_at": None,
             "batch_id": "a8a526f9-84be-44a6-b751-62c95c4b9329",
             "is_a_batched_report": True,
+            "will_be_archived_at": "2024-06-29 23:59",
         }
     ]
 
@@ -313,6 +314,7 @@ def test_unsubscribe_request_report_for_processed_batched_reports(client_request
             "processed_by_service_at": "2024-06-10",
             "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
             "is_a_batched_report": True,
+            "will_be_archived_at": "2024-01-08 23:00",
         },
     ]
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
@@ -355,6 +357,7 @@ def test_unsubscribe_request_report_with_forced_download(
                 "processed_by_service_at": None,
                 "batch_id": fake_uuid,
                 "is_a_batched_report": True,
+                "will_be_archived_at": "2024-01-08 23:00",
             },
         ],
     )


### PR DESCRIPTION
Makes it so the information about how long the report is available for:
- matches the [updated retention policy](https://github.com/alphagov/notifications-api/pull/4167#issuecomment-2324372565)
- is relative (for example _3 days_ not _18 October 2024_), like we do elsewhere 
- is consistently in the same place on the page 

Before | After
---|---
<img width="767" alt="image" src="https://github.com/user-attachments/assets/bc070f8a-5902-4d83-89b7-24152b4c6f99"> | <img width="769" alt="image" src="https://github.com/user-attachments/assets/a9709ebc-40aa-40b7-b8bd-bd1ab2647726">
<img width="767" alt="image" src="https://github.com/user-attachments/assets/d8d6e43b-dfe8-4555-b952-aa3a2a5b5e15"> | <img width="775" alt="image" src="https://github.com/user-attachments/assets/40825e21-7d1a-4dc5-9144-5654dca650f9">
<img width="760" alt="image" src="https://github.com/user-attachments/assets/f8a243a0-bebb-46d8-9cd2-64d67d3a7946"> | <img width="759" alt="image" src="https://github.com/user-attachments/assets/b1414a14-645a-42d1-b2b0-b196cf899e6e">

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/4167