### PR TITLE
Change port mapping to use the loopback address

### DIFF
--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -28,7 +28,7 @@ docker run -it --rm \
   -e SENTRY_ERRORS_SAMPLE_RATE=${SENTRY_ERRORS_SAMPLE_RATE:-} \
   -e SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE:-} \
   -e PORT=6012 \
-  -p 6012:6012 \
+  -p 127.0.0.1:6012:6012 \
   -v $(pwd):/home/vcap/app \
   ${DOCKER_ARGS} \
   ${DOCKER_IMAGE_NAME} \


### PR DESCRIPTION
Docker defaults to using `0.0.0.0`, the default route listening on all network interfaces, as opposed to the loopback address (`127.0.0.1`). This has security implications and we have been asked to change it.