### PR TITLE
API clients: make thread-local, allowing use of persistent requests sessions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -128,6 +128,7 @@ from app.notify_client.upload_api_client import upload_api_client  # noqa
 from app.notify_client.user_api_client import user_api_client  # noqa
 from app.notify_session import NotifyAdminSessionInterface
 from app.s3_client.logo_client import logo_client
+from app.template_previews import template_preview_client  # noqa
 from app.url_converters import (
     AgreementTypeConverter,
     BrandingTypeConverter,

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,7 +1,33 @@
+from contextvars import ContextVar
+
+from flask import current_app
 from notifications_utils.clients.antivirus.antivirus_client import AntivirusClient
 from notifications_utils.clients.redis.redis_client import RedisClient
 from notifications_utils.clients.zendesk.zendesk_client import ZendeskClient
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
 
-antivirus_client = AntivirusClient()
-zendesk_client = ZendeskClient()
+from app import memo_resetters
+
+_antivirus_client_context_var: ContextVar[AntivirusClient] = ContextVar("antivirus_client")
+get_antivirus_client: LazyLocalGetter[AntivirusClient] = LazyLocalGetter(
+    _antivirus_client_context_var,
+    lambda: AntivirusClient(
+        api_host=current_app.config["ANTIVIRUS_API_HOST"],
+        auth_token=current_app.config["ANTIVIRUS_API_KEY"],
+    ),
+)
+memo_resetters.append(lambda: get_antivirus_client.clear())
+antivirus_client = LocalProxy(get_antivirus_client)
+
+_zendesk_client_context_var: ContextVar[ZendeskClient] = ContextVar("zendesk_client")
+get_zendesk_client: LazyLocalGetter[ZendeskClient] = LazyLocalGetter(
+    _zendesk_client_context_var,
+    lambda: ZendeskClient(
+        api_key=current_app.config["ZENDESK_API_KEY"],
+    ),
+)
+memo_resetters.append(lambda: get_zendesk_client.clear())
+zendesk_client = LocalProxy(get_zendesk_client)
+
 redis_client = RedisClient()

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -30,10 +30,10 @@ from app import (
     format_date_numeric,
     job_api_client,
     notification_api_client,
+    template_preview_client,
 )
 from app.main import json_updates, main
 from app.notify_client.api_key_api_client import KEY_TYPE_TEST
-from app.template_previews import TemplatePreview
 from app.utils import (
     DELIVERED_STATUSES,
     FAILURE_STATUSES,
@@ -209,11 +209,12 @@ def get_preview_error_image():
 def view_letter_notification_as_preview(service_id, notification_id, filetype, with_metadata=False):
     notification = notification_api_client.get_notification(service_id, notification_id)
     if not notification["template"]["is_precompiled_letter"]:
-        return TemplatePreview.get_preview_for_templated_letter(
+        return template_preview_client.get_preview_for_templated_letter(
             db_template=notification["template"],
             filetype=filetype,
             values=notification["personalisation"],
             page=request.args.get("page"),
+            service=current_service,
         )
 
     image_data = get_letter_file_data(service_id, notification_id, filetype, with_metadata)

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -27,6 +27,7 @@ from app import (
     nl2br,
     notification_api_client,
     service_api_client,
+    template_preview_client,
 )
 from app.main import main, no_cookie
 from app.main.forms import (
@@ -44,7 +45,6 @@ from app.s3_client.s3_csv_client import (
     s3upload,
     set_metadata_on_csv_upload,
 )
-from app.template_previews import TemplatePreview
 from app.utils import PermanentRedirect, should_skip_template_page, unicode_truncate
 from app.utils.csv import Spreadsheet, get_errors_for_csv
 from app.utils.user import user_has_permissions
@@ -540,11 +540,12 @@ def send_test_preview(service_id, template_id, filetype):
         ),
     )
 
-    return TemplatePreview.get_preview_for_templated_letter(
+    return template_preview_client.get_preview_for_templated_letter(
         db_template=template._template,
         filetype=filetype,
         values=get_normalised_placeholders_from_session(),
         page=request.args.get("page"),
+        service=current_service,
     )
 
 
@@ -742,8 +743,12 @@ def check_messages_preview(service_id, template_id, upload_id, filetype, row_ind
         page = request.args.get("page", 1)
 
     template = _check_messages(service_id, template_id, upload_id, row_index)["template"]
-    return TemplatePreview.get_preview_for_templated_letter(
-        db_template=template._template, filetype=filetype, values=template.values, page=page
+    return template_preview_client.get_preview_for_templated_letter(
+        db_template=template._template,
+        filetype=filetype,
+        values=template.values,
+        page=page,
+        service=current_service,
     )
 
 
@@ -762,8 +767,12 @@ def check_notification_preview(service_id, template_id, filetype):
         service_id,
         template_id,
     )["template"]
-    return TemplatePreview.get_preview_for_templated_letter(
-        db_template=template._template, filetype=filetype, values=template.values, page=page
+    return template_preview_client.get_preview_for_templated_letter(
+        db_template=template._template,
+        filetype=filetype,
+        values=template.values,
+        page=page,
+        service=current_service,
     )
 
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -30,6 +30,7 @@ from xlrd.xldate import XLDateError
 from app import (
     current_service,
     notification_api_client,
+    template_preview_client,
     upload_api_client,
 )
 from app.main import main
@@ -43,7 +44,6 @@ from app.s3_client.s3_letter_upload_client import (
     get_transient_letter_file_location,
     upload_letter_to_s3,
 )
-from app.template_previews import TemplatePreview
 from app.utils import unicode_truncate
 from app.utils.csv import Spreadsheet, get_errors_for_csv
 from app.utils.letters import (
@@ -160,7 +160,7 @@ def upload_letter(service_id):
             file_location = get_transient_letter_file_location(service_id, upload_id)
 
             try:
-                response = TemplatePreview.sanitise_letter(
+                response = template_preview_client.sanitise_letter(
                     BytesIO(pdf_file_bytes),
                     upload_id=upload_id,
                     allow_international_letters=current_service.has_permission("international_letters"),
@@ -284,9 +284,9 @@ def view_letter_upload_as_preview(service_id, file_id):
     invalid_pages = json.loads(metadata.get("invalid_pages", "[]"))
 
     if metadata.get("message") == "content-outside-printable-area" and page in invalid_pages:
-        return TemplatePreview.get_png_for_invalid_pdf_page(pdf_file, page)
+        return template_preview_client.get_png_for_invalid_pdf_page(pdf_file, page)
     else:
-        return TemplatePreview.get_png_for_valid_pdf_page(pdf_file, page)
+        return template_preview_client.get_png_for_valid_pdf_page(pdf_file, page)
 
 
 @main.route("/services/<uuid:service_id>/upload-letter/send/<uuid:file_id>", methods=["POST"])

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -56,11 +56,11 @@ class JSONModel(SerialisedModel, SortingAndEqualityMixin):
 class ModelList(SerialisedModelCollection):
     @property
     @abstractmethod
-    def client_method(self):
+    def _get_items(self):
         pass
 
     def __init__(self, *args):
-        self.items = self.client_method(*args)
+        self.items = self._get_items(*args)
 
 
 class PaginatedModelList(ModelList):
@@ -71,7 +71,7 @@ class PaginatedModelList(ModelList):
             self.current_page = int(page)
         except TypeError:
             self.current_page = 1
-        response = self.client_method(
+        response = self._get_items(
             *args,
             **kwargs,
             page=self.current_page,

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -200,8 +200,11 @@ class AllBranding(ModelList):
 
 
 class AllEmailBranding(AllBranding):
-    client_method = email_branding_client.get_all_email_branding
     model = EmailBranding
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return email_branding_client.get_all_email_branding(*args, **kwargs)
 
     @property
     def example_government_identity_branding(self):
@@ -211,26 +214,35 @@ class AllEmailBranding(AllBranding):
 
 
 class EmailBrandingPool(AllEmailBranding):
-    client_method = organisations_client.get_email_branding_pool
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return organisations_client.get_email_branding_pool(*args, **kwargs)
 
     def __init__(self, id):
         self.items = ()
         if id:
-            self.items = self.client_method(id)
+            self.items = self._get_items(id)
 
 
 class AllLetterBranding(AllBranding):
-    client_method = letter_branding_client.get_all_letter_branding
     model = LetterBranding
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return letter_branding_client.get_all_letter_branding(*args, **kwargs)
 
 
 class LetterBrandingPool(AllLetterBranding):
-    client_method = organisations_client.get_letter_branding_pool
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return organisations_client.get_letter_branding_pool(*args, **kwargs)
 
     def __init__(self, id):
         self.items = ()
         if id:
-            self.items = self.client_method(id)
+            self.items = self._get_items(id)
 
 
 GOVERNMENT_IDENTITY_SYSTEM_COLOURS = {

--- a/app/models/contact_list.py
+++ b/app/models/contact_list.py
@@ -149,13 +149,16 @@ class ContactList(JSONModel):
 
 
 class ContactLists(ModelList):
-    client_method = contact_list_api_client.get_contact_lists
     model = ContactList
     sort_function = partial(
         sorted,
         key=lambda item: item["created_at"],
         reverse=True,
     )
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return contact_list_api_client.get_contact_lists(*args, **kwargs)
 
     def __init__(self, service_id, template_type=None):
         super().__init__(service_id)

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -132,15 +132,21 @@ class APIKeyEvent(Event):
 
 class APIKeyEvents(ModelList):
     model = APIKeyEvent
-    client_method = service_api_client.get_service_api_key_history
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return service_api_client.get_service_api_key_history(*args, **kwargs)
 
 
 class ServiceEvents(ModelList):
-    client_method = service_api_client.get_service_service_history
 
     @property
     def model(self):
         return lambda x: x
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return service_api_client.get_service_service_history(*args, **kwargs)
 
     @staticmethod
     def splat(events):
@@ -158,4 +164,4 @@ class ServiceEvents(ModelList):
                     )
 
     def __init__(self, service_id):
-        self.items = [event for event in self.splat(self.client_method(service_id)) if event.relevant]
+        self.items = [event for event in self.splat(self._get_items(service_id)) if event.relevant]

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -11,7 +11,7 @@ from notifications_utils.letter_timings import (
 from werkzeug.utils import cached_property
 
 from app.models import JSONModel, ModelList, PaginatedModelList
-from app.notify_client.job_api_client import job_api_client
+from app.notify_client.job_api_client import JobApiClient, job_api_client
 from app.notify_client.notification_api_client import notification_api_client
 from app.notify_client.service_api_client import service_api_client
 from app.utils import set_status_filters
@@ -204,17 +204,26 @@ class Job(JSONModel):
 
 
 class ImmediateJobs(ModelList):
-    client_method = job_api_client.get_immediate_jobs
     model = Job
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return job_api_client.get_immediate_jobs(*args, **kwargs)
 
 
 class ScheduledJobs(ImmediateJobs):
-    client_method = job_api_client.get_scheduled_jobs
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return job_api_client.get_scheduled_jobs(*args, **kwargs)
 
 
 class PaginatedJobs(PaginatedModelList, ImmediateJobs):
-    client_method = job_api_client.get_page_of_jobs
     statuses = None
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return job_api_client.get_page_of_jobs(*args, **kwargs)
 
     def __init__(self, service_id, *, contact_list_id=None, page=None, limit_days=None):
         super().__init__(
@@ -227,8 +236,11 @@ class PaginatedJobs(PaginatedModelList, ImmediateJobs):
 
 
 class PaginatedJobsAndScheduledJobs(PaginatedJobs):
-    statuses = job_api_client.NON_CANCELLED_JOB_STATUSES
+    statuses = JobApiClient.NON_CANCELLED_JOB_STATUSES
 
 
 class PaginatedUploads(PaginatedModelList, ImmediateJobs):
-    client_method = job_api_client.get_uploads
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return job_api_client.get_uploads(*args, **kwargs)

--- a/app/models/letter_rates.py
+++ b/app/models/letter_rates.py
@@ -20,7 +20,6 @@ class LetterRate(JSONModel):
 
 class LetterRates(ModelList):
     model = LetterRate
-    client_method = letter_rate_api_client.get_letter_rates
 
     post_classes = {
         # The API doesn’t store names or a sort order for the classes
@@ -33,6 +32,10 @@ class LetterRates(ModelList):
         # for `rest-of-world`
         "europe": "International",
     }
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return letter_rate_api_client.get_letter_rates(*args, **kwargs)
 
     @property
     def rates(self):

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -253,4 +253,7 @@ class Organisations(SerialisedModelCollection):
 
 
 class AllOrganisations(ModelList, Organisations):
-    client_method = organisations_client.get_organisations
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return organisations_client.get_organisations(*args, **kwargs)

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -93,8 +93,11 @@ class UnsubscribeRequestsReport(JSONModel):
 
 
 class UnsubscribeRequestsReports(ModelList):
-    client_method = service_api_client.get_unsubscribe_reports_summary
     model = UnsubscribeRequestsReport
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return service_api_client.get_unsubscribe_reports_summary(*args, **kwargs)
 
     def __getitem__(self, index):
         instance = super().__getitem__(index)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -677,8 +677,11 @@ class AnonymousUser(AnonymousUserMixin):
 
 
 class Users(ModelList):
-    client_method = user_api_client.get_users_for_service
     model = User
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return user_api_client.get_users_for_service(*args, **kwargs)
 
     def get_name_from_id(self, id):
         for user in self:
@@ -694,17 +697,26 @@ class Users(ModelList):
 
 
 class OrganisationUsers(Users):
-    client_method = user_api_client.get_users_for_organisation
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return user_api_client.get_users_for_organisation(*args, **kwargs)
 
 
 class InvitedUsers(Users):
-    client_method = invite_api_client.get_invites_for_service
     model = InvitedUser
 
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return invite_api_client.get_invites_for_service(*args, **kwargs)
+
     def __init__(self, service_id):
-        self.items = [user for user in self.client_method(service_id) if user["status"] != "accepted"]
+        self.items = [user for user in self._get_items(service_id) if user["status"] != "accepted"]
 
 
 class OrganisationInvitedUsers(InvitedUsers):
-    client_method = org_invite_api_client.get_invites_for_organisation
     model = InvitedOrgUser
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return org_invite_api_client.get_invites_for_organisation(*args, **kwargs)

--- a/app/models/webauthn_credential.py
+++ b/app/models/webauthn_credential.py
@@ -70,7 +70,10 @@ class WebAuthnCredential(JSONModel):
 
 class WebAuthnCredentials(ModelList):
     model = WebAuthnCredential
-    client_method = user_api_client.get_webauthn_credentials_for_user
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return user_api_client.get_webauthn_credentials_for_user(*args, **kwargs)
 
     @property
     def as_cbor(self):

--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -14,11 +14,13 @@ def _attach_current_user(data):
 
 
 class NotifyAdminAPIClient(BaseAPIClient):
-    def __init__(self):
-        super().__init__("a" * 73, "b")
-
-    def init_app(self, app):
-        self.base_url = app.config["API_HOST_NAME"]
+    def __init__(self, app):
+        super().__init__(
+            "x" * 100,
+            base_url=app.config["API_HOST_NAME"],
+        )
+        # our credential lengths aren't what BaseAPIClient's __init__ will expect
+        # given it's designed for destructuring end-user api keys
         self.service_id = app.config["ADMIN_CLIENT_USER_NAME"]
         self.api_key = app.config["ADMIN_CLIENT_SECRET"]
 

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -1,3 +1,10 @@
+from contextvars import ContextVar
+
+from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
+
+from app import memo_resetters
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 
 # must match key types in notifications-api/app/models.py
@@ -21,4 +28,10 @@ class ApiKeyApiClient(NotifyAdminAPIClient):
         return self.post(url=f"/service/{service_id}/api-key/revoke/{key_id}", data=data)
 
 
-api_key_api_client = ApiKeyApiClient()
+_api_key_api_client_context_var: ContextVar[ApiKeyApiClient] = ContextVar("api_key_api_client")
+get_api_key_api_client: LazyLocalGetter[ApiKeyApiClient] = LazyLocalGetter(
+    _api_key_api_client_context_var,
+    lambda: ApiKeyApiClient(current_app),
+)
+memo_resetters.append(lambda: get_api_key_api_client.clear())
+api_key_api_client = LocalProxy(get_api_key_api_client)

--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -1,3 +1,10 @@
+from contextvars import ContextVar
+
+from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
+
+from app import memo_resetters
 from app.notify_client import NotifyAdminAPIClient
 
 
@@ -66,4 +73,10 @@ class BillingAPIClient(NotifyAdminAPIClient):
         )
 
 
-billing_api_client = BillingAPIClient()
+_billing_api_client_context_var: ContextVar[BillingAPIClient] = ContextVar("billing_api_client")
+get_billing_api_client: LazyLocalGetter[BillingAPIClient] = LazyLocalGetter(
+    _billing_api_client_context_var,
+    lambda: BillingAPIClient(current_app),
+)
+memo_resetters.append(lambda: get_billing_api_client.clear())
+billing_api_client = LocalProxy(get_billing_api_client)

--- a/app/notify_client/complaint_api_client.py
+++ b/app/notify_client/complaint_api_client.py
@@ -1,3 +1,10 @@
+from contextvars import ContextVar
+
+from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
+
+from app import memo_resetters
 from app.notify_client import NotifyAdminAPIClient
 
 
@@ -10,4 +17,10 @@ class ComplaintApiClient(NotifyAdminAPIClient):
         return self.get("/complaint/count-by-date-range", params=params_dict)
 
 
-complaint_api_client = ComplaintApiClient()
+_complaint_api_client_context_var: ContextVar[ComplaintApiClient] = ContextVar("complaint_api_client")
+get_complaint_api_client: LazyLocalGetter[ComplaintApiClient] = LazyLocalGetter(
+    _complaint_api_client_context_var,
+    lambda: ComplaintApiClient(current_app),
+)
+memo_resetters.append(lambda: get_complaint_api_client.clear())
+complaint_api_client = LocalProxy(get_complaint_api_client)

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -1,3 +1,10 @@
+from contextvars import ContextVar
+
+from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
+
+from app import memo_resetters
 from app.extensions import redis_client
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 
@@ -111,4 +118,10 @@ class JobApiClient(NotifyAdminAPIClient):
         return self.post(url=f"/service/{service_id}/job/{job_id}/cancel-letter-job", data={})
 
 
-job_api_client = JobApiClient()
+_job_api_client_context_var: ContextVar[JobApiClient] = ContextVar("job_api_client")
+get_job_api_client: LazyLocalGetter[JobApiClient] = LazyLocalGetter(
+    _job_api_client_context_var,
+    lambda: JobApiClient(current_app),
+)
+memo_resetters.append(lambda: get_job_api_client.clear())
+job_api_client = LocalProxy(get_job_api_client)

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -1,3 +1,10 @@
+from contextvars import ContextVar
+
+from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
+
+from app import memo_resetters
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 
 
@@ -142,4 +149,10 @@ class NotificationApiClient(NotifyAdminAPIClient):
         return response.get("notifications_sent_count")
 
 
-notification_api_client = NotificationApiClient()
+_notification_api_client_context_var: ContextVar[NotificationApiClient] = ContextVar("notification_api_client")
+get_notification_api_client: LazyLocalGetter[NotificationApiClient] = LazyLocalGetter(
+    _notification_api_client_context_var,
+    lambda: NotificationApiClient(current_app),
+)
+memo_resetters.append(lambda: get_notification_api_client.clear())
+notification_api_client = LocalProxy(get_notification_api_client)

--- a/app/notify_client/performance_dashboard_api_client.py
+++ b/app/notify_client/performance_dashboard_api_client.py
@@ -1,3 +1,10 @@
+from contextvars import ContextVar
+
+from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
+
+from app import memo_resetters
 from app.notify_client import NotifyAdminAPIClient, cache
 
 
@@ -18,4 +25,12 @@ class PerformanceDashboardAPIClient(NotifyAdminAPIClient):
         )
 
 
-performance_dashboard_api_client = PerformanceDashboardAPIClient()
+_performance_dashboard_api_client_context_var: ContextVar[PerformanceDashboardAPIClient] = ContextVar(
+    "performance_dashboard_api_client"
+)
+get_performance_dashboard_api_client: LazyLocalGetter[PerformanceDashboardAPIClient] = LazyLocalGetter(
+    _performance_dashboard_api_client_context_var,
+    lambda: PerformanceDashboardAPIClient(current_app),
+)
+memo_resetters.append(lambda: get_performance_dashboard_api_client.clear())
+performance_dashboard_api_client = LocalProxy(get_performance_dashboard_api_client)

--- a/app/notify_client/platform_admin_api_client.py
+++ b/app/notify_client/platform_admin_api_client.py
@@ -1,3 +1,10 @@
+from contextvars import ContextVar
+
+from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
+
+from app import memo_resetters
 from app.notify_client import NotifyAdminAPIClient
 
 
@@ -8,4 +15,10 @@ class AdminApiClient(NotifyAdminAPIClient):
         return self.post(url="/platform-admin/find-by-uuid", data={"uuid": uuid_})
 
 
-admin_api_client = AdminApiClient()
+_admin_api_client_context_var: ContextVar[AdminApiClient] = ContextVar("admin_api_client")
+get_admin_api_client: LazyLocalGetter[AdminApiClient] = LazyLocalGetter(
+    _admin_api_client_context_var,
+    lambda: AdminApiClient(current_app),
+)
+memo_resetters.append(lambda: get_admin_api_client.clear())
+admin_api_client = LocalProxy(get_admin_api_client)

--- a/app/notify_client/protected_sender_id_api_client.py
+++ b/app/notify_client/protected_sender_id_api_client.py
@@ -1,3 +1,10 @@
+from contextvars import ContextVar
+
+from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
+
+from app import memo_resetters
 from app.notify_client import NotifyAdminAPIClient
 
 
@@ -7,4 +14,12 @@ class ProtectedSenderIDApiClient(NotifyAdminAPIClient):
         return self.get(url="/protected-sender-id/check", params={"sender_id": sender_id})
 
 
-protected_sender_id_api_client = ProtectedSenderIDApiClient()
+_protected_sender_id_api_client_context_var: ContextVar[ProtectedSenderIDApiClient] = ContextVar(
+    "protected_sender_id_api_client"
+)
+get_protected_sender_id_api_client: LazyLocalGetter[ProtectedSenderIDApiClient] = LazyLocalGetter(
+    _protected_sender_id_api_client_context_var,
+    lambda: ProtectedSenderIDApiClient(current_app),
+)
+memo_resetters.append(lambda: get_protected_sender_id_api_client.clear())
+protected_sender_id_api_client = LocalProxy(get_protected_sender_id_api_client)

--- a/app/notify_client/upload_api_client.py
+++ b/app/notify_client/upload_api_client.py
@@ -1,3 +1,10 @@
+from contextvars import ContextVar
+
+from flask import current_app
+from notifications_utils.local_vars import LazyLocalGetter
+from werkzeug.local import LocalProxy
+
+from app import memo_resetters
 from app.notify_client import NotifyAdminAPIClient
 
 
@@ -12,4 +19,10 @@ class UploadApiClient(NotifyAdminAPIClient):
         return self.get(url=f"/service/{service_id}/upload/uploaded-letters/{letter_print_day}?page={page}")
 
 
-upload_api_client = UploadApiClient()
+_upload_api_client_context_var: ContextVar[UploadApiClient] = ContextVar("upload_api_client")
+get_upload_api_client: LazyLocalGetter[UploadApiClient] = LazyLocalGetter(
+    _upload_api_client_context_var,
+    lambda: UploadApiClient(current_app),
+)
+memo_resetters.append(lambda: get_upload_api_client.clear())
+upload_api_client = LocalProxy(get_upload_api_client)

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -143,13 +143,17 @@ class TemplatedLetterImageTemplate(BaseLetterImageTemplate):
 
     @property
     def all_page_counts(self):
-        from app.template_previews import TemplatePreview
+        from app import current_service, template_preview_client
 
         if self._all_page_counts:
             return self._all_page_counts
 
         if self.values:
-            self._all_page_counts = TemplatePreview.get_page_counts_for_letter(self._template, self.values)
+            self._all_page_counts = template_preview_client.get_page_counts_for_letter(
+                self._template,
+                service=current_service,
+                values=self.values,
+            )
             return self._all_page_counts
 
         cache_key = (
@@ -159,7 +163,11 @@ class TemplatedLetterImageTemplate(BaseLetterImageTemplate):
             self._all_page_counts = json.loads(cached_value)
             return self._all_page_counts
 
-        self._all_page_counts = TemplatePreview.get_page_counts_for_letter(self._template, self.values)
+        self._all_page_counts = template_preview_client.get_page_counts_for_letter(
+            self._template,
+            service=current_service,
+            values=self.values,
+        )
         redis_client.set(cache_key, json.dumps(self._all_page_counts), ex=cache.DEFAULT_TTL)
 
         return self._all_page_counts

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==8.0.1
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@87.0.0
 
 govuk-frontend-jinja==3.1.0
 

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ pyexcel-io==0.6.6
 pyexcel-xls==0.7.0
 pyexcel-xlsx==0.6.0
 pyexcel-ods3==0.6.1
-notifications-python-client==8.0.1
+notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@87.0.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,7 +105,7 @@ markupsafe==2.1.1
     #   wtforms
 mistune==0.8.4
     # via notifications-utils
-notifications-python-client==8.0.1
+notifications-python-client==10.0.0
     # via -r requirements.in
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@87.0.0
     # via -r requirements.in

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -639,7 +639,7 @@ def validate_route_permission(
     mocker.patch("app.user_api_client.get_user", return_value=usr)
     mocker.patch("app.user_api_client.get_user_by_email", return_value=usr)
     mocker.patch("app.service_api_client.get_service", return_value={"data": service})
-    mocker.patch("app.models.user.Users.client_method", return_value=[usr])
+    mocker.patch("app.models.user.Users._get_items", return_value=[usr])
     mocker.patch("app.job_api_client.has_jobs", return_value=False)
     with notify_admin.test_request_context():
         with notify_admin.test_client() as client:

--- a/tests/app/main/forms/test_service_sms_senders_form.py
+++ b/tests/app/main/forms/test_service_sms_senders_form.py
@@ -59,6 +59,7 @@ from app.models.service import Service
     ],
 )
 def test_sms_sender_form_validation(
+    notify_admin,
     sms_sender,
     error_expected,
     error_message,
@@ -112,7 +113,7 @@ def test_sms_validation_logs_and_creates_ticket_for_phishing_sender(client_reque
     mock_send_zendesk_ticket.assert_called_once()
 
 
-def test_sms_validation_does_not_log_or_create_ticket_for_safe_sender(caplog, mocker):
+def test_sms_validation_does_not_log_or_create_ticket_for_safe_sender(notify_admin, caplog, mocker):
     mocker.patch("app.protected_sender_id_api_client.get_check_sender_id", return_value=False)
     form = ServiceSmsSenderForm(sms_sender="UK&GOV")
 

--- a/tests/app/main/forms/test_strip_whitespace.py
+++ b/tests/app/main/forms/test_strip_whitespace.py
@@ -31,6 +31,7 @@ class ExampleFormSpecialField(Form):
     ],
 )
 def test_form_strips_all_whitespace(
+    notify_admin,
     form,
     submitted_data,
 ):

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -127,8 +127,8 @@ def test_405_returns_something_went_wrong_page(client_request, mocker):
 
 
 def test_api_error_response_logging(
-    requests_mock,
     client_request,
+    requests_mock,
     caplog,
 ):
     response = requests.Response()

--- a/tests/app/main/test_forms.py
+++ b/tests/app/main/test_forms.py
@@ -5,7 +5,7 @@ from tests.conftest import set_config_values
 
 
 class TestOrderableFieldsForm:
-    def test_can_reorder_fields(self):
+    def test_can_reorder_fields(self, notify_admin):
         class TestForm(OrderableFieldsForm):
             field1 = StripWhitespaceStringField()
             field2 = StripWhitespaceStringField()
@@ -15,7 +15,7 @@ class TestOrderableFieldsForm:
         form = TestForm()
         assert [field.name for field in form] == ["field2", "field1"]
 
-    def test_all_fields_must_be_listed(self):
+    def test_all_fields_must_be_listed(self, notify_admin):
         class TestForm(OrderableFieldsForm):
             field1 = StripWhitespaceStringField()
             field2 = StripWhitespaceStringField()

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -69,7 +69,7 @@ SAMPLE_DATA = {
 
 
 @pytest.fixture
-def mock_get_orgs_and_services(mocker):
+def mock_get_orgs_and_services(notify_admin, mocker):
     return mocker.patch("app.user_api_client.get_organisations_and_services_for_user", return_value=SAMPLE_DATA)
 
 
@@ -158,8 +158,8 @@ def test_choose_account_should_show_choose_accounts_page_if_no_services(
 
 
 def test_choose_account_should_show_join_service_button(
-    mocker,
     client_request,
+    mocker,
     mock_get_non_empty_organisations_and_services_for_user,
 ):
     mocker.patch(

--- a/tests/app/main/views/organisations/test_organisation_branding.py
+++ b/tests/app/main/views/organisations/test_organisation_branding.py
@@ -25,13 +25,13 @@ def test_organisation_email_branding_page_is_not_accessible_by_non_platform_admi
     ),
 )
 def test_organisation_email_branding_page_shows_all_branding_pool_options(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
     default_email_branding,
     expected_branding_options,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -70,11 +70,11 @@ def test_organisation_email_branding_page_shows_all_branding_pool_options(
 
 
 def test_organisation_email_branding_page_shows_remove_brand_links(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -123,11 +123,11 @@ def test_organisation_email_branding_page_shows_remove_brand_links(
 
 
 def test_get_organisation_email_branding_page_with_remove_param(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -151,11 +151,11 @@ def test_get_organisation_email_branding_page_with_remove_param(
 
 
 def test_post_organisation_email_branding_page_with_remove_param(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -182,11 +182,11 @@ def test_post_organisation_email_branding_page_with_remove_param(
 
 
 def test_remove_org_email_branding_from_pool_invalid_brand_id(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -224,13 +224,13 @@ def test_remove_org_email_branding_from_pool_invalid_brand_id(
     ),
 )
 def test_reset_org_email_branding_to_govuk_only_for_central_government(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
     organisation_type,
     should_be_available,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -278,7 +278,6 @@ def test_reset_org_email_branding_to_govuk_only_for_central_government(
     ),
 )
 def test_reset_org_email_branding_to_govuk_successfully(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
@@ -286,6 +285,7 @@ def test_reset_org_email_branding_to_govuk_successfully(
     mock_update_organisation,
     organisation_type,
     should_succeed,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -311,11 +311,11 @@ def test_reset_org_email_branding_to_govuk_successfully(
 
 
 def test_change_default_org_email_branding_invalid_brand_id(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -337,12 +337,12 @@ def test_change_default_org_email_branding_invalid_brand_id(
 
 
 def test_change_default_org_email_branding_shows_confirmation_question_from_govuk(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
     mock_update_organisation,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -367,13 +367,13 @@ def test_change_default_org_email_branding_shows_confirmation_question_from_govu
 
 
 def test_change_default_org_email_branding_successfully_from_govuk(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
     mock_get_organisation_services,
     mock_update_organisation,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -402,12 +402,12 @@ def test_change_default_org_email_branding_successfully_from_govuk(
 
 
 def test_change_default_org_email_branding_successfully_from_explicit_brand(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
     mock_update_organisation,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -457,12 +457,12 @@ def test_add_organisation_email_branding_options_is_platform_admin_only(
 
 
 def test_add_organisation_email_branding_options_shows_branding_not_in_branding_pool(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_organisation,
     mock_get_all_email_branding,
+    mocker,
 ):
     branding_pool = [
         {
@@ -744,11 +744,11 @@ def test_add_organisation_letter_branding_options_is_platform_admin_only(
 
 
 def test_change_default_org_letter_branding_invalid_brand_id(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_letter_branding_pool,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -770,12 +770,12 @@ def test_change_default_org_letter_branding_invalid_brand_id(
 
 
 def test_change_default_org_letter_branding_shows_confirmation_question_when_changing_from_no_branding(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_letter_branding_pool,
     mock_update_organisation,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -800,13 +800,13 @@ def test_change_default_org_letter_branding_shows_confirmation_question_when_cha
 
 
 def test_change_default_org_letter_branding_successfully_from_no_branding(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_letter_branding_pool,
     mock_get_organisation_services,
     mock_update_organisation,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -833,12 +833,12 @@ def test_change_default_org_letter_branding_successfully_from_no_branding(
 
 
 def test_change_default_org_letter_branding_successfully_from_explicit_brand(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_letter_branding_pool,
     mock_update_organisation,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -863,12 +863,12 @@ def test_change_default_org_letter_branding_successfully_from_explicit_brand(
 
 
 def test_add_organisation_letter_branding_options_shows_branding_not_in_branding_pool(
-    mocker,
     client_request,
     platform_admin_user,
     organisation_one,
     mock_get_organisation,
     mock_get_letter_branding_pool,
+    mocker,
 ):
     # The first 3 items in all_letter_branding are in the pool, the last 2 are not
     all_letter_branding = [

--- a/tests/app/main/views/organisations/test_organisation_branding.py
+++ b/tests/app/main/views/organisations/test_organisation_branding.py
@@ -482,7 +482,7 @@ def test_add_organisation_email_branding_options_shows_branding_not_in_branding_
             "brand_type": "org",
         },
     ]
-    mocker.patch("app.models.branding.EmailBrandingPool.client_method", return_value=branding_pool)
+    mocker.patch("app.models.branding.EmailBrandingPool._get_items", return_value=branding_pool)
 
     client_request.login(platform_admin_user)
     page = client_request.get(".add_organisation_email_branding_options", org_id=organisation_one["id"])
@@ -898,7 +898,7 @@ def test_add_organisation_letter_branding_options_shows_branding_not_in_branding
             "filename": "apha",
         },
     ]
-    mocker.patch("app.models.branding.AllLetterBranding.client_method", return_value=all_letter_branding)
+    mocker.patch("app.models.branding.AllLetterBranding._get_items", return_value=all_letter_branding)
 
     client_request.login(platform_admin_user)
     page = client_request.get(".add_organisation_letter_branding_options", org_id=organisation_one["id"])

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -154,7 +154,12 @@ def test_accepted_invite_when_other_user_already_logged_in(client_request, mock_
 
 
 def test_cancelled_invite_opened_by_user(
-    mocker, client_request, api_user_active, mock_check_org_cancelled_invite_token, mock_get_organisation, fake_uuid
+    client_request,
+    api_user_active,
+    mock_check_org_cancelled_invite_token,
+    mock_get_organisation,
+    fake_uuid,
+    mocker,
 ):
     client_request.logout()
     mock_get_user = mocker.patch("app.user_api_client.get_user", return_value=api_user_active)

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -478,7 +478,7 @@ class TestEditOrganisationUser:
         _get_user_fn,
         mocker,
     ):
-        mocker.patch("app.models.user.OrganisationUsers.client_method", return_value=[_other_user])
+        mocker.patch("app.models.user.OrganisationUsers._get_items", return_value=[_other_user])
         client_request.login(platform_admin_user)
 
         # Override the `get_user` mock from `login` because we need to be able to get multiple users
@@ -505,7 +505,7 @@ class TestEditOrganisationUser:
         mocker,
     ):
         self._mock_get_organistion_can_approve_go_live(mocker)
-        mocker.patch("app.models.user.OrganisationUsers.client_method", return_value=[_other_user])
+        mocker.patch("app.models.user.OrganisationUsers._get_items", return_value=[_other_user])
         mock_set_org_permissions = mocker.patch(
             "app.notify_client.user_api_client.UserApiClient.set_organisation_permissions"
         )
@@ -553,7 +553,7 @@ class TestEditOrganisationUser:
         _get_user_fn,
         mocker,
     ):
-        mocker.patch("app.models.user.OrganisationUsers.client_method", return_value=[_other_user])
+        mocker.patch("app.models.user.OrganisationUsers._get_items", return_value=[_other_user])
         mocker.patch("app.notify_client.user_api_client.UserApiClient.set_organisation_permissions")
         mocker.patch("app.models.user.create_set_organisation_user_permissions_event")
         client_request.login(platform_admin_user)

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -24,7 +24,7 @@ def test_organisation_page_shows_all_organisations(client_request, platform_admi
         {"id": "C2", "name": "Test 2", "active": False, "count_of_live_services": 2},
     ]
 
-    get_organisations = mocker.patch("app.models.organisation.AllOrganisations.client_method", return_value=orgs)
+    get_organisations = mocker.patch("app.models.organisation.AllOrganisations._get_items", return_value=orgs)
     client_request.login(platform_admin_user)
     page = client_request.get(".organisations")
 
@@ -256,7 +256,7 @@ def test_nhs_local_can_create_own_organisations(
 ):
     mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
     mocker.patch(
-        "app.models.organisation.AllOrganisations.client_method",
+        "app.models.organisation.AllOrganisations._get_items",
         return_value=[
             organisation_json("t3", "Trust 3", active=False, organisation_type="nhs_local"),
             organisation_json("t2", "Trust 2", organisation_type="nhs_local"),
@@ -419,7 +419,7 @@ def test_nhs_local_assigns_to_selected_organisation(
     mock_update_service_organisation,
 ):
     mocker.patch(
-        "app.models.organisation.AllOrganisations.client_method",
+        "app.models.organisation.AllOrganisations._get_items",
         return_value=[
             organisation_json(ORGANISATION_ID, "Trust 1", organisation_type="nhs_local"),
         ],
@@ -924,7 +924,7 @@ def test_manage_org_users_shows_no_link_for_cancelled_users(
     mocker,
 ):
     sample_org_invite["status"] = "cancelled"
-    mocker.patch("app.models.user.OrganisationInvitedUsers.client_method", return_value=[sample_org_invite])
+    mocker.patch("app.models.user.OrganisationInvitedUsers._get_items", return_value=[sample_org_invite])
 
     page = client_request.get(
         ".manage_org_users",
@@ -951,11 +951,11 @@ def test_manage_org_users_should_show_live_search_if_more_than_7_users(
     number_of_users,
 ):
     mocker.patch(
-        "app.models.user.OrganisationInvitedUsers.client_method",
+        "app.models.user.OrganisationInvitedUsers._get_items",
         return_value=[],
     )
     mocker.patch(
-        "app.models.user.OrganisationUsers.client_method",
+        "app.models.user.OrganisationUsers._get_items",
         return_value=[active_user_with_permissions] * number_of_users,
     )
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1482,7 +1482,6 @@ def test_view_organisation_settings(
     ),
 )
 def test_update_organisation_settings(
-    mocker,
     client_request,
     organisation_one,
     mock_get_organisation,
@@ -1491,6 +1490,7 @@ def test_update_organisation_settings(
     post_data,
     expected_persisted,
     user,
+    mocker,
 ):
     mocker.patch("app.organisations_client.get_organisation_services", return_value=[])
     client_request.login(user)
@@ -1548,9 +1548,9 @@ def test_update_organisation_sector_sends_service_id_data_to_api_client(
     ),
 )
 def test_view_organisation_domains(
-    mocker,
     client_request,
     user,
+    mocker,
 ):
     client_request.login(user)
 
@@ -1667,10 +1667,10 @@ def test_update_organisation_domains(
 
 
 def test_update_organisation_domains_when_domain_already_exists(
-    mocker,
     client_request,
     organisation_one,
     mock_get_organisation,
+    mocker,
 ):
     user = create_platform_admin_user()
     client_request.login(user)
@@ -1698,8 +1698,8 @@ def test_update_organisation_domains_when_domain_already_exists(
 
 
 def test_update_organisation_domains_with_more_than_just_domain(
-    mocker,
     client_request,
+    mocker,
 ):
     user = create_platform_admin_user()
     client_request.login(user)
@@ -1911,6 +1911,7 @@ def test_organisation_settings_links_to_edit_organisation_notes_page(
     organisation_one,
     client_request,
     platform_admin_user,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
@@ -1978,6 +1979,7 @@ def test_organisation_settings_links_to_edit_can_approve_own_go_live_request(
     organisation_one,
     client_request,
     platform_admin_user,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
@@ -1995,6 +1997,7 @@ def test_organisation_settings_links_to_edit_can_ask_to_join_a_service(
     organisation_one,
     client_request,
     platform_admin_user,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])
@@ -2013,7 +2016,6 @@ def test_organisation_settings_links_to_edit_can_ask_to_join_a_service(
     ),
 )
 def test_get_can_ask_to_join_a_service(
-    mocker,
     client_request,
     fake_uuid,
     platform_admin_user,
@@ -2021,6 +2023,7 @@ def test_get_can_ask_to_join_a_service(
     expected_checked_value,
     expected_label,
     permission_list,
+    mocker,
 ):
     client_request.login(platform_admin_user)
 
@@ -2091,13 +2094,13 @@ def test_add_delete_can_ask_to_join_a_service(
     ),
 )
 def test_get_can_approve_own_go_live_requests(
-    mocker,
     client_request,
     fake_uuid,
     platform_admin_user,
     value_from_api,
     expected_checked_value,
     expected_label,
+    mocker,
 ):
     client_request.login(platform_admin_user)
 
@@ -2198,6 +2201,7 @@ def test_organisation_settings_links_to_edit_organisation_billing_details_page(
     organisation_one,
     client_request,
     platform_admin_user,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_settings", org_id=organisation_one["id"])

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -41,12 +41,12 @@ def test_email_branding_options_page_back_link(
 
 
 def test_email_branding_options_page_shows_branding_if_set(
-    mocker,
     service_one,
     client_request,
     mock_get_empty_email_branding_pool,
     mock_get_email_branding,
     mock_get_service_organisation,
+    mocker,
 ):
     mocker.patch(
         "app.models.service.Service.email_branding_id",
@@ -156,7 +156,6 @@ def test_email_branding_options_shows_query_param_branding_choice_selected(
     ),
 )
 def test_email_branding_options_page_shows_branding_pool_options_if_branding_pool_set_for_org(
-    mocker,
     service_one,
     organisation_one,
     client_request,
@@ -164,6 +163,7 @@ def test_email_branding_options_page_shows_branding_pool_options_if_branding_poo
     mock_get_email_branding_pool,
     organisation_type,
     expected_options,
+    mocker,
 ):
     service_one["organisation_type"] = organisation_type
     organisation_one["organisation_type"] = organisation_type
@@ -212,7 +212,6 @@ def test_email_branding_options_page_shows_branding_pool_options_if_branding_poo
     ),
 )
 def test_email_branding_options_page_shows_divider_if_there_are_lots_of_options(
-    mocker,
     service_one,
     organisation_one,
     client_request,
@@ -220,6 +219,7 @@ def test_email_branding_options_page_shows_divider_if_there_are_lots_of_options(
     mock_get_email_branding_pool,
     pool_contents,
     expected_options,
+    mocker,
 ):
     service_one["organisation"] = organisation_one
 
@@ -242,11 +242,11 @@ def test_email_branding_options_page_shows_divider_if_there_are_lots_of_options(
 
 
 def test_email_branding_options_does_not_show_nhs_branding_twice(
-    mocker,
     service_one,
     organisation_one,
     client_request,
     mock_get_email_branding,
+    mocker,
 ):
     organisation_one["organisation_type"] = "nhs_central"
     service_one["organisation"] = organisation_one
@@ -273,11 +273,11 @@ def test_email_branding_options_does_not_show_nhs_branding_twice(
 
 
 def test_email_branding_options_page_shows_preview_if_something_else_is_only_option(
-    mocker,
     service_one,
     client_request,
     mock_get_email_branding,
     mock_get_empty_email_branding_pool,
+    mocker,
 ):
     service_one["organisation_type"] = "other"
     mocker.patch(
@@ -397,11 +397,11 @@ def test_email_branding_options_submit_when_no_radio_button_is_selected(
 
 
 def test_email_branding_options_page_redirects_to_choose_banner_type_page_if_something_else_is_only_option(
-    mocker,
     service_one,
     client_request,
     mock_get_email_branding,
     mock_get_empty_email_branding_pool,
+    mocker,
 ):
     service_one["organisation_type"] = "other"
     mocker.patch(
@@ -425,10 +425,10 @@ def test_email_branding_options_page_redirects_to_choose_banner_type_page_if_som
 
 
 def test_email_branding_options_page_redirects_nhs_specific_page(
-    mocker,
     service_one,
     client_request,
     organisation_one,
+    mocker,
 ):
     service_one["organisation"] = organisation_one["id"]
     mocker.patch(
@@ -460,7 +460,12 @@ def test_email_branding_options_page_redirects_nhs_specific_page(
 
 
 def test_email_branding_options_redirects_to_branding_preview_for_a_branding_pool_option(
-    mocker, service_one, organisation_one, client_request, mock_get_email_branding, mock_get_email_branding_pool
+    service_one,
+    organisation_one,
+    client_request,
+    mock_get_email_branding,
+    mock_get_email_branding_pool,
+    mocker,
 ):
     organisation_one["organisation_type"] = "central"
     service_one["organisation"] = organisation_one
@@ -538,7 +543,6 @@ def test_email_branding_option_preview_page_redirects_to_branding_request_page_i
 
 
 def test_email_branding_option_preview_changes_email_branding_when_user_confirms(
-    mocker,
     service_one,
     organisation_one,
     client_request,
@@ -547,6 +551,7 @@ def test_email_branding_option_preview_changes_email_branding_when_user_confirms
     mock_get_email_branding_pool,
     mock_update_service,
     mock_get_service_data_retention,
+    mocker,
 ):
     organisation_one["organisation_type"] = "central"
     service_one["organisation"] = organisation_one
@@ -636,7 +641,6 @@ def test_email_branding_pages_give_404_if_selected_branding_not_allowed(
 
 
 def test_email_branding_govuk_submit(
-    mocker,
     client_request,
     service_one,
     organisation_one,
@@ -646,6 +650,7 @@ def test_email_branding_govuk_submit(
     single_sms_sender,
     mock_update_service,
     mock_get_service_data_retention,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -682,6 +687,7 @@ def test_email_branding_nhs_submit(
     single_sms_sender,
     mock_update_service,
     mock_get_service_data_retention,
+    mocker,
 ):
     service_one["email_branding"] = sample_uuid()
     service_one["organisation_type"] = "nhs_local"
@@ -880,11 +886,11 @@ def test_GET_email_branding_enter_government_identity_logo_text(client_request, 
     ),
 )
 def test_email_branding_create_government_identity_logo(
-    mocker,
     client_request,
     service_one,
     extra_brandings_to_create,
     expected_branding_id_in_iframe,
+    mocker,
 ):
     mocker.patch(
         "app.models.branding.AllEmailBranding._get_items",
@@ -986,7 +992,12 @@ def test_GET_email_branding_enter_government_identity_logo_text_protects_against
     ],
 )
 def test_POST_email_branding_enter_government_identity_logo_text(
-    mocker, client_request, service_one, extra_url_args, expected_ticket_content, expected_extra_url_args
+    client_request,
+    service_one,
+    extra_url_args,
+    expected_ticket_content,
+    expected_extra_url_args,
+    mocker,
 ):
     mock_send_ticket_to_zendesk = mocker.patch(
         "app.main.views.service_settings.index.zendesk_client.send_ticket_to_zendesk",
@@ -1022,7 +1033,11 @@ def test_POST_email_branding_enter_government_identity_logo_text(
     )
 
 
-def test_email_branding_choose_logo_page(mocker, client_request, service_one):
+def test_email_branding_choose_logo_page(
+    client_request,
+    service_one,
+    mocker,
+):
     class FakeMD5:
         def hexdigest(self):
             return "abc123"
@@ -1110,10 +1125,10 @@ def test_email_branding_choose_logo_page_shows_form_prefilled(client_request, se
 
 
 def test_email_branding_choose_logo_page_prevents_xss_attacks(
-    mocker,
     client_request,
     service_one,
     organisation_one,
+    mocker,
 ):
     service_one["organisation"] = organisation_one
     organisation_one["name"] = "<script>evil</script>"
@@ -1272,7 +1287,12 @@ def test_GET_email_branding_upload_logo(
         {"brand_type": "org_banner", "colour": "#abcdef"},
     ),
 )
-def test_POST_email_branding_upload_logo_success(mocker, client_request, service_one, email_branding_data):
+def test_POST_email_branding_upload_logo_success(
+    client_request,
+    service_one,
+    email_branding_data,
+    mocker,
+):
     antivirus_mock = mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mock_save_temporary = mocker.patch(
         "app.main.views.service_settings.branding.logo_client.save_temporary_logo", return_value="my-logo-path"
@@ -1326,7 +1346,11 @@ def test_POST_email_branding_upload_logo_success(mocker, client_request, service
     ),
 )
 def test_POST_email_branding_upload_logo_validation_errors(
-    mocker, client_request, service_one, post_data, expected_error
+    client_request,
+    service_one,
+    post_data,
+    expected_error,
+    mocker,
 ):
     # File opens are wrapped in a lambda (we only want to do this during the test run, not when tests are gathered)
     if callable(post_data):
@@ -1355,7 +1379,11 @@ def test_POST_email_branding_upload_logo_validation_errors(
     ),
 )
 def test_POST_email_branding_upload_logo_enforces_minimum_logo_height(
-    mocker, client_request, service_one, min_logo_height, expect_error
+    client_request,
+    service_one,
+    min_logo_height,
+    expect_error,
+    mocker,
 ):
     mocker.patch("app.main.views.service_settings.branding.logo_client.save_temporary_logo")
     mocker.patch("app.utils.image_processing.ImageProcessor")
@@ -1379,7 +1407,11 @@ def test_POST_email_branding_upload_logo_enforces_minimum_logo_height(
         assert f"Logo must be at least {min_logo_height} pixels high" in page.text
 
 
-def test_POST_email_branding_upload_logo_resizes_and_pads_wide_short_logo(mocker, client_request, service_one):
+def test_POST_email_branding_upload_logo_resizes_and_pads_wide_short_logo(
+    client_request,
+    service_one,
+    mocker,
+):
     mocker.patch("app.main.views.service_settings.branding.logo_client.save_temporary_logo")
     mock_image_processor = mocker.patch("app.main.forms.ImageProcessor")
     mock_image_processor().height = ComparablePropertyMock(side_effect=[26, 13])

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -229,7 +229,7 @@ def test_email_branding_options_page_shows_divider_if_there_are_lots_of_options(
     )
 
     mocker.patch(
-        "app.models.branding.EmailBrandingPool.client_method",
+        "app.models.branding.EmailBrandingPool._get_items",
         return_value=pool_contents,
     )
 
@@ -257,7 +257,7 @@ def test_email_branding_options_does_not_show_nhs_branding_twice(
         "email_branding"
     ]
     updated_branding_pool = create_email_branding_pool(additional_values=nhs_branding)
-    mocker.patch("app.models.branding.EmailBrandingPool.client_method", return_value=updated_branding_pool)
+    mocker.patch("app.models.branding.EmailBrandingPool._get_items", return_value=updated_branding_pool)
 
     page = client_request.get(".email_branding_options", service_id=SERVICE_ONE_ID)
 
@@ -437,7 +437,7 @@ def test_email_branding_options_page_redirects_nhs_specific_page(
     )
 
     mocker.patch(
-        "app.models.branding.EmailBrandingPool.client_method",
+        "app.models.branding.EmailBrandingPool._get_items",
         return_value=[
             {
                 "name": "NHS",
@@ -887,7 +887,7 @@ def test_email_branding_create_government_identity_logo(
     expected_branding_id_in_iframe,
 ):
     mocker.patch(
-        "app.models.branding.AllEmailBranding.client_method",
+        "app.models.branding.AllEmailBranding._get_items",
         return_value=create_email_brandings(5, non_standard_values=extra_brandings_to_create),
     )
     page = client_request.get("main.email_branding_request_government_identity_logo", service_id=service_one["id"])

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -763,7 +763,6 @@ def test_letter_branding_option_preview_page_redirects_to_branding_options_page_
 
 
 def test_letter_branding_option_preview_changes_letter_branding_when_user_confirms(
-    mocker,
     service_one,
     organisation_one,
     client_request,
@@ -772,6 +771,7 @@ def test_letter_branding_option_preview_changes_letter_branding_when_user_confir
     mock_get_letter_branding_pool,
     mock_update_service,
     mock_get_service_data_retention,
+    mocker,
 ):
     organisation_one["organisation_type"] = "central"
     service_one["organisation"] = organisation_one
@@ -836,7 +836,6 @@ def test_letter_branding_nhs_page_returns_404_if_service_not_nhs(
 
 
 def test_letter_branding_nhs_changes_letter_branding_when_user_confirms(
-    mocker,
     service_one,
     organisation_one,
     client_request,
@@ -844,6 +843,7 @@ def test_letter_branding_nhs_changes_letter_branding_when_user_confirms(
     single_sms_sender,
     mock_get_letter_branding_pool,
     mock_update_service,
+    mocker,
 ):
     organisation_one["organisation_type"] = "nhs_central"
     service_one["organisation"] = organisation_one

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -72,7 +72,7 @@ def test_letter_branding_options_page_when_no_branding_is_set(
             "app.organisations_client.get_organisation",
             return_value=organisation_json(id_=ORGANISATION_ID, name="NHS Org 1", organisation_type=organisation_type),
         )
-        mocker.patch("app.models.branding.LetterBrandingPool.client_method", side_effect=[letter_branding_pool])
+        mocker.patch("app.models.branding.LetterBrandingPool._get_items", side_effect=[letter_branding_pool])
 
     page = client_request.get(".letter_branding_options", service_id=SERVICE_ONE_ID)
 
@@ -257,7 +257,7 @@ def test_letter_branding_options_redirects_to_nhs_page(
     service_one["organisation"] = organisation_one["id"]
     mocker.patch("app.organisations_client.get_organisation", return_value=organisation_one)
     mocker.patch(
-        "app.models.branding.LetterBrandingPool.client_method",
+        "app.models.branding.LetterBrandingPool._get_items",
         return_value=[{"name": "NHS", "id": LetterBranding.NHS_ID}],
     )
 

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -29,6 +29,7 @@ def get_service_settings_page(
 def test_service_set_permission_requires_platform_admin(
     client_request,
     service_one,
+    mocker,
 ):
     client_request.post(
         "main.service_set_permission",
@@ -105,7 +106,6 @@ def test_service_set_permission_requires_platform_admin(
     ],
 )
 def test_service_set_permission(
-    mocker,
     client_request,
     platform_admin_user,
     service_one,
@@ -114,6 +114,7 @@ def test_service_set_permission(
     initial_permissions,
     form_data,
     expected_update,
+    mocker,
 ):
     service_one["permissions"] = initial_permissions
     mock_update_service = mocker.patch("app.service_api_client.update_service")
@@ -161,7 +162,7 @@ def test_service_set_permission(
     ],
 )
 def test_service_setting_toggles_show(
-    mocker,
+    notify_admin,
     mock_get_service_organisation,
     get_service_settings_page,
     service_one,
@@ -169,6 +170,7 @@ def test_service_setting_toggles_show(
     endpoint,
     kwargs,
     text,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -963,7 +963,7 @@ def test_should_check_for_sending_things_right(
     )
 
     mock_get_users = mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=(
             [active_user_with_permissions] * count_of_users_with_manage_service + [active_user_no_settings_permission]
         ),
@@ -984,7 +984,7 @@ def test_should_check_for_sending_things_right(
     invite_two["permissions"] = "view_activity"
 
     mock_get_invites = mocker.patch(
-        "app.models.user.InvitedUsers.client_method",
+        "app.models.user.InvitedUsers._get_items",
         return_value=(([invite_one] * count_of_invites_with_manage_service) + [invite_two]),
     )
 
@@ -3848,7 +3848,7 @@ def test_should_show_branding_styles(
     assert "checked" not in branding_style_choices[4].attrs
     assert "checked" not in branding_style_choices[5].attrs
 
-    app.models.branding.AllEmailBranding.client_method.assert_called_once_with()
+    app.models.branding.AllEmailBranding._get_items.assert_called_once_with()
     app.service_api_client.get_service.assert_called_once_with(service_one["id"])
 
 
@@ -4994,7 +4994,7 @@ class TestSetAuthType:
         client_request,
         service_one,
     ):
-        mocker.patch("app.models.user.Users.client_method")
+        mocker.patch("app.models.user.Users._get_items")
         page = client_request.get(
             "main.service_set_auth_type",
             service_id=SERVICE_ONE_ID,
@@ -5007,7 +5007,7 @@ class TestSetAuthType:
         client_request,
         service_one,
     ):
-        mocker.patch("app.models.user.Users.client_method")
+        mocker.patch("app.models.user.Users._get_items")
         page = client_request.get(
             "main.service_set_auth_type",
             service_id=SERVICE_ONE_ID,
@@ -5020,7 +5020,7 @@ class TestSetAuthType:
 
     def tests_redirects_to_set_auth_type_for_users_on_success(self, mocker, client_request, service_one):
         mock_update_service = mocker.patch("app.notify_client.service_api_client.service_api_client.update_service")
-        mocker.patch("app.models.user.Users.client_method")
+        mocker.patch("app.models.user.Users._get_items")
         client_request.post(
             "main.service_set_auth_type",
             service_id=SERVICE_ONE_ID,
@@ -5037,7 +5037,7 @@ class TestSetAuthType:
     ):
         service_one["permissions"] += ["email_auth"]
         mocker.patch("app.notify_client.service_api_client.service_api_client.update_service")
-        mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+        mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
         client_request.post(
             "main.service_set_auth_type",
             service_id=SERVICE_ONE_ID,
@@ -5049,7 +5049,7 @@ class TestSetAuthType:
         self, mocker, client_request, service_one, active_user_with_permissions
     ):
         active_user_with_permissions["mobile_number"] = None
-        mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+        mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
         service_one["permissions"] += ["email_auth"]
         mocker.patch("app.notify_client.service_api_client.service_api_client.update_service")
         page = client_request.get("main.service_set_auth_type", service_id=SERVICE_ONE_ID)
@@ -5073,7 +5073,7 @@ class TestConfirmDisableEmailAuth:
 
     def test_page_loads(self, mocker, client_request, service_one, active_user_with_permissions):
         service_one["permissions"] += ["email_auth"]
-        mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+        mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
         client_request.get(
             "main.service_confirm_disable_email_auth",
             service_id=SERVICE_ONE_ID,
@@ -5082,7 +5082,7 @@ class TestConfirmDisableEmailAuth:
     def test_page_redirects_to_set_auth_type_if_service_doesnt_use_email_auth(
         self, mocker, client_request, service_one, active_user_with_permissions
     ):
-        mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+        mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
         client_request.get(
             "main.service_confirm_disable_email_auth",
             service_id=SERVICE_ONE_ID,
@@ -5093,7 +5093,7 @@ class TestConfirmDisableEmailAuth:
         self, mocker, client_request, service_one, active_user_with_permissions
     ):
         active_user_with_permissions["mobile_number"] = None
-        mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+        mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
         client_request.get(
             "main.service_confirm_disable_email_auth",
             service_id=SERVICE_ONE_ID,
@@ -5105,7 +5105,7 @@ class TestConfirmDisableEmailAuth:
     ):
         service_one["permissions"] += ["email_auth"]
         mocker.patch(
-            "app.models.user.Users.client_method",
+            "app.models.user.Users._get_items",
             return_value=[active_user_with_permissions],
         )
         mocker.patch("app.notify_client.service_api_client.service_api_client.update_service")
@@ -5122,7 +5122,7 @@ class TestConfirmDisableEmailAuth:
         active_user_with_permissions["permissions"][service_one["id"]].append("email_auth")
         mock_update_service = mocker.patch("app.notify_client.service_api_client.service_api_client.update_service")
         mock_update_user = mocker.patch("app.notify_client.user_api_client.user_api_client.update_user_attribute")
-        mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+        mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
         service_one["permissions"] += ["email_auth"]
         client_request.post(
             "main.service_confirm_disable_email_auth",
@@ -5143,7 +5143,7 @@ class TestConfirmDisableEmailAuth:
     ):
         active_user_with_permissions["auth_type"] = "webauthn_auth"
         mocker.patch("app.notify_client.service_api_client.service_api_client.update_service")
-        mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+        mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
         mock_update_user = mocker.patch("app.notify_client.user_api_client.user_api_client.update_user_attribute")
         service_one["permissions"] += ["email_auth"]
         client_request.post(
@@ -5191,7 +5191,7 @@ class TestSetAuthTypeForUsers:
         active_user_with_permissions,
         mock_get_users_by_service,
     ):
-        mocker.patch("app.models.user.InvitedUsers.client_method", return_value=[])
+        mocker.patch("app.models.user.InvitedUsers._get_items", return_value=[])
 
         service_one["permissions"] += ["email_auth"]
         client_request.login(active_user_with_permissions)
@@ -5222,7 +5222,7 @@ class TestSetAuthTypeForUsers:
         self, mocker, client_request, service_one, active_user_with_permissions, sample_invite
     ):
         mocker.patch(
-            "app.models.user.Users.client_method",
+            "app.models.user.Users._get_items",
             return_value=[
                 create_service_one_user(
                     id="a", name="Alpha", email_address="notify+1@notify.test", auth_type="sms_auth"
@@ -5233,7 +5233,7 @@ class TestSetAuthTypeForUsers:
             ],
         )
         mocker.patch(
-            "app.models.user.InvitedUsers.client_method",
+            "app.models.user.InvitedUsers._get_items",
             return_value=[sample_invite],
         )
         service_one["permissions"] += ["email_auth"]
@@ -5261,7 +5261,7 @@ class TestSetAuthTypeForUsers:
         mock_update_user_attribute,
     ):
         mocker.patch(
-            "app.models.user.Users.client_method",
+            "app.models.user.Users._get_items",
             return_value=[
                 create_service_one_user(
                     id="a", name="Alpha", email_address="notify+1@notify.test", auth_type="sms_auth"
@@ -5291,7 +5291,7 @@ class TestSetAuthTypeForUsers:
         mock_update_user_attribute,
     ):
         mocker.patch(
-            "app.models.user.Users.client_method",
+            "app.models.user.Users._get_items",
             return_value=[
                 create_service_one_user(
                     id="a", name="Alpha", email_address="notify+1@notify.test", auth_type="sms_auth"
@@ -5317,11 +5317,11 @@ class TestSetAuthTypeForUsers:
         self, mocker, client_request, service_one, active_user_with_permissions, sample_invite
     ):
         mocker.patch(
-            "app.models.user.Users.client_method",
+            "app.models.user.Users._get_items",
             return_value=[],
         )
         mocker.patch(
-            "app.models.user.InvitedUsers.client_method",
+            "app.models.user.InvitedUsers._get_items",
             return_value=[sample_invite],
         )
         mock_update_invite = mocker.patch("app.invite_api_client.update_invite", autospec=True)
@@ -5357,7 +5357,7 @@ class TestSetAuthTypeForUsers:
         mock_update_user_attribute,
     ):
         mocker.patch(
-            "app.models.user.Users.client_method",
+            "app.models.user.Users._get_items",
             return_value=[
                 create_service_one_user(
                     id="a", name="Alpha", email_address="notify+1@notify.test", auth_type="sms_auth"

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -639,13 +639,13 @@ def test_show_limits_for_live_service(
 )
 @freeze_time("2017-04-01 11:09:00.061258")
 def test_switch_service_to_live(
-    mocker,
     client_request,
     platform_admin_user,
     mock_update_service,
     mock_get_inbound_number_for_service,
     mock_get_service_organisation,
     agreement_signed,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation",
@@ -740,13 +740,13 @@ def test_switch_service_to_restricted(
     ),
 )
 def test_show_switch_service_to_count_as_live_page(
-    mocker,
     client_request,
     platform_admin_user,
     mock_update_service,
     count_as_live,
     selected,
     labelled,
+    mocker,
 ):
     mocker.patch(
         "app.models.service.Service.count_as_live",
@@ -1842,10 +1842,10 @@ class TestServiceDataRetention:
     ),
 )
 def test_should_show_estimate_volumes(
-    mocker,
     client_request,
     volumes,
     displayed_volumes,
+    mocker,
 ):
     for channel, volume in volumes:
         mocker.patch(
@@ -2413,7 +2413,6 @@ def test_ready_to_go_live(
     ],
 )
 def test_route_permissions(
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
@@ -2425,6 +2424,7 @@ def test_route_permissions(
     route,
     mock_get_service_settings_page_common,
     mock_get_service_templates,
+    mocker,
 ):
     validate_route_permission(
         mocker,
@@ -2451,7 +2451,6 @@ def test_route_permissions(
     ],
 )
 def test_route_invalid_permissions(
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
@@ -2459,6 +2458,7 @@ def test_route_invalid_permissions(
     route,
     mock_get_service_templates,
     mock_get_invites_for_service,
+    mocker,
 ):
     validate_route_permission(
         mocker,
@@ -2482,7 +2482,6 @@ def test_route_invalid_permissions(
     ],
 )
 def test_route_for_platform_admin(
-    mocker,
     notify_admin,
     client_request,
     platform_admin_user,
@@ -2494,6 +2493,7 @@ def test_route_for_platform_admin(
     mock_get_service_settings_page_common,
     mock_get_service_templates,
     mock_get_invites_for_service,
+    mocker,
 ):
     validate_route_permission(
         mocker,
@@ -2786,7 +2786,11 @@ def test_incorrect_sms_sender_input_with_multiple_errors_only_shows_the_first(
     ],
 )
 def test_add_reply_to_email_address_sends_test_notification(
-    mocker, client_request, reply_to_addresses, data, api_default_args
+    client_request,
+    reply_to_addresses,
+    data,
+    api_default_args,
+    mocker,
 ):
     mocker.patch("app.service_api_client.get_reply_to_email_addresses", return_value=reply_to_addresses)
     data["email_address"] = "test@example.com"
@@ -2809,7 +2813,9 @@ def test_add_reply_to_email_address_sends_test_notification(
 
 
 def test_service_add_reply_to_email_address_without_verification_for_platform_admin(
-    mocker, client_request, platform_admin_user
+    client_request,
+    platform_admin_user,
+    mocker,
 ):
     client_request.login(platform_admin_user)
 
@@ -2844,7 +2850,6 @@ def test_service_add_reply_to_email_address_without_verification_for_platform_ad
 )
 @freeze_time("2018-06-01 11:11:00.061258")
 def test_service_verify_reply_to_address(
-    mocker,
     client_request,
     fake_uuid,
     get_non_default_reply_to_email_address,
@@ -2853,6 +2858,7 @@ def test_service_verify_reply_to_address(
     expected_success,
     is_default,
     replace,
+    mocker,
 ):
     notification = {
         "id": fake_uuid,
@@ -2902,7 +2908,11 @@ def test_service_verify_reply_to_address(
 
 
 @freeze_time("2018-06-01 11:11:00.061258")
-def test_add_reply_to_email_address_fails_if_notification_not_delivered_in_45_sec(mocker, client_request, fake_uuid):
+def test_add_reply_to_email_address_fails_if_notification_not_delivered_in_45_sec(
+    client_request,
+    fake_uuid,
+    mocker,
+):
     notification = {
         "id": fake_uuid,
         "status": "sending",
@@ -2935,7 +2945,12 @@ def test_add_reply_to_email_address_fails_if_notification_not_delivered_in_45_se
     ],
 )
 def test_add_letter_contact(
-    letter_contact_blocks, data, api_default_args, mocker, client_request, mock_add_letter_contact
+    letter_contact_blocks,
+    data,
+    api_default_args,
+    client_request,
+    mock_add_letter_contact,
+    mocker,
 ):
     mocker.patch("app.service_api_client.get_letter_contacts", return_value=letter_contact_blocks)
 
@@ -3001,7 +3016,14 @@ def test_add_letter_contact_when_coming_from_template(
         (create_multiple_sms_senders(), {"is_default": "y"}, True),
     ],
 )
-def test_add_sms_sender(sms_senders, data, api_default_args, mocker, client_request, mock_add_sms_sender):
+def test_add_sms_sender(
+    sms_senders,
+    data,
+    api_default_args,
+    client_request,
+    mock_add_sms_sender,
+    mocker,
+):
     mocker.patch(
         "app.protected_sender_id_api_client.get_check_sender_id",
         return_value=False,
@@ -3020,7 +3042,12 @@ def test_add_sms_sender(sms_senders, data, api_default_args, mocker, client_requ
         (create_multiple_email_reply_to_addresses(), True),
     ],
 )
-def test_default_box_doesnt_show_on_first_email_sender(reply_to_addresses, mocker, checkbox_present, client_request):
+def test_default_box_doesnt_show_on_first_email_sender(
+    reply_to_addresses,
+    checkbox_present,
+    client_request,
+    mocker,
+):
     mocker.patch("app.service_api_client.get_reply_to_email_addresses", return_value=reply_to_addresses)
 
     page = client_request.get("main.service_add_email_reply_to", service_id=SERVICE_ONE_ID)
@@ -3031,7 +3058,12 @@ def test_default_box_doesnt_show_on_first_email_sender(reply_to_addresses, mocke
 @pytest.mark.parametrize(
     "contact_blocks, checkbox_present", [([], False), (create_multiple_letter_contact_blocks(), True)]
 )
-def test_default_box_doesnt_show_on_first_letter_sender(contact_blocks, mocker, checkbox_present, client_request):
+def test_default_box_doesnt_show_on_first_letter_sender(
+    contact_blocks,
+    checkbox_present,
+    client_request,
+    mocker,
+):
     mocker.patch("app.service_api_client.get_letter_contacts", return_value=contact_blocks)
 
     page = client_request.get("main.service_add_letter_contact", service_id=SERVICE_ONE_ID)
@@ -3051,9 +3083,9 @@ def test_default_box_doesnt_show_on_first_letter_sender(contact_blocks, mocker, 
 def test_edit_reply_to_email_address_sends_verification_notification_if_address_is_changed(
     reply_to_address,
     data,
-    mocker,
     fake_uuid,
     client_request,
+    mocker,
 ):
     mock_verify = mocker.patch(
         "app.service_api_client.verify_reply_to_email_address", return_value={"data": {"id": "123"}}
@@ -3067,7 +3099,10 @@ def test_edit_reply_to_email_address_sends_verification_notification_if_address_
 
 
 def test_service_edit_email_reply_to_updates_email_address_without_verification_for_platform_admin(
-    mocker, fake_uuid, client_request, platform_admin_user
+    fake_uuid,
+    client_request,
+    platform_admin_user,
+    mocker,
 ):
     client_request.login(platform_admin_user)
 
@@ -3103,7 +3138,13 @@ def test_service_edit_email_reply_to_updates_email_address_without_verification_
     ],
 )
 def test_edit_reply_to_email_address_goes_straight_to_update_if_address_not_changed(
-    reply_to_address, data, api_default_args, mocker, fake_uuid, client_request, mock_update_reply_to_email_address
+    reply_to_address,
+    data,
+    api_default_args,
+    fake_uuid,
+    client_request,
+    mock_update_reply_to_email_address,
+    mocker,
 ):
     mocker.patch("app.service_api_client.get_reply_to_email_address", return_value=reply_to_address)
     mock_verify = mocker.patch("app.service_api_client.verify_reply_to_email_address")
@@ -3126,7 +3167,12 @@ def test_edit_reply_to_email_address_goes_straight_to_update_if_address_not_chan
     ],
 )
 def test_add_and_edit_reply_to_email_address(
-    mocker, fake_uuid, client_request, mock_update_reply_to_email_address, url, header_text
+    fake_uuid,
+    client_request,
+    mock_update_reply_to_email_address,
+    url,
+    header_text,
+    mocker,
 ):
     reply_to_email_address = create_reply_to_email_address()
     mocker.patch("app.service_api_client.get_reply_to_email_addresses", return_value=[reply_to_email_address])
@@ -3165,10 +3211,10 @@ def test_add_and_edit_reply_to_email_address(
     ],
 )
 def test_shows_delete_link_for_get_request_for_edit_email_reply_to_address(
-    mocker,
     reply_to_address,
     default_choice_and_delete_link_expected,
     client_request,
+    mocker,
 ):
     mocker.patch("app.service_api_client.get_reply_to_email_address", return_value=reply_to_address)
 
@@ -3209,11 +3255,11 @@ def test_shows_delete_link_for_get_request_for_edit_email_reply_to_address(
     ],
 )
 def test_shows_delete_link_for_error_on_post_request_for_edit_email_reply_to_address(
-    mocker,
     reply_to_address,
     default_choice_and_delete_link_expected,
     default_checkbox_checked,
     client_request,
+    mocker,
 ):
     mocker.patch("app.service_api_client.get_reply_to_email_address", return_value=reply_to_address)
 
@@ -3296,7 +3342,13 @@ def test_delete_reply_to_email_address(
     ],
 )
 def test_edit_letter_contact_block(
-    letter_contact_block, data, api_default_args, mocker, fake_uuid, client_request, mock_update_letter_contact
+    letter_contact_block,
+    data,
+    api_default_args,
+    fake_uuid,
+    client_request,
+    mock_update_letter_contact,
+    mocker,
 ):
     mocker.patch("app.service_api_client.get_letter_contact", return_value=letter_contact_block)
     data["letter_contact_block"] = "1 Example Street"
@@ -3360,7 +3412,15 @@ def test_delete_letter_contact_block(
         (create_sms_sender(is_default=False), {"is_default": "y", "sms_sender": "test"}, True),
     ],
 )
-def test_edit_sms_sender(sms_sender, data, api_default_args, mocker, fake_uuid, client_request, mock_update_sms_sender):
+def test_edit_sms_sender(
+    sms_sender,
+    data,
+    api_default_args,
+    fake_uuid,
+    client_request,
+    mock_update_sms_sender,
+    mocker,
+):
 
     mocker.patch(
         "app.protected_sender_id_api_client.get_check_sender_id",
@@ -3430,7 +3490,6 @@ def test_edit_sms_sender(sms_sender, data, api_default_args, mocker, fake_uuid, 
 )
 def test_default_box_shows_on_non_default_sender_details_while_editing(
     fake_uuid,
-    mocker,
     sender_page,
     endpoint_to_mock,
     sender_details,
@@ -3438,6 +3497,7 @@ def test_default_box_shows_on_non_default_sender_details_while_editing(
     default_message,
     checkbox_present,
     params,
+    mocker,
 ):
     page_arguments = {"service_id": SERVICE_ONE_ID}
     page_arguments[params] = fake_uuid
@@ -3481,11 +3541,11 @@ def test_sender_details_are_escaped(client_request, mocker, fake_uuid):
     ],
 )
 def test_shows_delete_link_for_sms_sender(
-    mocker,
     sms_sender,
     expected_link_text,
     partial_href,
     client_request,
+    mocker,
 ):
     mocker.patch("app.service_api_client.get_sms_sender", return_value=sms_sender)
 
@@ -3651,7 +3711,6 @@ def test_service_set_letter_branding_platform_admin_only(
     ],
 )
 def test_service_set_letter_branding_prepopulates(
-    mocker,
     client_request,
     platform_admin_user,
     service_one,
@@ -3659,6 +3718,7 @@ def test_service_set_letter_branding_prepopulates(
     letter_branding,
     expected_selected,
     expected_items,
+    mocker,
 ):
     service_one["letter_branding"] = letter_branding
 
@@ -3804,7 +3864,6 @@ def test_service_preview_letter_branding_saves(
     ],
 )
 def test_should_show_branding_styles(
-    mocker,
     client_request,
     platform_admin_user,
     service_one,
@@ -3812,6 +3871,7 @@ def test_should_show_branding_styles(
     current_branding,
     expected_values,
     expected_labels,
+    mocker,
 ):
     service_one["email_branding"] = current_branding
     mocker.patch(
@@ -3942,7 +4002,6 @@ def test_should_preview_email_branding(
     ),
 )
 def test_should_set_branding_for_service_with_organisation(
-    mocker,
     client_request,
     platform_admin_user,
     service_one,
@@ -3960,6 +4019,7 @@ def test_should_set_branding_for_service_with_organisation(
     service_should_be_updated,
     expected_redirect,
     expected_branding_id_in_call,
+    mocker,
 ):
     service_one["organisation"] = organisation_one
     service_id = SERVICE_ONE_ID
@@ -4020,7 +4080,11 @@ def test_should_set_branding_for_service_with_no_organisation(
 
 
 def test_get_service_set_email_branding_add_to_branding_pool_step(
-    mocker, client_request, platform_admin_user, service_one, organisation_one
+    client_request,
+    platform_admin_user,
+    service_one,
+    organisation_one,
+    mocker,
 ):
     service_one["organisation"] = organisation_one
     client_request.login(platform_admin_user)
@@ -4042,7 +4106,10 @@ def test_get_service_set_email_branding_add_to_branding_pool_step(
 
 
 def test_service_set_email_branding_add_to_branding_pool_step_is_platform_admin_only(
-    mocker, client_request, service_one, organisation_one
+    client_request,
+    service_one,
+    organisation_one,
+    mocker,
 ):
     service_one["organisation"] = organisation_one
     email_branding_id = "234"
@@ -4063,7 +4130,6 @@ def test_service_set_email_branding_add_to_branding_pool_step_is_platform_admin_
 
 @pytest.mark.parametrize("add_to_pool", ["yes", "no"])
 def test_service_set_email_branding_add_to_branding_pool_step_choices_yes_or_no(
-    mocker,
     client_request,
     platform_admin_user,
     service_one,
@@ -4074,6 +4140,7 @@ def test_service_set_email_branding_add_to_branding_pool_step_choices_yes_or_no(
     mock_get_free_sms_fragment_limit,
     mock_get_service_data_retention,
     mock_update_service,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     service_one["organisation"] = organisation_one
@@ -4116,7 +4183,11 @@ def test_service_set_email_branding_add_to_branding_pool_step_choices_yes_or_no(
 
 
 def test_get_service_set_letter_branding_add_to_branding_pool_step(
-    mocker, client_request, platform_admin_user, service_one, organisation_one
+    client_request,
+    platform_admin_user,
+    service_one,
+    organisation_one,
+    mocker,
 ):
     service_one["organisation"] = organisation_one
     client_request.login(platform_admin_user)
@@ -4139,7 +4210,11 @@ def test_get_service_set_letter_branding_add_to_branding_pool_step(
 
 
 def test_get_service_set_letter_branding_add_to_branding_pool_step_protects_against_xss(
-    mocker, client_request, platform_admin_user, service_one, organisation_one
+    client_request,
+    platform_admin_user,
+    service_one,
+    organisation_one,
+    mocker,
 ):
     service_one["organisation"] = organisation_one
     service_one["name"] = "<script>evil</script>"
@@ -4161,7 +4236,10 @@ def test_get_service_set_letter_branding_add_to_branding_pool_step_protects_agai
 
 
 def test_service_set_letter_branding_add_to_branding_pool_step_is_platform_admin_only(
-    mocker, client_request, service_one, organisation_one
+    client_request,
+    service_one,
+    organisation_one,
+    mocker,
 ):
     service_one["organisation"] = organisation_one
     letter_branding_id = "234"
@@ -4183,7 +4261,6 @@ def test_service_set_letter_branding_add_to_branding_pool_step_is_platform_admin
 
 @pytest.mark.parametrize("add_to_pool", ["yes", "no"])
 def test_service_set_letter_branding_add_to_branding_pool_step_choices_yes_or_no(
-    mocker,
     client_request,
     platform_admin_user,
     service_one,
@@ -4194,6 +4271,7 @@ def test_service_set_letter_branding_add_to_branding_pool_step_choices_yes_or_no
     mock_get_free_sms_fragment_limit,
     mock_get_service_data_retention,
     mock_update_service,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     service_one["organisation"] = organisation_one
@@ -4956,6 +5034,7 @@ def test_send_files_by_email_contact_details_does_not_update_invalid_contact_det
     contact_details_type,
     invalid_value,
     error,
+    mocker,
 ):
     service_one["contact_link"] = "http://example.com/"
     service_one["permissions"].append("upload_document")
@@ -4990,9 +5069,9 @@ class TestSetAuthType:
 
     def test_page_loads(
         self,
-        mocker,
         client_request,
         service_one,
+        mocker,
     ):
         mocker.patch("app.models.user.Users._get_items")
         page = client_request.get(
@@ -5003,9 +5082,9 @@ class TestSetAuthType:
 
     def test_current_setting_selected(
         self,
-        mocker,
         client_request,
         service_one,
+        mocker,
     ):
         mocker.patch("app.models.user.Users._get_items")
         page = client_request.get(
@@ -5018,7 +5097,12 @@ class TestSetAuthType:
         assert normalize_spaces(radio_items[1].select_one("label").text) == "Email link or text message code"
         assert not radio_items[1].select_one("input").has_attr("checked")
 
-    def tests_redirects_to_set_auth_type_for_users_on_success(self, mocker, client_request, service_one):
+    def tests_redirects_to_set_auth_type_for_users_on_success(
+        self,
+        client_request,
+        service_one,
+        mocker,
+    ):
         mock_update_service = mocker.patch("app.notify_client.service_api_client.service_api_client.update_service")
         mocker.patch("app.models.user.Users._get_items")
         client_request.post(
@@ -5033,7 +5117,11 @@ class TestSetAuthType:
         assert set(mock_update_call[1]["permissions"]) == {"email_auth", "email", "sms"}
 
     def test_redirects_to_confirmation_when_disabling_email_auth(
-        self, mocker, client_request, service_one, active_user_with_permissions
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        mocker,
     ):
         service_one["permissions"] += ["email_auth"]
         mocker.patch("app.notify_client.service_api_client.service_api_client.update_service")
@@ -5046,7 +5134,11 @@ class TestSetAuthType:
         )
 
     def test_cannot_disable_email_auth_if_some_users_dont_have_a_mobile_number(
-        self, mocker, client_request, service_one, active_user_with_permissions
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        mocker,
     ):
         active_user_with_permissions["mobile_number"] = None
         mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
@@ -5071,7 +5163,13 @@ class TestConfirmDisableEmailAuth:
             _expected_status=403,
         )
 
-    def test_page_loads(self, mocker, client_request, service_one, active_user_with_permissions):
+    def test_page_loads(
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        mocker,
+    ):
         service_one["permissions"] += ["email_auth"]
         mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
         client_request.get(
@@ -5080,7 +5178,11 @@ class TestConfirmDisableEmailAuth:
         )
 
     def test_page_redirects_to_set_auth_type_if_service_doesnt_use_email_auth(
-        self, mocker, client_request, service_one, active_user_with_permissions
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        mocker,
     ):
         mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
         client_request.get(
@@ -5090,7 +5192,11 @@ class TestConfirmDisableEmailAuth:
         )
 
     def test_redirects_to_set_auth_type_if_some_users_dont_have_mobile_number(
-        self, mocker, client_request, service_one, active_user_with_permissions
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        mocker,
     ):
         active_user_with_permissions["mobile_number"] = None
         mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
@@ -5101,7 +5207,11 @@ class TestConfirmDisableEmailAuth:
         )
 
     def test_save_redirects_to_service_settings(
-        self, mocker, client_request, service_one, active_user_with_permissions
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        mocker,
     ):
         service_one["permissions"] += ["email_auth"]
         mocker.patch(
@@ -5116,7 +5226,12 @@ class TestConfirmDisableEmailAuth:
         )
 
     def test_save_disables_email_auth_for_service_users(
-        self, mocker, client_request, service_one, active_user_with_permissions, mock_update_user_attribute
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        mock_update_user_attribute,
+        mocker,
     ):
         active_user_with_permissions["auth_type"] = "email_auth"
         active_user_with_permissions["permissions"][service_one["id"]].append("email_auth")
@@ -5139,7 +5254,11 @@ class TestConfirmDisableEmailAuth:
         ]
 
     def test_save_does_not_disable_webauthn_sign_in_for_service_users(
-        self, mocker, client_request, service_one, active_user_with_permissions
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        mocker,
     ):
         active_user_with_permissions["auth_type"] = "webauthn_auth"
         mocker.patch("app.notify_client.service_api_client.service_api_client.update_service")
@@ -5185,11 +5304,11 @@ class TestSetAuthTypeForUsers:
 
     def test_redirects_away_if_no_other_users(
         self,
-        mocker,
         client_request,
         service_one,
         active_user_with_permissions,
         mock_get_users_by_service,
+        mocker,
     ):
         mocker.patch("app.models.user.InvitedUsers._get_items", return_value=[])
 
@@ -5219,7 +5338,12 @@ class TestSetAuthTypeForUsers:
         )
 
     def test_page_shows_other_users_on_service(
-        self, mocker, client_request, service_one, active_user_with_permissions, sample_invite
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        sample_invite,
+        mocker,
     ):
         mocker.patch(
             "app.models.user.Users._get_items",
@@ -5253,12 +5377,12 @@ class TestSetAuthTypeForUsers:
 
     def test_sets_email_auth_for_users(
         self,
-        mocker,
         client_request,
         service_one,
         active_user_with_permissions,
         mock_get_invites_for_service,
         mock_update_user_attribute,
+        mocker,
     ):
         mocker.patch(
             "app.models.user.Users._get_items",
@@ -5283,12 +5407,12 @@ class TestSetAuthTypeForUsers:
 
     def test_sets_sms_auth_for_deselected_users(
         self,
-        mocker,
         client_request,
         service_one,
         active_user_with_permissions,
         mock_get_invites_for_service,
         mock_update_user_attribute,
+        mocker,
     ):
         mocker.patch(
             "app.models.user.Users._get_items",
@@ -5314,7 +5438,12 @@ class TestSetAuthTypeForUsers:
         assert mock_update_user_attribute.call_args_list == [mocker.call("b", auth_type="sms_auth")]
 
     def test_updates_invited_users(
-        self, mocker, client_request, service_one, active_user_with_permissions, sample_invite
+        self,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        sample_invite,
+        mocker,
     ):
         mocker.patch(
             "app.models.user.Users._get_items",
@@ -5347,7 +5476,6 @@ class TestSetAuthTypeForUsers:
     )
     def test_user_with_webauthn_auth_not_listed_or_editable(
         self,
-        mocker,
         client_request,
         service_one,
         active_user_with_permissions,
@@ -5355,6 +5483,7 @@ class TestSetAuthTypeForUsers:
         form_data,
         should_fail,
         mock_update_user_attribute,
+        mocker,
     ):
         mocker.patch(
             "app.models.user.Users._get_items",
@@ -5730,6 +5859,7 @@ def test_service_settings_links_to_branding_options_page_for_letters(
     no_letter_contact_blocks,
     single_sms_sender,
     mock_get_service_data_retention,
+    mocker,
 ):
     service_one["permissions"].append("letter")
     page = client_request.get(".service_settings", service_id=SERVICE_ONE_ID)
@@ -5863,6 +5993,7 @@ def test_service_settings_links_to_edit_service_notes_page_for_platform_admins(
     no_letter_contact_blocks,
     single_sms_sender,
     mock_get_service_settings_page_common,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     page = client_request.get(
@@ -5909,6 +6040,7 @@ def test_service_settings_links_to_edit_service_billing_details_page_for_platfor
     no_letter_contact_blocks,
     single_sms_sender,
     mock_get_service_settings_page_common,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     page = client_request.get(

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -17,7 +17,7 @@ from tests.conftest import (
 
 @pytest.fixture()
 def mock_no_users_for_service(mocker):
-    mocker.patch("app.models.user.Users.client_method", return_value=[])
+    mocker.patch("app.models.user.Users._get_items", return_value=[])
 
 
 @pytest.fixture(scope="function")
@@ -205,7 +205,7 @@ def test_existing_user_of_service_get_redirected_to_signin(
 ):
     client_request.logout()
     sample_invite["email_address"] = api_user_active["email_address"]
-    mocker.patch("app.models.user.Users.client_method", return_value=[api_user_active])
+    mocker.patch("app.models.user.Users._get_items", return_value=[api_user_active])
 
     page = client_request.get(
         "main.accept_invite",
@@ -496,7 +496,7 @@ def test_accept_invite_does_not_treat_email_addresses_as_case_sensitive(
 ):
     # the email address of api_user_active is 'test@user.gov.uk'
     sample_invite["email_address"] = "TEST@user.gov.uk"
-    mocker.patch("app.models.user.Users.client_method", return_value=[api_user_active])
+    mocker.patch("app.models.user.Users._get_items", return_value=[api_user_active])
 
     client_request.get(
         "main.accept_invite",

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -583,8 +583,8 @@ def test_new_invited_user_verifies_and_added_to_service(
 
 @pytest.mark.parametrize("trial_mode", (True, False))
 def test_new_invited_user_is_redirected_to_correct_place(
-    mocker,
     client_request,
+    mocker,
     sample_invite,
     mock_check_invite_token,
     mock_dont_get_user_by_email,

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -114,7 +114,6 @@ def test_can_show_notifications(
     expected_page_argument,
     to_argument,
     expected_to_argument,
-    mocker,
     mock_cache_search_query,
 ):
     client_request.login(user)
@@ -343,13 +342,13 @@ def test_download_not_available_to_users_if_invalid_message_type(
 
 
 def test_letters_with_status_virus_scan_failed_shows_a_failure_description(
-    mocker,
     client_request,
     service_one,
     mock_get_service_statistics,
     mock_get_service_data_retention,
     mock_get_notifications_count_for_service,
     mock_get_api_keys,
+    mocker,
 ):
     notifications = create_notifications(
         template_type="letter",
@@ -372,7 +371,6 @@ def test_letters_with_status_virus_scan_failed_shows_a_failure_description(
 
 @pytest.mark.parametrize("letter_status", ["pending-virus-check", "virus-scan-failed"])
 def test_should_not_show_preview_link_for_precompiled_letters_in_virus_states(
-    mocker,
     client_request,
     service_one,
     mock_get_service_statistics,
@@ -380,6 +378,7 @@ def test_should_not_show_preview_link_for_precompiled_letters_in_virus_states(
     mock_get_no_api_keys,
     mock_get_notifications_count_for_service,
     letter_status,
+    mocker,
 ):
     notifications = create_notifications(
         template_type="letter", status=letter_status, is_precompiled_letter=True, client_reference="ref"

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -134,7 +134,6 @@ def test_shows_back_link_if_come_from_join_service_page(
 )
 @freeze_time("2021-01-01")
 def test_should_add_service_and_redirect_to_tour_when_no_services(
-    mocker,
     client_request,
     mock_create_service,
     mock_create_service_template,
@@ -145,6 +144,7 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
     email_address,
     posted,
     persisted,
+    mocker,
 ):
     api_user_active["email_address"] = email_address
     client_request.login(api_user_active)
@@ -188,10 +188,10 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
 
 
 def test_add_service_has_to_choose_org_type(
-    mocker,
     client_request,
     mock_create_service,
     mock_create_service_template,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation_by_domain",
@@ -454,9 +454,9 @@ def test_email_auth_user_creates_service_with_email_auth_permission(
     ),
 )
 def test_join_or_add_service_page_403s_without_permission(
-    mocker,
     client_request,
     organisation,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation_by_domain",
@@ -469,8 +469,8 @@ def test_join_or_add_service_page_403s_without_permission(
 
 
 def test_join_or_add_service_page(
-    mocker,
     client_request,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation_by_domain",
@@ -516,10 +516,10 @@ def test_join_or_add_service_page(
     ),
 )
 def test_post_join_or_add_service_page(
-    mocker,
     client_request,
     mock_get_organisation_services,
     choice,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation_by_domain",

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -324,6 +324,7 @@ def test_accept_agreement_page_validates(
     mock_get_organisations,
     data,
     expected_errors,
+    mocker,
 ):
     page = client_request.post(
         "main.service_accept_agreement",
@@ -392,6 +393,7 @@ def test_accept_agreement_page_persists(
     mock_update_organisation,
     data,
     expected_persisted,
+    mocker,
 ):
     client_request.post(
         "main.service_accept_agreement",

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -494,13 +494,13 @@ def test_should_redirect_after_revoking_api_key(
 
 @pytest.mark.parametrize("route", ["main.api_keys", "main.create_api_key", "main.revoke_api_key"])
 def test_route_permissions(
-    mocker,
     notify_admin,
     fake_uuid,
     api_user_active,
     service_one,
     mock_get_api_keys,
     route,
+    mocker,
 ):
     with notify_admin.test_request_context():
         validate_route_permission(
@@ -517,13 +517,13 @@ def test_route_permissions(
 
 @pytest.mark.parametrize("route", ["main.api_keys", "main.create_api_key", "main.revoke_api_key"])
 def test_route_invalid_permissions(
-    mocker,
     notify_admin,
     fake_uuid,
     api_user_active,
     service_one,
     mock_get_api_keys,
     route,
+    mocker,
 ):
     with notify_admin.test_request_context():
         validate_route_permission(

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -19,7 +19,7 @@ INV_PARENT_FOLDER_ID = "7e979e79-d970-43a5-ac69-b625a8d147b0"
 VIS_PARENT_FOLDER_ID = "bbbb222b-2b22-2b22-222b-b222b22b2222"
 
 
-def test_get_user_phone_number_when_only_inbound_exists(mocker):
+def test_get_user_phone_number_when_only_inbound_exists(notify_admin, mocker):
     mock_get_inbound_sms = mocker.patch(
         "app.main.views.conversation.service_api_client.get_inbound_sms_by_id",
         return_value={"user_number": "4407900900123", "notify_number": "07900000002"},
@@ -33,7 +33,7 @@ def test_get_user_phone_number_when_only_inbound_exists(mocker):
     assert mock_get_notification.called is False
 
 
-def test_get_user_phone_number_when_only_outbound_exists(mocker):
+def test_get_user_phone_number_when_only_outbound_exists(notify_admin, mocker):
     mock_get_inbound_sms = mocker.patch(
         "app.main.views.conversation.service_api_client.get_inbound_sms_by_id",
         side_effect=HTTPError(response=Mock(status_code=404)),
@@ -46,7 +46,7 @@ def test_get_user_phone_number_when_only_outbound_exists(mocker):
     mock_get_notification.assert_called_once_with("service", "notification")
 
 
-def test_get_user_phone_number_raises_if_both_api_requests_fail(mocker):
+def test_get_user_phone_number_raises_if_both_api_requests_fail(notify_admin, mocker):
     mock_get_inbound_sms = mocker.patch(
         "app.main.views.conversation.service_api_client.get_inbound_sms_by_id",
         side_effect=HTTPError(response=Mock(status_code=404)),
@@ -369,7 +369,7 @@ def test_conversation_reply_redirects_with_phone_number_from_notification(
         assert normalize_spaces(page.select_one(element).text) == expected_text
 
 
-def test_get_user_phone_number_when_not_a_standard_phone_number(mocker):
+def test_get_user_phone_number_when_not_a_standard_phone_number(notify_admin, mocker):
     mocker.patch(
         "app.main.views.conversation.service_api_client.get_inbound_sms_by_id",
         return_value={"user_number": "ALPHANUM3R1C", "notify_number": "07900000002"},

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -452,11 +452,11 @@ def test_download_inbox(
     ],
 )
 def test_download_inbox_strips_formulae(
-    mocker,
     client_request,
     fake_uuid,
     message_content,
     expected_cell,
+    mocker,
 ):
     mocker.patch(
         "app.service_api_client.get_inbound_sms",
@@ -904,7 +904,6 @@ def test_should_show_upcoming_jobs_on_dashboard(
 
 
 def test_should_not_show_upcoming_jobs_on_dashboard_if_count_is_0(
-    mocker,
     client_request,
     mock_get_service_templates,
     mock_get_template_statistics,
@@ -915,6 +914,7 @@ def test_should_not_show_upcoming_jobs_on_dashboard_if_count_is_0(
     mock_get_free_sms_fragment_limit,
     mock_get_inbound_sms_summary,
     mock_get_returned_letter_statistics_with_no_returned_letters,
+    mocker,
 ):
     mocker.patch(
         "app.job_api_client.get_scheduled_job_stats",
@@ -933,7 +933,6 @@ def test_should_not_show_upcoming_jobs_on_dashboard_if_count_is_0(
 
 
 def test_should_not_show_upcoming_jobs_on_dashboard_if_service_has_no_jobs(
-    mocker,
     client_request,
     mock_get_service_templates,
     mock_get_template_statistics,
@@ -945,6 +944,7 @@ def test_should_not_show_upcoming_jobs_on_dashboard_if_service_has_no_jobs(
     mock_get_free_sms_fragment_limit,
     mock_get_inbound_sms_summary,
     mock_get_returned_letter_statistics_with_no_returned_letters,
+    mocker,
 ):
     page = client_request.get(
         "main.service_dashboard",
@@ -1083,7 +1083,10 @@ def test_usage_page(
 
 @freeze_time("2012-03-31 12:12:12")
 def test_usage_page_no_sms_spend(
-    mocker, client_request, mock_get_monthly_usage_for_service, mock_get_free_sms_fragment_limit
+    client_request,
+    mock_get_monthly_usage_for_service,
+    mock_get_free_sms_fragment_limit,
+    mocker,
 ):
     mocker.patch(
         "app.billing_api_client.get_annual_usage_for_service",
@@ -1143,13 +1146,13 @@ def test_usage_page_no_sms_spend(
 )
 @freeze_time("2012-03-31 12:12:12")
 def test_usage_page_font_size(
-    mocker,
     client_request,
     mock_get_monthly_usage_for_service,
     mock_get_free_sms_fragment_limit,
     annual_usage,
     expected_css_class,
     expected_item_count,
+    mocker,
 ):
     mocker.patch(
         "app.billing_api_client.get_annual_usage_for_service",
@@ -1232,10 +1235,10 @@ def test_usage_page_letter_breakdown_ordered_by_postage_and_rate(
 
 
 def test_usage_page_with_0_free_allowance(
-    mocker,
     client_request,
     mock_get_annual_usage_for_service,
     mock_get_monthly_usage_for_service,
+    mocker,
 ):
     mocker.patch(
         "app.billing_api_client.get_free_sms_fragment_limit_for_year",
@@ -1481,7 +1484,6 @@ def test_menu_all_services_for_platform_admin_user(
 
 
 def test_route_for_service_permissions(
-    mocker,
     notify_admin,
     api_user_active,
     service_one,
@@ -1496,6 +1498,7 @@ def test_route_for_service_permissions(
     mock_get_free_sms_fragment_limit,
     mock_get_inbound_sms_summary,
     mock_get_returned_letter_statistics_with_no_returned_letters,
+    mocker,
 ):
     with notify_admin.test_request_context():
         validate_route_permission(
@@ -1541,7 +1544,6 @@ def test_aggregate_notifications_stats():
 
 
 def test_service_dashboard_updates_gets_dashboard_totals(
-    mocker,
     client_request,
     mock_get_service_templates,
     mock_get_template_statistics,
@@ -1552,6 +1554,7 @@ def test_service_dashboard_updates_gets_dashboard_totals(
     mock_get_free_sms_fragment_limit,
     mock_get_inbound_sms_summary,
     mock_get_returned_letter_statistics_with_no_returned_letters,
+    mocker,
 ):
     mocker.patch(
         "app.main.views.dashboard.get_dashboard_totals",
@@ -1574,7 +1577,6 @@ def test_service_dashboard_updates_gets_dashboard_totals(
 
 
 def test_service_dashboard_totals_link_to_view_notifications(
-    mocker,
     client_request,
     mock_get_service_templates,
     mock_get_template_statistics,
@@ -1585,6 +1587,7 @@ def test_service_dashboard_totals_link_to_view_notifications(
     mock_get_free_sms_fragment_limit,
     mock_get_inbound_sms_summary,
     mock_get_returned_letter_statistics_with_no_returned_letters,
+    mocker,
 ):
     mocker.patch(
         "app.main.views.dashboard.get_dashboard_totals",
@@ -1745,7 +1748,6 @@ def test_org_breadcrumbs_do_not_show_if_service_has_no_org(
 
 
 def test_org_breadcrumbs_do_not_show_if_user_is_not_an_org_member(
-    mocker,
     mock_get_service_templates_when_no_templates_exist,
     mock_has_no_jobs,
     active_caseworking_user,
@@ -1754,6 +1756,7 @@ def test_org_breadcrumbs_do_not_show_if_user_is_not_an_org_member(
     mock_get_unsubscribe_requests_statistics,
     mock_get_returned_letter_statistics_with_no_returned_letters,
     mock_get_api_keys,
+    mocker,
 ):
     # active_caseworking_user is not an org member
 
@@ -1769,7 +1772,6 @@ def test_org_breadcrumbs_do_not_show_if_user_is_not_an_org_member(
 
 
 def test_org_breadcrumbs_show_if_user_is_a_member_of_the_services_org(
-    mocker,
     mock_get_template_statistics,
     mock_get_service_templates_when_no_templates_exist,
     mock_has_no_jobs,
@@ -1779,6 +1781,7 @@ def test_org_breadcrumbs_show_if_user_is_a_member_of_the_services_org(
     mock_get_returned_letter_statistics_with_no_returned_letters,
     active_user_with_permissions,
     client_request,
+    mocker,
 ):
     # active_user_with_permissions (used by the client_request) is an org member
 
@@ -1802,7 +1805,6 @@ def test_org_breadcrumbs_show_if_user_is_a_member_of_the_services_org(
 
 
 def test_org_breadcrumbs_do_not_show_if_user_is_a_member_of_the_services_org_but_service_is_in_trial_mode(
-    mocker,
     mock_get_template_statistics,
     mock_get_service_templates_when_no_templates_exist,
     mock_has_no_jobs,
@@ -1812,6 +1814,7 @@ def test_org_breadcrumbs_do_not_show_if_user_is_a_member_of_the_services_org_but
     mock_get_returned_letter_statistics_with_no_returned_letters,
     active_user_with_permissions,
     client_request,
+    mocker,
 ):
     # active_user_with_permissions (used by the client_request) is an org member
 
@@ -1828,7 +1831,6 @@ def test_org_breadcrumbs_do_not_show_if_user_is_a_member_of_the_services_org_but
 
 
 def test_org_breadcrumbs_show_if_user_is_platform_admin(
-    mocker,
     mock_get_template_statistics,
     mock_get_service_templates_when_no_templates_exist,
     mock_has_no_jobs,
@@ -1838,6 +1840,7 @@ def test_org_breadcrumbs_show_if_user_is_platform_admin(
     mock_get_returned_letter_statistics_with_no_returned_letters,
     platform_admin_user,
     client_request,
+    mocker,
 ):
     service_one_json = service_json(SERVICE_ONE_ID, users=[platform_admin_user["id"]], organisation_id=ORGANISATION_ID)
 
@@ -1859,7 +1862,6 @@ def test_org_breadcrumbs_show_if_user_is_platform_admin(
 
 
 def test_breadcrumb_shows_if_service_is_suspended(
-    mocker,
     mock_get_template_statistics,
     mock_get_service_templates_when_no_templates_exist,
     mock_has_no_jobs,
@@ -1869,6 +1871,7 @@ def test_breadcrumb_shows_if_service_is_suspended(
     mock_get_returned_letter_statistics_with_no_returned_letters,
     platform_admin_user,
     client_request,
+    mocker,
 ):
     service_one_json = service_json(SERVICE_ONE_ID, active=False)
     client_request.login(platform_admin_user, service=service_one_json)
@@ -1906,7 +1909,6 @@ def test_service_dashboard_shows_usage(
 
 
 def test_service_dashboard_shows_free_allowance(
-    mocker,
     client_request,
     service_one,
     mock_get_service_templates,
@@ -1915,6 +1917,7 @@ def test_service_dashboard_shows_free_allowance(
     mock_has_no_jobs,
     mock_get_free_sms_fragment_limit,
     mock_get_returned_letter_statistics_with_no_returned_letters,
+    mocker,
 ):
     mocker.patch(
         "app.billing_api_client.get_annual_usage_for_service",
@@ -1960,7 +1963,6 @@ def test_service_dashboard_shows_free_allowance(
     ),
 )
 def test_service_dashboard_shows_usage_in_correct_font_size(
-    mocker,
     client_request,
     service_one,
     mock_get_service_templates,
@@ -1971,6 +1973,7 @@ def test_service_dashboard_shows_usage_in_correct_font_size(
     mock_get_returned_letter_statistics_with_no_returned_letters,
     annual_usage,
     expected_css_class,
+    mocker,
 ):
     mocker.patch(
         "app.billing_api_client.get_annual_usage_for_service",

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -47,7 +47,13 @@ def test_email_branding_page_shows_full_branding_list(client_request, platform_a
     "user_fixture, expected_response_status", (("api_user_active_email_auth", 403), ("platform_admin_user", 200))
 )
 def test_view_email_branding_requires_platform_admin(
-    mocker, client_request, mock_get_email_branding, user_fixture, expected_response_status, request, fake_uuid
+    client_request,
+    mock_get_email_branding,
+    user_fixture,
+    expected_response_status,
+    request,
+    fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.email_branding_client.get_orgs_and_services_associated_with_branding",
@@ -944,7 +950,11 @@ def test_create_email_branding_government_identity_colour_400_if_no_filename_or_
     )
 
 
-def test_post_create_email_branding_government_identity_form_colour(mocker, client_request, platform_admin_user):
+def test_post_create_email_branding_government_identity_form_colour(
+    client_request,
+    platform_admin_user,
+    mocker,
+):
     mock_save_temporary = mocker.patch(
         "app.main.views.email_branding.logo_client.save_temporary_logo",
         return_value="temporary/email/example.png",

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -180,10 +180,10 @@ def test_user_information_page_shows_archive_link_for_active_users(
 
 
 def test_user_information_page_does_not_show_archive_link_for_inactive_users(
-    mocker,
     client_request,
     platform_admin_user,
     mock_get_organisations_and_services_for_user,
+    mocker,
 ):
     inactive_user_id = uuid.uuid4()
     inactive_user = user_json(id_=inactive_user_id, state="inactive")

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -352,12 +352,12 @@ def test_should_show_letter_job(
 
 @freeze_time("2016-01-01 11:09:00")
 def test_should_show_letter_job_with_banner_after_sending_before_1730(
-    mocker,
     client_request,
     mock_get_service_letter_template,
     mock_get_letter_job,
     mock_get_service_data_retention,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.notification_api_client.get_notifications_for_service",
@@ -380,12 +380,12 @@ def test_should_show_letter_job_with_banner_after_sending_before_1730(
 
 @freeze_time("2016-01-01 11:09:00")
 def test_should_show_letter_job_with_banner_when_there_are_multiple_CSV_rows(
-    mocker,
     client_request,
     mock_get_service_letter_template,
     mock_get_letter_job_in_progress,
     mock_get_service_data_retention,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.notification_api_client.get_notifications_for_service",
@@ -407,12 +407,12 @@ def test_should_show_letter_job_with_banner_when_there_are_multiple_CSV_rows(
 
 @freeze_time("2016-01-01 18:09:00")
 def test_should_show_letter_job_with_banner_after_sending_after_1730(
-    mocker,
     client_request,
     mock_get_service_letter_template,
     mock_get_letter_job,
     mock_get_service_data_retention,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.notification_api_client.get_notifications_for_service",
@@ -434,13 +434,13 @@ def test_should_show_letter_job_with_banner_after_sending_after_1730(
 
 @freeze_time("2016-01-01T00:00:00.061258")
 def test_should_show_scheduled_job(
-    mocker,
     client_request,
     mock_get_service_template,
     mock_get_scheduled_job,
     mock_get_service_data_retention,
     mock_get_notifications,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.main.views.jobs.s3download",
@@ -494,10 +494,10 @@ def test_should_show_scheduled_job(
 
 
 def test_should_download_scheduled_job(
-    mocker,
     client_request,
     mock_get_scheduled_job,
     fake_uuid,
+    mocker,
 ):
     original_file_contents = "phone number,name\n+447700900986,John\n+447700900986,Smith\n"
     mocker.patch(
@@ -519,6 +519,7 @@ def test_should_not_download_unscheduled_job(
     mock_get_service_data_retention,
     mock_get_notifications,
     fake_uuid,
+    mocker,
 ):
     client_request.get(
         "main.view_job_original_file_csv",

--- a/tests/app/main/views/test_join_service.py
+++ b/tests/app/main/views/test_join_service.py
@@ -16,8 +16,8 @@ from tests.conftest import (
 
 
 def test_choose_service_to_join(
-    mocker,
     client_request,
+    mocker,
 ):
     mocker.patch(
         "app.organisations_client.get_organisation_by_domain",
@@ -62,11 +62,11 @@ def test_cannot_join_service_without_organisation(client_request):
     ),
 )
 def test_cannot_join_service_without_organisation_permission(
-    mocker,
     client_request,
     service_one,
     fake_uuid,
     can_ask_to_join_a_service,
+    mocker,
 ):
     service_one["organisation"] = fake_uuid
     mocker.patch(
@@ -89,10 +89,10 @@ def test_cannot_join_service_without_organisation_permission(
 
 
 def test_cannot_join_service_for_different_organisation(
-    mocker,
     client_request,
     service_one,
     fake_uuid,
+    mocker,
 ):
     service_one["organisation"] = fake_uuid
     mocker.patch(
@@ -112,10 +112,10 @@ def test_cannot_join_service_for_different_organisation(
 
 @freeze_time("2023-02-03 01:00")
 def test_page_lists_team_members_of_service(
-    mocker,
     client_request,
     service_one,
     mock_get_organisation_by_domain,
+    mocker,
 ):
     service_one["organisation"] = ORGANISATION_ID
     mocker.patch(
@@ -184,11 +184,11 @@ def test_page_lists_team_members_of_service(
 
 
 def test_page_redirects_on_post(
-    mocker,
     client_request,
     mock_request_invite_for,
     service_one,
     mock_get_organisation_by_domain,
+    mocker,
 ):
     service_one["organisation"] = ORGANISATION_ID
     mocker.patch(

--- a/tests/app/main/views/test_join_service.py
+++ b/tests/app/main/views/test_join_service.py
@@ -131,7 +131,7 @@ def test_page_lists_team_members_of_service(
     manage_service_user_2["logged_in_at"] = "2023-02-03 01:00"
 
     mock_get_users = mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[
             # These three users should not appear on the page
             create_active_user_empty_permissions(),
@@ -202,7 +202,7 @@ def test_page_redirects_on_post(
     manage_service_user_2["logged_in_at"] = "2023-02-03 01:00"
 
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[
             manage_service_user_1,
             manage_service_user_2,

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -41,7 +41,13 @@ def test_letter_branding_page_shows_full_branding_list(
     "user_fixture, expected_response_status", (("api_user_active_email_auth", 403), ("platform_admin_user", 200))
 )
 def test_view_letter_branding_requires_platform_admin(
-    mocker, client_request, mock_get_letter_branding_by_id, user_fixture, expected_response_status, request, fake_uuid
+    client_request,
+    mock_get_letter_branding_by_id,
+    user_fixture,
+    expected_response_status,
+    request,
+    fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.letter_branding_client.get_orgs_and_services_associated_with_branding",
@@ -62,11 +68,11 @@ def test_view_letter_branding_requires_platform_admin(
 
 
 def test_view_letter_branding_with_services_but_no_orgs(
-    mocker,
     client_request,
     platform_admin_user,
     mock_get_letter_branding_by_id,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.letter_branding_client.get_orgs_and_services_associated_with_branding",
@@ -96,11 +102,11 @@ def test_view_letter_branding_with_services_but_no_orgs(
 
 
 def test_view_letter_branding_with_org_but_no_services(
-    mocker,
     client_request,
     platform_admin_user,
     mock_get_letter_branding_by_id,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.letter_branding_client.get_orgs_and_services_associated_with_branding",
@@ -168,11 +174,11 @@ def test_view_letter_branding_shows_created_by_and_helpful_dates_if_available(
 
 
 def test_view_letter_branding_bottom_links(
-    mocker,
     client_request,
     platform_admin_user,
     mock_get_letter_branding_by_id,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.letter_branding_client.get_orgs_and_services_associated_with_branding",
@@ -208,7 +214,11 @@ def test_update_letter_branding_shows_the_current_letter_brand(
 
 
 def test_update_letter_branding_with_new_valid_file_shows_page_with_file_preview(
-    mocker, client_request, platform_admin_user, mock_get_letter_branding_by_id, fake_uuid
+    client_request,
+    platform_admin_user,
+    mock_get_letter_branding_by_id,
+    fake_uuid,
+    mocker,
 ):
     mock_save_temporary = mocker.patch(
         "app.main.views.letter_branding.logo_client.save_temporary_logo", return_value="temporary.svg"
@@ -251,7 +261,12 @@ def test_update_letter_branding_when_uploading_invalid_file(
 
 
 def test_update_letter_branding_with_original_file_and_new_details(
-    mocker, client_request, platform_admin_user, mock_get_all_letter_branding, mock_get_letter_branding_by_id, fake_uuid
+    client_request,
+    platform_admin_user,
+    mock_get_all_letter_branding,
+    mock_get_letter_branding_by_id,
+    fake_uuid,
+    mocker,
 ):
     mock_client_update = mocker.patch("app.main.views.letter_branding.letter_branding_client.update_letter_branding")
     mock_save_temporary = mocker.patch("app.main.views.letter_branding.logo_client.save_temporary_logo")
@@ -286,7 +301,12 @@ def test_update_letter_branding_with_original_file_and_new_details(
 
 
 def test_update_letter_branding_shows_form_errors_on_name_fields(
-    mocker, client_request, platform_admin_user, mock_get_letter_branding_by_id, fake_uuid, logo_client
+    client_request,
+    platform_admin_user,
+    mock_get_letter_branding_by_id,
+    fake_uuid,
+    logo_client,
+    mocker,
 ):
     mocker.patch("app.main.views.letter_branding.letter_branding_client.update_letter_branding")
 
@@ -307,11 +327,11 @@ def test_update_letter_branding_shows_form_errors_on_name_fields(
 
 
 def test_update_letter_branding_shows_database_errors_on_name_field(
-    mocker,
     client_request,
     platform_admin_user,
     mock_get_letter_branding_by_id,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.main.views.letter_branding.letter_branding_client.update_letter_branding",
@@ -336,7 +356,11 @@ def test_update_letter_branding_shows_database_errors_on_name_field(
 
 
 def test_update_letter_branding_with_new_file_and_new_details(
-    mocker, client_request, platform_admin_user, mock_get_letter_branding_by_id, fake_uuid
+    client_request,
+    platform_admin_user,
+    mock_get_letter_branding_by_id,
+    fake_uuid,
+    mocker,
 ):
     mock_save_temporary = mocker.patch("app.main.views.letter_branding.logo_client.save_temporary_logo")
     mock_save_permanent = mocker.patch(
@@ -374,12 +398,12 @@ def test_update_letter_branding_with_new_file_and_new_details(
 
 
 def test_update_letter_branding_does_not_save_to_db_if_uploading_fails(
-    mocker,
     client_request,
     platform_admin_user,
     mock_get_letter_branding_by_id,
     fake_uuid,
     logo_client,
+    mocker,
 ):
     mock_client_update = mocker.patch("app.main.views.letter_branding.letter_branding_client.update_letter_branding")
     mock_create_update_letter_branding_event = mocker.patch(
@@ -417,7 +441,12 @@ def test_create_letter_branding_does_not_show_branding_info(
     assert page.select_one("#file").attrs.get("accept") == ".svg"
 
 
-def test_create_letter_branding_when_uploading_valid_file(mocker, client_request, platform_admin_user, fake_uuid):
+def test_create_letter_branding_when_uploading_valid_file(
+    client_request,
+    platform_admin_user,
+    fake_uuid,
+    mocker,
+):
     mock_save_temporary = mocker.patch(
         "app.main.views.letter_branding.logo_client.save_temporary_logo", return_value="temporary.svg"
     )
@@ -452,7 +481,11 @@ def test_create_letter_branding_when_uploading_valid_file(mocker, client_request
     ),
 )
 def test_create_letter_branding_calls_antivirus_scan(
-    mocker, client_request, platform_admin_user, scan_result, expected_status_code
+    client_request,
+    platform_admin_user,
+    scan_result,
+    expected_status_code,
+    mocker,
 ):
     mock_antivirus = mocker.patch("app.extensions.antivirus_client.scan", return_value=scan_result)
     mock_save_temporary = mocker.patch(
@@ -501,11 +534,11 @@ def test_create_letter_branding_calls_antivirus_scan(
     ),
 )
 def test_create_letter_branding_fails_validation_when_uploading_SVG_with_bad_element(
-    mocker,
     client_request,
     platform_admin_user,
     svg_contents,
     expected_error,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mock_save_temporary = mocker.patch("app.main.views.letter_branding.logo_client.save_temporary_logo")
@@ -569,12 +602,12 @@ def test_create_letter_branding_shows_an_error_when_submitting_details_with_no_l
 
 
 def test_create_letter_branding_persists_logo_when_all_data_is_valid(
-    mocker,
     client_request,
     platform_admin_user,
     mock_get_all_letter_branding,
     fake_uuid,
     mock_create_letter_branding,
+    mocker,
 ):
     mock_save_permanent = mocker.patch(
         "app.main.views.letter_branding.logo_client.save_permanent_logo", return_value="permanent.svg"
@@ -616,9 +649,9 @@ def test_create_letter_branding_shows_form_errors_on_name_field(client_request, 
 
 
 def test_create_letter_branding_shows_database_errors_on_name_fields(
-    mocker,
     client_request,
     platform_admin_user,
+    mocker,
 ):
     mocker.patch(
         "app.main.views.letter_branding.letter_branding_client.create_letter_branding",

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -76,7 +76,6 @@ test_user_auth_combinations = (
 
 @pytest.mark.parametrize(*test_user_auth_combinations)
 def test_get_org_member_make_service_live_start(
-    mocker,
     client_request,
     service_one,
     organisation_one,
@@ -84,6 +83,7 @@ def test_get_org_member_make_service_live_start(
     organisation_can_approve_own_go_live_requests,
     service_has_active_go_live_request,
     expected_status,
+    mocker,
 ):
     organisation_one["can_approve_own_go_live_requests"] = organisation_can_approve_own_go_live_requests
 
@@ -119,6 +119,7 @@ def test_get_org_member_make_service_live_start(
 def test_make_service_live_start_with_no_organisation(
     client_request,
     service_one,
+    mocker,
 ):
     service_one["has_active_go_live_request"] = True
     service_one["organisation"] = None
@@ -134,6 +135,7 @@ def test_make_service_live_start_with_no_organisation_platform_admin(
     client_request,
     service_one,
     platform_admin_user,
+    mocker,
 ):
     service_one["has_active_go_live_request"] = True
     service_one["organisation"] = None
@@ -154,7 +156,6 @@ def test_make_service_live_start_with_no_organisation_platform_admin(
 
 @pytest.mark.parametrize(*test_user_auth_combinations)
 def test_get_org_member_make_service_live_service_name(
-    mocker,
     client_request,
     service_one,
     organisation_one,
@@ -162,6 +163,7 @@ def test_get_org_member_make_service_live_service_name(
     organisation_can_approve_own_go_live_requests,
     service_has_active_go_live_request,
     expected_status,
+    mocker,
 ):
     organisation_one["can_approve_own_go_live_requests"] = organisation_can_approve_own_go_live_requests
 
@@ -189,10 +191,10 @@ def test_get_org_member_make_service_live_service_name(
 
 
 def test_post_org_member_make_service_live_service_name_error_summary(
-    mocker,
     client_request,
     service_one,
     organisation_one,
+    mocker,
 ):
     user = create_user(
         id=sample_uuid(),
@@ -288,7 +290,6 @@ def test_post_org_member_make_service_live_service_name_error_summary(
     ),
 )
 def test_post_org_member_make_service_live_service_name(
-    mocker,
     client_request,
     service_one,
     organisation_one,
@@ -296,6 +297,7 @@ def test_post_org_member_make_service_live_service_name(
     query_args,
     expected_redirect_url,
     expected_notify_calls,
+    mocker,
 ):
     user = create_user(
         id=sample_uuid(),
@@ -326,7 +328,6 @@ def test_post_org_member_make_service_live_service_name(
 
 @pytest.mark.parametrize(*test_user_auth_combinations)
 def test_get_org_member_make_service_live_unique_service(
-    mocker,
     client_request,
     service_one,
     organisation_one,
@@ -334,6 +335,7 @@ def test_get_org_member_make_service_live_unique_service(
     organisation_can_approve_own_go_live_requests,
     service_has_active_go_live_request,
     expected_status,
+    mocker,
 ):
     organisation_one["can_approve_own_go_live_requests"] = organisation_can_approve_own_go_live_requests
 
@@ -360,10 +362,10 @@ def test_get_org_member_make_service_live_unique_service(
 
 
 def test_post_org_member_make_service_live_unique_service_error_summary(
-    mocker,
     client_request,
     service_one,
     organisation_one,
+    mocker,
 ):
     user = create_user(
         id=sample_uuid(),
@@ -413,7 +415,13 @@ def test_post_org_member_make_service_live_unique_service_error_summary(
     ),
 )
 def test_post_org_member_make_service_live_unique_service(
-    mocker, client_request, service_one, organisation_one, request_url, data, expected_redirect_url
+    client_request,
+    service_one,
+    organisation_one,
+    request_url,
+    data,
+    expected_redirect_url,
+    mocker,
 ):
     user = create_user(
         id=sample_uuid(),
@@ -451,7 +459,6 @@ def test_post_org_member_make_service_live_unique_service(
 )
 @pytest.mark.parametrize(*test_user_auth_combinations)
 def test_get_org_member_make_service_live_contact_user(
-    mocker,
     client_request,
     service_one,
     organisation_one,
@@ -461,6 +468,7 @@ def test_get_org_member_make_service_live_contact_user(
     expected_status,
     data,
     expected_redirect,
+    mocker,
 ):
     organisation_one["can_approve_own_go_live_requests"] = organisation_can_approve_own_go_live_requests
 
@@ -488,7 +496,6 @@ def test_get_org_member_make_service_live_contact_user(
 
 @pytest.mark.parametrize(*test_user_auth_combinations)
 def test_get_org_member_make_service_live_decision(
-    mocker,
     client_request,
     service_one,
     organisation_one,
@@ -496,6 +503,7 @@ def test_get_org_member_make_service_live_decision(
     organisation_can_approve_own_go_live_requests,
     service_has_active_go_live_request,
     expected_status,
+    mocker,
 ):
     organisation_one["can_approve_own_go_live_requests"] = organisation_can_approve_own_go_live_requests
 
@@ -533,7 +541,12 @@ def test_get_org_member_make_service_live_decision(
     ),
 )
 def test_post_org_member_make_service_live_decision_error_summary(
-    mocker, client_request, service_one, organisation_one, post_data, expected_error_message
+    client_request,
+    service_one,
+    organisation_one,
+    post_data,
+    expected_error_message,
+    mocker,
 ):
     user = create_user(
         id=sample_uuid(),
@@ -597,7 +610,6 @@ def test_post_org_member_make_service_live_decision_error_summary(
 )
 @freeze_time("2022-12-22 12:12:12")
 def test_post_org_member_make_service_live_decision(
-    mocker,
     client_request,
     platform_admin_user,
     service_one,
@@ -607,6 +619,7 @@ def test_post_org_member_make_service_live_decision(
     post_data,
     expected_arguments_to_update_service,
     should_notify,
+    mocker,
 ):
     service_one["has_active_go_live_request"] = True
     service_one["organisation"] = ORGANISATION_ID

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -141,7 +141,7 @@ def test_should_show_overview_page(
     other_user["id"] = "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"
 
     mock_get_users = mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[
             current_user,
             other_user,
@@ -184,7 +184,7 @@ def test_should_show_change_details_link(
 
     mocker.patch("app.user_api_client.get_user", return_value=current_user)
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[
             current_user,
             other_user,
@@ -219,8 +219,8 @@ def test_should_show_live_search_if_more_than_7_users(
     number_of_users,
 ):
     mocker.patch("app.user_api_client.get_user", return_value=active_user_with_permissions)
-    mocker.patch("app.models.user.InvitedUsers.client_method", return_value=[])
-    mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions] * number_of_users)
+    mocker.patch("app.models.user.InvitedUsers._get_items", return_value=[])
+    mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions] * number_of_users)
 
     page = client_request.get("main.manage_users", service_id=SERVICE_ONE_ID)
 
@@ -258,7 +258,7 @@ def test_should_show_caseworker_on_overview_page(
     other_user["email_address"] = "zzzzzzz@example.gov.uk"
 
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[
             current_user,
             other_user,
@@ -405,7 +405,7 @@ def test_manage_users_page_does_not_links_to_user_profile_page_if_user_only_invi
     mock_get_template_folders,
 ):
     active_user_with_permissions["platform_admin"] = True
-    mocker.patch("app.models.user.Users.client_method", return_value=[])
+    mocker.patch("app.models.user.Users._get_items", return_value=[])
     client_request.login(active_user_with_permissions)
     page = client_request.get("main.manage_users", service_id=service_one["id"])
     user_links = page.select("h2.user-list-item-heading a")
@@ -1038,8 +1038,8 @@ def test_invite_user(
     sample_invite["email_address"] = email_address
 
     assert is_gov_user(email_address) == gov_user
-    mocker.patch("app.models.user.InvitedUsers.client_method", return_value=[sample_invite])
-    mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+    mocker.patch("app.models.user.InvitedUsers._get_items", return_value=[sample_invite])
+    mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
     mocker.patch("app.invite_api_client.create_invite", return_value=sample_invite)
     page = client_request.post(
         "main.invite_user",
@@ -1126,8 +1126,8 @@ def test_invite_user_with_email_auth_service(
     sample_invite["email_address"] = "test@example.gov.uk"
 
     assert is_gov_user(email_address) is gov_user
-    mocker.patch("app.models.user.InvitedUsers.client_method", return_value=[sample_invite])
-    mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+    mocker.patch("app.models.user.InvitedUsers._get_items", return_value=[sample_invite])
+    mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
     mocker.patch("app.invite_api_client.create_invite", return_value=sample_invite)
 
     page = client_request.post(
@@ -1240,8 +1240,8 @@ def test_manage_users_shows_invited_user(
     expected_text,
 ):
     sample_invite["status"] = invite_status
-    mocker.patch("app.models.user.InvitedUsers.client_method", return_value=[sample_invite])
-    mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+    mocker.patch("app.models.user.InvitedUsers._get_items", return_value=[sample_invite])
+    mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
 
     page = client_request.get("main.manage_users", service_id=SERVICE_ONE_ID)
     assert page.select_one("h1").string.strip() == "Team members"
@@ -1258,8 +1258,8 @@ def test_manage_users_does_not_show_accepted_invite(
     invited_user_id = uuid.uuid4()
     sample_invite["id"] = invited_user_id
     sample_invite["status"] = "accepted"
-    mocker.patch("app.models.user.InvitedUsers.client_method", return_value=[sample_invite])
-    mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+    mocker.patch("app.models.user.InvitedUsers._get_items", return_value=[sample_invite])
+    mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
 
     page = client_request.get("main.manage_users", service_id=SERVICE_ONE_ID)
 
@@ -1402,7 +1402,7 @@ def test_can_invite_user_as_platform_admin(
     mock_get_template_folders,
     mocker,
 ):
-    mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
+    mocker.patch("app.models.user.Users._get_items", return_value=[active_user_with_permissions])
 
     client_request.login(platform_admin_user)
 
@@ -1611,7 +1611,7 @@ def test_confirm_edit_user_email_changes_user_email(
     # We want active_user_with_permissions (the current user) to update the email address for api_user_active
     # By default both users would have the same id, so we change the id of api_user_active
     api_user_active["id"] = str(uuid.uuid4())
-    mocker.patch("app.models.user.Users.client_method", return_value=[api_user_active, active_user_with_permissions])
+    mocker.patch("app.models.user.Users._get_items", return_value=[api_user_active, active_user_with_permissions])
     # get_user gets called twice - first to check if current user can see the page, then to see if the team member
     # whose email address we're changing belongs to the service
     mocker.patch("app.user_api_client.get_user", side_effect=[active_user_with_permissions, api_user_active])
@@ -1799,7 +1799,7 @@ def test_confirm_edit_user_mobile_number_changes_user_mobile_number(
     # By default both users would have the same id, so we change the id of api_user_active
     api_user_active["id"] = str(uuid.uuid4())
 
-    mocker.patch("app.models.user.Users.client_method", return_value=[api_user_active, active_user_with_permissions])
+    mocker.patch("app.models.user.Users._get_items", return_value=[api_user_active, active_user_with_permissions])
     # get_user gets called twice - first to check if current user can see the page, then to see if the team member
     # whose mobile number we're changing belongs to the service
     mocker.patch("app.user_api_client.get_user", side_effect=[active_user_with_permissions, api_user_active])

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -397,12 +397,12 @@ def test_manage_users_page_links_to_user_profile_page_for_platform_admins(
 
 
 def test_manage_users_page_does_not_links_to_user_profile_page_if_user_only_invited(
-    mocker,
     client_request,
     active_user_with_permissions,
     service_one,
     mock_get_invites_for_service,
     mock_get_template_folders,
+    mocker,
 ):
     active_user_with_permissions["platform_admin"] = True
     mocker.patch("app.models.user.Users._get_items", return_value=[])
@@ -896,12 +896,12 @@ def test_should_show_page_for_inviting_user_with_email_prefilled(
 
 
 def test_should_show_page_if_prefilled_user_is_already_a_team_member(
-    mocker,
     client_request,
     mock_get_template_folders,
     fake_uuid,
     active_user_with_permissions,
     active_caseworking_user,
+    mocker,
 ):
     mocker.patch(
         "app.models.user.user_api_client.get_user",
@@ -927,13 +927,13 @@ def test_should_show_page_if_prefilled_user_is_already_a_team_member(
 
 
 def test_should_show_page_if_prefilled_user_is_already_invited(
-    mocker,
     client_request,
     mock_get_template_folders,
     fake_uuid,
     active_user_with_permissions,
     active_user_with_permission_to_other_service,
     mock_get_invites_for_service,
+    mocker,
 ):
     active_user_with_permission_to_other_service["email_address"] = "user_1@testnotify.gov.uk"
     client_request.login(active_user_with_permissions)
@@ -956,7 +956,6 @@ def test_should_show_page_if_prefilled_user_is_already_invited(
 
 
 def test_should_403_if_trying_to_prefill_email_address_for_user_with_no_organisation(
-    mocker,
     client_request,
     service_one,
     mock_get_template_folders,
@@ -965,6 +964,7 @@ def test_should_403_if_trying_to_prefill_email_address_for_user_with_no_organisa
     active_user_with_permission_to_other_service,
     mock_get_invites_for_service,
     mock_get_no_organisation_by_domain,
+    mocker,
 ):
     service_one["organisation"] = ORGANISATION_ID
     client_request.login(active_user_with_permissions)
@@ -981,7 +981,6 @@ def test_should_403_if_trying_to_prefill_email_address_for_user_with_no_organisa
 
 
 def test_should_403_if_trying_to_prefill_email_address_for_user_from_other_organisation(
-    mocker,
     client_request,
     service_one,
     mock_get_template_folders,
@@ -990,6 +989,7 @@ def test_should_403_if_trying_to_prefill_email_address_for_user_from_other_organ
     active_user_with_permission_to_other_service,
     mock_get_invites_for_service,
     mock_get_organisation_by_domain,
+    mocker,
 ):
     service_one["organisation"] = ORGANISATION_TWO_ID
     client_request.login(active_user_with_permissions)

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -12,10 +12,10 @@ from tests.conftest import SERVICE_ONE_ID, url_for_endpoint_with_token
 
 @freeze_time("2021-01-01 11:11:11")
 def test_should_render_new_password_template(
-    mocker,
     notify_admin,
     client_request,
     mock_get_user_by_email_request_password_reset,
+    mocker,
 ):
     client_request.logout()
     user = mock_get_user_by_email_request_password_reset.return_value
@@ -138,7 +138,6 @@ def test_should_redirect_to_forgot_password_with_flash_message_when_token_is_exp
 
 
 def test_should_sign_in_when_password_reset_is_successful_for_email_auth(
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
@@ -146,6 +145,7 @@ def test_should_sign_in_when_password_reset_is_successful_for_email_auth(
     mock_send_verify_code,
     mock_reset_failed_login_count,
     mock_update_user_password,
+    mocker,
 ):
     client_request.logout()
     user = mock_get_user_by_email_request_password_reset.return_value

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -216,12 +216,12 @@ def test_notification_status_shows_expected_back_link(
     ),
 )
 def test_notification_page_doesnt_link_to_template_in_tour(
-    mocker,
     client_request,
     fake_uuid,
     mock_get_notification,
     time_of_viewing_page,
     expected_message,
+    mocker,
 ):
     with freeze_time("2012-01-01 01:01"):
         notification = create_notification()
@@ -914,10 +914,10 @@ def test_cancel_letter_catches_errors_from_API(
 
 @pytest.mark.parametrize("notification_type", ["sms", "email"])
 def test_should_show_reply_to_from_notification(
-    mocker,
     fake_uuid,
     notification_type,
     client_request,
+    mocker,
 ):
     notification = create_notification(reply_to_text="reply to info", template_type=notification_type)
     mocker.patch("app.notification_api_client.get_notification", return_value=notification)

--- a/tests/app/main/views/test_performance.py
+++ b/tests/app/main/views/test_performance.py
@@ -101,9 +101,9 @@ def _get_example_performance_data():
 
 @freeze_time("2021-01-01")
 def test_should_render_performance_page(
-    mocker,
     client_request,
     mock_get_service_and_organisation_counts,
+    mocker,
 ):
     mock_get_performance_data = mocker.patch(
         "app.performance_dashboard_api_client.get_performance_dashboard_stats",

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -236,9 +236,9 @@ def test_platform_admin_show_submit_returned_letters_page(
 
 
 def test_platform_admin_submit_returned_letters(
-    mocker,
     client_request,
     platform_admin_user,
+    mocker,
 ):
     mock_client = mocker.patch("app.letter_jobs_client.submit_returned_letters")
 
@@ -255,9 +255,9 @@ def test_platform_admin_submit_returned_letters(
 
 
 def test_platform_admin_submit_empty_returned_letters(
-    mocker,
     client_request,
     platform_admin_user,
+    mocker,
 ):
     mock_client = mocker.patch("app.letter_jobs_client.submit_returned_letters")
 
@@ -358,10 +358,10 @@ def test_clear_cache_shows_form(
 def test_clear_cache_submits_and_tells_you_how_many_things_were_deleted(
     client_request,
     platform_admin_user,
-    mocker,
     model_type,
     expected_calls,
     expected_confirmation,
+    mocker,
 ):
     redis = mocker.patch("app.main.views.platform_admin.redis_client")
     redis.delete_by_pattern.return_value = 2
@@ -483,9 +483,9 @@ def test_get_notifications_sent_by_service_shows_date_form(
 
 
 def test_get_notifications_sent_by_service_validates_form(
-    mocker,
     client_request,
     platform_admin_user,
+    mocker,
 ):
     mock_get_stats_from_api = mocker.patch("app.main.views.platform_admin.notification_api_client")
 
@@ -645,11 +645,11 @@ class TestGetDvlaBillingReport:
 
 
 def test_get_notifications_sent_by_service_calls_api_and_downloads_data(
-    mocker,
     client_request,
     platform_admin_user,
     service_one,
     service_two,
+    mocker,
 ):
     api_data = [
         ["2019-01-01", SERVICE_ONE_ID, service_one["name"], "email", 191, 0, 0, 14, 0, 0],
@@ -842,7 +842,7 @@ class TestPlatformAdminSearch:
         client_request.login(platform_admin_user)
         client_request.get(".platform_admin_search")
 
-    def test_can_search_for_user(self, mocker, client_request, platform_admin_user, active_caseworking_user):
+    def test_can_search_for_user(self, client_request, platform_admin_user, active_caseworking_user, mocker):
         mocker.patch(
             "app.main.views.platform_admin.user_api_client.find_users_by_full_or_partial_email",
             return_value={"data": [active_caseworking_user]},
@@ -866,7 +866,7 @@ class TestPlatformAdminSearch:
         assert found_user_links[0].text == "caseworker@example.gov.uk"
         assert found_user_links[0].get("href") == "/users/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6"
 
-    def test_can_search_for_services(self, mocker, client_request, platform_admin_user, service_one, service_two):
+    def test_can_search_for_services(self, client_request, platform_admin_user, service_one, service_two, mocker):
         mocker.patch(
             "app.main.views.platform_admin.user_api_client.find_users_by_full_or_partial_email",
             return_value={"data": []},
@@ -892,7 +892,7 @@ class TestPlatformAdminSearch:
         assert found_service_links[1].text == "service two"
         assert found_service_links[1].get("href") == "/services/147ad62a-2951-4fa1-9ca0-093cd1a52c52"
 
-    def test_can_search_for_organisations(self, mocker, client_request, platform_admin_user, organisation_one):
+    def test_can_search_for_organisations(self, client_request, platform_admin_user, organisation_one, mocker):
         mocker.patch(
             "app.main.views.platform_admin.user_api_client.find_users_by_full_or_partial_email",
             return_value={"data": []},
@@ -918,13 +918,13 @@ class TestPlatformAdminSearch:
 
     def test_shows_results_from_all_categories(
         self,
-        mocker,
         client_request,
         platform_admin_user,
         active_caseworking_user,
         service_one,
         service_two,
         organisation_one,
+        mocker,
     ):
         mocker.patch(
             "app.main.views.platform_admin.user_api_client.find_users_by_full_or_partial_email",
@@ -1017,7 +1017,7 @@ class TestPlatformAdminSearch:
             ),
         ),
     )
-    def test_find_uuid_redirects(self, mocker, client_request, platform_admin_user, api_response, expected_redirect):
+    def test_find_uuid_redirects(self, client_request, platform_admin_user, api_response, expected_redirect, mocker):
         mocker.patch(
             "app.main.views.platform_admin.user_api_client.find_users_by_full_or_partial_email",
             return_value={"data": []},
@@ -1037,7 +1037,7 @@ class TestPlatformAdminSearch:
             _expected_redirect=expected_redirect,
         )
 
-    def test_error_summary(self, mocker, client_request, platform_admin_user):
+    def test_error_summary(self, client_request, platform_admin_user, mocker):
         client_request.login(platform_admin_user)
 
         page = client_request.post(".platform_admin_search", _data={"search": ""}, _expected_status=200)

--- a/tests/app/main/views/test_pricing.py
+++ b/tests/app/main/views/test_pricing.py
@@ -52,12 +52,12 @@ def test_guidance_pricing_letters(client_request, mock_get_letter_rates):
     ),
 )
 def test_guidance_pricing_sms(
-    mocker,
     client_request,
     rate,
     expected_paragraph,
     valid_from,
     expected_last_updated,
+    mocker,
 ):
     mocker.patch(
         "app.models.sms_rate.sms_rate_api_client.get_sms_rate",

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2289,9 +2289,7 @@ def test_send_test_works_as_letter_preview(
 ):
     service_one["permissions"] = ["letter"]
     mocker.patch("app.service_api_client.get_service", return_value={"data": service_one})
-    mocked_preview = mocker.patch(
-        "app.main.views.send.TemplatePreview.get_preview_for_templated_letter", return_value="foo"
-    )
+    mocked_preview = mocker.patch("app.template_preview_client.get_preview_for_templated_letter", return_value="foo")
 
     service_id = service_one["id"]
     template_id = fake_uuid
@@ -2311,6 +2309,7 @@ def test_send_test_works_as_letter_preview(
     assert mocked_preview.call_args_list[0].kwargs["db_template"]["id"] == template_id
     assert mocked_preview.call_args_list[0].kwargs["values"] == {"addressline1": "Jo Lastname"}
     assert mocked_preview.call_args_list[0].kwargs["filetype"] == filetype
+    assert mocked_preview.call_args_list[0].kwargs["service"].id == service_id
 
 
 def test_send_one_off_clears_session(
@@ -2972,9 +2971,7 @@ def test_should_show_preview_letter_message(
         "app.main.views.send.get_csv_metadata",
         return_value={"original_file_name": f"example.{filetype}"},
     )
-    mocked_preview = mocker.patch(
-        "app.main.views.send.TemplatePreview.get_preview_for_templated_letter", return_value="foo"
-    )
+    mocked_preview = mocker.patch("app.template_preview_client.get_preview_for_templated_letter", return_value="foo")
 
     service_id = service_one["id"]
     template_id = fake_uuid
@@ -2999,6 +2996,7 @@ def test_should_show_preview_letter_message(
     assert mocked_preview.call_args_list[0].kwargs["filetype"] == filetype
     assert mocked_preview.call_args_list[0].kwargs["values"] == expected_values
     assert mocked_preview.call_args_list[0].kwargs["page"] == expected_page
+    assert mocked_preview.call_args_list[0].kwargs["service"].id == service_id
 
 
 def test_dont_show_preview_letter_templates_for_bad_filetype(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1219,7 +1219,6 @@ def test_404_for_previewing_a_row_out_of_range(
 
 @pytest.mark.parametrize("template_type", ["sms", "email", "letter"])
 def test_send_one_off_step_redirects_to_start_if_session_not_setup(
-    mocker,
     client_request,
     mock_get_service_statistics,
     mock_get_users_by_service,
@@ -1227,6 +1226,7 @@ def test_send_one_off_step_redirects_to_start_if_session_not_setup(
     mock_get_no_contact_lists,
     fake_uuid,
     template_type,
+    mocker,
 ):
     template_data = create_template(template_type=template_type, content="Hi ((name))")
     mocker.patch("app.service_api_client.get_service_template", return_value={"data": template_data})
@@ -1396,7 +1396,6 @@ def test_send_one_off_shows_placeholders_in_correct_order(
     ),
 )
 def test_send_one_off_only_asks_for_recipient_once(
-    mocker,
     client_request,
     fake_uuid,
     template_type,
@@ -1407,6 +1406,7 @@ def test_send_one_off_only_asks_for_recipient_once(
     step_index,
     css_selector_for_content,
     expected_content,
+    mocker,
 ):
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -1505,7 +1505,6 @@ def test_send_one_off_has_skip_link(
     ],
 )
 def test_send_one_off_has_sticky_header_for_email(
-    mocker,
     client_request,
     fake_uuid,
     mock_has_no_jobs,
@@ -1514,6 +1513,7 @@ def test_send_one_off_has_sticky_header_for_email(
     multiple_sms_senders,
     template_type,
     expected_sticky,
+    mocker,
 ):
     template_data = create_template(template_type=template_type, content="((body))")
     mocker.patch("app.service_api_client.get_service_template", return_value={"data": template_data})
@@ -1531,10 +1531,10 @@ def test_send_one_off_has_sticky_header_for_email(
 
 
 def test_send_one_off_has_sticky_header_for_letter_on_non_address_placeholders(
-    mocker,
     client_request,
     fake_uuid,
     mock_get_live_service,
+    mocker,
 ):
     template_data = create_template(template_type="letter", content="((body))")
     mocker.patch("app.service_api_client.get_service_template", return_value={"data": template_data})
@@ -1676,13 +1676,13 @@ def test_send_one_off_has_link_to_use_existing_list(
 
 
 def test_no_link_to_use_existing_list_for_service_without_lists(
-    mocker,
     client_request,
     mock_get_service_template,
     mock_has_jobs,
     multiple_sms_senders,
     platform_admin_user,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.models.contact_list.ContactLists._get_items",
@@ -2674,7 +2674,6 @@ def test_upload_csvfile_with_valid_phone_shows_all_numbers(
     ],
 )
 def test_upload_csvfile_with_international_validates(
-    mocker,
     client_request,
     mock_get_service_template,
     mock_s3_set_metadata,
@@ -2689,6 +2688,7 @@ def test_upload_csvfile_with_international_validates(
     international_sms_permission,
     should_allow_international,
     service_one,
+    mocker,
 ):
     if international_sms_permission:
         service_one["permissions"] += ("sms", "international_sms")
@@ -2720,7 +2720,6 @@ def test_upload_csvfile_with_international_validates(
     ],
 )
 def test_upload_csvfile_with_sms_to_landline_validates(
-    mocker,
     client_request,
     mock_get_service_template,
     mock_s3_set_metadata,
@@ -2735,6 +2734,7 @@ def test_upload_csvfile_with_sms_to_landline_validates(
     sms_to_uk_landline_permission,
     should_allow_sms_to_uk_landline,
     service_one,
+    mocker,
 ):
     if sms_to_uk_landline_permission:
         service_one["permissions"] += ("sms", "sms_to_uk_landlines")
@@ -3019,7 +3019,6 @@ def test_dont_show_preview_letter_templates_for_bad_filetype(
     "route, response_code", [("main.send_messages", 200), ("main.get_example_csv", 200), ("main.send_one_off", 302)]
 )
 def test_route_permissions(
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
@@ -3033,6 +3032,7 @@ def test_route_permissions(
     fake_uuid,
     route,
     response_code,
+    mocker,
 ):
     validate_route_permission(
         mocker,
@@ -3050,7 +3050,6 @@ def test_route_permissions(
     "route, response_code, method", [("main.check_notification", 200, "GET"), ("main.send_notification", 302, "POST")]
 )
 def test_route_permissions_send_check_notifications(
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
@@ -3061,6 +3060,7 @@ def test_route_permissions_send_check_notifications(
     route,
     response_code,
     method,
+    mocker,
 ):
     with client_request.session_transaction() as session:
         session["recipient"] = "07700900001"
@@ -3086,7 +3086,6 @@ def test_route_permissions_send_check_notifications(
     ],
 )
 def test_route_permissions_sending(
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
@@ -3099,6 +3098,7 @@ def test_route_permissions_sending(
     fake_uuid,
     route,
     expected_status,
+    mocker,
 ):
     validate_route_permission(
         mocker,
@@ -3179,7 +3179,6 @@ def test_check_messages_back_link(
     ids=["none_sent", "none_sent", "some_sent"],
 )
 def test_check_messages_shows_too_many_messages_errors(
-    mocker,
     client_request,
     mock_get_service,  # set sms_message_limit to 50
     mock_get_users_by_service,
@@ -3190,6 +3189,7 @@ def test_check_messages_shows_too_many_messages_errors(
     num_requested,
     expected_msg,
     mock_s3_get_metadata,
+    mocker,
 ):
     # csv with 100 phone numbers
     mocker.patch(
@@ -3365,7 +3365,6 @@ def test_check_messages_does_not_allow_to_send_letter_longer_than_10_pages(
 
 
 def test_check_messages_shows_data_errors_before_trial_mode_errors_for_letters(
-    mocker,
     client_request,
     mock_get_service_letter_template,
     mock_has_permissions,
@@ -3375,6 +3374,7 @@ def test_check_messages_shows_data_errors_before_trial_mode_errors_for_letters(
     mock_get_jobs,
     fake_uuid,
     mock_s3_get_metadata,
+    mocker,
 ):
     mocker.patch(
         "app.main.views.send.s3download",
@@ -3454,7 +3454,6 @@ def test_warns_if_file_sent_already(
 
 
 def test_check_messages_column_error_doesnt_show_optional_columns(
-    mocker,
     client_request,
     mock_get_service_letter_template,
     mock_has_permissions,
@@ -3464,6 +3463,7 @@ def test_check_messages_column_error_doesnt_show_optional_columns(
     mock_get_job_doesnt_exist,
     mock_get_jobs,
     mock_s3_get_metadata,
+    mocker,
 ):
     mocker.patch(
         "app.main.views.send.s3download",
@@ -3832,7 +3832,7 @@ def test_check_notification_shows_preview(client_request, service_one, fake_uuid
     )
 
 
-def test_check_notification_shows_back_link(mocker, client_request, service_one, fake_uuid, mock_template_preview):
+def test_check_notification_shows_back_link(client_request, service_one, fake_uuid, mock_template_preview, mocker):
     service_one["restricted"] = False
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -4273,7 +4273,6 @@ def test_redirects_to_template_if_job_exists_already(
 )
 @freeze_time("2020-06-13 13:00")
 def test_choose_from_contact_list(
-    mocker,
     client_request,
     mock_get_contact_lists,
     fake_uuid,
@@ -4282,6 +4281,7 @@ def test_choose_from_contact_list(
     expected_filenames,
     expected_time,
     expected_count,
+    mocker,
 ):
     template = create_template(template_type=template_type)
     mocker.patch(
@@ -4308,10 +4308,10 @@ def test_choose_from_contact_list(
 
 
 def test_choose_from_contact_list_with_personalised_template(
-    mocker,
     client_request,
     mock_get_contact_lists,
     fake_uuid,
+    mocker,
 ):
     template = create_template(content="Hey ((name)) ((thing)) is happening")
     mocker.patch(
@@ -4332,10 +4332,10 @@ def test_choose_from_contact_list_with_personalised_template(
 
 
 def test_choose_from_contact_list_with_no_lists(
-    mocker,
     client_request,
     mock_get_service_template,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.models.contact_list.ContactLists._get_items",
@@ -4358,10 +4358,10 @@ def test_choose_from_contact_list_with_no_lists(
 
 
 def test_send_from_contact_list(
-    mocker,
     client_request,
     fake_uuid,
     mock_get_contact_list,
+    mocker,
 ):
     new_uuid = uuid.uuid4()
     mock_download = mocker.patch("app.models.contact_list.s3download", return_value="contents")
@@ -4394,7 +4394,9 @@ def test_send_from_contact_list(
 
 
 def test_send_to_myself_sets_placeholder_and_redirects_for_email(
-    client_request, fake_uuid, mock_get_service_email_template
+    client_request,
+    fake_uuid,
+    mock_get_service_email_template,
 ):
     with client_request.session_transaction() as session:
         session["recipient"] = None
@@ -4417,7 +4419,11 @@ def test_send_to_myself_sets_placeholder_and_redirects_for_email(
         assert session["placeholders"] == {"email address": "test@user.gov.uk"}
 
 
-def test_send_to_myself_sets_placeholder_and_redirects_for_sms(client_request, fake_uuid, mock_get_service_template):
+def test_send_to_myself_sets_placeholder_and_redirects_for_sms(
+    client_request,
+    fake_uuid,
+    mock_get_service_template,
+):
     with client_request.session_transaction() as session:
         session["recipient"] = None
         session["placeholders"] = {}
@@ -4440,7 +4446,12 @@ def test_send_to_myself_sets_placeholder_and_redirects_for_sms(client_request, f
         assert session["placeholders"] == {"phone number": "07700 900762"}
 
 
-def test_send_to_myself_404s_for_letter(mocker, client_request, fake_uuid, mock_get_service_letter_template):
+def test_send_to_myself_404s_for_letter(
+    client_request,
+    fake_uuid,
+    mock_get_service_letter_template,
+    mocker,
+):
     with client_request.session_transaction() as session:
         session["recipient"] = None
         session["placeholders"] = {}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1685,7 +1685,7 @@ def test_no_link_to_use_existing_list_for_service_without_lists(
     fake_uuid,
 ):
     mocker.patch(
-        "app.models.contact_list.ContactLists.client_method",
+        "app.models.contact_list.ContactLists._get_items",
         return_value=[],
     )
     client_request.login(platform_admin_user)
@@ -4338,7 +4338,7 @@ def test_choose_from_contact_list_with_no_lists(
     fake_uuid,
 ):
     mocker.patch(
-        "app.models.contact_list.ContactLists.client_method",
+        "app.models.contact_list.ContactLists._get_items",
         return_value=[],
     )
     page = client_request.get(

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -574,7 +574,7 @@ def test_get_manage_folder_page(
         _folder("folder_two", folder_id, None, [active_user_with_permissions["id"]]),
     ]
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[active_user_with_permissions],
     )
     page = client_request.get(
@@ -607,7 +607,7 @@ def test_get_manage_folder_viewing_permissions_for_users(
         _folder("folder_two", folder_id, None, [active_user_with_permissions["id"], team_member_2["id"]]),
     ]
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[active_user_with_permissions, team_member, team_member_2],
     )
 
@@ -656,7 +656,7 @@ def test_get_manage_folder_viewing_permissions_for_users_not_visible_when_no_man
         },
     ]
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[team_member, team_member_2],
     )
 
@@ -688,7 +688,7 @@ def test_get_manage_folder_viewing_permissions_for_users_not_visible_for_service
         },
     ]
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[active_user_with_permissions],
     )
 
@@ -796,7 +796,7 @@ def test_rename_folder(client_request, active_user_with_permissions, service_one
         _folder("folder_two", folder_id, None, [active_user_with_permissions["id"]])
     ]
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[active_user_with_permissions],
     )
 
@@ -827,7 +827,7 @@ def test_manage_folder_users(
         _folder("folder_two", folder_id, None, [active_user_with_permissions["id"], team_member["id"]])
     ]
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[active_user_with_permissions, team_member],
     )
 
@@ -874,7 +874,7 @@ def test_manage_folder_users_doesnt_change_permissions_current_user_cannot_manag
         }
     ]
     mocker.patch(
-        "app.models.user.Users.client_method",
+        "app.models.user.Users._get_items",
         return_value=[team_member],
     )
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1298,7 +1298,7 @@ def test_post_attach_pages_errors_when_content_outside_printable_area(
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
     mock_sanitise_response.json = lambda: {"message": "content-outside-printable-area", "invalid_pages": [1]}
-    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", return_value=mock_sanitise_response)
+    mocker.patch("app.template_preview_client.sanitise_letter", return_value=mock_sanitise_response)
 
     with open("tests/test_pdf_files/one_page_pdf.pdf", "rb") as file:
         file_contents = file.read()
@@ -1355,7 +1355,7 @@ def test_post_attach_pages_errors_when_base_template_plus_attachment_too_long(
             "data": template_version_json(SERVICE_ONE_ID, fake_uuid, api_user_active, version=1, type_="letter")
         },
     )
-    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter")
+    mocker.patch("app.template_preview_client.sanitise_letter")
     do_mock_get_page_counts_for_letter(mocker, count=9)
 
     with open("tests/test_pdf_files/multi_page_pdf.pdf", "rb") as file:
@@ -1389,7 +1389,7 @@ def test_post_attach_pages_redirects_to_template_view_when_validation_successful
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
-    mock_sanitise = mocker.patch("app.template_previews.TemplatePreview.sanitise_letter")
+    mock_sanitise = mocker.patch("app.template_preview_client.sanitise_letter")
 
     # page count for the attachment
     mocker.patch("app.main.views.templates.pdf_page_count", return_value=page_count)
@@ -1434,7 +1434,7 @@ def test_post_attach_pages_archives_existing_attachment_when_it_exists(
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
-    mock_sanitise = mocker.patch("app.template_previews.TemplatePreview.sanitise_letter")
+    mock_sanitise = mocker.patch("app.template_preview_client.sanitise_letter")
 
     # page count for the attachment
     mocker.patch("app.main.views.templates.pdf_page_count", return_value=1)
@@ -1490,7 +1490,7 @@ def test_post_attach_pages_doesnt_replace_existing_attachment_if_new_attachment_
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
     mock_sanitise_response.json = lambda: {"message": "content-outside-printable-area", "invalid_pages": [1]}
-    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", return_value=mock_sanitise_response)
+    mocker.patch("app.template_preview_client.sanitise_letter", return_value=mock_sanitise_response)
 
     mocker.patch("app.main.views.templates.upload_letter_to_s3")
     mocker.patch("app.main.views.templates.pdf_page_count", return_value=1)
@@ -2040,9 +2040,7 @@ def test_should_show_message_with_prefix_hint_if_enabled_for_service(
 def test_should_show_preview_letter_templates(
     view, extra_view_args, filetype, client_request, mock_get_service_email_template, service_one, fake_uuid, mocker
 ):
-    mocked_preview = mocker.patch(
-        "app.main.views.templates.TemplatePreview.get_preview_for_templated_letter", return_value="foo"
-    )
+    mocked_preview = mocker.patch("app.template_preview_client.get_preview_for_templated_letter", return_value="foo")
 
     service_id, template_id = service_one["id"], fake_uuid
 
@@ -2055,6 +2053,7 @@ def test_should_show_preview_letter_templates(
     assert mocked_preview.call_args_list[0].kwargs["db_template"]["id"] == template_id
     assert mocked_preview.call_args_list[0].kwargs["db_template"]["service"] == service_id
     assert mocked_preview.call_args_list[0].kwargs["filetype"] == filetype
+    assert mocked_preview.call_args_list[0].kwargs["service"].id == service_id
 
     if "page" in extra_view_args:
         assert mocked_preview.call_args[1]["page"] == extra_view_args["page"]
@@ -2063,9 +2062,7 @@ def test_should_show_preview_letter_templates(
 
 
 def test_should_show_preview_letter_attachment(client_request, service_one, fake_uuid, mocker):
-    mocked_preview = mocker.patch(
-        "app.main.views.templates.TemplatePreview.get_png_for_letter_attachment_page", return_value="foo"
-    )
+    mocked_preview = mocker.patch("app.template_preview_client.get_png_for_letter_attachment_page", return_value="foo")
 
     service_id, attachment_id = service_one["id"], fake_uuid
 
@@ -2077,6 +2074,7 @@ def test_should_show_preview_letter_attachment(client_request, service_one, fake
 
     assert response.get_data(as_text=True) == "foo"
     assert mocked_preview.call_args[0][0] == attachment_id
+    assert mocked_preview.call_args[1]["service"].id == service_id
 
 
 def test_dont_show_preview_letter_templates_for_bad_filetype(
@@ -2102,7 +2100,7 @@ def test_letter_branding_preview_image(
         status_code = 200
         headers = {}
 
-    mocked_preview = mocker.patch("app.template_previews.requests.post", return_value=MockedResponse())
+    mocked_preview = mocker.patch("app.template_preview_client.requests_session.post", return_value=MockedResponse())
     response = client_request.get_response(
         "no_cookie.letter_branding_preview_image",
         filename="example",
@@ -2137,13 +2135,13 @@ def test_letter_template_preview_handles_no_branding_style_or_filename_correctly
     filename,
     mocker,
 ):
-    mocked_preview = mocker.patch("app.template_previews.TemplatePreview.get_preview_for_templated_letter")
+    mocked_preview = mocker.patch("app.template_preview_client.get_preview_for_templated_letter")
     client_request.get_response(
         "no_cookie.letter_branding_preview_image",
         branding_style=branding_style,
         filename=filename,
     )
-    mocked_preview.assert_called_once_with(ANY, branding_filename=None, filetype="png")
+    mocked_preview.assert_called_once_with(ANY, branding_filename=None, filetype="png", service=ANY)
 
 
 @pytest.mark.parametrize("filename", [None, FieldWithNoneOption.NONE_OPTION_VALUE])
@@ -2153,7 +2151,7 @@ def test_letter_template_preview_links_to_the_correct_image_when_passed_existing
     filename,
     mocker,
 ):
-    mocked_preview = mocker.patch("app.template_previews.TemplatePreview.get_preview_for_templated_letter")
+    mocked_preview = mocker.patch("app.template_preview_client.get_preview_for_templated_letter")
     client_request.get_response(
         "no_cookie.letter_branding_preview_image",
         branding_style="12341234-1234-1234-1234-123412341234",
@@ -2161,7 +2159,7 @@ def test_letter_template_preview_links_to_the_correct_image_when_passed_existing
     )
 
     mock_get_letter_branding_by_id.assert_called_once_with("12341234-1234-1234-1234-123412341234")
-    mocked_preview.assert_called_once_with(ANY, branding_filename="hm-government", filetype="png")
+    mocked_preview.assert_called_once_with(ANY, branding_filename="hm-government", filetype="png", service=ANY)
 
 
 @pytest.mark.parametrize("branding_style", [None, FieldWithNoneOption.NONE_OPTION_VALUE])
@@ -2170,13 +2168,13 @@ def test_letter_template_preview_links_to_the_correct_image_when_passed_a_filena
     branding_style,
     mocker,
 ):
-    mocked_preview = mocker.patch("app.template_previews.TemplatePreview.get_preview_for_templated_letter")
+    mocked_preview = mocker.patch("app.template_preview_client.get_preview_for_templated_letter")
     client_request.get_response(
         "no_cookie.letter_branding_preview_image",
         branding_style=branding_style,
         filename="foo.svg",
     )
-    mocked_preview.assert_called_once_with(ANY, branding_filename="foo.svg", filetype="png")
+    mocked_preview.assert_called_once_with(ANY, branding_filename="foo.svg", filetype="png", service=ANY)
 
 
 def test_letter_template_preview_returns_400_if_both_branding_style_and_filename_provided(
@@ -2606,7 +2604,7 @@ def test_copy_letter_template_across_service_boundary(
     request_mock_returns = Mock(
         content=b'{"count": 4, "welsh_page_count": 1, "attachment_page_count": 2}', status_code=200
     )
-    mocker.patch("app.template_previews.requests.post", return_value=request_mock_returns)
+    mocker.patch("app.template_preview_client.requests_session.post", return_value=request_mock_returns)
 
     page = client_request.get(
         "main.copy_template",
@@ -4387,11 +4385,11 @@ def test_letter_attachment_preview_image_shows_overlay_when_content_outside_prin
         ),
     )
     template_preview_mock_valid = mocker.patch(
-        "app.main.views.templates.TemplatePreview.get_png_for_valid_pdf_page",
+        "app.template_preview_client.get_png_for_valid_pdf_page",
         return_value=make_response("page.html", 200),
     )
     template_preview_mock_invalid = mocker.patch(
-        "app.main.views.templates.TemplatePreview.get_png_for_invalid_pdf_page",
+        "app.template_preview_client.get_png_for_invalid_pdf_page",
         return_value=make_response("page.html", 200),
     )
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -452,7 +452,6 @@ def test_should_show_page_for_email_template(
     ),
 )
 def test_should_show_page_for_sms_template(
-    mocker,
     client_request,
     mock_get_service_template,
     service_one,
@@ -461,6 +460,7 @@ def test_should_show_page_for_sms_template(
     permissions,
     template_content,
     expected_hint_text,
+    mocker,
 ):
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -530,10 +530,10 @@ def test_should_show_page_for_one_template(
     ),
 )
 def test_edit_email_template_should_have_unsubscribe_checkbox(
-    mocker,
     client_request,
     fake_uuid,
     template_type,
+    mocker,
 ):
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -567,13 +567,13 @@ def test_edit_email_template_should_have_unsubscribe_checkbox(
     ),
 )
 def test_edit_email_template_should_update_unsubscribe(
-    mocker,
     client_request,
     platform_admin_user,
     mock_update_service_template,
     post_data,
     expected_unsubscribeable,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -621,6 +621,7 @@ def test_add_email_template_should_add_unsubscribe(
     client_request,
     platform_admin_user,
     mock_create_service_template,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     client_request.post(
@@ -1281,7 +1282,11 @@ def test_GET_letter_template_attach_pages_404s_if_invalid_template_id(client_req
 
 
 def test_post_attach_pages_errors_when_content_outside_printable_area(
-    mocker, client_request, fake_uuid, service_one, mock_get_service_letter_template
+    client_request,
+    fake_uuid,
+    service_one,
+    mock_get_service_letter_template,
+    mocker,
 ):
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
@@ -1335,11 +1340,11 @@ def test_post_attach_pages_errors_when_content_outside_printable_area(
 
 
 def test_post_attach_pages_errors_when_base_template_plus_attachment_too_long(
-    mocker,
     client_request,
     api_user_active,
     fake_uuid,
     service_one,
+    mocker,
 ):
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
@@ -1375,7 +1380,12 @@ def test_post_attach_pages_errors_when_base_template_plus_attachment_too_long(
 
 @pytest.mark.parametrize("page_count", [1, 2])
 def test_post_attach_pages_redirects_to_template_view_when_validation_successful(
-    mocker, client_request, service_one, mock_get_service_letter_template, page_count, mock_get_page_counts_for_letter
+    client_request,
+    service_one,
+    mock_get_service_letter_template,
+    page_count,
+    mock_get_page_counts_for_letter,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
@@ -1415,12 +1425,12 @@ def test_post_attach_pages_redirects_to_template_view_when_validation_successful
 
 
 def test_post_attach_pages_archives_existing_attachment_when_it_exists(
-    mocker,
     client_request,
     service_one,
     active_user_with_permissions,
     mock_get_service_letter_template_with_attachment,
     mock_get_page_counts_for_letter,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
@@ -1468,11 +1478,11 @@ def test_post_attach_pages_archives_existing_attachment_when_it_exists(
 
 
 def test_post_attach_pages_doesnt_replace_existing_attachment_if_new_attachment_errors(
-    mocker,
     client_request,
     fake_uuid,
     service_one,
     mock_get_service_letter_template_with_attachment,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
@@ -1747,6 +1757,7 @@ def test_should_be_able_to_view_a_letter_template_with_links(
     single_letter_contact_block,
     fake_uuid,
     mock_get_page_counts_for_letter,
+    mocker,
 ):
     page = client_request.get(
         "main.view_template",
@@ -1808,11 +1819,11 @@ def test_should_be_able_to_view_a_letter_template_with_links(
 
 
 def test_should_not_be_able_to_view_edit_links_for_an_archived_letter_template(
-    mocker,
     client_request,
     single_letter_contact_block,
     fake_uuid,
     mock_get_page_counts_for_letter,
+    mocker,
 ):
     archived_letter_template = template_json(
         service_id=SERVICE_ONE_ID,
@@ -1871,12 +1882,12 @@ def test_should_not_be_able_to_view_edit_links_for_an_archived_letter_template(
 
 
 def test_should_be_able_to_view_a_letter_template_with_bilingual_content(
-    mocker,
     client_request,
     service_one,
     mock_get_service_letter_template_welsh_language,
     single_letter_contact_block,
     fake_uuid,
+    mocker,
 ):
     service_one["permissions"].append("extra_letter_formatting")
     do_mock_get_page_counts_for_letter(mocker, count=5, welsh_page_count=3)
@@ -1978,7 +1989,6 @@ def test_should_show_sms_template_with_downgraded_unicode_characters(
     ),
 )
 def test_should_let_letter_contact_block_be_changed_for_the_template(
-    mocker,
     mock_get_service_letter_template,
     client_request,
     service_one,
@@ -1986,6 +1996,7 @@ def test_should_let_letter_contact_block_be_changed_for_the_template(
     contact_block_data,
     expected_partial_url,
     mock_get_page_counts_for_letter,
+    mocker,
 ):
     mocker.patch("app.service_api_client.get_letter_contacts", return_value=contact_block_data)
 
@@ -2082,9 +2093,9 @@ def test_dont_show_preview_letter_templates_for_bad_filetype(
 
 
 def test_letter_branding_preview_image(
-    mocker,
     client_request,
     mock_onwards_request_headers,
+    mocker,
 ):
     class MockedResponse:
         content = "foo"
@@ -2121,10 +2132,10 @@ def test_letter_branding_preview_image(
 @pytest.mark.parametrize("filename", [None, FieldWithNoneOption.NONE_OPTION_VALUE])
 @pytest.mark.parametrize("branding_style", [None, FieldWithNoneOption.NONE_OPTION_VALUE])
 def test_letter_template_preview_handles_no_branding_style_or_filename_correctly(
-    mocker,
     client_request,
     branding_style,
     filename,
+    mocker,
 ):
     mocked_preview = mocker.patch("app.template_previews.TemplatePreview.get_preview_for_templated_letter")
     client_request.get_response(
@@ -2137,10 +2148,10 @@ def test_letter_template_preview_handles_no_branding_style_or_filename_correctly
 
 @pytest.mark.parametrize("filename", [None, FieldWithNoneOption.NONE_OPTION_VALUE])
 def test_letter_template_preview_links_to_the_correct_image_when_passed_existing_branding(
-    mocker,
     client_request,
     mock_get_letter_branding_by_id,
     filename,
+    mocker,
 ):
     mocked_preview = mocker.patch("app.template_previews.TemplatePreview.get_preview_for_templated_letter")
     client_request.get_response(
@@ -2155,9 +2166,9 @@ def test_letter_template_preview_links_to_the_correct_image_when_passed_existing
 
 @pytest.mark.parametrize("branding_style", [None, FieldWithNoneOption.NONE_OPTION_VALUE])
 def test_letter_template_preview_links_to_the_correct_image_when_passed_a_filename(
-    mocker,
     client_request,
     branding_style,
+    mocker,
 ):
     mocked_preview = mocker.patch("app.template_previews.TemplatePreview.get_preview_for_templated_letter")
     client_request.get_response(
@@ -2405,11 +2416,11 @@ def test_choose_a_template_to_copy_when_user_has_one_service(
 
 
 def test_choose_a_template_to_copy_from_folder_within_service(
-    mocker,
     client_request,
     mock_get_template_folders,
     mock_get_non_empty_organisations_and_services_for_user,
     mock_get_no_api_keys,
+    mocker,
 ):
     mock_get_template_folders.return_value = [
         _folder("Parent folder", PARENT_FOLDER_ID),
@@ -2505,7 +2516,6 @@ def test_choose_a_template_to_copy_from_folder_within_service(
     ),
 )
 def test_copy_template_page_renders_preview(
-    mocker,
     client_request,
     active_user_with_permission_to_two_services,
     multiple_sms_senders,
@@ -2514,6 +2524,7 @@ def test_copy_template_page_renders_preview(
     mock_get_non_empty_organisations_and_services_for_user,
     existing_template_names,
     expected_name,
+    mocker,
 ):
     mock_get_service_templates.side_effect = lambda service_id: {
         "data": [
@@ -2583,11 +2594,11 @@ def test_copy_template_loads_template_from_within_subfolder(
 
 
 def test_copy_letter_template_across_service_boundary(
-    mocker,
     client_request,
     active_user_with_permission_to_two_services,
     mock_get_service_templates,
     multiple_sms_senders,
+    mocker,
 ):
     template = template_json(service_id=SERVICE_TWO_ID, id_=TEMPLATE_ONE_ID, name="foo", folder=None, type_="letter")
     mocker.patch("app.service_api_client.get_service_template", return_value={"data": template})
@@ -2624,7 +2635,6 @@ def test_cant_copy_template_from_non_member_service(
 
 
 def test_post_copy_template(
-    mocker,
     client_request,
     active_user_with_permissions,
     mock_get_service,
@@ -2633,6 +2643,7 @@ def test_post_copy_template(
     mock_get_service_templates,
     mock_get_organisations_and_services_for_user,
     mock_create_service_template,
+    mocker,
 ):
     active_user_with_permissions["services"].append(SERVICE_TWO_ID)
     active_user_with_permissions["permissions"][SERVICE_TWO_ID] = active_user_with_permissions["permissions"][
@@ -2666,7 +2677,6 @@ def test_post_copy_template(
 
 
 def test_post_copy_template_into_folder(
-    mocker,
     client_request,
     active_user_with_permissions,
     mock_get_service,
@@ -2675,6 +2685,7 @@ def test_post_copy_template_into_folder(
     mock_get_service_templates,
     mock_get_organisations_and_services_for_user,
     mock_create_service_template,
+    mocker,
 ):
     active_user_with_permissions["services"].append(SERVICE_TWO_ID)
     active_user_with_permissions["permissions"][SERVICE_TWO_ID] = active_user_with_permissions["permissions"][
@@ -2709,7 +2720,6 @@ def test_post_copy_template_into_folder(
 
 
 def test_post_copy_letter_template(
-    mocker,
     client_request,
     mock_get_service_letter_template,
     mock_get_service_templates,
@@ -2717,6 +2727,7 @@ def test_post_copy_letter_template(
     mock_get_organisations_and_services_for_user,
     mock_create_service_template,
     service_one,
+    mocker,
 ):
     service_one["permissions"].append("letter")
 
@@ -2749,7 +2760,6 @@ def test_post_copy_letter_template(
 
 @pytest.mark.parametrize("from_service", (SERVICE_ONE_ID, SERVICE_TWO_ID))
 def test_copy_letter_template_with_letter_attachment(
-    mocker,
     client_request,
     active_user_with_permission_to_two_services,
     mock_get_service_templates,
@@ -2757,6 +2767,7 @@ def test_copy_letter_template_with_letter_attachment(
     mock_create_service_template,
     multiple_sms_senders,
     from_service,
+    mocker,
 ):
     client_request.login(active_user_with_permission_to_two_services)
     mocker.patch(
@@ -3034,10 +3045,10 @@ def test_name_required_to_rename_template(
 
 @pytest.mark.parametrize("template_type", ("email", "sms"))
 def test_only_letters_can_be_renamed_through_rename_page(
-    mocker,
     client_request,
     fake_uuid,
     template_type,
+    mocker,
 ):
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -3614,12 +3625,12 @@ def test_update_template_for_welsh_language_content(
 
 
 def test_update_template_for_english_content_in_welsh_letter(
-    mocker,
     client_request,
     mock_update_service_template,
     mock_get_service_letter_template_welsh_language,
     fake_uuid,
     service_one,
+    mocker,
 ):
     do_mock_get_page_counts_for_letter(mocker, count=1, welsh_page_count=1)
     service_one["permissions"].append("letter")
@@ -3767,11 +3778,11 @@ def test_should_show_delete_template_page_with_escaped_template_name(client_requ
 
 @pytest.mark.parametrize("parent", (PARENT_FOLDER_ID, None))
 def test_should_redirect_when_deleting_a_template(
-    mocker,
     client_request,
     mock_delete_service_template,
     mock_get_template_folders,
     parent,
+    mocker,
 ):
     mock_get_template_folders.return_value = [
         {"id": PARENT_FOLDER_ID, "name": "Folder", "parent": None, "users_with_permission": [ANY]}
@@ -3832,7 +3843,6 @@ def test_should_show_page_for_a_deleted_template(
 )
 def test_route_permissions(
     route,
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
@@ -3840,6 +3850,7 @@ def test_route_permissions(
     mock_get_service_template,
     mock_get_template_folders,
     fake_uuid,
+    mocker,
 ):
     mocker.patch("app.template_statistics_client.get_last_used_date_for_template", return_value="2012-01-01 12:00:00")
     validate_route_permission(
@@ -3855,7 +3866,6 @@ def test_route_permissions(
 
 
 def test_route_permissions_for_choose_template(
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
@@ -3863,6 +3873,7 @@ def test_route_permissions_for_choose_template(
     service_one,
     mock_get_service_templates,
     mock_get_no_api_keys,
+    mocker,
 ):
     mocker.patch("app.job_api_client.get_job")
     validate_route_permission(
@@ -3885,13 +3896,13 @@ def test_route_permissions_for_choose_template(
 )
 def test_route_invalid_permissions(
     route,
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
     service_one,
     mock_get_service_template,
     fake_uuid,
+    mocker,
 ):
     validate_route_permission(
         mocker,
@@ -3969,11 +3980,11 @@ def test_should_not_create_sms_template_with_emoji(
 
 
 def test_should_not_update_sms_template_with_emoji(
-    mocker,
     client_request,
     service_one,
     mock_update_service_template,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -4358,12 +4369,12 @@ def test_content_count_json_endpoint_for_unsupported_template_types(
     ),
 )
 def test_letter_attachment_preview_image_shows_overlay_when_content_outside_printable_area(
-    mocker,
     client_request,
     fake_uuid,
     invalid_pages,
     page_requested,
     overlay_expected,
+    mocker,
 ):
     mocker.patch(
         "app.main.views.templates.get_attachment_pdf_and_metadata",

--- a/tests/app/main/views/test_tour.py
+++ b/tests/app/main/views/test_tour.py
@@ -91,13 +91,13 @@ def test_should_404_if_no_mobile_number_for_tour_start(
 
 
 def test_should_403_if_user_does_not_have_send_permissions_for_tour_start(
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
     mock_get_service_template_with_multiple_placeholders,
     service_one,
     fake_uuid,
+    mocker,
 ):
     validate_route_permission(
         mocker,
@@ -207,7 +207,6 @@ def test_should_404_for_get_tour_step_0(
 
 @pytest.mark.parametrize("method", ["GET", "POST"])
 def test_should_403_if_user_does_not_have_send_permissions_for_tour_step(
-    mocker,
     notify_admin,
     client_request,
     api_user_active,
@@ -215,6 +214,7 @@ def test_should_403_if_user_does_not_have_send_permissions_for_tour_step(
     service_one,
     fake_uuid,
     method,
+    mocker,
 ):
     validate_route_permission(
         mocker,

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -226,7 +226,7 @@ def test_unsubscribe_request_reports_summary(
     expected_rows,
     expected_grey_text_statuses,
 ):
-    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
+    mocker.patch.object(UnsubscribeRequestsReports, "_get_items", return_value=test_data)
 
     page = client_request.get("main.unsubscribe_request_reports_summary", service_id=SERVICE_ONE_ID)
 
@@ -239,7 +239,7 @@ def test_unsubscribe_request_reports_summary(
 
 def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocker):
 
-    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=[])
+    mocker.patch.object(UnsubscribeRequestsReports, "_get_items", return_value=[])
 
     page = client_request.get("main.unsubscribe_request_reports_summary", service_id=SERVICE_ONE_ID)
 
@@ -262,7 +262,7 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
         }
     ]
 
-    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
+    mocker.patch.object(UnsubscribeRequestsReports, "_get_items", return_value=test_data)
 
     page = client_request.get(
         "main.unsubscribe_request_report",
@@ -302,7 +302,7 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
         }
     ]
 
-    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
+    mocker.patch.object(UnsubscribeRequestsReports, "_get_items", return_value=test_data)
     page = client_request.get(
         "main.unsubscribe_request_report",
         service_id=SERVICE_ONE_ID,
@@ -344,7 +344,7 @@ def test_unsubscribe_request_report_for_processed_batched_reports(client_request
             "will_be_archived_at": "2024-01-08 23:00",
         },
     ]
-    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
+    mocker.patch.object(UnsubscribeRequestsReports, "_get_items", return_value=test_data)
     page = client_request.get(
         "main.unsubscribe_request_report",
         service_id=SERVICE_ONE_ID,
@@ -375,7 +375,7 @@ def test_unsubscribe_request_report_with_forced_download(
 ):
     mocker.patch.object(
         UnsubscribeRequestsReports,
-        "client_method",
+        "_get_items",
         return_value=[
             {
                 "count": 321,
@@ -408,7 +408,7 @@ def test_cannot_force_download_for_unbatched_unsubscribe_request_report(
 ):
     mocker.patch.object(
         UnsubscribeRequestsReports,
-        "client_method",
+        "_get_items",
         return_value=[
             {
                 "count": 321,
@@ -432,7 +432,7 @@ def test_cannot_force_download_for_unbatched_unsubscribe_request_report(
 @pytest.mark.parametrize("batch_id", ["32b4e359-d4df-49b6-a92b-2eaa9343cfdd", None])
 def test_non_existing_unsubscribe_request_report_batch_id_returns_404(client_request, mocker, batch_id):
 
-    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=[])
+    mocker.patch.object(UnsubscribeRequestsReports, "_get_items", return_value=[])
     page = client_request.get(
         "main.unsubscribe_request_report",
         _expected_status=404,
@@ -446,7 +446,7 @@ def test_non_existing_unsubscribe_request_report_batch_id_returns_404(client_req
 def test_mark_report_as_completed(client_request, mocker, fake_uuid):
     mocker.patch.object(
         UnsubscribeRequestsReports,
-        "client_method",
+        "_get_items",
         return_value=[
             {
                 "count": 321,
@@ -510,7 +510,7 @@ def test_create_unsubscribe_request_report_creates_batched_report(client_request
         }
     ]
     test_batch_id = "daaa3f82-faf0-4199-82da-15ec6aa8abe8"
-    mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=summary_data)
+    mocker.patch.object(UnsubscribeRequestsReports, "_get_items", return_value=summary_data)
     mock_batch_report = mocker.patch.object(
         service_api_client, "create_unsubscribe_request_report", return_value={"report_id": test_batch_id}
     )

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -632,7 +632,11 @@ def test_unsubscribe_landing_page(client_request, fake_uuid):
     assert normalize_spaces(page.select_one("form[method=post] button[type=submit]").text) == "Confirm"
 
 
-def test_unsubscribe_valid_request(mocker, client_request, fake_uuid):
+def test_unsubscribe_valid_request(
+    client_request,
+    fake_uuid,
+    mocker,
+):
     mock_unsubscribe = mocker.patch("app.unsubscribe_api_client.unsubscribe", return_value=True)
     client_request.post(
         "main.unsubscribe",
@@ -654,7 +658,11 @@ def test_unsubscribe_confirmation_page(client_request):
     assert not page.select_one("form")
 
 
-def test_unsubscribe_request_not_found(mocker, client_request, fake_uuid):
+def test_unsubscribe_request_not_found(
+    client_request,
+    fake_uuid,
+    mocker,
+):
     def _post(notification_id, token):
         raise HTTPError(response=Mock(status_code=404))
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -67,12 +67,12 @@ def test_overview_page_shows_disable_for_platform_admin(client_request, platform
     ],
 )
 def test_overview_page_shows_security_keys_if_user_they_can_use_webauthn(
-    mocker,
     client_request,
     platform_admin_user,
     webauthn_credential,
     key_count,
     expected_row_text,
+    mocker,
 ):
     client_request.login(platform_admin_user)
     credentials = [webauthn_credential for _ in range(key_count)]
@@ -495,11 +495,11 @@ def test_user_doesnt_see_security_keys_unless_they_can_use_webauthn(client_reque
 
 @freeze_time("2022-10-10")
 def test_should_show_security_keys_page(
-    mocker,
     client_request,
     platform_admin_user,
     webauthn_credential,
     webauthn_credential_2,
+    mocker,
 ):
     client_request.login(platform_admin_user)
 
@@ -527,10 +527,10 @@ def test_should_show_security_keys_page(
 
 
 def test_get_key_from_list_of_keys(
-    mocker,
     webauthn_credential,
     webauthn_credential_2,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.models.webauthn_credential.WebAuthnCredentials._get_items",
@@ -540,10 +540,10 @@ def test_get_key_from_list_of_keys(
 
 
 def test_should_show_manage_security_key_page(
-    mocker,
     client_request,
     platform_admin_user,
     webauthn_credential,
+    mocker,
 ):
     client_request.login(platform_admin_user)
 
@@ -562,7 +562,11 @@ def test_should_show_manage_security_key_page(
 
 
 def test_manage_security_key_page_404s_when_key_not_found(
-    mocker, client_request, platform_admin_user, webauthn_credential, webauthn_credential_2
+    client_request,
+    platform_admin_user,
+    webauthn_credential,
+    webauthn_credential_2,
+    mocker,
 ):
     client_request.login(platform_admin_user)
 
@@ -661,10 +665,10 @@ def test_user_profile_manage_security_key_should_not_call_api_if_key_name_stays_
 
 
 def test_shows_delete_link_for_security_key(
-    mocker,
     client_request,
     platform_admin_user,
     webauthn_credential,
+    mocker,
 ):
     client_request.login(platform_admin_user)
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -47,7 +47,7 @@ def test_overview_page_change_links_for_regular_user(client_request):
 
 
 def test_overview_page_shows_disable_for_platform_admin(client_request, platform_admin_user, mocker):
-    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials.client_method")
+    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials._get_items")
     client_request.login(platform_admin_user)
     page = client_request.get("main.user_profile")
     assert page.select_one("h1").text.strip() == "Your profile"
@@ -77,7 +77,7 @@ def test_overview_page_shows_security_keys_if_user_they_can_use_webauthn(
     client_request.login(platform_admin_user)
     credentials = [webauthn_credential for _ in range(key_count)]
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=credentials,
     )
     page = client_request.get("main.user_profile")
@@ -504,7 +504,7 @@ def test_should_show_security_keys_page(
     client_request.login(platform_admin_user)
 
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential, webauthn_credential_2],
     )
 
@@ -533,7 +533,7 @@ def test_get_key_from_list_of_keys(
     fake_uuid,
 ):
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential, webauthn_credential_2],
     )
     assert WebAuthnCredentials(fake_uuid).by_id(webauthn_credential["id"]) == WebAuthnCredential(webauthn_credential)
@@ -548,7 +548,7 @@ def test_should_show_manage_security_key_page(
     client_request.login(platform_admin_user)
 
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential],
     )
 
@@ -567,7 +567,7 @@ def test_manage_security_key_page_404s_when_key_not_found(
     client_request.login(platform_admin_user)
 
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential_2],
     )
     client_request.get(
@@ -614,7 +614,7 @@ def test_should_redirect_after_change_of_security_key_name(
     client_request.login(platform_admin_user)
 
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential],
     )
 
@@ -641,7 +641,7 @@ def test_user_profile_manage_security_key_should_not_call_api_if_key_name_stays_
     client_request.login(platform_admin_user)
 
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential],
     )
 
@@ -669,7 +669,7 @@ def test_shows_delete_link_for_security_key(
     client_request.login(platform_admin_user)
 
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential],
     )
 
@@ -685,7 +685,7 @@ def test_confirm_delete_security_key(client_request, platform_admin_user, webaut
     client_request.login(platform_admin_user)
 
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential],
     )
 
@@ -724,7 +724,7 @@ def test_delete_security_key_handles_last_credential_error(
 ):
     client_request.login(platform_admin_user)
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential],
     )
 

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -203,12 +203,12 @@ def test_verify_redirects_to_sign_in_if_not_logged_in(client_request):
 
 
 def test_activate_user_redirects_to_service_dashboard_if_user_already_belongs_to_service(
-    mocker,
     client_request,
     service_one,
     sample_invite,
     api_user_active,
     mock_get_invited_user_by_id,
+    mocker,
 ):
     mocker.patch(
         "app.user_api_client.add_user_to_service",

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -57,7 +57,7 @@ def test_begin_register_returns_encoded_options(
     client_request,
     webauthn_dev_server,
 ):
-    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials.client_method", return_value=[])
+    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials._get_items", return_value=[])
 
     client_request.login(platform_admin_user)
     response = client_request.get_response(
@@ -88,7 +88,7 @@ def test_begin_register_includes_existing_credentials(
     mocker,
 ):
     mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method",
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items",
         return_value=[webauthn_credential, webauthn_credential],
     )
 
@@ -106,7 +106,7 @@ def test_begin_register_stores_state_in_session(
     platform_admin_user,
     mocker,
 ):
-    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials.client_method", return_value=[])
+    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials._get_items", return_value=[])
 
     client_request.login(platform_admin_user)
     client_request.get_response(
@@ -236,7 +236,7 @@ def test_begin_authentication_returns_encoded_options(
         session["user_details"] = {"id": platform_admin_user["id"]}
 
     get_creds_mock = mocker.patch(
-        "app.models.webauthn_credential.WebAuthnCredentials.client_method", return_value=[webauthn_credential]
+        "app.models.webauthn_credential.WebAuthnCredentials._get_items", return_value=[webauthn_credential]
     )
     response = client_request.get_response("main.webauthn_begin_authentication")
 
@@ -259,7 +259,7 @@ def test_begin_authentication_stores_state_in_session(
     with client_request.session_transaction() as session:
         session["user_details"] = {"id": platform_admin_user["id"]}
 
-    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials.client_method", return_value=[webauthn_credential])
+    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials._get_items", return_value=[webauthn_credential])
     client_request.get_response("main.webauthn_begin_authentication")
 
     with client_request.session_transaction() as session:
@@ -279,7 +279,7 @@ def test_complete_authentication_checks_credentials(
     _set_up_webauthn_session(platform_admin_user["id"], client_request)
 
     mocker.patch("app.user_api_client.get_user", return_value=platform_admin_user)
-    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials.client_method", return_value=[webauthn_credential])
+    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials._get_items", return_value=[webauthn_credential])
     mocker.patch(
         "app.main.views.webauthn_credentials._complete_webauthn_login_attempt", return_value=Mock(location="/foo")
     )
@@ -306,7 +306,7 @@ def test_complete_authentication_403s_if_key_isnt_in_users_credentials(
 
     mocker.patch("app.user_api_client.get_user", return_value=platform_admin_user)
     # user has no keys in the database
-    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials.client_method", return_value=[])
+    mocker.patch("app.models.webauthn_credential.WebAuthnCredentials._get_items", return_value=[])
     mock_verify_webauthn_login = mocker.patch("app.main.views.webauthn_credentials._complete_webauthn_login_attempt")
     mock_unsuccesful_login_api_call = mocker.patch("app.user_api_client.complete_webauthn_login_attempt")
 

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -52,10 +52,10 @@ def test_begin_register_forbidden_unless_can_use_webauthn(
 
 
 def test_begin_register_returns_encoded_options(
-    mocker,
     platform_admin_user,
     client_request,
     webauthn_dev_server,
+    mocker,
 ):
     mocker.patch("app.models.webauthn_credential.WebAuthnCredentials._get_items", return_value=[])
 

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -340,10 +340,10 @@ def test_upload_csv_shows_ok_page(client_request, mock_get_live_service, fake_uu
 
 
 def test_save_contact_list(
-    mocker,
     client_request,
     fake_uuid,
     mock_create_contact_list,
+    mocker,
 ):
     mock_get_metadata = mocker.patch(
         "app.models.contact_list.get_csv_metadata",
@@ -374,10 +374,10 @@ def test_save_contact_list(
 
 
 def test_cant_save_bad_contact_list(
-    mocker,
     client_request,
     fake_uuid,
     mock_create_contact_list,
+    mocker,
 ):
     mocker.patch(
         "app.models.contact_list.get_csv_metadata",
@@ -401,7 +401,6 @@ def test_cant_save_bad_contact_list(
 )
 @freeze_time("2020-06-13 16:51:56")
 def test_view_contact_list(
-    mocker,
     client_request,
     mock_get_contact_list,
     mock_get_no_jobs,
@@ -409,6 +408,7 @@ def test_view_contact_list(
     fake_uuid,
     has_jobs,
     expected_empty_message,
+    mocker,
 ):
     mocker.patch(
         "app.models.contact_list.contact_list_api_client.get_contact_list",
@@ -467,11 +467,11 @@ def test_view_contact_list(
 
 @freeze_time("2015-12-31 16:51:56")
 def test_view_jobs_for_contact_list(
-    mocker,
     client_request,
     mock_get_jobs,
     mock_get_service_data_retention,
     fake_uuid,
+    mocker,
 ):
     mocker.patch(
         "app.models.contact_list.contact_list_api_client.get_contact_list",
@@ -527,10 +527,10 @@ def test_view_contact_list_404s_for_non_existing_list(
 
 
 def test_download_contact_list(
-    mocker,
     client_request,
     fake_uuid,
     mock_get_contact_list,
+    mocker,
 ):
     mocker.patch("app.models.contact_list.s3download", return_value="phone number\n07900900321")
     response = client_request.get_response(
@@ -544,12 +544,12 @@ def test_download_contact_list(
 
 
 def test_confirm_delete_contact_list(
-    mocker,
     client_request,
     fake_uuid,
     mock_get_jobs,
     mock_get_service_data_retention,
     mock_get_contact_list,
+    mocker,
 ):
     mocker.patch("app.models.contact_list.s3download", return_value="phone number\n07900900321")
     page = client_request.get(
@@ -565,10 +565,10 @@ def test_confirm_delete_contact_list(
 
 
 def test_delete_contact_list(
-    mocker,
     client_request,
     fake_uuid,
     mock_get_contact_list,
+    mocker,
 ):
     mock_delete = mocker.patch("app.models.contact_list.contact_list_api_client.delete_contact_list")
     client_request.post(

--- a/tests/app/main/views/uploads/test_upload_hub.py
+++ b/tests/app/main/views/uploads/test_upload_hub.py
@@ -78,13 +78,13 @@ def test_all_users_have_upload_contact_list(
     ),
 )
 def test_get_upload_hub_with_no_uploads(
-    mocker,
     client_request,
     service_one,
     mock_get_no_uploads,
     mock_get_no_contact_lists,
     extra_permissions,
     expected_empty_message,
+    mocker,
 ):
     mocker.patch("app.job_api_client.get_jobs", return_value={"data": []})
     service_one["permissions"] += extra_permissions
@@ -95,11 +95,11 @@ def test_get_upload_hub_with_no_uploads(
 
 @freeze_time("2017-10-10 10:10:10")
 def test_get_upload_hub_page(
-    mocker,
     client_request,
     service_one,
     mock_get_uploads,
     mock_get_no_contact_lists,
+    mocker,
 ):
     mocker.patch("app.job_api_client.get_jobs", return_value={"data": []})
     service_one["permissions"] += ["letter", "upload_letters"]
@@ -142,6 +142,7 @@ def test_get_uploaded_letters(
     client_request,
     service_one,
     mock_get_uploaded_letters,
+    mocker,
 ):
     page = client_request.get("main.uploaded_letters", service_id=SERVICE_ONE_ID, letter_print_day="2020-02-02")
     assert page.select_one(".govuk-back-link")["href"] == url_for(
@@ -195,6 +196,7 @@ def test_get_empty_uploaded_letters_page(
     client_request,
     service_one,
     mock_get_no_uploaded_letters,
+    mocker,
 ):
     page = client_request.get("main.uploaded_letters", service_id=SERVICE_ONE_ID, letter_print_day="2020-02-02")
     page.select_one("main table")
@@ -209,6 +211,7 @@ def test_get_uploaded_letters_passes_through_page_argument(
     client_request,
     service_one,
     mock_get_uploaded_letters,
+    mocker,
 ):
     client_request.get(
         "main.uploaded_letters",
@@ -225,6 +228,7 @@ def test_get_uploaded_letters_passes_through_page_argument(
 
 def test_get_uploaded_letters_404s_for_bad_page_arguments(
     client_request,
+    mocker,
 ):
     client_request.get(
         "main.uploaded_letters",
@@ -237,6 +241,7 @@ def test_get_uploaded_letters_404s_for_bad_page_arguments(
 
 def test_get_uploaded_letters_404s_for_invalid_date(
     client_request,
+    mocker,
 ):
     client_request.get(
         "main.uploaded_letters",
@@ -260,6 +265,7 @@ def test_uploads_page_shows_scheduled_jobs(
     mock_get_jobs,
     mock_get_no_contact_lists,
     user,
+    mocker,
 ):
     client_request.login(user)
     page = client_request.get("main.uploads", service_id=SERVICE_ONE_ID)
@@ -279,6 +285,7 @@ def test_uploads_page_shows_contact_lists_first(
     mock_get_jobs,
     mock_get_contact_lists,
     mock_get_service_data_retention,
+    mocker,
 ):
     page = client_request.get("main.uploads", service_id=SERVICE_ONE_ID)
 

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -39,7 +39,7 @@ def test_post_upload_letter_redirects_for_valid_file(
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     antivirus_mock = mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mock_sanitise = mocker.patch(
-        "app.template_previews.TemplatePreview.sanitise_letter",
+        "app.template_preview_client.sanitise_letter",
         return_value=Mock(
             content="The sanitised content",
             json=lambda: {"file": "VGhlIHNhbml0aXNlZCBjb250ZW50", "recipient_address": "The Queen"},
@@ -125,7 +125,7 @@ def test_post_upload_letter_shows_letter_preview_for_valid_file(
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mocker.patch(
-        "app.template_previews.TemplatePreview.sanitise_letter",
+        "app.template_preview_client.sanitise_letter",
         return_value=Mock(
             content="The sanitised content",
             json=lambda: {"file": "VGhlIHNhbml0aXNlZCBjb250ZW50", "recipient_address": "The Queen"},
@@ -193,7 +193,7 @@ def test_upload_international_letter_shows_preview_with_no_choice_of_postage(
 
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch(
-        "app.template_previews.TemplatePreview.sanitise_letter",
+        "app.template_preview_client.sanitise_letter",
         return_value=Mock(
             content="The sanitised content",
             json=lambda: {"file": "VGhlIHNhbml0aXNlZCBjb250ZW50", "recipient_address": "The Queen"},
@@ -462,7 +462,7 @@ def test_post_upload_letter_with_invalid_file(
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
     mock_sanitise_response.json = lambda: {"message": "content-outside-printable-area", "invalid_pages": [1]}
-    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", return_value=mock_sanitise_response)
+    mocker.patch("app.template_preview_client.sanitise_letter", return_value=mock_sanitise_response)
     mocker.patch("app.models.service.service_api_client.get_precompiled_template")
     mocker.patch(
         "app.main.views.uploads.get_letter_metadata",
@@ -521,7 +521,7 @@ def test_post_upload_letter_shows_letter_preview_for_invalid_file(
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
     mock_sanitise_response.json = lambda: {"message": "template preview error", "recipient_address": "The Queen"}
-    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", return_value=mock_sanitise_response)
+    mocker.patch("app.template_preview_client.sanitise_letter", return_value=mock_sanitise_response)
     mocker.patch("app.models.service.service_api_client.get_precompiled_template", return_value=letter_template)
     mocker.patch(
         "app.main.views.uploads.get_letter_metadata",
@@ -566,7 +566,7 @@ def test_post_upload_letter_does_not_upload_to_s3_if_template_preview_raises_unk
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mock_s3 = mocker.patch("app.main.views.uploads.upload_letter_to_s3")
 
-    mocker.patch("app.template_previews.TemplatePreview.sanitise_letter", side_effect=RequestException())
+    mocker.patch("app.template_preview_client.sanitise_letter", side_effect=RequestException())
 
     with pytest.raises(RequestException):
         with open("tests/test_pdf_files/one_page_pdf.pdf", "rb") as file:
@@ -693,11 +693,11 @@ def test_uploaded_letter_preview_image_shows_overlay_when_content_outside_printa
         ),
     )
     template_preview_mock_valid = mocker.patch(
-        "app.main.views.uploads.TemplatePreview.get_png_for_valid_pdf_page",
+        "app.template_preview_client.get_png_for_valid_pdf_page",
         return_value=make_response("page.html", 200),
     )
     template_preview_mock_invalid = mocker.patch(
-        "app.main.views.uploads.TemplatePreview.get_png_for_invalid_pdf_page",
+        "app.template_preview_client.get_png_for_invalid_pdf_page",
         return_value=make_response("page.html", 200),
     )
 
@@ -732,7 +732,7 @@ def test_uploaded_letter_preview_image_does_not_show_overlay_if_no_content_outsi
 ):
     mocker.patch("app.main.views.uploads.get_letter_pdf_and_metadata", return_value=("pdf_file", metadata))
     template_preview_mock = mocker.patch(
-        "app.main.views.uploads.TemplatePreview.get_png_for_valid_pdf_page",
+        "app.template_preview_client.get_png_for_valid_pdf_page",
         return_value=make_response("page.html", 200),
     )
 

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -28,13 +28,13 @@ def test_get_upload_letter(client_request):
     ),
 )
 def test_post_upload_letter_redirects_for_valid_file(
-    mocker,
     active_user_with_permissions,
     service_one,
     client_request,
     fake_uuid,
     extra_permissions,
     expected_allow_international,
+    mocker,
 ):
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     antivirus_mock = mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
@@ -106,11 +106,11 @@ def test_post_upload_letter_redirects_for_valid_file(
 
 
 def test_post_upload_letter_shows_letter_preview_for_valid_file(
-    mocker,
     active_user_with_permissions,
     service_one,
     client_request,
     fake_uuid,
+    mocker,
 ):
     letter_template = {
         "service": SERVICE_ONE_ID,
@@ -175,11 +175,11 @@ def test_post_upload_letter_shows_letter_preview_for_valid_file(
 
 
 def test_upload_international_letter_shows_preview_with_no_choice_of_postage(
-    mocker,
     active_user_with_permissions,
     service_one,
     client_request,
     fake_uuid,
+    mocker,
 ):
     letter_template = {
         "service": SERVICE_ONE_ID,
@@ -290,7 +290,10 @@ def test_uploading_a_letter_shows_error_when_no_file_uploaded(
 
 
 def test_uploading_a_letter_shows_error_when_file_contains_virus(
-    mocker, client_request, service_one, mock_get_service_letter_template
+    client_request,
+    service_one,
+    mock_get_service_letter_template,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=False)
     mock_s3_backup = mocker.patch("app.main.views.uploads.backup_original_letter_to_s3")
@@ -309,7 +312,10 @@ def test_uploading_a_letter_shows_error_when_file_contains_virus(
 
 
 def test_uploading_a_letter_errors_when_file_is_too_big(
-    mocker, client_request, service_one, mock_get_service_letter_template
+    client_request,
+    service_one,
+    mock_get_service_letter_template,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
@@ -326,7 +332,10 @@ def test_uploading_a_letter_errors_when_file_is_too_big(
 
 
 def test_post_choose_upload_letter_when_file_is_malformed(
-    mocker, client_request, service_one, mock_get_service_letter_template
+    client_request,
+    service_one,
+    mock_get_service_letter_template,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
@@ -375,7 +384,10 @@ def test_uploading_a_letter_attachment_shows_error_when_no_file_uploaded(
 
 
 def test_uploading_a_letter_attachment_shows_error_when_file_contains_virus(
-    mocker, client_request, service_one, mock_get_service_letter_template
+    client_request,
+    service_one,
+    mock_get_service_letter_template,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=False)
     mock_s3_backup = mocker.patch("app.main.views.uploads.backup_original_letter_to_s3")
@@ -394,7 +406,10 @@ def test_uploading_a_letter_attachment_shows_error_when_file_contains_virus(
 
 
 def test_uploading_a_letter_attachment_errors_when_file_is_too_big(
-    mocker, client_request, service_one, mock_get_service_letter_template
+    client_request,
+    service_one,
+    mock_get_service_letter_template,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
@@ -411,7 +426,10 @@ def test_uploading_a_letter_attachment_errors_when_file_is_too_big(
 
 
 def test_post_choose_upload_letter_attachment_when_file_is_malformed(
-    mocker, client_request, service_one, mock_get_service_letter_template
+    client_request,
+    service_one,
+    mock_get_service_letter_template,
+    mocker,
 ):
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
@@ -431,7 +449,11 @@ def test_post_choose_upload_letter_attachment_when_file_is_malformed(
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 
 
-def test_post_upload_letter_with_invalid_file(mocker, client_request, fake_uuid):
+def test_post_upload_letter_with_invalid_file(
+    client_request,
+    fake_uuid,
+    mocker,
+):
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mock_s3_upload = mocker.patch("app.main.views.uploads.upload_letter_to_s3")
@@ -478,7 +500,11 @@ def test_post_upload_letter_with_invalid_file(mocker, client_request, fake_uuid)
     assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 
 
-def test_post_upload_letter_shows_letter_preview_for_invalid_file(mocker, client_request, fake_uuid):
+def test_post_upload_letter_shows_letter_preview_for_invalid_file(
+    client_request,
+    fake_uuid,
+    mocker,
+):
     letter_template = {
         "service": SERVICE_ONE_ID,
         "template_type": "letter",
@@ -532,9 +558,9 @@ def test_post_upload_letter_shows_letter_preview_for_invalid_file(mocker, client
 
 
 def test_post_upload_letter_does_not_upload_to_s3_if_template_preview_raises_unknown_error(
-    mocker,
     client_request,
     fake_uuid,
+    mocker,
 ):
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
@@ -552,11 +578,11 @@ def test_post_upload_letter_does_not_upload_to_s3_if_template_preview_raises_unk
 
 
 def test_uploaded_letter_preview(
-    mocker,
     active_user_with_permissions,
     service_one,
     client_request,
     fake_uuid,
+    mocker,
 ):
     mocker.patch("app.models.service.service_api_client.get_precompiled_template")
     mocker.patch(
@@ -588,9 +614,9 @@ def test_uploaded_letter_preview(
 
 
 def test_uploaded_letter_preview_does_not_show_send_button_if_service_in_trial_mode(
-    mocker,
     client_request,
     fake_uuid,
+    mocker,
 ):
     mocker.patch("app.models.service.service_api_client.get_precompiled_template")
     mocker.patch(
@@ -619,7 +645,11 @@ def test_uploaded_letter_preview_does_not_show_send_button_if_service_in_trial_m
     assert len(page.select("form button")) == 0
 
 
-def test_uploaded_letter_preview_redirects_if_file_not_in_s3(mocker, client_request, fake_uuid):
+def test_uploaded_letter_preview_redirects_if_file_not_in_s3(
+    client_request,
+    fake_uuid,
+    mocker,
+):
     mocker.patch("app.main.views.uploads.get_letter_metadata", side_effect=LetterNotFoundError)
 
     client_request.get(
@@ -645,12 +675,12 @@ def test_uploaded_letter_preview_redirects_if_file_not_in_s3(mocker, client_requ
     ),
 )
 def test_uploaded_letter_preview_image_shows_overlay_when_content_outside_printable_area_on_a_page(
-    mocker,
     client_request,
     fake_uuid,
     invalid_pages,
     page_requested,
     overlay_expected,
+    mocker,
 ):
     mocker.patch(
         "app.main.views.uploads.get_letter_pdf_and_metadata",
@@ -695,10 +725,10 @@ def test_uploaded_letter_preview_image_shows_overlay_when_content_outside_printa
     ],
 )
 def test_uploaded_letter_preview_image_does_not_show_overlay_if_no_content_outside_printable_area(
-    mocker,
     client_request,
     metadata,
     fake_uuid,
+    mocker,
 ):
     mocker.patch("app.main.views.uploads.get_letter_pdf_and_metadata", return_value=("pdf_file", metadata))
     template_preview_mock = mocker.patch(
@@ -761,13 +791,13 @@ def test_uploaded_letter_preview_image_400s_for_bad_page_type(
     ),
 )
 def test_send_uploaded_letter_sends_letter_and_redirects_to_notification_page(
-    mocker,
     service_one,
     client_request,
     fake_uuid,
     address,
     post_data,
     expected_postage,
+    mocker,
 ):
     metadata = LetterMetadata(
         {
@@ -805,10 +835,10 @@ def test_send_uploaded_letter_sends_letter_and_redirects_to_notification_page(
 
 
 def test_send_uploaded_letter_redirects_if_file_not_in_s3(
-    mocker,
     client_request,
     fake_uuid,
     service_one,
+    mocker,
 ):
     mocker.patch("app.main.views.uploads.get_letter_metadata", side_effect=LetterNotFoundError)
 
@@ -835,11 +865,11 @@ def test_send_uploaded_letter_redirects_if_file_not_in_s3(
     ],
 )
 def test_send_uploaded_letter_when_service_does_not_have_correct_permissions(
-    mocker,
     service_one,
     client_request,
     permissions,
     fake_uuid,
+    mocker,
 ):
     mocker.patch("app.main.views.uploads.get_letter_pdf_and_metadata", return_value=("file", {"status": "valid"}))
     mock_send = mocker.patch("app.main.views.uploads.notification_api_client.send_precompiled_letter")
@@ -857,10 +887,10 @@ def test_send_uploaded_letter_when_service_does_not_have_correct_permissions(
 
 
 def test_send_uploaded_letter_when_metadata_states_pdf_is_invalid(
-    mocker,
     service_one,
     client_request,
     fake_uuid,
+    mocker,
 ):
     mock_send = mocker.patch("app.main.views.uploads.notification_api_client.send_precompiled_letter")
     mocker.patch(

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -6,7 +6,7 @@ from tests import organisation_json, service_json
 from tests.conftest import ORGANISATION_ID, create_folder, create_template
 
 
-def test_organisation_type_when_services_organisation_has_no_org_type(mocker, service_one):
+def test_organisation_type_when_services_organisation_has_no_org_type(notify_admin, mocker, service_one):
     service = Service(service_one)
     service._dict["organisation_id"] = ORGANISATION_ID
     org = organisation_json(organisation_type=None)
@@ -16,7 +16,7 @@ def test_organisation_type_when_services_organisation_has_no_org_type(mocker, se
     assert service.organisation_type == "central"
 
 
-def test_organisation_type_when_service_and_its_org_both_have_an_org_type(mocker, service_one):
+def test_organisation_type_when_service_and_its_org_both_have_an_org_type(notify_admin, mocker, service_one):
     # service_one has an organisation_type of 'central'
     service = Service(service_one)
     service._dict["organisation"] = ORGANISATION_ID
@@ -26,7 +26,7 @@ def test_organisation_type_when_service_and_its_org_both_have_an_org_type(mocker
     assert service.organisation_type == "local"
 
 
-def test_organisation_name_comes_from_cache(mocker, service_one):
+def test_organisation_name_comes_from_cache(notify_admin, mocker, service_one):
     mock_redis_get = mocker.patch(
         "app.extensions.RedisClient.get",
         return_value=b'"Borchester Council"',
@@ -40,7 +40,7 @@ def test_organisation_name_comes_from_cache(mocker, service_one):
     assert mock_get_organisation.called is False
 
 
-def test_organisation_name_goes_into_cache(mocker, service_one):
+def test_organisation_name_goes_into_cache(notify_admin, mocker, service_one):
     mocker.patch(
         "app.extensions.RedisClient.get",
         return_value=None,
@@ -63,7 +63,7 @@ def test_organisation_name_goes_into_cache(mocker, service_one):
     )
 
 
-def test_service_without_organisation_doesnt_need_org_api(mocker, service_one):
+def test_service_without_organisation_doesnt_need_org_api(notify_admin, mocker, service_one):
     mock_redis_get = mocker.patch("app.extensions.RedisClient.get")
     mock_get_organisation = mocker.patch("app.organisations_client.get_organisation")
     service = Service(service_one)
@@ -93,9 +93,9 @@ def test_service_billing_details(purchase_order_number, expected_result):
 
 
 def test_has_templates_of_type_includes_folders(
-    mocker,
     service_one,
     mock_get_template_folders,
+    mocker,
 ):
     mocker.patch(
         "app.service_api_client.get_service_templates",

--- a/tests/app/notify_client/test_base_client.py
+++ b/tests/app/notify_client/test_base_client.py
@@ -3,8 +3,7 @@ from app.notify_client import NotifyAdminAPIClient
 
 class TestBaseClient:
     def test_does_not_add_header_outside_request_context(self, notify_admin, mocker):
-        api_client = NotifyAdminAPIClient()
-        api_client.init_app(notify_admin)
+        api_client = NotifyAdminAPIClient(notify_admin)
         perform_request_mock = mocker.patch.object(api_client, "_perform_request")
 
         api_client.get("/mocked-request")
@@ -14,8 +13,7 @@ class TestBaseClient:
         assert "X-Notify-User-Id" not in headers
 
     def test_does_not_add_header_if_no_user_in_session(self, notify_admin, mocker):
-        api_client = NotifyAdminAPIClient()
-        api_client.init_app(notify_admin)
+        api_client = NotifyAdminAPIClient(notify_admin)
         perform_request_mock = mocker.patch.object(api_client, "_perform_request")
 
         with notify_admin.test_request_context():
@@ -29,8 +27,7 @@ class TestBaseClient:
     def test_adds_notify_user_id_header_if_in_request_and_logged_in(
         self, notify_admin, active_user_with_permissions, mocker, fake_uuid
     ):
-        api_client = NotifyAdminAPIClient()
-        api_client.init_app(notify_admin)
+        api_client = NotifyAdminAPIClient(notify_admin)
         perform_request_mock = mocker.patch.object(api_client, "_perform_request")
 
         with notify_admin.test_request_context(), notify_admin.test_client() as client:

--- a/tests/app/notify_client/test_billing_client.py
+++ b/tests/app/notify_client/test_billing_client.py
@@ -8,7 +8,7 @@ from app.notify_client.billing_api_client import BillingAPIClient
 def test_get_free_sms_fragment_limit_for_year_correct_endpoint(mocker):
     service_id = uuid.uuid4()
     expected_url = f"/service/{service_id}/billing/free-sms-fragment-limit"
-    client = BillingAPIClient()
+    client = BillingAPIClient(mocker.MagicMock())
 
     mock_get = mocker.patch("app.notify_client.billing_api_client.BillingAPIClient.get")
 
@@ -20,7 +20,7 @@ def test_post_free_sms_fragment_limit_for_current_year_endpoint(mocker):
     service_id = uuid.uuid4()
     sms_limit_data = {"free_sms_fragment_limit": 1111, "financial_year_start": None}
     mock_post = mocker.patch("app.notify_client.billing_api_client.BillingAPIClient.post")
-    client = BillingAPIClient()
+    client = BillingAPIClient(mocker.MagicMock())
 
     client.create_or_update_free_sms_fragment_limit(service_id=service_id, free_sms_fragment_limit=1111)
 
@@ -31,7 +31,7 @@ def test_post_free_sms_fragment_limit_for_year_endpoint(mocker):
     service_id = uuid.uuid4()
     sms_limit_data = {"free_sms_fragment_limit": 1111, "financial_year_start": 2017}
     mock_post = mocker.patch("app.notify_client.billing_api_client.BillingAPIClient.post")
-    client = BillingAPIClient()
+    client = BillingAPIClient(mocker.MagicMock())
 
     client.create_or_update_free_sms_fragment_limit(service_id=service_id, free_sms_fragment_limit=1111, year=2017)
     mock_post.assert_called_once_with(url=f"/service/{service_id}/billing/free-sms-fragment-limit", data=sms_limit_data)
@@ -50,7 +50,7 @@ def test_post_free_sms_fragment_limit_for_year_endpoint(mocker):
 )
 def test_get_data_for_volume_reports(mocker, func, expected_url):
     mock_get = mocker.patch("app.notify_client.billing_api_client.BillingAPIClient.get")
-    client = BillingAPIClient()
+    client = BillingAPIClient(mocker.MagicMock())
 
     func(client, "2022-03-01", "2022-03-31")
 

--- a/tests/app/notify_client/test_compliant_client.py
+++ b/tests/app/notify_client/test_compliant_client.py
@@ -2,7 +2,7 @@ from app.notify_client.complaint_api_client import ComplaintApiClient
 
 
 def test_get_all_complaints(mocker):
-    client = ComplaintApiClient()
+    client = ComplaintApiClient(mocker.MagicMock())
 
     mock = mocker.patch("app.notify_client.complaint_api_client.ComplaintApiClient.get")
 
@@ -11,7 +11,7 @@ def test_get_all_complaints(mocker):
 
 
 def test_get_all_complaints_with_a_page_number_specified(mocker):
-    client = ComplaintApiClient()
+    client = ComplaintApiClient(mocker.MagicMock())
 
     mock = mocker.patch("app.notify_client.complaint_api_client.ComplaintApiClient.get")
 
@@ -20,7 +20,7 @@ def test_get_all_complaints_with_a_page_number_specified(mocker):
 
 
 def test_get_complaint_count(mocker):
-    client = ComplaintApiClient()
+    client = ComplaintApiClient(mocker.MagicMock())
     mock = mocker.patch.object(client, "get")
     params_dict = {"start_date": "2018-06-01", "end_date": "2018-06-15"}
 

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -13,7 +13,7 @@ def test_get_email_branding(mocker, fake_uuid):
     mock_redis_set = mocker.patch(
         "app.extensions.RedisClient.set",
     )
-    EmailBrandingClient().get_email_branding(fake_uuid)
+    EmailBrandingClient(mocker.MagicMock()).get_email_branding(fake_uuid)
     mock_get.assert_called_once_with(url=f"/email-branding/{fake_uuid}")
     mock_redis_get.assert_called_once_with(f"email_branding-{fake_uuid}")
     mock_redis_set.assert_called_once_with(
@@ -34,7 +34,7 @@ def test_get_all_email_branding(mocker):
     mock_redis_set = mocker.patch(
         "app.extensions.RedisClient.set",
     )
-    EmailBrandingClient().get_all_email_branding()
+    EmailBrandingClient(mocker.MagicMock()).get_all_email_branding()
     mock_get.assert_called_once_with(url="/email-branding")
     mock_redis_get.assert_called_once_with("email_branding")
     mock_redis_set.assert_called_once_with(
@@ -57,7 +57,7 @@ def test_create_email_branding(mocker, fake_uuid):
 
     mock_post = mocker.patch("app.notify_client.email_branding_client.EmailBrandingClient.post")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
-    EmailBrandingClient().create_email_branding(
+    EmailBrandingClient(mocker.MagicMock()).create_email_branding(
         logo=org_data["logo"],
         name=org_data["name"],
         alt_text=org_data["alt_text"],
@@ -88,7 +88,7 @@ def test_update_email_branding(mocker, fake_uuid):
     mock_redis_delete_by_pattern = mocker.patch(
         "app.extensions.RedisClient.delete_by_pattern", new_callable=RedisClientMock
     )
-    EmailBrandingClient().update_email_branding(
+    EmailBrandingClient(mocker.MagicMock()).update_email_branding(
         branding_id=fake_uuid,
         logo=org_data["logo"],
         name=org_data["name"],
@@ -127,7 +127,7 @@ def test_create_email_branding_sends_none_values(mocker, fake_uuid):
     }
 
     mock_post = mocker.patch("app.notify_client.email_branding_client.EmailBrandingClient.post")
-    EmailBrandingClient().create_email_branding(**form_data)
+    EmailBrandingClient(mocker.MagicMock()).create_email_branding(**form_data)
 
     mock_post.assert_called_once_with(url="/email-branding", data=expected_data)
 
@@ -155,7 +155,7 @@ def test_update_email_branding_sends_none_values(mocker, fake_uuid):
     }
 
     mock_post = mocker.patch("app.notify_client.email_branding_client.EmailBrandingClient.post")
-    EmailBrandingClient().update_email_branding(**form_data)
+    EmailBrandingClient(mocker.MagicMock()).update_email_branding(**form_data)
 
     mock_post.assert_called_once_with(url=f"/email-branding/{fake_uuid}", data=expected_data)
 
@@ -164,6 +164,6 @@ def test_get_email_branding_name_for_alt_text(mocker):
     mock_post = mocker.patch(
         "app.notify_client.email_branding_client.EmailBrandingClient.post", return_value={"name": "bar"}
     )
-    resp = EmailBrandingClient().get_email_branding_name_for_alt_text("foo")
+    resp = EmailBrandingClient(mocker.MagicMock()).get_email_branding_name_for_alt_text("foo")
     assert resp == "bar"
     mock_post.assert_called_once_with(url="/email-branding/get-name-for-alt-text", data={"alt_text": "foo"})

--- a/tests/app/notify_client/test_events_client.py
+++ b/tests/app/notify_client/test_events_client.py
@@ -7,7 +7,7 @@ def test_events_client_calls_correct_api_endpoint(mocker):
     event_data = {"does_not": "matter"}
     expected_data = {"event_type": event_type, "data": event_data}
 
-    client = EventsApiClient()
+    client = EventsApiClient(mocker.MagicMock())
 
     mock_post = mocker.patch("app.notify_client.events_api_client.EventsApiClient.post")
 

--- a/tests/app/notify_client/test_inbound_number_client.py
+++ b/tests/app/notify_client/test_inbound_number_client.py
@@ -11,7 +11,7 @@ from tests.utils import RedisClientMock
         ("1234", {"inbound_number_id": "1234"}),
     ],
 )
-def test_add_inbound_number_to_service(mocker, inbound_number_id, data):
+def test_add_inbound_number_to_service(mocker, notify_admin, inbound_number_id, data):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_redis_delete_by_pattern = mocker.patch(
         "app.extensions.RedisClient.delete_by_pattern", new_callable=RedisClientMock

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -70,7 +70,7 @@ def test_client_update_invite(
     )
 
 
-def test_client_returns_invite(mocker, sample_invite):
+def test_client_returns_invite(notify_admin, sample_invite, mocker):
     sample_invite["status"] = "pending"
     service_id = sample_invite["service"]
 

--- a/tests/app/notify_client/test_letter_branding_client.py
+++ b/tests/app/notify_client/test_letter_branding_client.py
@@ -9,7 +9,7 @@ def test_get_letter_branding(mocker, fake_uuid):
     mock_redis_get = mocker.patch("app.extensions.RedisClient.get", return_value=None)
     mock_redis_set = mocker.patch("app.extensions.RedisClient.set")
 
-    LetterBrandingClient().get_letter_branding(fake_uuid)
+    LetterBrandingClient(mocker.MagicMock()).get_letter_branding(fake_uuid)
 
     mock_get.assert_called_once_with(url=f"/letter-branding/{fake_uuid}")
     mock_redis_get.assert_called_once_with(f"letter_branding-{fake_uuid}")
@@ -25,7 +25,7 @@ def test_get_all_letter_branding(mocker):
     mock_redis_get = mocker.patch("app.extensions.RedisClient.get", return_value=None)
     mock_redis_set = mocker.patch("app.extensions.RedisClient.set")
 
-    LetterBrandingClient().get_all_letter_branding()
+    LetterBrandingClient(mocker.MagicMock()).get_all_letter_branding()
 
     mock_get.assert_called_once_with(url="/letter-branding")
     mock_redis_get.assert_called_once_with("letter_branding")
@@ -41,7 +41,7 @@ def test_get_unique_name_for_letter_branding(mocker):
         "app.notify_client.letter_branding_client.LetterBrandingClient.post", return_value={"name": "some unique name"}
     )
 
-    ret = LetterBrandingClient().get_unique_name_for_letter_branding("some name")
+    ret = LetterBrandingClient(mocker.MagicMock()).get_unique_name_for_letter_branding("some name")
 
     mock_post.assert_called_once_with(url="/letter-branding/get-unique-name", data={"name": "some name"})
     assert ret == "some unique name"
@@ -53,7 +53,7 @@ def test_create_letter_branding(mocker):
     mock_post = mocker.patch("app.notify_client.letter_branding_client.LetterBrandingClient.post")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
 
-    LetterBrandingClient().create_letter_branding(
+    LetterBrandingClient(mocker.MagicMock()).create_letter_branding(
         filename=new_branding["filename"],
         name=new_branding["name"],
         created_by_id=new_branding["created_by_id"],
@@ -71,7 +71,7 @@ def test_update_letter_branding(mocker, fake_uuid):
     mock_redis_delete_by_pattern = mocker.patch(
         "app.extensions.RedisClient.delete_by_pattern", new_callable=RedisClientMock
     )
-    LetterBrandingClient().update_letter_branding(
+    LetterBrandingClient(mocker.MagicMock()).update_letter_branding(
         branding_id=fake_uuid,
         filename=branding["filename"],
         name=branding["name"],

--- a/tests/app/notify_client/test_letter_jobs_client.py
+++ b/tests/app/notify_client/test_letter_jobs_client.py
@@ -2,7 +2,7 @@ from app import letter_jobs_client
 from tests.utils import RedisClientMock
 
 
-def test_submit_returned_letters(mocker):
+def test_submit_returned_letters(notify_admin, mocker):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete_by_pattern", new_callable=RedisClientMock)
     mock_post = mocker.patch("app.notify_client.letter_jobs_client.LetterJobsClient.post")
 

--- a/tests/app/notify_client/test_letter_rate_api_client.py
+++ b/tests/app/notify_client/test_letter_rate_api_client.py
@@ -2,7 +2,7 @@ from app.notify_client.letter_rate_api_client import LetterRateApiClient
 
 
 def test_sets_value_in_cache(mocker):
-    client = LetterRateApiClient()
+    client = LetterRateApiClient(mocker.MagicMock())
 
     mock_redis_get = mocker.patch("app.extensions.RedisClient.get", return_value=None)
     mock_api_get = mocker.patch(
@@ -21,7 +21,7 @@ def test_sets_value_in_cache(mocker):
 
 
 def test_returns_value_from_cache(mocker):
-    client = LetterRateApiClient()
+    client = LetterRateApiClient(mocker.MagicMock())
 
     mock_redis_get = mocker.patch(
         "app.extensions.RedisClient.get",

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -34,7 +34,7 @@ from tests import notification_json, single_notification_json
 )
 def test_client_gets_notifications_for_service_and_job_by_page(mocker, arguments, expected_call):
     mock_get = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.get")
-    NotificationApiClient().get_notifications_for_service("abcd1234", **arguments)
+    NotificationApiClient(mocker.MagicMock()).get_notifications_for_service("abcd1234", **arguments)
     mock_get.assert_called_once_with(**expected_call)
 
 
@@ -62,7 +62,7 @@ def test_client_gets_notifications_for_service_and_job_by_page(mocker, arguments
 )
 def test_client_gets_notifications_for_service_and_job_by_page_posts_for_to(mocker, arguments, expected_call):
     mock_post = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.post")
-    NotificationApiClient().get_notifications_for_service("abcd1234", **arguments)
+    NotificationApiClient(mocker.MagicMock()).get_notifications_for_service("abcd1234", **arguments)
     mock_post.assert_called_once_with(**expected_call)
 
 
@@ -107,13 +107,18 @@ def test_client_gets_notifications_for_service_and_job_by_page_posts_for_to(mock
 )
 def test_client_gets_notifications_for_service_for_csv(mocker, arguments, expected_call):
     mock_get = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.get")
-    NotificationApiClient().get_notifications_for_service_for_csv("abcd1234", **arguments)
+    NotificationApiClient(mocker.MagicMock()).get_notifications_for_service_for_csv("abcd1234", **arguments)
     mock_get.assert_called_once_with(**expected_call)
 
 
-def test_send_notification(mocker, client_request, active_user_with_permissions):
+def test_send_notification(
+    notify_admin,
+    client_request,
+    active_user_with_permissions,
+    mocker,
+):
     mock_post = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.post")
-    NotificationApiClient().send_notification(
+    NotificationApiClient(notify_admin).send_notification(
         "foo", template_id="bar", recipient="07700900001", personalisation=None, sender_id=None
     )
     mock_post.assert_called_once_with(
@@ -127,9 +132,14 @@ def test_send_notification(mocker, client_request, active_user_with_permissions)
     )
 
 
-def test_send_precompiled_letter(mocker, client_request, active_user_with_permissions):
+def test_send_precompiled_letter(
+    notify_admin,
+    client_request,
+    active_user_with_permissions,
+    mocker,
+):
     mock_post = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.post")
-    NotificationApiClient().send_precompiled_letter(
+    NotificationApiClient(notify_admin).send_precompiled_letter(
         "abcd-1234", "my_file.pdf", "file-ID", "second", "Bugs Bunny, 12 Hole Avenue, Looney Town"
     )
     mock_post.assert_called_once_with(
@@ -146,7 +156,7 @@ def test_send_precompiled_letter(mocker, client_request, active_user_with_permis
 
 def test_get_notification(mocker):
     mock_get = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.get")
-    NotificationApiClient().get_notification("foo", "bar")
+    NotificationApiClient(mocker.MagicMock()).get_notification("foo", "bar")
     mock_get.assert_called_once_with(url="/service/foo/notifications/bar")
 
 
@@ -170,7 +180,7 @@ def test_get_api_notifications_changes_letter_statuses(mocker, letter_status, ex
 
     mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.get", return_value=notis)
 
-    ret = NotificationApiClient().get_api_notifications_for_service(service_id)
+    ret = NotificationApiClient(mocker.MagicMock()).get_api_notifications_for_service(service_id)
 
     assert ret["notifications"][0]["notification_type"] == "sms"
     assert ret["notifications"][1]["notification_type"] == "email"
@@ -182,7 +192,7 @@ def test_get_api_notifications_changes_letter_statuses(mocker, letter_status, ex
 
 def test_update_notification_to_cancelled(mocker):
     mock_post = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.post")
-    NotificationApiClient().update_notification_to_cancelled("foo", "bar")
+    NotificationApiClient(mocker.MagicMock()).update_notification_to_cancelled("foo", "bar")
     mock_post.assert_called_once_with(
         url="/service/foo/notifications/bar/cancel",
         data={},
@@ -191,7 +201,7 @@ def test_update_notification_to_cancelled(mocker):
 
 def test_get_notification_count_for_job_id(mocker):
     mock_get = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.get")
-    NotificationApiClient().get_notification_count_for_job_id(service_id="foo", job_id="bar")
+    NotificationApiClient(mocker.MagicMock()).get_notification_count_for_job_id(service_id="foo", job_id="bar")
     mock_get.assert_called_once_with(
         url="/service/foo/job/bar/notification_count",
     )
@@ -212,7 +222,7 @@ def test_get_notifications_count_for_service(mocker, test_case):
     mock_get = mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.get")
     mock_get.return_value = {"notifications_sent_count": test_case.expected_count}
 
-    result = NotificationApiClient().get_notifications_count_for_service(
+    result = NotificationApiClient(mocker.MagicMock()).get_notifications_count_for_service(
         service_id="foo", template_type=test_case.template_type, limit_days=test_case.limit_days
     )
 

--- a/tests/app/notify_client/test_notify_admin_api_client.py
+++ b/tests/app/notify_client/test_notify_admin_api_client.py
@@ -5,8 +5,7 @@ from app.notify_client.notification_api_client import notification_api_client
 
 
 def test_generate_headers_sets_standard_headers(notify_admin):
-    api_client = NotifyAdminAPIClient()
-    api_client.init_app(notify_admin)
+    api_client = NotifyAdminAPIClient(notify_admin)
 
     # with patch('app.notify_client.has_request_context', return_value=False):
     headers = api_client.generate_headers("api_token")
@@ -18,8 +17,7 @@ def test_generate_headers_sets_standard_headers(notify_admin):
 
 
 def test_generate_headers_sets_request_id_if_in_request_context(notify_admin, mock_onwards_request_headers):
-    api_client = NotifyAdminAPIClient()
-    api_client.init_app(notify_admin)
+    api_client = NotifyAdminAPIClient(notify_admin)
 
     with notify_admin.test_request_context():
         notify_admin.preprocess_request()
@@ -34,7 +32,7 @@ def test_generate_headers_sets_request_id_if_in_request_context(notify_admin, mo
     assert headers["some-onwards"] == "request-headers"
 
 
-def test_get_notification_status_by_service(mocker):
+def test_get_notification_status_by_service(notify_admin, mocker):
     mock_get = mocker.patch.object(notification_api_client, "get")
     start_date = date(2019, 4, 1)
     end_date = date(2019, 4, 30)

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -126,7 +126,7 @@ def test_deletes_domain_cache(
     assert len(mock_request.call_args_list) == 1
 
 
-def test_update_organisation(mocker, fake_uuid):
+def test_update_organisation(notify_admin, mocker, fake_uuid):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_post = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.post")
 
@@ -142,7 +142,7 @@ def test_update_organisation(mocker, fake_uuid):
     )
 
 
-def test_update_organisation_when_org_has_services(mocker, fake_uuid):
+def test_update_organisation_when_org_has_services(notify_admin, mocker, fake_uuid):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_post = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.post")
 
@@ -165,7 +165,7 @@ def test_update_organisation_when_org_has_services(mocker, fake_uuid):
     )
 
 
-def test_add_brandings_to_email_branding_pool(mocker, fake_uuid):
+def test_add_brandings_to_email_branding_pool(notify_admin, mocker, fake_uuid):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_post = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.post")
 
@@ -179,7 +179,7 @@ def test_add_brandings_to_email_branding_pool(mocker, fake_uuid):
     mock_redis_delete.assert_called_with_args(f"organisation-{fake_uuid}-email-branding-pool")
 
 
-def test_update_service_organisation_deletes_cache(mocker, fake_uuid):
+def test_update_service_organisation_deletes_cache(notify_admin, mocker, fake_uuid):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_post = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.post")
 
@@ -193,7 +193,7 @@ def test_update_service_organisation_deletes_cache(mocker, fake_uuid):
     mock_post.assert_called_with(url=f"/organisations/{fake_uuid}/service", data=ANY)
 
 
-def test_remove_user_from_organisation_deletes_user_cache(mocker):
+def test_remove_user_from_organisation_deletes_user_cache(notify_admin, mocker):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_delete = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.delete")
 
@@ -209,7 +209,7 @@ def test_remove_user_from_organisation_deletes_user_cache(mocker):
     mock_delete.assert_called_with(f"/organisations/{org_id}/users/{user_id}")
 
 
-def test_archive_organisation(mocker):
+def test_archive_organisation(notify_admin, mocker):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_post = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.post")
 
@@ -225,7 +225,7 @@ def test_archive_organisation(mocker):
     mock_post.assert_called_with(url=f"/organisations/{org_id}/archive", data=None)
 
 
-def test_remove_email_branding_from_organisation_pool(mocker):
+def test_remove_email_branding_from_organisation_pool(notify_admin, mocker):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_delete = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.delete")
 
@@ -240,7 +240,7 @@ def test_remove_email_branding_from_organisation_pool(mocker):
     mock_delete.assert_called_with(f"/organisations/{org_id}/email-branding-pool/{branding_id}")
 
 
-def test_get_letter_branding_pool(mocker):
+def test_get_letter_branding_pool(notify_admin, mocker):
     mock_redis_set = mocker.patch("app.extensions.RedisClient.set")
     mock_get = mocker.patch(
         "app.notify_client.organisations_api_client.OrganisationsClient.get",
@@ -256,7 +256,7 @@ def test_get_letter_branding_pool(mocker):
     mock_get.assert_called_with(url=f"/organisations/{org_id}/letter-branding-pool")
 
 
-def test_add_brandings_to_letter_branding_pool(mocker, fake_uuid):
+def test_add_brandings_to_letter_branding_pool(notify_admin, mocker, fake_uuid):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_post = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.post")
 
@@ -270,7 +270,7 @@ def test_add_brandings_to_letter_branding_pool(mocker, fake_uuid):
     mock_redis_delete.assert_called_with_args(f"organisation-{fake_uuid}-letter-branding-pool")
 
 
-def test_remove_letter_branding_from_organisation_pool(mocker):
+def test_remove_letter_branding_from_organisation_pool(notify_admin, mocker):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_delete = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.delete")
 
@@ -285,7 +285,7 @@ def test_remove_letter_branding_from_organisation_pool(mocker):
     mock_delete.assert_called_with(f"/organisations/{org_id}/letter-branding-pool/{branding_id}")
 
 
-def test_notify_users_of_request_to_go_live_for_service(mocker, fake_uuid):
+def test_notify_users_of_request_to_go_live_for_service(notify_admin, mocker, fake_uuid):
     mock_post = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.post")
 
     organisations_client.notify_users_of_request_to_go_live_for_service(fake_uuid)

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -8,7 +8,7 @@ from tests.utils import RedisClientMock
 
 @pytest.mark.parametrize(
     (
-        "client_method,"
+        "_get_items,"
         "expected_cache_get_calls,"
         "cache_value,"
         "expected_api_calls,"
@@ -85,7 +85,7 @@ from tests.utils import RedisClientMock
 def test_returns_value_from_cache(
     notify_admin,
     mocker,
-    client_method,
+    _get_items,
     expected_cache_get_calls,
     cache_value,
     expected_return_value,
@@ -104,7 +104,7 @@ def test_returns_value_from_cache(
         "app.extensions.RedisClient.set",
     )
 
-    getattr(organisations_client, client_method)()
+    getattr(organisations_client, _get_items)()
 
     assert mock_redis_get.call_args_list == expected_cache_get_calls
     assert mock_api_get.call_args_list == expected_api_calls

--- a/tests/app/notify_client/test_performance_platform_api_client.py
+++ b/tests/app/notify_client/test_performance_platform_api_client.py
@@ -7,7 +7,7 @@ from app.notify_client.performance_dashboard_api_client import (
 
 def test_get_aggregate_platform_stats(mocker):
     mocker.patch("app.extensions.RedisClient.get", return_value=None)
-    client = PerformanceDashboardAPIClient()
+    client = PerformanceDashboardAPIClient(mocker.MagicMock())
     mock = mocker.patch.object(client, "get", return_value={})
 
     client.get_performance_dashboard_stats(
@@ -21,7 +21,7 @@ def test_get_aggregate_platform_stats(mocker):
 
 
 def test_sets_value_in_cache(mocker):
-    client = PerformanceDashboardAPIClient()
+    client = PerformanceDashboardAPIClient(mocker.MagicMock())
 
     mock_redis_get = mocker.patch(
         "app.extensions.RedisClient.get",
@@ -52,7 +52,7 @@ def test_sets_value_in_cache(mocker):
 
 
 def test_returns_value_from_cache(mocker):
-    client = PerformanceDashboardAPIClient()
+    client = PerformanceDashboardAPIClient(mocker.MagicMock())
 
     mock_redis_get = mocker.patch(
         "app.extensions.RedisClient.get",

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -19,7 +19,7 @@ def test_client_posts_archived_true_when_deleting_template(mocker):
     expected_data = {"archived": True, "created_by": "1"}
     expected_url = f"/service/{SERVICE_ONE_ID}/template/{FAKE_TEMPLATE_ID}"
 
-    client = ServiceAPIClient()
+    client = ServiceAPIClient(mocker.MagicMock())
     mock_post = mocker.patch("app.notify_client.service_api_client.ServiceAPIClient.post")
     mocker.patch(
         "app.notify_client.service_api_client.ServiceAPIClient.get",
@@ -32,7 +32,7 @@ def test_client_posts_archived_true_when_deleting_template(mocker):
 
 
 def test_client_gets_service(mocker):
-    client = ServiceAPIClient()
+    client = ServiceAPIClient(mocker.MagicMock())
     mock_get = mocker.patch.object(client, "get", return_value={})
 
     client.get_service("foo")
@@ -41,7 +41,7 @@ def test_client_gets_service(mocker):
 
 @pytest.mark.parametrize("limit_days", [None, 30])
 def test_client_gets_service_statistics(mocker, limit_days):
-    client = ServiceAPIClient()
+    client = ServiceAPIClient(mocker.MagicMock())
     mock_get = mocker.patch.object(client, "get", return_value={"data": {"a": "b"}})
 
     ret = client.get_service_statistics("foo", limit_days)
@@ -53,7 +53,7 @@ def test_client_gets_service_statistics(mocker, limit_days):
 def test_client_only_updates_allowed_attributes(mocker):
     mocker.patch("app.notify_client.current_user", id="1")
     with pytest.raises(TypeError) as error:
-        ServiceAPIClient().update_service("service_id", foo="bar")
+        ServiceAPIClient(mocker.MagicMock()).update_service("service_id", foo="bar")
     assert str(error.value) == "Not allowed to update service attributes: foo"
 
 
@@ -61,7 +61,7 @@ def test_client_creates_service_with_correct_data(
     mocker,
     fake_uuid,
 ):
-    client = ServiceAPIClient()
+    client = ServiceAPIClient(mocker.MagicMock())
     mock_post = mocker.patch.object(client, "post", return_value={"data": {"id": None}})
     mocker.patch("app.notify_client.current_user", id="123")
 
@@ -96,7 +96,7 @@ def test_client_creates_service_with_correct_data(
 def test_get_precompiled_template(mocker):
     mock_redis_set = mocker.patch("app.extensions.RedisClient.set")
 
-    client = ServiceAPIClient()
+    client = ServiceAPIClient(mocker.MagicMock())
     mock_get = mocker.patch.object(client, "get", return_value={"data": "foo"})
 
     client.get_precompiled_template(SERVICE_ONE_ID)
@@ -161,7 +161,7 @@ def test_client_returns_count_of_service_templates(
 
 @pytest.mark.parametrize(
     (
-        "client_method,"
+        "method,"
         "extra_args,"
         "expected_cache_get_calls,"
         "cache_value,"
@@ -171,7 +171,7 @@ def test_client_returns_count_of_service_templates(
     ),
     [
         (
-            service_api_client.get_service,
+            "get_service",
             [SERVICE_ONE_ID],
             [call(f"service-{SERVICE_ONE_ID}")],
             b'{"data_from": "cache"}',
@@ -180,7 +180,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "cache"},
         ),
         (
-            service_api_client.get_service,
+            "get_service",
             [SERVICE_ONE_ID],
             [call(f"service-{SERVICE_ONE_ID}")],
             None,
@@ -195,7 +195,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "api"},
         ),
         (
-            service_api_client.get_service_template,
+            "get_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None")],
             b'{"data_from": "cache"}',
@@ -204,7 +204,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "cache"},
         ),
         (
-            service_api_client.get_service_template,
+            "get_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [
                 call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None"),
@@ -221,7 +221,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "api"},
         ),
         (
-            service_api_client.get_service_template,
+            "get_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 1],
             [call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1")],
             b'{"data_from": "cache"}',
@@ -230,7 +230,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "cache"},
         ),
         (
-            service_api_client.get_service_template,
+            "get_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 1],
             [
                 call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1"),
@@ -247,7 +247,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "api"},
         ),
         (
-            service_api_client.get_service_templates,
+            "get_service_templates",
             [SERVICE_ONE_ID],
             [call(f"service-{SERVICE_ONE_ID}-templates")],
             b'{"data_from": "cache"}',
@@ -256,7 +256,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "cache"},
         ),
         (
-            service_api_client.get_service_templates,
+            "get_service_templates",
             [SERVICE_ONE_ID],
             [call(f"service-{SERVICE_ONE_ID}-templates")],
             None,
@@ -271,7 +271,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "api"},
         ),
         (
-            service_api_client.get_service_template_versions,
+            "get_service_template_versions",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions")],
             b'{"data_from": "cache"}',
@@ -280,7 +280,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "cache"},
         ),
         (
-            service_api_client.get_service_template_versions,
+            "get_service_template_versions",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [
                 call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions"),
@@ -297,7 +297,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "api"},
         ),
         (
-            service_api_client.get_returned_letter_summary,
+            "get_returned_letter_summary",
             [SERVICE_ONE_ID],
             [call(f"service-{SERVICE_ONE_ID}-returned-letters-summary")],
             None,
@@ -312,7 +312,7 @@ def test_client_returns_count_of_service_templates(
             {"data_from": "api"},
         ),
         (
-            service_api_client.get_returned_letter_statistics,
+            "get_returned_letter_statistics",
             [SERVICE_ONE_ID],
             [call(f"service-{SERVICE_ONE_ID}-returned-letters-statistics")],
             None,
@@ -330,7 +330,8 @@ def test_client_returns_count_of_service_templates(
 )
 def test_returns_value_from_cache(
     mocker,
-    client_method,
+    notify_admin,
+    method,
     extra_args,
     expected_cache_get_calls,
     cache_value,
@@ -350,41 +351,50 @@ def test_returns_value_from_cache(
         "app.extensions.RedisClient.set",
     )
 
-    assert client_method(*extra_args) == expected_return_value
+    assert getattr(service_api_client, method)(*extra_args) == expected_return_value
 
     assert mock_redis_get.call_args_list == expected_cache_get_calls
     assert mock_api_get.call_args_list == expected_api_calls
     assert mock_redis_set.call_args_list == expected_cache_set_calls
 
 
+# feeding LocalProxys that need an app context into pytest's parametrization system
+# leads to bad things
+_clients_by_name = {
+    "user": user_api_client,
+    "service": service_api_client,
+    "invite": invite_api_client,
+}
+
+
 @pytest.mark.parametrize(
-    "client, method, extra_args, extra_kwargs",
+    "client_name, method, extra_args, extra_kwargs",
     [
-        (service_api_client, "update_service", [SERVICE_ONE_ID], {"name": "foo"}),
-        (service_api_client, "archive_service", [SERVICE_ONE_ID, []], {}),
-        (service_api_client, "remove_user_from_service", [SERVICE_ONE_ID, ""], {}),
-        (service_api_client, "update_guest_list", [SERVICE_ONE_ID, {}], {}),
-        (service_api_client, "create_service_inbound_api", [SERVICE_ONE_ID] + [""] * 3, {}),
-        (service_api_client, "update_service_inbound_api", [SERVICE_ONE_ID] + [""] * 4, {}),
-        (service_api_client, "add_reply_to_email_address", [SERVICE_ONE_ID, ""], {}),
-        (service_api_client, "update_reply_to_email_address", [SERVICE_ONE_ID] + [""] * 2, {}),
-        (service_api_client, "delete_reply_to_email_address", [SERVICE_ONE_ID, ""], {}),
-        (service_api_client, "add_letter_contact", [SERVICE_ONE_ID, ""], {}),
-        (service_api_client, "update_letter_contact", [SERVICE_ONE_ID] + [""] * 2, {}),
-        (service_api_client, "delete_letter_contact", [SERVICE_ONE_ID, ""], {}),
-        (service_api_client, "add_sms_sender", [SERVICE_ONE_ID, ""], {}),
-        (service_api_client, "update_sms_sender", [SERVICE_ONE_ID] + [""] * 2, {}),
-        (service_api_client, "delete_sms_sender", [SERVICE_ONE_ID, ""], {}),
-        (service_api_client, "update_service_callback_api", [SERVICE_ONE_ID] + [""] * 4, {}),
-        (service_api_client, "create_service_callback_api", [SERVICE_ONE_ID] + [""] * 3, {}),
-        (user_api_client, "add_user_to_service", [SERVICE_ONE_ID, uuid4(), [], []], {}),
-        (invite_api_client, "accept_invite", [SERVICE_ONE_ID, uuid4()], {}),
+        ("service", "update_service", [SERVICE_ONE_ID], {"name": "foo"}),
+        ("service", "archive_service", [SERVICE_ONE_ID, []], {}),
+        ("service", "remove_user_from_service", [SERVICE_ONE_ID, ""], {}),
+        ("service", "update_guest_list", [SERVICE_ONE_ID, {}], {}),
+        ("service", "create_service_inbound_api", [SERVICE_ONE_ID] + [""] * 3, {}),
+        ("service", "update_service_inbound_api", [SERVICE_ONE_ID] + [""] * 4, {}),
+        ("service", "add_reply_to_email_address", [SERVICE_ONE_ID, ""], {}),
+        ("service", "update_reply_to_email_address", [SERVICE_ONE_ID] + [""] * 2, {}),
+        ("service", "delete_reply_to_email_address", [SERVICE_ONE_ID, ""], {}),
+        ("service", "add_letter_contact", [SERVICE_ONE_ID, ""], {}),
+        ("service", "update_letter_contact", [SERVICE_ONE_ID] + [""] * 2, {}),
+        ("service", "delete_letter_contact", [SERVICE_ONE_ID, ""], {}),
+        ("service", "add_sms_sender", [SERVICE_ONE_ID, ""], {}),
+        ("service", "update_sms_sender", [SERVICE_ONE_ID] + [""] * 2, {}),
+        ("service", "delete_sms_sender", [SERVICE_ONE_ID, ""], {}),
+        ("service", "update_service_callback_api", [SERVICE_ONE_ID] + [""] * 4, {}),
+        ("service", "create_service_callback_api", [SERVICE_ONE_ID] + [""] * 3, {}),
+        ("user", "add_user_to_service", [SERVICE_ONE_ID, uuid4(), [], []], {}),
+        ("invite", "accept_invite", [SERVICE_ONE_ID, uuid4()], {}),
     ],
 )
 def test_deletes_service_cache(
     notify_admin,
     mocker,
-    client,
+    client_name,
     method,
     extra_args,
     extra_kwargs,
@@ -393,7 +403,7 @@ def test_deletes_service_cache(
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_request = mocker.patch("notifications_python_client.base.BaseAPIClient.request")
 
-    getattr(client, method)(*extra_args, **extra_kwargs)
+    getattr(_clients_by_name[client_name], method)(*extra_args, **extra_kwargs)
 
     mock_redis_delete.assert_called_with_subset_of_args(f"service-{SERVICE_ONE_ID}")
     assert len(mock_request.call_args_list) == 1
@@ -480,7 +490,11 @@ def test_deletes_caches_when_modifying_templates(
     mock_redis_delete_by_pattern.assert_called_with_args(*expected_cache_deletes_by_pattern)
 
 
-def test_deletes_cached_users_when_archiving_service(mocker, mock_get_service_templates):
+def test_deletes_cached_users_when_archiving_service(
+    notify_admin,
+    mock_get_service_templates,
+    mocker,
+):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_redis_delete_by_pattern = mocker.patch(
         "app.extensions.RedisClient.delete_by_pattern", new_callable=RedisClientMock
@@ -495,7 +509,7 @@ def test_deletes_cached_users_when_archiving_service(mocker, mock_get_service_te
 
 
 def test_client_gets_guest_list(mocker):
-    client = ServiceAPIClient()
+    client = ServiceAPIClient(mocker.MagicMock())
     mock_get = mocker.patch.object(client, "get", return_value=["a", "b", "c"])
 
     response = client.get_guest_list("foo")
@@ -507,7 +521,7 @@ def test_client_gets_guest_list(mocker):
 
 
 def test_client_updates_guest_list(mocker):
-    client = ServiceAPIClient()
+    client = ServiceAPIClient(mocker.MagicMock())
     mock_put = mocker.patch.object(client, "put")
 
     client.update_guest_list("foo", data=["a", "b", "c"])
@@ -535,7 +549,7 @@ def test_client_deletes_service_template_cache_when_service_is_updated(notify_ad
 def test_client_updates_service_with_allowed_attributes(
     mocker,
 ):
-    client = ServiceAPIClient()
+    client = ServiceAPIClient(mocker.MagicMock())
     mock_post = mocker.patch.object(client, "post", return_value={"data": {"id": None}})
     mocker.patch("app.notify_client.current_user", id="123")
 
@@ -582,8 +596,8 @@ def test_client_updates_service_with_allowed_attributes(
         ({"other": "blah"}, None),
     ),
 )
-def test_client_parsing_service_name_errors(err_data, expected_message):
-    client = ServiceAPIClient()
+def test_client_parsing_service_name_errors(err_data, expected_message, mocker):
+    client = ServiceAPIClient(mocker.MagicMock())
     error = Mock()
     error.message = err_data
 

--- a/tests/app/notify_client/test_status_api_client.py
+++ b/tests/app/notify_client/test_status_api_client.py
@@ -3,7 +3,7 @@ from app.notify_client.status_api_client import StatusApiClient
 
 def test_get_count_of_live_services_and_organisations(mocker):
     mocker.patch("app.extensions.RedisClient.get", return_value=None)
-    client = StatusApiClient()
+    client = StatusApiClient(mocker.MagicMock())
     mock = mocker.patch.object(client, "get", return_value={})
 
     client.get_count_of_live_services_and_organisations()
@@ -12,7 +12,7 @@ def test_get_count_of_live_services_and_organisations(mocker):
 
 
 def test_sets_value_in_cache(mocker):
-    client = StatusApiClient()
+    client = StatusApiClient(mocker.MagicMock())
 
     mock_redis_get = mocker.patch("app.extensions.RedisClient.get", return_value=None)
     mock_api_get = mocker.patch(
@@ -31,7 +31,7 @@ def test_sets_value_in_cache(mocker):
 
 
 def test_returns_value_from_cache(mocker):
-    client = StatusApiClient()
+    client = StatusApiClient(mocker.MagicMock())
 
     mock_redis_get = mocker.patch(
         "app.extensions.RedisClient.get",

--- a/tests/app/notify_client/test_template_folder_client.py
+++ b/tests/app/notify_client/test_template_folder_client.py
@@ -15,7 +15,7 @@ def test_create_template_folder_calls_correct_api_endpoint(mocker, parent_id):
     expected_url = f"/service/{some_service_id}/template-folder"
     data = {"name": "foo", "parent_id": parent_id}
 
-    client = TemplateFolderAPIClient()
+    client = TemplateFolderAPIClient(mocker.MagicMock())
 
     mock_post = mocker.patch("app.notify_client.template_folder_api_client.TemplateFolderAPIClient.post")
 
@@ -36,7 +36,7 @@ def test_get_template_folders_calls_correct_api_endpoint(mocker):
     expected_url = f"/service/{some_service_id}/template-folder"
     redis_key = f"service-{some_service_id}-template-folders"
 
-    client = TemplateFolderAPIClient()
+    client = TemplateFolderAPIClient(mocker.MagicMock())
 
     ret = client.get_template_folders(some_service_id)
 
@@ -54,7 +54,7 @@ def test_move_templates_and_folders(mocker):
     some_service_id = uuid.uuid4()
     some_folder_id = uuid.uuid4()
 
-    TemplateFolderAPIClient().move_to_folder(
+    TemplateFolderAPIClient(mocker.MagicMock()).move_to_folder(
         some_service_id,
         some_folder_id,
         template_ids=OrderedSet(("a", "b", "c")),
@@ -82,7 +82,7 @@ def test_move_templates_and_folders_to_root(mocker):
 
     some_service_id = uuid.uuid4()
 
-    TemplateFolderAPIClient().move_to_folder(
+    TemplateFolderAPIClient(mocker.MagicMock()).move_to_folder(
         some_service_id,
         None,
         template_ids=OrderedSet(("a", "b", "c")),
@@ -106,7 +106,7 @@ def test_update_template_folder_calls_correct_api_endpoint(mocker):
     expected_url = f"/service/{some_service_id}/template-folder/{template_folder_id}"
     data = {"name": "foo", "users_with_permission": ["some_id"]}
 
-    client = TemplateFolderAPIClient()
+    client = TemplateFolderAPIClient(mocker.MagicMock())
 
     mock_post = mocker.patch("app.notify_client.template_folder_api_client.TemplateFolderAPIClient.post")
 
@@ -123,7 +123,7 @@ def test_delete_template_folder_calls_correct_api_endpoint(mocker):
     template_folder_id = uuid.uuid4()
     expected_url = f"/service/{some_service_id}/template-folder/{template_folder_id}"
 
-    client = TemplateFolderAPIClient()
+    client = TemplateFolderAPIClient(mocker.MagicMock())
 
     mock_delete = mocker.patch("app.notify_client.template_folder_api_client.TemplateFolderAPIClient.delete")
 

--- a/tests/app/notify_client/test_template_statistics_client.py
+++ b/tests/app/notify_client/test_template_statistics_client.py
@@ -7,7 +7,7 @@ def test_template_statistics_client_calls_correct_api_endpoint_for_service(mocke
     some_service_id = uuid.uuid4()
     expected_url = f"/service/{some_service_id}/template-statistics"
 
-    client = TemplateStatisticsApiClient()
+    client = TemplateStatisticsApiClient(mocker.MagicMock())
 
     mock_get = mocker.patch("app.notify_client.template_statistics_api_client.TemplateStatisticsApiClient.get")
 
@@ -21,7 +21,7 @@ def test_template_statistics_client_calls_correct_api_endpoint_for_template(mock
     some_template_id = uuid.uuid4()
     expected_url = f"/service/{some_service_id}/template-statistics/last-used/{some_template_id}"
 
-    client = TemplateStatisticsApiClient()
+    client = TemplateStatisticsApiClient(mocker.MagicMock())
     mock_get = mocker.patch("app.notify_client.template_statistics_api_client.TemplateStatisticsApiClient.get")
 
     client.get_last_used_date_for_template(some_service_id, some_template_id)

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -16,6 +16,7 @@ user_id = sample_uuid()
 
 
 def test_client_gets_all_users_for_service(
+    notify_admin,
     mocker,
     fake_uuid,
 ):
@@ -36,7 +37,7 @@ def test_client_gets_all_users_for_service(
     assert users[0]["id"] == fake_uuid
 
 
-def test_client_uses_correct_find_by_email(mocker, api_user_active):
+def test_client_uses_correct_find_by_email(notify_admin, mocker, api_user_active):
     expected_url = "/user/email"
     expected_data = {"email": api_user_active["email_address"]}
 
@@ -48,14 +49,14 @@ def test_client_uses_correct_find_by_email(mocker, api_user_active):
     mock_post.assert_called_once_with(expected_url, data=expected_data)
 
 
-def test_client_only_updates_allowed_attributes(mocker):
+def test_client_only_updates_allowed_attributes(notify_admin, mocker):
     mocker.patch("app.notify_client.current_user", id="1")
     with pytest.raises(TypeError) as error:
         user_api_client.update_user_attribute("user_id", id="1")
     assert str(error.value) == "Not allowed to update user attributes: id"
 
 
-def test_client_updates_password_separately(mocker, api_user_active):
+def test_client_updates_password_separately(notify_admin, mocker, api_user_active):
     expected_url = f"/user/{api_user_active['id']}/update-password"
     expected_params = {"_password": "newpassword"}
     user_api_client.max_failed_login_count = 1  # doesn't matter for this test
@@ -65,7 +66,7 @@ def test_client_updates_password_separately(mocker, api_user_active):
     mock_update_password.assert_called_once_with(expected_url, data=expected_params)
 
 
-def test_client_activates_if_pending(mocker, api_user_pending):
+def test_client_activates_if_pending(notify_admin, mocker, api_user_pending):
     mock_post = mocker.patch("app.notify_client.user_api_client.UserApiClient.post")
     user_api_client.max_failed_login_count = 1  # doesn't matter for this test
 
@@ -179,49 +180,58 @@ def test_returns_value_from_cache(
     assert mock_redis_set.call_args_list == expected_cache_set_calls
 
 
+# feeding LocalProxys that need an app context into pytest's parametrization system
+# leads to bad things
+_clients_by_name = {
+    "user": user_api_client,
+    "service": service_api_client,
+    "invite": invite_api_client,
+}
+
+
 @pytest.mark.parametrize(
-    "client, method, extra_args, extra_kwargs",
+    "client_name, method, extra_args, extra_kwargs",
     [
-        (user_api_client, "add_user_to_service", [SERVICE_ONE_ID, sample_uuid(), [], []], {}),
-        (user_api_client, "update_user_attribute", [user_id], {}),
-        (user_api_client, "reset_failed_login_count", [user_id], {}),
-        (user_api_client, "update_user_attribute", [user_id], {}),
-        (user_api_client, "update_password", [user_id, "hunter2"], {}),
-        (user_api_client, "verify_password", [user_id, "hunter2"], {}),
-        (user_api_client, "check_verify_code", [user_id, "", ""], {}),
+        ("user", "add_user_to_service", [SERVICE_ONE_ID, sample_uuid(), [], []], {}),
+        ("user", "update_user_attribute", [user_id], {}),
+        ("user", "reset_failed_login_count", [user_id], {}),
+        ("user", "update_user_attribute", [user_id], {}),
+        ("user", "update_password", [user_id, "hunter2"], {}),
+        ("user", "verify_password", [user_id, "hunter2"], {}),
+        ("user", "check_verify_code", [user_id, "", ""], {}),
         (
-            user_api_client,
+            "user",
             "complete_webauthn_login_attempt",
             [user_id],
             {"is_successful": True, "webauthn_credential_id": "123"},
         ),
-        (user_api_client, "add_user_to_service", [SERVICE_ONE_ID, user_id, [], []], {}),
+        ("user", "add_user_to_service", [SERVICE_ONE_ID, user_id, [], []], {}),
         (
-            user_api_client,
+            "user",
             "add_user_to_organisation",
             [sample_uuid(), user_id, [PERMISSION_CAN_MAKE_SERVICES_LIVE]],
             {},
         ),
-        (user_api_client, "set_user_permissions", [user_id, SERVICE_ONE_ID, []], {}),
-        (user_api_client, "activate_user", [user_id], {}),
-        (user_api_client, "archive_user", [user_id], {}),
-        (service_api_client, "remove_user_from_service", [SERVICE_ONE_ID, user_id], {}),
-        (service_api_client, "create_service", ["", "", 0, 0, 0, False, user_id], {}),
-        (invite_api_client, "accept_invite", [SERVICE_ONE_ID, user_id], {}),
+        ("user", "set_user_permissions", [user_id, SERVICE_ONE_ID, []], {}),
+        ("user", "activate_user", [user_id], {}),
+        ("user", "archive_user", [user_id], {}),
+        ("service", "remove_user_from_service", [SERVICE_ONE_ID, user_id], {}),
+        ("service", "create_service", ["", "", 0, 0, 0, False, user_id], {}),
+        ("invite", "accept_invite", [SERVICE_ONE_ID, user_id], {}),
     ],
 )
-def test_deletes_user_cache(notify_admin, mock_get_user, mocker, client, method, extra_args, extra_kwargs):
+def test_deletes_user_cache(notify_admin, mock_get_user, mocker, client_name, method, extra_args, extra_kwargs):
     mocker.patch("app.notify_client.current_user", id="1")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
     mock_request = mocker.patch("notifications_python_client.base.BaseAPIClient.request")
 
-    getattr(client, method)(*extra_args, **extra_kwargs)
+    getattr(_clients_by_name[client_name], method)(*extra_args, **extra_kwargs)
 
     assert len(mock_request.call_args_list) == 1
     mock_redis_delete.assert_called_with_subset_of_args(f"user-{user_id}")
 
 
-def test_add_user_to_service_calls_correct_endpoint_and_deletes_keys_from_cache(mocker):
+def test_add_user_to_service_calls_correct_endpoint_and_deletes_keys_from_cache(notify_admin, mocker):
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete", new_callable=RedisClientMock)
 
     service_id = uuid.uuid4()
@@ -243,7 +253,7 @@ def test_add_user_to_service_calls_correct_endpoint_and_deletes_keys_from_cache(
     )
 
 
-def test_get_webauthn_credentials_for_user(mocker, webauthn_credential, fake_uuid):
+def test_get_webauthn_credentials_for_user(notify_admin, mocker, webauthn_credential, fake_uuid):
     mock_get = mocker.patch(
         "app.notify_client.user_api_client.UserApiClient.get", return_value={"data": [webauthn_credential]}
     )
@@ -255,7 +265,7 @@ def test_get_webauthn_credentials_for_user(mocker, webauthn_credential, fake_uui
     assert credentials[0]["name"] == "Test credential"
 
 
-def test_create_webauthn_credential_for_user(mocker, webauthn_credential, fake_uuid):
+def test_create_webauthn_credential_for_user(notify_admin, mocker, webauthn_credential, fake_uuid):
     credential = WebAuthnCredential(webauthn_credential)
 
     mock_post = mocker.patch("app.notify_client.user_api_client.UserApiClient.post")
@@ -265,7 +275,7 @@ def test_create_webauthn_credential_for_user(mocker, webauthn_credential, fake_u
     mock_post.assert_called_once_with(expected_url, data=credential.serialize())
 
 
-def test_complete_webauthn_login_attempt_returns_true_and_no_message_normally(fake_uuid, mocker):
+def test_complete_webauthn_login_attempt_returns_true_and_no_message_normally(notify_admin, fake_uuid, mocker):
     mock_post = mocker.patch("app.notify_client.user_api_client.UserApiClient.post")
     webauthn_credential_id = str(uuid.uuid4())
 
@@ -278,7 +288,7 @@ def test_complete_webauthn_login_attempt_returns_true_and_no_message_normally(fa
     assert resp == (True, "")
 
 
-def test_complete_webauthn_login_attempt_returns_false_and_message_on_403(fake_uuid, mocker):
+def test_complete_webauthn_login_attempt_returns_false_and_message_on_403(notify_admin, fake_uuid, mocker):
     mock_post = mocker.patch(
         "app.notify_client.user_api_client.UserApiClient.post",
         side_effect=HTTPError(response=Mock(status_code=403, json=Mock(return_value={"message": "forbidden"}))),
@@ -295,7 +305,7 @@ def test_complete_webauthn_login_attempt_returns_false_and_message_on_403(fake_u
     assert resp == (False, "forbidden")
 
 
-def test_complete_webauthn_login_attempt_raises_on_api_error(fake_uuid, mocker):
+def test_complete_webauthn_login_attempt_raises_on_api_error(notify_admin, fake_uuid, mocker):
     mocker.patch(
         "app.notify_client.user_api_client.UserApiClient.post",
         side_effect=HTTPError(response=Mock(status_code=503, message="error")),
@@ -306,6 +316,7 @@ def test_complete_webauthn_login_attempt_raises_on_api_error(fake_uuid, mocker):
 
 
 def test_reset_password(
+    notify_admin,
     mocker,
 ):
     mock_post = mocker.patch("app.notify_client.user_api_client.UserApiClient.post")
@@ -322,6 +333,7 @@ def test_reset_password(
 
 
 def test_send_registration_email(
+    notify_admin,
     mocker,
     fake_uuid,
 ):

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -392,17 +392,15 @@ EXCLUDED_ENDPOINTS = set(
 )
 
 
-def flask_app():
+def _get_all_endpoints():
     app = Flask("app")
     create_app(app)
 
-    ctx = app.app_context()
-    ctx.push()
-
-    yield app
+    with app.app_context():
+        return {rule.endpoint for rule in app.url_map.iter_rules()}
 
 
-all_endpoints = {rule.endpoint for rule in next(flask_app()).url_map.iter_rules()}
+all_endpoints = _get_all_endpoints()
 
 navigation_instances = (
     MainNavigation(),

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -33,8 +33,8 @@ from tests.conftest import create_notification
     [(LetterBranding({"filename": "hm-government"}), "hm-government"), (LetterBranding.from_id(None), None)],
 )
 def test_get_preview_for_templated_letter_makes_request(
-    mocker,
     client_request,
+    mocker,
     partial_call,
     expected_url,
     letter_branding,
@@ -79,8 +79,8 @@ def test_get_preview_for_templated_letter_makes_request(
     ),
 )
 def test_get_preview_for_templated_letter_allows_service_branding_to_be_overridden(
-    mocker,
     client_request,
+    mocker,
     extra_args,
     expected_filename,
     mock_get_service_letter_template,
@@ -100,8 +100,8 @@ def test_get_preview_for_templated_letter_allows_service_branding_to_be_overridd
 
 
 def test_get_preview_for_templated_letter_from_notification_has_correct_args(
-    mocker,
     client_request,
+    mocker,
     mock_onwards_request_headers,
 ):
     # This test is calling `current_service` outside a Flask endpoint, so we need to make sure
@@ -192,8 +192,8 @@ def test_get_preview_for_templated_letter_from_notification_400s_for_page_of_pdf
     ],
 )
 def test_get_png_for_valid_pdf_page_makes_request(
-    mocker,
     client_request,
+    mocker,
     mock_onwards_request_headers,
     page_number,
     expected_url,
@@ -218,8 +218,8 @@ def test_get_png_for_valid_pdf_page_makes_request(
 
 
 def test_get_png_for_invalid_pdf_page_makes_request(
-    mocker,
     client_request,
+    mocker,
     mock_onwards_request_headers,
 ):
     mocker.patch("app.template_previews.extract_page_from_pdf", return_value=b"pdf page")
@@ -257,8 +257,8 @@ def test_page_count_returns_none_for_non_letter_templates(template_type):
     ],
 )
 def test_page_count_makes_a_call_to_template_preview_and_gets_page_count(
-    mocker,
     client_request,
+    mocker,
     mock_get_service_letter_template,
     mock_onwards_request_headers,
     values,
@@ -297,8 +297,8 @@ def test_page_count_makes_a_call_to_template_preview_and_gets_page_count(
 
 @pytest.mark.parametrize("allow_international_letters, query_param_value", [[False, "false"], [True, "true"]])
 def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file(
-    mocker,
     client_request,
+    mocker,
     mock_onwards_request_headers,
     allow_international_letters,
     query_param_value,
@@ -327,8 +327,8 @@ def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file(
 
 
 def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file_for_an_attachment(
-    mocker,
     client_request,
+    mocker,
     mock_onwards_request_headers,
     fake_uuid,
 ):

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -1,29 +1,28 @@
 import base64
-from functools import partial
 from unittest.mock import Mock
 
 import pytest
 from werkzeug.exceptions import BadRequest, NotFound
 
-from app import load_service_before_request
+from app import load_service_before_request, template_preview_client
 from app.models.branding import LetterBranding
-from app.template_previews import TemplatePreview
+from app.models.service import Service
 from tests.conftest import create_notification
 
 
 @pytest.mark.parametrize(
-    "partial_call, expected_url",
+    "extra_kwargs, expected_url",
     [
         (
-            partial(TemplatePreview.get_preview_for_templated_letter, filetype="bar"),
+            {"filetype": "bar"},
             "http://localhost:9999/preview.bar",
         ),
         (
-            partial(TemplatePreview.get_preview_for_templated_letter, filetype="baz"),
+            {"filetype": "baz"},
             "http://localhost:9999/preview.baz",
         ),
         (
-            partial(TemplatePreview.get_preview_for_templated_letter, filetype="bar", page=99),
+            {"filetype": "bar", "page": 99},
             "http://localhost:9999/preview.bar?page=99",
         ),
     ],
@@ -35,23 +34,24 @@ from tests.conftest import create_notification
 def test_get_preview_for_templated_letter_makes_request(
     client_request,
     mocker,
-    partial_call,
+    service_one,
+    extra_kwargs,
     expected_url,
     letter_branding,
     expected_filename,
     mock_get_service_letter_template,
     mock_onwards_request_headers,
 ):
-    # This test is calling `current_service` outside a Flask endpoint, so we need to make sure
-    # `service` is in the `_request_ctx_stack` to avoid an error
-    load_service_before_request()
-
     request_mock_returns = Mock(content="a", status_code="b", headers={"content-type": "image/png"})
-    request_mock = mocker.patch("app.template_previews.requests.post", return_value=request_mock_returns)
-    mocker.patch("app.template_previews.current_service", letter_branding=letter_branding)
+    request_mock = mocker.patch("app.template_preview_client.requests_session.post", return_value=request_mock_returns)
+    service = mocker.Mock(spec=Service, letter_branding=letter_branding)
     template = mock_get_service_letter_template("123", "456")["data"]
 
-    response = partial_call(db_template=template)
+    response = template_preview_client.get_preview_for_templated_letter(
+        db_template=template,
+        service=service,
+        **extra_kwargs,
+    )
 
     assert response[0] == "a"
     assert response[1] == "b"
@@ -87,12 +87,13 @@ def test_get_preview_for_templated_letter_allows_service_branding_to_be_overridd
 ):
     load_service_before_request()
 
-    request_mock = mocker.patch("app.template_previews.requests.post")
-    mocker.patch("app.template_previews.current_service", letter_branding=LetterBranding({"filename": "hm-government"}))
+    request_mock = mocker.patch("app.template_preview_client.requests_session.post")
+    service = mocker.Mock(spec=Service, letter_branding=LetterBranding({"filename": "hm-government"}))
 
-    TemplatePreview.get_preview_for_templated_letter(
+    template_preview_client.get_preview_for_templated_letter(
         db_template=create_notification(template_type="letter")["template"],
         filetype="png",
+        service=service,
         **extra_args,
     )
 
@@ -104,13 +105,9 @@ def test_get_preview_for_templated_letter_from_notification_has_correct_args(
     mocker,
     mock_onwards_request_headers,
 ):
-    # This test is calling `current_service` outside a Flask endpoint, so we need to make sure
-    # `service` is in the `_request_ctx_stack` to avoid an error
-    load_service_before_request()
-
     request_mock_returns = Mock(content="a", status_code="b", headers={"content-type": "image/png"})
-    request_mock = mocker.patch("app.template_previews.requests.post", return_value=request_mock_returns)
-    mocker.patch("app.template_previews.current_service", letter_branding=LetterBranding({"filename": "hm-government"}))
+    request_mock = mocker.patch("app.template_preview_client.requests_session.post", return_value=request_mock_returns)
+    service = mocker.Mock(spec=Service, letter_branding=LetterBranding({"filename": "hm-government"}))
 
     notification = create_notification(
         service_id="abcd",
@@ -118,8 +115,11 @@ def test_get_preview_for_templated_letter_from_notification_has_correct_args(
         template_name="sample template",
         is_precompiled_letter=False,
     )
-    response = TemplatePreview.get_preview_for_templated_letter(
-        notification["template"], "png", notification["personalisation"]
+    response = template_preview_client.get_preview_for_templated_letter(
+        notification["template"],
+        "png",
+        notification["personalisation"],
+        service=service,
     )
 
     assert response[0] == "a"
@@ -140,7 +140,7 @@ def test_get_preview_for_templated_letter_from_notification_has_correct_args(
     request_mock.assert_called_once_with("http://localhost:9999/preview.png", json=data, headers=headers)
 
 
-def test_get_preview_for_templated_letter_from_notification_rejects_precompiled_templates(mocker):
+def test_get_preview_for_templated_letter_from_notification_rejects_precompiled_templates(notify_admin, mocker):
     notification = create_notification(
         service_id="abcd",
         template_type="letter",
@@ -149,14 +149,19 @@ def test_get_preview_for_templated_letter_from_notification_rejects_precompiled_
     )
 
     with pytest.raises(ValueError):
-        TemplatePreview.get_preview_for_templated_letter(
+        template_preview_client.get_preview_for_templated_letter(
             notification["template"], "png", notification["personalisation"]
         )
 
 
 @pytest.mark.parametrize("template_type", ("email", "sms"))
 @pytest.mark.parametrize("file_type", ("pdf", "png"))
-def test_get_preview_for_templated_letter_from_notification_404s_non_letter_templates(mocker, template_type, file_type):
+def test_get_preview_for_templated_letter_from_notification_404s_non_letter_templates(
+    notify_admin,
+    mocker,
+    template_type,
+    file_type,
+):
     notification = create_notification(
         service_id="abcd",
         template_type=template_type,
@@ -164,12 +169,12 @@ def test_get_preview_for_templated_letter_from_notification_404s_non_letter_temp
     )
 
     with pytest.raises(NotFound):
-        TemplatePreview.get_preview_for_templated_letter(
+        template_preview_client.get_preview_for_templated_letter(
             notification["template"], file_type, notification["personalisation"]
         )
 
 
-def test_get_preview_for_templated_letter_from_notification_400s_for_page_of_pdf(mocker):
+def test_get_preview_for_templated_letter_from_notification_400s_for_page_of_pdf(notify_admin, mocker):
     notification = create_notification(
         service_id="abcd",
         template_type="letter",
@@ -177,7 +182,7 @@ def test_get_preview_for_templated_letter_from_notification_400s_for_page_of_pdf
     )
 
     with pytest.raises(BadRequest):
-        TemplatePreview.get_preview_for_templated_letter(
+        template_preview_client.get_preview_for_templated_letter(
             notification["template"],
             "pdf",
             page=1,
@@ -200,11 +205,11 @@ def test_get_png_for_valid_pdf_page_makes_request(
 ):
     mocker.patch("app.template_previews.extract_page_from_pdf", return_value=b"pdf page")
     request_mock = mocker.patch(
-        "app.template_previews.requests.post",
+        "app.template_preview_client.requests_session.post",
         return_value=Mock(content="a", status_code="b", headers={"content-type": "image/png"}),
     )
 
-    response = TemplatePreview.get_png_for_valid_pdf_page(b"pdf file", page_number)
+    response = template_preview_client.get_png_for_valid_pdf_page(b"pdf file", page_number)
 
     assert response == ("a", "b", {"content-type": "image/png"}.items())
     request_mock.assert_called_once_with(
@@ -224,11 +229,11 @@ def test_get_png_for_invalid_pdf_page_makes_request(
 ):
     mocker.patch("app.template_previews.extract_page_from_pdf", return_value=b"pdf page")
     request_mock = mocker.patch(
-        "app.template_previews.requests.post",
+        "app.template_preview_client.requests_session.post",
         return_value=Mock(content="a", status_code="b", headers={"content-type": "image/png"}),
     )
 
-    response = TemplatePreview.get_png_for_invalid_pdf_page(b"pdf file", "1")
+    response = template_preview_client.get_png_for_invalid_pdf_page(b"pdf file", "1")
 
     assert response == ("a", "b", {"content-type": "image/png"}.items())
     request_mock.assert_called_once_with(
@@ -242,8 +247,14 @@ def test_get_png_for_invalid_pdf_page_makes_request(
 
 
 @pytest.mark.parametrize("template_type", ["email", "sms"])
-def test_page_count_returns_none_for_non_letter_templates(template_type):
-    assert TemplatePreview.get_page_counts_for_letter({"template_type": template_type}) is None
+def test_page_count_returns_none_for_non_letter_templates(notify_admin, template_type, mocker):
+    assert (
+        template_preview_client.get_page_counts_for_letter(
+            {"template_type": template_type},
+            service=mocker.Mock(),
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(
@@ -264,18 +275,18 @@ def test_page_count_makes_a_call_to_template_preview_and_gets_page_count(
     values,
     expected_template_preview_args,
 ):
-    # This test is calling `current_service` outside a Flask endpoint, so we need to make sure
-    # `service` is in the `_request_ctx_stack` to avoid an error
-    load_service_before_request()
-
     request_mock_returns = Mock(
         content=b'{"count": 9, "welsh_page_count": 4, "attachment_page_count": 1}', status_code=200
     )
-    request_mock = mocker.patch("app.template_previews.requests.post", return_value=request_mock_returns)
-    mocker.patch("app.template_previews.current_service", letter_branding=LetterBranding({"filename": "hm-government"}))
+    request_mock = mocker.patch("app.template_preview_client.requests_session.post", return_value=request_mock_returns)
+    service = mocker.Mock(spec=Service, letter_branding=LetterBranding({"filename": "hm-government"}))
     template = mock_get_service_letter_template("123", "456")["data"]
 
-    assert TemplatePreview.get_page_counts_for_letter(template, values=values) == {
+    assert template_preview_client.get_page_counts_for_letter(
+        template,
+        values=values,
+        service=service,
+    ) == {
         "count": 9,
         "welsh_page_count": 4,
         "attachment_page_count": 1,
@@ -304,9 +315,9 @@ def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file(
     query_param_value,
     fake_uuid,
 ):
-    request_mock = mocker.patch("app.template_previews.requests.post")
+    request_mock = mocker.patch("app.template_preview_client.requests_session.post")
 
-    TemplatePreview.sanitise_letter(
+    template_preview_client.sanitise_letter(
         "pdf_data", upload_id=fake_uuid, allow_international_letters=allow_international_letters
     )
 
@@ -332,9 +343,9 @@ def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file_for_
     mock_onwards_request_headers,
     fake_uuid,
 ):
-    request_mock = mocker.patch("app.template_previews.requests.post")
+    request_mock = mocker.patch("app.template_preview_client.requests_session.post")
 
-    TemplatePreview.sanitise_letter(
+    template_preview_client.sanitise_letter(
         "pdf_data", upload_id=fake_uuid, allow_international_letters=False, is_an_attachment=True
     )
 

--- a/tests/app/utils/test_branding.py
+++ b/tests/app/utils/test_branding.py
@@ -75,7 +75,7 @@ def test_get_choices_service_not_assigned_to_org(
     ],
 )
 def test_get_email_choices_service_assigned_to_org(
-    mocker,
+    notify_admin,
     service_one,
     org_type,
     branding_id,
@@ -83,6 +83,7 @@ def test_get_email_choices_service_assigned_to_org(
     mock_get_empty_email_branding_pool,
     mock_get_service_organisation,
     mock_get_email_branding,
+    mocker,
 ):
     service = Service(service_one)
 
@@ -115,13 +116,14 @@ def test_get_email_choices_service_assigned_to_org(
     ],
 )
 def test_get_email_choices_org_has_default_branding(
-    mocker,
+    notify_admin,
     service_one,
     org_type,
     expected_options,
     mock_get_empty_email_branding_pool,
     mock_get_service_organisation,
     mock_get_email_branding,
+    mocker,
 ):
     service = Service(service_one)
 
@@ -156,12 +158,13 @@ def test_get_email_choices_org_has_default_branding(
     ],
 )
 def test_get_email_choices_branding_name_in_use(
-    mocker,
+    notify_admin,
     service_one,
     branding_name,
     expected_options,
     mock_get_empty_email_branding_pool,
     mock_get_service_organisation,
+    mocker,
 ):
     service = Service(service_one)
 
@@ -230,13 +233,14 @@ def test_get_email_choices_branding_name_in_use(
     ),
 )
 def test_current_email_branding_is_not_displayed_in_email_branding_pool_options(
-    mocker,
+    notify_admin,
     service_one,
     mock_get_email_branding_pool,
     mock_get_service_organisation,
     mock_get_email_branding,
     branding_pool,
     expected_options,
+    mocker,
 ):
     service = Service(service_one)
 
@@ -265,13 +269,14 @@ def test_current_email_branding_is_not_displayed_in_email_branding_pool_options(
     ],
 )
 def test_get_letter_choices_service_assigned_to_org(
-    mocker,
+    notify_admin,
     service_one,
     org_type,
     branding_id,
     expected_options,
     mock_get_service_organisation,
     mock_get_empty_letter_branding_pool,
+    mocker,
 ):
     service = Service(service_one)
 
@@ -289,10 +294,11 @@ def test_get_letter_choices_service_assigned_to_org(
 
 
 def test_get_letter_choices_shows_org_branding_if_org_has_empty_pool(
-    mocker,
+    notify_admin,
     service_one,
     mock_get_service_organisation,
     mock_get_empty_letter_branding_pool,
+    mocker,
 ):
     service = Service(service_one)
 
@@ -329,12 +335,13 @@ def test_get_letter_choices_shows_org_branding_if_org_has_empty_pool(
     ],
 )
 def test_get_letter_choices_shows_nhs_branding_for_nhs_services(
-    mocker,
+    notify_admin,
     service_one,
     branding_name,
     expected_options,
     mock_get_service_organisation,
     mock_get_empty_letter_branding_pool,
+    mocker,
 ):
     service = Service(service_one)
 
@@ -353,10 +360,11 @@ def test_get_letter_choices_shows_nhs_branding_for_nhs_services(
 
 
 def test_current_letter_branding_is_not_displayed_in_letter_branding_pool_options(
-    mocker,
+    notify_admin,
     service_one,
     mock_get_letter_branding_pool,
     mock_get_service_organisation,
+    mocker,
 ):
     service = Service(service_one)
 

--- a/tests/app/utils/test_branding.py
+++ b/tests/app/utils/test_branding.py
@@ -249,7 +249,7 @@ def test_current_email_branding_is_not_displayed_in_email_branding_pool_options(
         return_value="email-branding-1-id",
     )
 
-    mocker.patch("app.models.branding.EmailBrandingPool.client_method", return_value=branding_pool)
+    mocker.patch("app.models.branding.EmailBrandingPool._get_items", return_value=branding_pool)
 
     options = get_email_choices(service)
     assert list(options) == expected_options
@@ -386,7 +386,7 @@ def test_current_letter_branding_is_not_displayed_in_letter_branding_pool_option
     expected_options = [
         ("letter-branding-2-id", "Letter branding name 2"),
     ]
-    mocker.patch("app.models.branding.LetterBrandingPool.client_method", return_value=branding_pool)
+    mocker.patch("app.models.branding.LetterBrandingPool._get_items", return_value=branding_pool)
 
     options = get_letter_choices(service)
     assert list(options) == expected_options

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3807,7 +3807,7 @@ def mock_get_returned_letter_summary_with_no_returned_letters(notify_admin, mock
 
 def do_mock_get_page_counts_for_letter(mocker, count, welsh_page_count=0, attachment_page_count=0):
     return mocker.patch(
-        "app.template_previews.TemplatePreview.get_page_counts_for_letter",
+        "app.template_preview_client.get_page_counts_for_letter",
         return_value={
             "count": count,
             "welsh_page_count": welsh_page_count,
@@ -3829,12 +3829,10 @@ def mock_template_preview(mocker, mock_get_page_counts_for_letter):
     status_code = 200
     headers = {}
     example_response = (content, status_code, headers)
-    mocker.patch(
-        "app.template_previews.TemplatePreview.get_preview_for_templated_letter", return_value=example_response
-    )
+    mocker.patch("app.template_preview_client.get_preview_for_templated_letter", return_value=example_response)
 
-    mocker.patch("app.template_previews.TemplatePreview.get_png_for_valid_pdf_page", return_value=example_response)
-    mocker.patch("app.template_previews.TemplatePreview.get_png_for_invalid_pdf_page", return_value=example_response)
+    mocker.patch("app.template_preview_client.get_png_for_valid_pdf_page", return_value=example_response)
+    mocker.patch("app.template_preview_client.get_png_for_invalid_pdf_page", return_value=example_response)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1751,7 +1751,7 @@ def mock_get_uploads(mocker, api_user_active):
         }
 
     # Why is mocking on the model needed?
-    return mocker.patch("app.models.job.PaginatedUploads.client_method", side_effect=_get_uploads)
+    return mocker.patch("app.models.job.PaginatedUploads._get_items", side_effect=_get_uploads)
 
 
 @pytest.fixture(scope="function")
@@ -1869,7 +1869,7 @@ def mock_get_no_uploaded_letters(mocker):
 @pytest.fixture(scope="function")
 def mock_get_no_uploads(mocker, api_user_active):
     mocker.patch(
-        "app.models.job.PaginatedUploads.client_method",
+        "app.models.job.PaginatedUploads._get_items",
         return_value={
             "data": [],
         },
@@ -1879,7 +1879,7 @@ def mock_get_no_uploads(mocker, api_user_active):
 @pytest.fixture(scope="function")
 def mock_get_no_jobs(mocker, api_user_active):
     return mocker.patch(
-        "app.models.job.PaginatedJobs.client_method",
+        "app.models.job.PaginatedJobs._get_items",
         return_value={
             "data": [],
             "links": {},
@@ -1940,7 +1940,7 @@ def mock_get_contact_lists(mocker, api_user_active, fake_uuid):
         ]
 
     return mocker.patch(
-        "app.models.contact_list.ContactLists.client_method",
+        "app.models.contact_list.ContactLists._get_items",
         side_effect=_get,
     )
 
@@ -1974,7 +1974,7 @@ def mock_get_no_contact_list(mocker, api_user_active, fake_uuid):
 @pytest.fixture(scope="function")
 def mock_get_no_contact_lists(mocker):
     return mocker.patch(
-        "app.models.contact_list.ContactLists.client_method",
+        "app.models.contact_list.ContactLists._get_items",
         return_value=[],
     )
 
@@ -2172,7 +2172,7 @@ def mock_get_users_by_service(mocker):
 
     # You shouldn’t be calling the user API client directly, so it’s the
     # instance on the model that’s mocked here
-    return mocker.patch("app.models.user.Users.client_method", side_effect=_get_users_for_service)
+    return mocker.patch("app.models.user.Users._get_items", side_effect=_get_users_for_service)
 
 
 @pytest.fixture(scope="function")
@@ -2248,7 +2248,7 @@ def mock_get_invites_for_service(mocker, service_one, sample_invite):
             data.append(invite)
         return data
 
-    return mocker.patch("app.models.user.InvitedUsers.client_method", side_effect=_get_invites)
+    return mocker.patch("app.models.user.InvitedUsers._get_items", side_effect=_get_invites)
 
 
 @pytest.fixture(scope="function")
@@ -2268,7 +2268,7 @@ def mock_get_invites_without_manage_permission(mocker, service_one, sample_invit
             )
         ]
 
-    return mocker.patch("app.models.user.InvitedUsers.client_method", side_effect=_get_invites)
+    return mocker.patch("app.models.user.InvitedUsers._get_items", side_effect=_get_invites)
 
 
 @pytest.fixture(scope="function")
@@ -2576,7 +2576,7 @@ def mock_get_all_email_branding(mocker):
         return create_email_brandings(5, non_standard_values=non_standard_values, shuffle=shuffle)
 
     return mocker.patch(
-        "app.models.branding.AllEmailBranding.client_method",
+        "app.models.branding.AllEmailBranding._get_items",
         side_effect=_get_all_email_branding,
     )
 
@@ -2602,7 +2602,7 @@ def mock_get_all_letter_branding(mocker):
             },
         ]
 
-    return mocker.patch("app.models.branding.AllLetterBranding.client_method", side_effect=_get_letter_branding)
+    return mocker.patch("app.models.branding.AllLetterBranding._get_items", side_effect=_get_letter_branding)
 
 
 @pytest.fixture
@@ -2638,7 +2638,7 @@ def mock_get_letter_branding_pool(mocker):
             },
         ]
 
-    return mocker.patch("app.models.branding.LetterBrandingPool.client_method", side_effect=_get_branding_pool)
+    return mocker.patch("app.models.branding.LetterBrandingPool._get_items", side_effect=_get_branding_pool)
 
 
 @pytest.fixture(scope="function")
@@ -2646,7 +2646,7 @@ def mock_get_empty_letter_branding_pool(mocker):
     def _get_branding_pool(org_id):
         return []
 
-    return mocker.patch("app.models.branding.LetterBrandingPool.client_method", side_effect=_get_branding_pool)
+    return mocker.patch("app.models.branding.LetterBrandingPool._get_items", side_effect=_get_branding_pool)
 
 
 @pytest.fixture(scope="function")
@@ -2716,7 +2716,7 @@ def mock_get_email_branding_pool(mocker):
     def _get_email_branding_pool(org_id):
         return create_email_branding_pool()
 
-    return mocker.patch("app.models.branding.EmailBrandingPool.client_method", side_effect=_get_email_branding_pool)
+    return mocker.patch("app.models.branding.EmailBrandingPool._get_items", side_effect=_get_email_branding_pool)
 
 
 @pytest.fixture(scope="function")
@@ -2724,7 +2724,7 @@ def mock_get_empty_email_branding_pool(mocker):
     def _get_email_branding_pool(org_id):
         return []
 
-    return mocker.patch("app.models.branding.EmailBrandingPool.client_method", side_effect=_get_email_branding_pool)
+    return mocker.patch("app.models.branding.EmailBrandingPool._get_items", side_effect=_get_email_branding_pool)
 
 
 @pytest.fixture(scope="function")
@@ -3356,7 +3356,7 @@ def mock_get_organisations(mocker):
         ]
 
     mocker.patch(
-        "app.models.organisation.AllOrganisations.client_method",
+        "app.models.organisation.AllOrganisations._get_items",
         side_effect=_get_organisations,
     )
 
@@ -3493,7 +3493,7 @@ def mock_get_users_for_organisation(mocker):
             user_json(id_="5678", name="Test User 2", email_address="testt@gov.uk"),
         ]
 
-    return mocker.patch("app.models.user.OrganisationUsers.client_method", side_effect=_get_users_for_organisation)
+    return mocker.patch("app.models.user.OrganisationUsers._get_items", side_effect=_get_users_for_organisation)
 
 
 @pytest.fixture(scope="function")
@@ -3502,7 +3502,7 @@ def mock_get_invited_users_for_organisation(mocker, sample_org_invite):
         return [sample_org_invite]
 
     return mocker.patch(
-        "app.models.user.OrganisationInvitedUsers.client_method",
+        "app.models.user.OrganisationInvitedUsers._get_items",
         side_effect=_get_invited_invited_users_for_organisation,
     )
 
@@ -3538,7 +3538,7 @@ def mock_get_invites_for_organisation(mocker, sample_org_invite):
             data.append(invite)
         return data
 
-    return mocker.patch("app.models.user.OrganisationInvitedUsers.client_method", side_effect=_get_org_invites)
+    return mocker.patch("app.models.user.OrganisationInvitedUsers._get_items", side_effect=_get_org_invites)
 
 
 @pytest.fixture(scope="function")
@@ -4322,7 +4322,7 @@ def mock_get_letter_rates(mocker):
             {"post_class": "rest-of-world", "rate": "1.63", "sheet_count": 5, "start_date": "2024-01-02T00:00:00"},
         ]
 
-    return mocker.patch("app.models.letter_rates.LetterRates.client_method", side_effect=_get_letter_rates)
+    return mocker.patch("app.models.letter_rates.LetterRates._get_items", side_effect=_get_letter_rates)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from flask import Flask, url_for
 from notifications_python_client.errors import HTTPError
 from notifications_utils.url_safe_token import generate_token
 
-from app import create_app, webauthn_server
+from app import create_app, reset_memos, webauthn_server
 from app.constants import LetterLanguageOptions
 
 from . import (
@@ -59,8 +59,12 @@ def notify_admin_without_context():
 
 @pytest.fixture
 def notify_admin(notify_admin_without_context):
+    reset_memos()
+
     with notify_admin_without_context.app_context():
         yield notify_admin_without_context
+
+    reset_memos()
 
 
 @pytest.fixture(scope="function")
@@ -110,7 +114,7 @@ def multiple_reply_to_email_addresses(mocker):
 
 
 @pytest.fixture(scope="function")
-def no_reply_to_email_addresses(mocker):
+def no_reply_to_email_addresses(notify_admin, mocker):
     def _get(service_id):
         return []
 
@@ -118,7 +122,7 @@ def no_reply_to_email_addresses(mocker):
 
 
 @pytest.fixture(scope="function")
-def single_reply_to_email_address(mocker):
+def single_reply_to_email_address(notify_admin, mocker):
     def _get(service_id):
         return [
             {
@@ -135,7 +139,7 @@ def single_reply_to_email_address(mocker):
 
 
 @pytest.fixture(scope="function")
-def get_default_reply_to_email_address(mocker):
+def get_default_reply_to_email_address(notify_admin, mocker):
     def _get(service_id, reply_to_email_id):
         return {
             "id": "1234",
@@ -150,7 +154,7 @@ def get_default_reply_to_email_address(mocker):
 
 
 @pytest.fixture(scope="function")
-def get_non_default_reply_to_email_address(mocker):
+def get_non_default_reply_to_email_address(notify_admin, mocker):
     def _get(service_id, reply_to_email_id):
         return {
             "id": "1234",
@@ -165,7 +169,7 @@ def get_non_default_reply_to_email_address(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_add_reply_to_email_address(mocker):
+def mock_add_reply_to_email_address(notify_admin, mocker):
     def _add_reply_to(service_id, email_address, is_default=False):
         return
 
@@ -173,7 +177,7 @@ def mock_add_reply_to_email_address(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_reply_to_email_address(mocker):
+def mock_update_reply_to_email_address(notify_admin, mocker):
     def _update_reply_to(service_id, reply_to_email_id, email_address=None, active=None, is_default=False):
         return
 
@@ -181,7 +185,7 @@ def mock_update_reply_to_email_address(mocker):
 
 
 @pytest.fixture(scope="function")
-def multiple_letter_contact_blocks(mocker):
+def multiple_letter_contact_blocks(notify_admin, mocker):
     def _get(service_id):
         return [
             {
@@ -214,7 +218,7 @@ def multiple_letter_contact_blocks(mocker):
 
 
 @pytest.fixture(scope="function")
-def no_letter_contact_blocks(mocker):
+def no_letter_contact_blocks(notify_admin, mocker):
     def _get(service_id):
         return []
 
@@ -222,7 +226,7 @@ def no_letter_contact_blocks(mocker):
 
 
 @pytest.fixture(scope="function")
-def single_letter_contact_block(mocker):
+def single_letter_contact_block(notify_admin, mocker):
     def _get(service_id):
         return [
             {
@@ -239,7 +243,7 @@ def single_letter_contact_block(mocker):
 
 
 @pytest.fixture(scope="function")
-def injected_letter_contact_block(mocker):
+def injected_letter_contact_block(notify_admin, mocker):
     def _get(service_id):
         return [
             {
@@ -256,7 +260,7 @@ def injected_letter_contact_block(mocker):
 
 
 @pytest.fixture(scope="function")
-def get_default_letter_contact_block(mocker):
+def get_default_letter_contact_block(notify_admin, mocker):
     def _get(service_id, letter_contact_id):
         return {
             "id": "1234",
@@ -271,7 +275,7 @@ def get_default_letter_contact_block(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_add_letter_contact(mocker):
+def mock_add_letter_contact(notify_admin, mocker):
     def _add_letter_contact(service_id, contact_block, is_default=False):
         return {
             "data": {
@@ -288,7 +292,7 @@ def mock_add_letter_contact(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_letter_contact(mocker):
+def mock_update_letter_contact(notify_admin, mocker):
     def _update_letter_contact(service_id, letter_contact_id, contact_block, is_default=False):
         return
 
@@ -296,7 +300,7 @@ def mock_update_letter_contact(mocker):
 
 
 @pytest.fixture(scope="function")
-def multiple_sms_senders(mocker):
+def multiple_sms_senders(notify_admin, mocker):
     def _get(service_id):
         return [
             {
@@ -332,7 +336,7 @@ def multiple_sms_senders(mocker):
 
 
 @pytest.fixture(scope="function")
-def multiple_sms_senders_with_diff_default(mocker):
+def multiple_sms_senders_with_diff_default(notify_admin, mocker):
     def _get(service_id):
         return [
             {
@@ -368,7 +372,7 @@ def multiple_sms_senders_with_diff_default(mocker):
 
 
 @pytest.fixture(scope="function")
-def multiple_sms_senders_no_inbound(mocker):
+def multiple_sms_senders_no_inbound(notify_admin, mocker):
     def _get(service_id):
         return [
             {
@@ -395,7 +399,7 @@ def multiple_sms_senders_no_inbound(mocker):
 
 
 @pytest.fixture(scope="function")
-def no_sms_senders(mocker):
+def no_sms_senders(notify_admin, mocker):
     def _get(service_id):
         return []
 
@@ -403,7 +407,7 @@ def no_sms_senders(mocker):
 
 
 @pytest.fixture(scope="function")
-def single_sms_sender(mocker):
+def single_sms_sender(notify_admin, mocker):
     def _get(service_id):
         return [
             {
@@ -421,7 +425,7 @@ def single_sms_sender(mocker):
 
 
 @pytest.fixture(scope="function")
-def get_default_sms_sender(mocker):
+def get_default_sms_sender(notify_admin, mocker):
     def _get(service_id, sms_sender_id):
         return {
             "id": "1234",
@@ -437,7 +441,7 @@ def get_default_sms_sender(mocker):
 
 
 @pytest.fixture(scope="function")
-def get_non_default_sms_sender(mocker):
+def get_non_default_sms_sender(notify_admin, mocker):
     def _get(service_id, sms_sender_id):
         return {
             "id": "1234",
@@ -453,7 +457,7 @@ def get_non_default_sms_sender(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_add_sms_sender(mocker):
+def mock_add_sms_sender(notify_admin, mocker):
     def _add_sms_sender(service_id, sms_sender, is_default=False):
         return
 
@@ -461,7 +465,7 @@ def mock_add_sms_sender(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_sms_sender(mocker):
+def mock_update_sms_sender(notify_admin, mocker):
     def _update_sms_sender(service_id, sms_sender_id, sms_sender=None, active=None, is_default=False):
         return
 
@@ -469,7 +473,7 @@ def mock_update_sms_sender(mocker):
 
 
 @pytest.fixture(scope="function")
-def multiple_available_inbound_numbers(mocker):
+def multiple_available_inbound_numbers(notify_admin, mocker):
     def _get():
         return {
             "data": [
@@ -507,7 +511,7 @@ def multiple_available_inbound_numbers(mocker):
 
 
 @pytest.fixture(scope="function")
-def no_available_inbound_numbers(mocker):
+def no_available_inbound_numbers(notify_admin, mocker):
     def _get():
         return {"data": []}
 
@@ -530,7 +534,7 @@ def mocked_get_service_data():
 
 
 @pytest.fixture(scope="function")
-def mock_get_service(mocker, api_user_active, mocked_get_service_data):
+def mock_get_service(notify_admin, mocker, api_user_active, mocked_get_service_data):
     def _get(service_id):
         return {
             "data": mocked_get_service_data.get(
@@ -549,7 +553,7 @@ def mock_get_service(mocker, api_user_active, mocked_get_service_data):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_statistics(mocker, api_user_active):
+def mock_get_service_statistics(notify_admin, mocker, api_user_active):
     def _get(service_id, limit_days=None):
         return {
             "email": {"requested": 0, "delivered": 0, "failed": 0},
@@ -561,7 +565,7 @@ def mock_get_service_statistics(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_unsubscribe_requests_statistics(mocker):
+def mock_get_unsubscribe_requests_statistics(notify_admin, mocker):
     return mocker.patch(
         "app.service_api_client.get_unsubscribe_request_statistics",
         return_value={
@@ -572,7 +576,7 @@ def mock_get_unsubscribe_requests_statistics(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_detailed_services(mocker, fake_uuid):
+def mock_get_detailed_services(notify_admin, mocker, fake_uuid):
     service_one = service_json(
         id_=SERVICE_ONE_ID,
         name="service_one",
@@ -609,7 +613,7 @@ def mock_get_detailed_services(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_live_service(mocker, api_user_active):
+def mock_get_live_service(notify_admin, mocker, api_user_active):
     def _get(service_id):
         service = service_json(service_id, users=[api_user_active["id"]], restricted=False)
         return {"data": service}
@@ -618,7 +622,7 @@ def mock_get_live_service(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_create_service(mocker):
+def mock_create_service(notify_admin, mocker):
     def _create(
         service_name,
         organisation_type,
@@ -643,7 +647,7 @@ def mock_create_service(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_service(mocker):
+def mock_update_service(notify_admin, mocker):
     def _update(service_id, **kwargs):
         service = service_json(
             service_id,
@@ -670,7 +674,7 @@ def mock_update_service(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_raise_httperror_duplicate_name(mocker):
+def mock_update_service_raise_httperror_duplicate_name(notify_admin, mocker):
     def _update(service_id, **kwargs):
         json_mock = Mock(return_value={"message": {"name": [f"Duplicate service name '{kwargs.get('name')}'"]}})
         resp_mock = Mock(status_code=400, json=json_mock)
@@ -689,7 +693,7 @@ USER_ONE_ID = "7b395b52-c6c1-469c-9d61-54166461c1ab"
 
 
 @pytest.fixture(scope="function")
-def mock_get_services(mocker, active_user_with_permissions):
+def mock_get_services(notify_admin, mocker, active_user_with_permissions):
     def _get_services(params_dict=None):
         service_one = service_json(
             SERVICE_ONE_ID, "service_one", [active_user_with_permissions["id"]], 1000, True, False
@@ -703,7 +707,7 @@ def mock_get_services(mocker, active_user_with_permissions):
 
 
 @pytest.fixture(scope="function")
-def mock_get_services_with_no_services(mocker):
+def mock_get_services_with_no_services(notify_admin, mocker):
     def _get_services(params_dict=None):
         return {"data": []}
 
@@ -711,7 +715,7 @@ def mock_get_services_with_no_services(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_services_with_one_service(mocker, api_user_active):
+def mock_get_services_with_one_service(notify_admin, mocker, api_user_active):
     def _get_services(params_dict=None):
         return {"data": [service_json(SERVICE_ONE_ID, "service_one", [api_user_active["id"]], 1000, True, True)]}
 
@@ -719,7 +723,7 @@ def mock_get_services_with_one_service(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_template(mocker):
+def mock_get_service_template(notify_admin, mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id=service_id,
@@ -736,7 +740,7 @@ def mock_get_service_template(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_deleted_template(mocker):
+def mock_get_deleted_template(notify_admin, mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id=service_id,
@@ -754,7 +758,7 @@ def mock_get_deleted_template(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_template_version(mocker, api_user_active):
+def mock_get_template_version(notify_admin, mocker, api_user_active):
     def _get(service_id, template_id, version):
         template_version = template_version_json(service_id, template_id, api_user_active, version=version)
         return {"data": template_version}
@@ -763,7 +767,7 @@ def mock_get_template_version(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_template_versions(mocker, api_user_active):
+def mock_get_template_versions(notify_admin, mocker, api_user_active):
     def _get(service_id, template_id):
         template_version = template_version_json(service_id, template_id, api_user_active, version=1)
         return {"data": [template_version]}
@@ -772,7 +776,7 @@ def mock_get_template_versions(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_template_with_placeholders(mocker):
+def mock_get_service_template_with_placeholders(notify_admin, mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id=service_id,
@@ -787,7 +791,7 @@ def mock_get_service_template_with_placeholders(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_empty_service_template_with_optional_placeholder(mocker):
+def mock_get_empty_service_template_with_optional_placeholder(notify_admin, mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id=service_id,
@@ -801,7 +805,7 @@ def mock_get_empty_service_template_with_optional_placeholder(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_template_with_multiple_placeholders(mocker):
+def mock_get_service_template_with_multiple_placeholders(notify_admin, mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id=service_id,
@@ -816,7 +820,7 @@ def mock_get_service_template_with_multiple_placeholders(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_template_with_placeholders_same_as_recipient(mocker):
+def mock_get_service_template_with_placeholders_same_as_recipient(notify_admin, mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id=service_id,
@@ -831,7 +835,7 @@ def mock_get_service_template_with_placeholders_same_as_recipient(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_email_template(mocker):
+def mock_get_service_email_template(notify_admin, mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id=service_id,
@@ -848,7 +852,7 @@ def mock_get_service_email_template(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_email_template_without_placeholders(mocker):
+def mock_get_service_email_template_without_placeholders(notify_admin, mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id=service_id,
@@ -865,7 +869,7 @@ def mock_get_service_email_template_without_placeholders(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_letter_template(mocker):
+def mock_get_service_letter_template(notify_admin, mocker):
     def _get(service_id, template_id, version=None, postage="second"):
         template = template_json(
             service_id=service_id,
@@ -882,7 +886,7 @@ def mock_get_service_letter_template(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_letter_template_welsh_language(mocker):
+def mock_get_service_letter_template_welsh_language(notify_admin, mocker):
     def _get(service_id, template_id, version=None, postage="second"):
         template = template_json(
             service_id=service_id,
@@ -902,7 +906,7 @@ def mock_get_service_letter_template_welsh_language(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_letter_template_with_attachment(mocker):
+def mock_get_service_letter_template_with_attachment(notify_admin, mocker):
     def _get(service_id, template_id, version=None, postage="second"):
         template = template_json(
             service_id=service_id,
@@ -924,7 +928,7 @@ def mock_get_service_letter_template_with_attachment(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_letter_template_with_placeholders(mocker):
+def mock_get_service_letter_template_with_placeholders(notify_admin, mocker):
     def _get(service_id, template_id, version=None, postage="second"):
         template = template_json(
             service_id=service_id,
@@ -941,7 +945,7 @@ def mock_get_service_letter_template_with_placeholders(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_letter_template_with_qr_placeholder(mocker):
+def mock_get_service_letter_template_with_qr_placeholder(notify_admin, mocker):
     def _get(service_id, template_id, version=None, postage="second"):
         template = template_json(
             service_id=service_id,
@@ -958,7 +962,7 @@ def mock_get_service_letter_template_with_qr_placeholder(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_create_service_template(mocker, fake_uuid):
+def mock_create_service_template(notify_admin, mocker, fake_uuid):
     def _create(
         *,
         name,
@@ -987,7 +991,7 @@ def mock_create_service_template(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_template(mocker):
+def mock_update_service_template(notify_admin, mocker):
     def _update(
         *,
         service_id,
@@ -1015,7 +1019,7 @@ def mock_update_service_template(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_create_service_template_content_too_big(mocker):
+def mock_create_service_template_content_too_big(notify_admin, mocker):
     def _create(
         *,
         name,
@@ -1042,7 +1046,7 @@ def mock_create_service_template_content_too_big(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_template_400_content_too_big(mocker):
+def mock_update_service_template_400_content_too_big(notify_admin, mocker):
     def _update(*, service_id, template_id, name=None, content=None, subject=None):
         json_mock = Mock(
             return_value={
@@ -1060,7 +1064,7 @@ def mock_update_service_template_400_content_too_big(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_template_400_qr_code_too_big(mocker):
+def mock_update_service_template_400_qr_code_too_big(notify_admin, mocker):
     def _update(*, service_id, template_id, name=None, content=None, subject=None):
         json_mock = Mock(
             return_value={
@@ -1112,7 +1116,7 @@ def _template(template_type, name, parent=None, template_id=None):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_templates(mocker):
+def mock_get_service_templates(notify_admin, mocker):
     def _create(service_id):
         return create_service_templates(service_id)
 
@@ -1120,7 +1124,7 @@ def mock_get_service_templates(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_more_service_templates_than_can_fit_onscreen(mocker):
+def mock_get_more_service_templates_than_can_fit_onscreen(notify_admin, mocker):
     def _create(service_id):
         return create_service_templates(service_id, number_of_templates=20)
 
@@ -1128,7 +1132,7 @@ def mock_get_more_service_templates_than_can_fit_onscreen(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_templates_when_no_templates_exist(mocker):
+def mock_get_service_templates_when_no_templates_exist(notify_admin, mocker):
     def _create(service_id):
         return {"data": []}
 
@@ -1136,7 +1140,7 @@ def mock_get_service_templates_when_no_templates_exist(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_templates_with_only_one_template(mocker):
+def mock_get_service_templates_with_only_one_template(notify_admin, mocker):
     def _get(service_id):
         return {
             "data": [
@@ -1154,7 +1158,7 @@ def mock_get_service_templates_with_only_one_template(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_delete_service_template(mocker):
+def mock_delete_service_template(notify_admin, mocker):
     def _delete(service_id, template_id):
         template = template_json(
             service_id=service_id,
@@ -1169,12 +1173,12 @@ def mock_delete_service_template(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_redact_template(mocker):
+def mock_redact_template(notify_admin, mocker):
     return mocker.patch("app.service_api_client.redact_service_template")
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_template_sender(mocker):
+def mock_update_service_template_sender(notify_admin, mocker):
     def _update(service_id, template_id, reply_to):
         return
 
@@ -1310,12 +1314,12 @@ def api_user_changed_password(fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_send_change_email_verification(mocker):
+def mock_send_change_email_verification(notify_admin, mocker):
     return mocker.patch("app.user_api_client.send_change_email_verification")
 
 
 @pytest.fixture(scope="function")
-def mock_register_user(mocker, api_user_pending):
+def mock_register_user(notify_admin, mocker, api_user_pending):
     def _register(name, email_address, mobile_number, password, auth_type):
         api_user_pending["name"] = name
         api_user_pending["email_address"] = email_address
@@ -1335,7 +1339,7 @@ def login_non_govuser(client_request, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_user(mocker, api_user_active):
+def mock_get_user(notify_admin, mocker, api_user_active):
     def _get_user(id_):
         api_user_active["id"] = id_
         return api_user_active
@@ -1344,7 +1348,7 @@ def mock_get_user(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_locked_user(mocker, api_user_locked):
+def mock_get_locked_user(notify_admin, mocker, api_user_locked):
     def _get_user(id_):
         api_user_locked["id"] = id_
         return api_user_locked
@@ -1353,12 +1357,12 @@ def mock_get_locked_user(mocker, api_user_locked):
 
 
 @pytest.fixture(scope="function")
-def mock_get_user_pending(mocker, api_user_pending):
+def mock_get_user_pending(notify_admin, mocker, api_user_pending):
     return mocker.patch("app.user_api_client.get_user", return_value=api_user_pending)
 
 
 @pytest.fixture(scope="function")
-def mock_get_user_by_email(mocker, api_user_active):
+def mock_get_user_by_email(notify_admin, mocker, api_user_active):
     def _get_user(email_address):
         api_user_active["email_address"] = email_address
         return api_user_active
@@ -1367,7 +1371,7 @@ def mock_get_user_by_email(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_dont_get_user_by_email(mocker):
+def mock_dont_get_user_by_email(notify_admin, mocker):
     def _get_user(email_address):
         return None
 
@@ -1375,27 +1379,27 @@ def mock_dont_get_user_by_email(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_user_by_email_request_password_reset(mocker, api_user_request_password_reset):
+def mock_get_user_by_email_request_password_reset(notify_admin, mocker, api_user_request_password_reset):
     return mocker.patch("app.user_api_client.get_user_by_email", return_value=api_user_request_password_reset)
 
 
 @pytest.fixture(scope="function")
-def mock_get_user_by_email_user_changed_password(mocker, api_user_changed_password):
+def mock_get_user_by_email_user_changed_password(notify_admin, mocker, api_user_changed_password):
     return mocker.patch("app.user_api_client.get_user_by_email", return_value=api_user_changed_password)
 
 
 @pytest.fixture(scope="function")
-def mock_get_user_by_email_locked(mocker, api_user_locked):
+def mock_get_user_by_email_locked(notify_admin, mocker, api_user_locked):
     return mocker.patch("app.user_api_client.get_user_by_email", return_value=api_user_locked)
 
 
 @pytest.fixture(scope="function")
-def mock_get_user_by_email_pending(mocker, api_user_pending):
+def mock_get_user_by_email_pending(notify_admin, mocker, api_user_pending):
     return mocker.patch("app.user_api_client.get_user_by_email", return_value=api_user_pending)
 
 
 @pytest.fixture(scope="function")
-def mock_get_user_by_email_not_found(mocker, api_user_active):
+def mock_get_user_by_email_not_found(notify_admin, mocker, api_user_active):
     def _get_user(email):
         json_mock = Mock(return_value={"message": "Not found", "result": "error"})
         resp_mock = Mock(status_code=404, json=json_mock)
@@ -1406,7 +1410,7 @@ def mock_get_user_by_email_not_found(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_verify_password(mocker):
+def mock_verify_password(notify_admin, mocker):
     def _verify_password(user, password):
         return True
 
@@ -1414,7 +1418,7 @@ def mock_verify_password(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_user_password(mocker, api_user_active):
+def mock_update_user_password(notify_admin, mocker, api_user_active):
     def _update(user_id, password):
         api_user_active["id"] = user_id
         return api_user_active
@@ -1423,7 +1427,7 @@ def mock_update_user_password(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_update_user_attribute(mocker, api_user_active):
+def mock_update_user_attribute(notify_admin, mocker, api_user_active):
     def _update(user_id, **kwargs):
         api_user_active["id"] = user_id
         return api_user_active
@@ -1432,7 +1436,7 @@ def mock_update_user_attribute(mocker, api_user_active):
 
 
 @pytest.fixture
-def mock_activate_user(mocker, api_user_active):
+def mock_activate_user(notify_admin, mocker, api_user_active):
     def _activate(user_id):
         api_user_active["id"] = user_id
         return {"data": api_user_active}
@@ -1441,12 +1445,12 @@ def mock_activate_user(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_email_is_not_already_in_use(mocker):
+def mock_email_is_not_already_in_use(notify_admin, mocker):
     return mocker.patch("app.user_api_client.get_user_by_email_or_none", return_value=None)
 
 
 @pytest.fixture(scope="function")
-def mock_revoke_api_key(mocker):
+def mock_revoke_api_key(notify_admin, mocker):
     def _revoke(service_id, key_id):
         return {}
 
@@ -1454,7 +1458,7 @@ def mock_revoke_api_key(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_api_keys(mocker, fake_uuid):
+def mock_get_api_keys(notify_admin, mocker, fake_uuid):
     def _get_keys(service_id, key_id=None):
         keys = {
             "apiKeys": [
@@ -1471,7 +1475,7 @@ def mock_get_api_keys(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_no_api_keys(mocker):
+def mock_get_no_api_keys(notify_admin, mocker):
     def _get_keys(service_id):
         keys = {"apiKeys": []}
         return keys
@@ -1480,7 +1484,7 @@ def mock_get_no_api_keys(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_login(mocker, mock_get_user, mock_update_user_attribute, mock_events):
+def mock_login(notify_admin, mocker, mock_get_user, mock_update_user_attribute, mock_events):
     def _verify_code(user_id, code, code_type):
         return True, ""
 
@@ -1494,17 +1498,17 @@ def mock_login(mocker, mock_get_user, mock_update_user_attribute, mock_events):
 
 
 @pytest.fixture(scope="function")
-def mock_send_verify_code(mocker):
+def mock_send_verify_code(notify_admin, mocker):
     return mocker.patch("app.user_api_client.send_verify_code")
 
 
 @pytest.fixture(scope="function")
-def mock_send_verify_email(mocker):
+def mock_send_verify_email(notify_admin, mocker):
     return mocker.patch("app.user_api_client.send_verify_email")
 
 
 @pytest.fixture(scope="function")
-def mock_check_verify_code(mocker):
+def mock_check_verify_code(notify_admin, mocker):
     def _verify(user_id, code, code_type):
         return True, ""
 
@@ -1512,7 +1516,7 @@ def mock_check_verify_code(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_check_verify_code_code_not_found(mocker):
+def mock_check_verify_code_code_not_found(notify_admin, mocker):
     def _verify(user_id, code, code_type):
         return False, "Code not found"
 
@@ -1520,7 +1524,7 @@ def mock_check_verify_code_code_not_found(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_check_verify_code_code_expired(mocker):
+def mock_check_verify_code_code_expired(notify_admin, mocker):
     def _verify(user_id, code, code_type):
         return False, "Code has expired"
 
@@ -1528,7 +1532,7 @@ def mock_check_verify_code_code_expired(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_create_job(mocker, api_user_active):
+def mock_create_job(notify_admin, mocker, api_user_active):
     def _create(job_id, service_id, scheduled_for=None, contact_list_id=None):
         return job_json(
             service_id,
@@ -1540,7 +1544,7 @@ def mock_create_job(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_job(mocker, api_user_active):
+def mock_get_job(notify_admin, mocker, api_user_active):
     def _get_job(service_id, job_id):
         return {"data": job_json(service_id, api_user_active, job_id=job_id)}
 
@@ -1548,7 +1552,7 @@ def mock_get_job(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_letter_job(mocker, api_user_active):
+def mock_get_letter_job(notify_admin, mocker, api_user_active):
     def _get_job(service_id, job_id):
         return {"data": job_json(service_id, api_user_active, job_id=job_id, template_type="letter")}
 
@@ -1556,7 +1560,7 @@ def mock_get_letter_job(mocker, api_user_active):
 
 
 @pytest.fixture
-def mock_get_job_doesnt_exist(mocker):
+def mock_get_job_doesnt_exist(notify_admin, mocker):
     def _get_job(service_id, job_id):
         raise HTTPError(response=Mock(status_code=404, json={}), message={})
 
@@ -1564,7 +1568,7 @@ def mock_get_job_doesnt_exist(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_scheduled_job(mocker, api_user_active):
+def mock_get_scheduled_job(notify_admin, mocker, api_user_active):
     def _get_job(service_id, job_id):
         return {
             "data": job_json(
@@ -1580,7 +1584,7 @@ def mock_get_scheduled_job(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_cancelled_job(mocker, api_user_active):
+def mock_get_cancelled_job(notify_admin, mocker, api_user_active):
     def _get_job(service_id, job_id):
         return {
             "data": job_json(
@@ -1596,7 +1600,7 @@ def mock_get_cancelled_job(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_job_in_progress(mocker, api_user_active):
+def mock_get_job_in_progress(notify_admin, mocker, api_user_active):
     def _get_job(service_id, job_id):
         return {
             "data": job_json(
@@ -1613,7 +1617,7 @@ def mock_get_job_in_progress(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_job_with_sending_limits_exceeded(mocker, api_user_active):
+def mock_get_job_with_sending_limits_exceeded(notify_admin, mocker, api_user_active):
     def _get_job(service_id, job_id):
         return {
             "data": job_json(
@@ -1630,7 +1634,7 @@ def mock_get_job_with_sending_limits_exceeded(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_letter_job_in_progress(mocker, api_user_active):
+def mock_get_letter_job_in_progress(notify_admin, mocker, api_user_active):
     def _get_job(service_id, job_id):
         return {
             "data": job_json(
@@ -1648,17 +1652,17 @@ def mock_get_letter_job_in_progress(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_has_jobs(mocker):
+def mock_has_jobs(notify_admin, mocker):
     return mocker.patch("app.job_api_client.has_jobs", return_value=True)
 
 
 @pytest.fixture(scope="function")
-def mock_has_no_jobs(mocker):
+def mock_has_no_jobs(notify_admin, mocker):
     return mocker.patch("app.job_api_client.has_jobs", return_value=False)
 
 
 @pytest.fixture(scope="function")
-def mock_get_jobs(mocker, api_user_active, fake_uuid):
+def mock_get_jobs(notify_admin, mocker, api_user_active, fake_uuid):
     def _get_jobs(service_id, limit_days=None, statuses=None, contact_list_id=None, page=1):
         if statuses is None:
             statuses = ["", "scheduled", "pending", "cancelled", "finished"]
@@ -1696,7 +1700,7 @@ def mock_get_jobs(mocker, api_user_active, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_scheduled_job_stats(mocker, api_user_active):
+def mock_get_scheduled_job_stats(notify_admin, mocker, api_user_active):
     return mocker.patch(
         "app.job_api_client.get_scheduled_job_stats",
         return_value={
@@ -1755,7 +1759,7 @@ def mock_get_uploads(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_uploaded_letters(mocker):
+def mock_get_uploaded_letters(notify_admin, mocker):
     def _get_uploaded_letters(service_id, *, letter_print_day, page=1):
         uploads = [
             {
@@ -1859,7 +1863,7 @@ def mock_get_uploaded_letters(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_no_uploaded_letters(mocker):
+def mock_get_no_uploaded_letters(notify_admin, mocker):
     return mocker.patch(
         "app.main.views.uploads.upload_api_client.get_letters_by_service_and_print_day",
         return_value={"notifications": [], "total": 0, "links": {}},
@@ -1888,7 +1892,7 @@ def mock_get_no_jobs(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_create_contact_list(mocker, api_user_active):
+def mock_create_contact_list(notify_admin, mocker, api_user_active):
     def _create(
         service_id,
         upload_id,
@@ -1946,7 +1950,7 @@ def mock_get_contact_lists(mocker, api_user_active, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_contact_list(mocker, api_user_active, fake_uuid):
+def mock_get_contact_list(notify_admin, mocker, api_user_active, fake_uuid):
     def _get(*, service_id, contact_list_id):
         return contact_list_json(
             id_=fake_uuid,
@@ -1961,7 +1965,7 @@ def mock_get_contact_list(mocker, api_user_active, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_no_contact_list(mocker, api_user_active, fake_uuid):
+def mock_get_no_contact_list(notify_admin, mocker, api_user_active, fake_uuid):
     def _get(*, service_id, contact_list_id):
         raise HTTPError(response=Mock(status_code=404))
 
@@ -1982,6 +1986,7 @@ def mock_get_no_contact_lists(mocker):
 @pytest.fixture(scope="function")
 def mock_get_notifications(
     mocker,
+    notify_admin,
     api_user_active,
 ):
     def _get_notifications(
@@ -2029,7 +2034,7 @@ def mock_get_notifications(
 
 
 @pytest.fixture(scope="function")
-def mock_get_notifications_with_previous_next(mocker):
+def mock_get_notifications_with_previous_next(notify_admin, mocker):
     def _get_notifications(
         service_id,
         job_id=None,
@@ -2049,7 +2054,7 @@ def mock_get_notifications_with_previous_next(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_notifications_with_no_notifications(mocker):
+def mock_get_notifications_with_no_notifications(notify_admin, mocker):
     def _get_notifications(
         service_id,
         job_id=None,
@@ -2069,7 +2074,7 @@ def mock_get_notifications_with_no_notifications(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_inbound_sms(mocker):
+def mock_get_inbound_sms(notify_admin, mocker):
     def _get_inbound_sms(service_id, user_number=None, page=1):
         return inbound_sms_json()
 
@@ -2080,7 +2085,7 @@ def mock_get_inbound_sms(mocker):
 
 
 @pytest.fixture
-def mock_get_inbound_sms_by_id_with_no_messages(mocker):
+def mock_get_inbound_sms_by_id_with_no_messages(notify_admin, mocker):
     def _get_inbound_sms_by_id(service_id, notification_id):
         raise HTTPError(response=Mock(status_code=404))
 
@@ -2091,7 +2096,7 @@ def mock_get_inbound_sms_by_id_with_no_messages(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_most_recent_inbound_sms(mocker):
+def mock_get_most_recent_inbound_sms(notify_admin, mocker):
     def _get_most_recent_inbound_sms(service_id, user_number=None, page=1):
         return inbound_sms_json()
 
@@ -2102,7 +2107,7 @@ def mock_get_most_recent_inbound_sms(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_most_recent_inbound_sms_with_no_messages(mocker):
+def mock_get_most_recent_inbound_sms_with_no_messages(notify_admin, mocker):
     def _get_most_recent_inbound_sms(service_id, user_number=None, page=1):
         return {"has_next": False, "data": []}
 
@@ -2113,7 +2118,7 @@ def mock_get_most_recent_inbound_sms_with_no_messages(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_inbound_sms_summary(mocker):
+def mock_get_inbound_sms_summary(notify_admin, mocker):
     def _get_inbound_sms_summary(
         service_id,
     ):
@@ -2126,7 +2131,7 @@ def mock_get_inbound_sms_summary(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_inbound_sms_summary_with_no_messages(mocker):
+def mock_get_inbound_sms_summary_with_no_messages(notify_admin, mocker):
     def _get_inbound_sms_summary(
         service_id,
     ):
@@ -2139,14 +2144,14 @@ def mock_get_inbound_sms_summary_with_no_messages(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_inbound_number_for_service(mocker):
+def mock_get_inbound_number_for_service(notify_admin, mocker):
     return mocker.patch(
         "app.inbound_number_client.get_inbound_sms_number_for_service", return_value={"data": {"number": "0781239871"}}
     )
 
 
 @pytest.fixture(scope="function")
-def mock_no_inbound_number_for_service(mocker):
+def mock_no_inbound_number_for_service(notify_admin, mocker):
     return mocker.patch("app.inbound_number_client.get_inbound_sms_number_for_service", return_value={"data": {}})
 
 
@@ -2225,7 +2230,7 @@ def sample_invite(mocker, service_one):
 
 
 @pytest.fixture(scope="function")
-def mock_create_invite(mocker, sample_invite):
+def mock_create_invite(notify_admin, mocker, sample_invite):
     def _create_invite(from_user, service_id, email_address, permissions, folder_permissions):
         sample_invite["from_user"] = from_user
         sample_invite["service"] = service_id
@@ -2272,7 +2277,7 @@ def mock_get_invites_without_manage_permission(mocker, service_one, sample_invit
 
 
 @pytest.fixture(scope="function")
-def mock_accept_invite(mocker, sample_invite):
+def mock_accept_invite(notify_admin, mocker, sample_invite):
     def _accept(service_id, invite_id):
         return sample_invite
 
@@ -2280,7 +2285,7 @@ def mock_accept_invite(mocker, sample_invite):
 
 
 @pytest.fixture(scope="function")
-def mock_add_user_to_service(mocker, service_one, api_user_active):
+def mock_add_user_to_service(notify_admin, mocker, service_one, api_user_active):
     def _add_user(service_id, user_id, permissions, folder_permissions):
         return
 
@@ -2288,17 +2293,17 @@ def mock_add_user_to_service(mocker, service_one, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_set_user_permissions(mocker):
+def mock_set_user_permissions(notify_admin, mocker):
     return mocker.patch("app.user_api_client.set_user_permissions", return_value=None)
 
 
 @pytest.fixture(scope="function")
-def mock_remove_user_from_service(mocker):
+def mock_remove_user_from_service(notify_admin, mocker):
     return mocker.patch("app.service_api_client.remove_user_from_service", return_value=None)
 
 
 @pytest.fixture(scope="function")
-def mock_get_template_statistics(mocker, service_one, fake_uuid):
+def mock_get_template_statistics(notify_admin, mocker, service_one, fake_uuid):
     template = template_json(
         service_id=service_one["id"],
         id_=fake_uuid,
@@ -2322,7 +2327,7 @@ def mock_get_template_statistics(mocker, service_one, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_monthly_template_usage(mocker, service_one, fake_uuid):
+def mock_get_monthly_template_usage(notify_admin, mocker, service_one, fake_uuid):
     def _stats(service_id, year):
         return [
             {"template_id": fake_uuid, "month": 4, "year": year, "count": 2, "name": "My first template", "type": "sms"}
@@ -2332,7 +2337,7 @@ def mock_get_monthly_template_usage(mocker, service_one, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_monthly_notification_stats(mocker, service_one, fake_uuid):
+def mock_get_monthly_notification_stats(notify_admin, mocker, service_one, fake_uuid):
     def _stats(service_id, year):
         return {
             "data": {
@@ -2357,7 +2362,7 @@ def mock_get_monthly_notification_stats(mocker, service_one, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_annual_usage_for_service(mocker, service_one, fake_uuid):
+def mock_get_annual_usage_for_service(notify_admin, mocker, service_one, fake_uuid):
     def _get_usage(service_id, year=None):
         return [
             {
@@ -2398,7 +2403,7 @@ def mock_get_annual_usage_for_service(mocker, service_one, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_monthly_usage_for_service(mocker):
+def mock_get_monthly_usage_for_service(notify_admin, mocker):
     def _get_usage(service_id, year):
         return [
             {
@@ -2495,7 +2500,7 @@ def mock_get_monthly_usage_for_service(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_annual_usage_for_service_in_future(mocker, service_one, fake_uuid):
+def mock_get_annual_usage_for_service_in_future(notify_admin, mocker, service_one, fake_uuid):
     def _get_usage(service_id, year=None):
         return [
             {
@@ -2520,7 +2525,7 @@ def mock_get_annual_usage_for_service_in_future(mocker, service_one, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_monthly_usage_for_service_in_future(mocker):
+def mock_get_monthly_usage_for_service_in_future(notify_admin, mocker):
     def _get_usage(service_id, year):
         return []
 
@@ -2528,7 +2533,7 @@ def mock_get_monthly_usage_for_service_in_future(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_events(mocker):
+def mock_events(notify_admin, mocker):
     def _create_event(event_type, event_data):
         return {"some": "data"}
 
@@ -2536,7 +2541,7 @@ def mock_events(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_send_already_registered_email(mocker):
+def mock_send_already_registered_email(notify_admin, mocker):
     return mocker.patch("app.user_api_client.send_already_registered_email")
 
 
@@ -2606,7 +2611,7 @@ def mock_get_all_letter_branding(mocker):
 
 
 @pytest.fixture
-def mock_get_letter_branding_by_id(mocker):
+def mock_get_letter_branding_by_id(notify_admin, mocker):
     def _get_branding_by_id(_id):
         return {
             "id": _id,
@@ -2650,7 +2655,7 @@ def mock_get_empty_letter_branding_pool(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_no_email_branding(mocker):
+def mock_no_email_branding(notify_admin, mocker):
     def _get_email_branding():
         return []
 
@@ -2728,7 +2733,7 @@ def mock_get_empty_email_branding_pool(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_email_branding(mocker, fake_uuid):
+def mock_get_email_branding(notify_admin, mocker, fake_uuid):
     def _get_email_branding(id):
         return create_email_branding(id)
 
@@ -2736,7 +2741,7 @@ def mock_get_email_branding(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_email_branding_with_both_brand_type(mocker, fake_uuid):
+def mock_get_email_branding_with_both_brand_type(notify_admin, mocker, fake_uuid):
     def _get_email_branding(id):
         return create_email_branding(fake_uuid, {"brand_type": "both"})
 
@@ -2744,7 +2749,7 @@ def mock_get_email_branding_with_both_brand_type(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_email_branding_with_org_banner_brand_type(mocker, fake_uuid):
+def mock_get_email_branding_with_org_banner_brand_type(notify_admin, mocker, fake_uuid):
     def _get_email_branding(id):
         return create_email_branding(fake_uuid, {"brand_type": "org_banner"})
 
@@ -2752,7 +2757,7 @@ def mock_get_email_branding_with_org_banner_brand_type(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_email_branding_without_brand_text(mocker, fake_uuid):
+def mock_get_email_branding_without_brand_text(notify_admin, mocker, fake_uuid):
     def _get_email_branding_without_brand_text(id):
         return create_email_branding(fake_uuid, {"text": "", "brand_type": "org_banner"})
 
@@ -2762,7 +2767,7 @@ def mock_get_email_branding_without_brand_text(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_create_email_branding(mocker, fake_uuid):
+def mock_create_email_branding(notify_admin, mocker, fake_uuid):
     def _create_email_branding(logo, name, alt_text, text, colour, brand_type, created_by_id):
         return create_email_branding(
             fake_uuid,
@@ -2780,7 +2785,7 @@ def mock_create_email_branding(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_create_letter_branding(mocker, fake_uuid):
+def mock_create_letter_branding(notify_admin, mocker, fake_uuid):
     def _create_letter_branding(filename, name, created_by_id):
         return create_letter_branding(
             fake_uuid,
@@ -2795,7 +2800,7 @@ def mock_create_letter_branding(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_email_branding_name_for_alt_text(mocker):
+def mock_get_email_branding_name_for_alt_text(notify_admin, mocker):
     def _get_email_branding_name_for_alt_text(alt_text):
         return alt_text
 
@@ -2806,7 +2811,7 @@ def mock_get_email_branding_name_for_alt_text(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_email_branding(mocker):
+def mock_update_email_branding(notify_admin, mocker):
     def _update_email_branding(branding_id, logo, name, alt_text, text, colour, brand_type, updated_by_id):
         return
 
@@ -2814,7 +2819,7 @@ def mock_update_email_branding(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_guest_list(mocker):
+def mock_get_guest_list(notify_admin, mocker):
     def _get_guest_list(service_id):
         return {"email_addresses": ["test@example.com"], "phone_numbers": ["07900900000"]}
 
@@ -2822,17 +2827,17 @@ def mock_get_guest_list(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_guest_list(mocker):
+def mock_update_guest_list(notify_admin, mocker):
     return mocker.patch("app.service_api_client.update_guest_list")
 
 
 @pytest.fixture(scope="function")
-def mock_reset_failed_login_count(mocker):
+def mock_reset_failed_login_count(notify_admin, mocker):
     return mocker.patch("app.user_api_client.reset_failed_login_count")
 
 
 @pytest.fixture
-def mock_get_notification(mocker):
+def mock_get_notification(notify_admin, mocker):
     def _get_notification(
         service_id,
         notification_id,
@@ -2855,7 +2860,7 @@ def mock_get_notification(mocker):
 
 
 @pytest.fixture
-def mock_send_notification(mocker, fake_uuid):
+def mock_send_notification(notify_admin, mocker, fake_uuid):
     def _send_notification(service_id, *, template_id, recipient, personalisation, sender_id):
         return {"id": fake_uuid}
 
@@ -3154,7 +3159,7 @@ def normalize_spaces(input):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_data_retention(mocker):
+def mock_get_service_data_retention(notify_admin, mocker):
     data = {
         "id": str(sample_uuid()),
         "service_id": str(sample_uuid()),
@@ -3168,23 +3173,23 @@ def mock_get_service_data_retention(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_create_service_data_retention(mocker):
+def mock_create_service_data_retention(notify_admin, mocker):
     return mocker.patch("app.service_api_client.create_service_data_retention")
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_data_retention(mocker):
+def mock_update_service_data_retention(notify_admin, mocker):
     return mocker.patch("app.service_api_client.update_service_data_retention")
 
 
 @pytest.fixture(scope="function")
-def mock_get_free_sms_fragment_limit(mocker):
+def mock_get_free_sms_fragment_limit(notify_admin, mocker):
     sample_limit = 250000
     return mocker.patch("app.billing_api_client.get_free_sms_fragment_limit_for_year", return_value=sample_limit)
 
 
 @pytest.fixture(scope="function")
-def mock_create_or_update_free_sms_fragment_limit(mocker):
+def mock_create_or_update_free_sms_fragment_limit(notify_admin, mocker):
     sample_limit = 250000
     return mocker.patch("app.billing_api_client.create_or_update_free_sms_fragment_limit", return_value=sample_limit)
 
@@ -3235,7 +3240,7 @@ def valid_token(notify_admin, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_orgs_and_services_associated_with_branding_empty(mocker):
+def mock_get_orgs_and_services_associated_with_branding_empty(notify_admin, mocker):
     def _get(email_branding_id):
         return {"data": {"services": [], "organisations": []}}
 
@@ -3243,7 +3248,7 @@ def mock_get_orgs_and_services_associated_with_branding_empty(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_orgs_and_services_associated_with_branding_no_orgs(mocker):
+def mock_get_orgs_and_services_associated_with_branding_no_orgs(notify_admin, mocker):
     def _get(email_branding_id):
         return {
             "data": {
@@ -3256,7 +3261,7 @@ def mock_get_orgs_and_services_associated_with_branding_no_orgs(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_orgs_and_services_associated_with_branding_no_services(mocker):
+def mock_get_orgs_and_services_associated_with_branding_no_services(notify_admin, mocker):
     def _get(email_branding_id):
         return {"data": {"services": [], "organisations": [{"name": "organisation 1", "id": "1234"}]}}
 
@@ -3264,7 +3269,7 @@ def mock_get_orgs_and_services_associated_with_branding_no_services(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_valid_service_inbound_api(mocker):
+def mock_get_valid_service_inbound_api(notify_admin, mocker):
     def _get(service_id, inbound_api_id):
         return {
             "created_at": "2017-12-04T10:52:55.289026Z",
@@ -3279,7 +3284,7 @@ def mock_get_valid_service_inbound_api(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_valid_service_callback_api(mocker):
+def mock_get_valid_service_callback_api(notify_admin, mocker):
     def _get(service_id, callback_api_id):
         return {
             "created_at": "2017-12-04T10:52:55.289026Z",
@@ -3294,7 +3299,7 @@ def mock_get_valid_service_callback_api(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_empty_service_inbound_api(mocker):
+def mock_get_empty_service_inbound_api(notify_admin, mocker):
     return mocker.patch(
         "app.service_api_client.get_service_inbound_api",
         side_effect=lambda service_id, callback_api_id: None,
@@ -3302,7 +3307,7 @@ def mock_get_empty_service_inbound_api(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_empty_service_callback_api(mocker):
+def mock_get_empty_service_callback_api(notify_admin, mocker):
     return mocker.patch(
         "app.service_api_client.get_service_callback_api",
         side_effect=lambda service_id, callback_api_id: None,
@@ -3310,7 +3315,7 @@ def mock_get_empty_service_callback_api(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_create_service_inbound_api(mocker):
+def mock_create_service_inbound_api(notify_admin, mocker):
     def _create_service_inbound_api(service_id, url, bearer_token, user_id):
         return
 
@@ -3318,7 +3323,7 @@ def mock_create_service_inbound_api(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_inbound_api(mocker):
+def mock_update_service_inbound_api(notify_admin, mocker):
     def _update_service_inbound_api(service_id, url, bearer_token, user_id, inbound_api_id):
         return
 
@@ -3326,7 +3331,7 @@ def mock_update_service_inbound_api(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_create_service_callback_api(mocker):
+def mock_create_service_callback_api(notify_admin, mocker):
     def _create_service_callback_api(service_id, url, bearer_token, user_id):
         return
 
@@ -3334,7 +3339,7 @@ def mock_create_service_callback_api(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_callback_api(mocker):
+def mock_update_service_callback_api(notify_admin, mocker):
     def _update_service_callback_api(service_id, url, bearer_token, user_id, callback_api_id):
         return
 
@@ -3347,7 +3352,7 @@ def organisation_one(api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_get_organisations(mocker):
+def mock_get_organisations(notify_admin, mocker):
     def _get_organisations():
         return [
             organisation_json("7aa5d4e9-4385-4488-a489-07812ba13383", "Org 1"),
@@ -3367,7 +3372,7 @@ def mock_get_organisations(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_organisations_with_unusual_domains(mocker):
+def mock_get_organisations_with_unusual_domains(notify_admin, mocker):
     def _get_organisations():
         return [
             organisation_json(
@@ -3386,7 +3391,7 @@ def mock_get_organisations_with_unusual_domains(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_organisation(mocker):
+def mock_get_organisation(notify_admin, mocker):
     def _get_organisation(org_id):
         return organisation_json(
             org_id,
@@ -3401,7 +3406,7 @@ def mock_get_organisation(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_organisation_by_domain(mocker):
+def mock_get_organisation_by_domain(notify_admin, mocker):
     def _get_organisation_by_domain(domain):
         return organisation_json(ORGANISATION_ID)
 
@@ -3412,7 +3417,7 @@ def mock_get_organisation_by_domain(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_organisation_nhs_gp(mocker):
+def mock_get_organisation_nhs_gp(notify_admin, mocker):
     def _get_organisation(domain):
         return organisation_json(ORGANISATION_ID, organisation_type="nhs_gp")
 
@@ -3420,7 +3425,7 @@ def mock_get_organisation_nhs_gp(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_no_organisation_by_domain(mocker):
+def mock_get_no_organisation_by_domain(notify_admin, mocker):
     return mocker.patch(
         "app.organisations_client.get_organisation_by_domain",
         return_value=None,
@@ -3429,8 +3434,8 @@ def mock_get_no_organisation_by_domain(mocker):
 
 @pytest.fixture(scope="function")
 def mock_get_service_organisation(
-    mocker,
     mock_get_organisation,
+    mocker,
 ):
     return mocker.patch(
         "app.models.service.Service.organisation_id",
@@ -3440,7 +3445,7 @@ def mock_get_service_organisation(
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_organisation(mocker):
+def mock_update_service_organisation(notify_admin, mocker):
     def _update_service_organisation(service_id, org_id):
         return
 
@@ -3470,12 +3475,12 @@ def _get_organisation_services(organisation_id):
 
 
 @pytest.fixture(scope="function")
-def mock_get_organisation_services(mocker, api_user_active):
+def mock_get_organisation_services(notify_admin, mocker, api_user_active):
     return mocker.patch("app.organisations_client.get_organisation_services", side_effect=_get_organisation_services)
 
 
 @pytest.fixture(scope="function")
-def mock_notify_users_of_request_to_go_live_for_service(mocker, api_user_active):
+def mock_notify_users_of_request_to_go_live_for_service(notify_admin, mocker, api_user_active):
     def _notify_users_of_request_to_go_live_for_service(service_id):
         return
 
@@ -3542,7 +3547,7 @@ def mock_get_invites_for_organisation(mocker, sample_org_invite):
 
 
 @pytest.fixture(scope="function")
-def mock_check_org_invite_token(mocker, sample_org_invite):
+def mock_check_org_invite_token(notify_admin, mocker, sample_org_invite):
     def _check_org_token(token):
         return sample_org_invite
 
@@ -3550,7 +3555,7 @@ def mock_check_org_invite_token(mocker, sample_org_invite):
 
 
 @pytest.fixture(scope="function")
-def mock_check_org_cancelled_invite_token(mocker, sample_org_invite):
+def mock_check_org_cancelled_invite_token(notify_admin, mocker, sample_org_invite):
     def _check_org_token(token):
         sample_org_invite["status"] = "cancelled"
         return sample_org_invite
@@ -3559,7 +3564,7 @@ def mock_check_org_cancelled_invite_token(mocker, sample_org_invite):
 
 
 @pytest.fixture(scope="function")
-def mock_check_org_accepted_invite_token(mocker, sample_org_invite):
+def mock_check_org_accepted_invite_token(notify_admin, mocker, sample_org_invite):
     sample_org_invite["status"] = "accepted"
 
     def _check_org_token(token):
@@ -3569,7 +3574,7 @@ def mock_check_org_accepted_invite_token(mocker, sample_org_invite):
 
 
 @pytest.fixture(scope="function")
-def mock_accept_org_invite(mocker, sample_org_invite):
+def mock_accept_org_invite(notify_admin, mocker, sample_org_invite):
     def _accept(organisation_id, invite_id):
         return sample_org_invite
 
@@ -3577,7 +3582,7 @@ def mock_accept_org_invite(mocker, sample_org_invite):
 
 
 @pytest.fixture(scope="function")
-def mock_add_user_to_organisation(mocker, organisation_one, api_user_active):
+def mock_add_user_to_organisation(notify_admin, mocker, organisation_one, api_user_active):
     def _add_user(organisation_id, user_id, permissions):
         return api_user_active
 
@@ -3585,7 +3590,7 @@ def mock_add_user_to_organisation(mocker, organisation_one, api_user_active):
 
 
 @pytest.fixture(scope="function")
-def mock_update_organisation(mocker):
+def mock_update_organisation(notify_admin, mocker):
     def _update_org(org, **kwargs):
         return
 
@@ -3593,7 +3598,7 @@ def mock_update_organisation(mocker):
 
 
 @pytest.fixture
-def mock_get_organisations_and_services_for_user(mocker, organisation_one, api_user_active):
+def mock_get_organisations_and_services_for_user(notify_admin, mocker, organisation_one, api_user_active):
     def _get_orgs_and_services(user_id):
         return {"organisations": [], "services": []}
 
@@ -3603,7 +3608,7 @@ def mock_get_organisations_and_services_for_user(mocker, organisation_one, api_u
 
 
 @pytest.fixture
-def mock_get_non_empty_organisations_and_services_for_user(mocker, organisation_one, api_user_active):
+def mock_get_non_empty_organisations_and_services_for_user(notify_admin, mocker, organisation_one, api_user_active):
     def _make_services(name, trial_mode=False):
         return [
             {
@@ -3645,7 +3650,7 @@ def mock_get_non_empty_organisations_and_services_for_user(mocker, organisation_
 
 
 @pytest.fixture
-def mock_get_just_services_for_user(mocker, organisation_one, api_user_active):
+def mock_get_just_services_for_user(notify_admin, mocker, organisation_one, api_user_active):
     def _make_services(name, trial_mode=False):
         return [
             {
@@ -3669,7 +3674,7 @@ def mock_get_just_services_for_user(mocker, organisation_one, api_user_active):
 
 
 @pytest.fixture
-def mock_get_empty_organisations_and_one_service_for_user(mocker, organisation_one, api_user_active):
+def mock_get_empty_organisations_and_one_service_for_user(notify_admin, mocker, organisation_one, api_user_active):
     def _get_orgs_and_services(user_id):
         return {
             "organisations": [],
@@ -3688,7 +3693,7 @@ def mock_get_empty_organisations_and_one_service_for_user(mocker, organisation_o
 
 
 @pytest.fixture
-def mock_create_event(mocker):
+def mock_create_event(notify_admin, mocker):
     """
     This should be used whenever your code is calling `flask_login.login_user`
     """
@@ -3705,22 +3710,22 @@ def url_for_endpoint_with_token(endpoint, token, next=None):
 
 
 @pytest.fixture
-def mock_get_template_folders(mocker):
+def mock_get_template_folders(notify_admin, mocker):
     return mocker.patch("app.template_folder_api_client.get_template_folders", return_value=[])
 
 
 @pytest.fixture
-def mock_move_to_template_folder(mocker):
+def mock_move_to_template_folder(notify_admin, mocker):
     return mocker.patch("app.template_folder_api_client.move_to_folder")
 
 
 @pytest.fixture
-def mock_create_template_folder(mocker):
+def mock_create_template_folder(notify_admin, mocker):
     return mocker.patch("app.template_folder_api_client.create_template_folder", return_value=sample_uuid())
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_and_organisation_counts(mocker):
+def mock_get_service_and_organisation_counts(notify_admin, mocker):
     return mocker.patch(
         "app.status_api_client.get_count_of_live_services_and_organisations",
         return_value={
@@ -3731,7 +3736,7 @@ def mock_get_service_and_organisation_counts(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_service_history(mocker):
+def mock_get_service_history(notify_admin, mocker):
     return mocker.patch(
         "app.service_api_client.get_service_history",
         return_value={
@@ -3793,7 +3798,7 @@ def mock_get_service_history(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_returned_letter_summary_with_no_returned_letters(mocker):
+def mock_get_returned_letter_summary_with_no_returned_letters(notify_admin, mocker):
     return mocker.patch(
         "app.service_api_client.get_returned_letter_summary",
         return_value=[],
@@ -3833,7 +3838,7 @@ def mock_template_preview(mocker, mock_get_page_counts_for_letter):
 
 
 @pytest.fixture(scope="function")
-def mock_get_returned_letter_statistics_with_no_returned_letters(mocker):
+def mock_get_returned_letter_statistics_with_no_returned_letters(notify_admin, mocker):
     return mocker.patch(
         "app.service_api_client.get_returned_letter_statistics",
         return_value={
@@ -4226,7 +4231,7 @@ def create_template(
 
 
 @pytest.fixture
-def mock_get_invited_user_by_id(mocker, sample_invite):
+def mock_get_invited_user_by_id(notify_admin, mocker, sample_invite):
     def _get(invited_user_id):
         return sample_invite
 
@@ -4237,7 +4242,7 @@ def mock_get_invited_user_by_id(mocker, sample_invite):
 
 
 @pytest.fixture
-def mock_get_invited_org_user_by_id(mocker, sample_org_invite):
+def mock_get_invited_org_user_by_id(notify_admin, mocker, sample_org_invite):
     def _get(invited_org_user_id):
         return sample_org_invite
 
@@ -4248,12 +4253,12 @@ def mock_get_invited_org_user_by_id(mocker, sample_org_invite):
 
 
 @pytest.fixture
-def mock_antivirus_virus_free(mocker):
+def mock_antivirus_virus_free(notify_admin, mocker):
     yield mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
 
 
 @pytest.fixture
-def mock_antivirus_virus_found(mocker):
+def mock_antivirus_virus_found(notify_admin, mocker):
     yield mocker.patch("app.extensions.antivirus_client.scan", return_value=False)
 
 
@@ -4289,7 +4294,7 @@ def logo_client(notify_admin):
 
 
 @pytest.fixture(scope="function")
-def mock_request_invite_for(mocker):
+def mock_request_invite_for(notify_admin, mocker):
     def _request_invite_for(*, user_to_invite_id, service_id, service_managers_ids, reason):
         return
 
@@ -4326,7 +4331,7 @@ def mock_get_letter_rates(mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_get_sms_rate(mocker):
+def mock_get_sms_rate(notify_admin, mocker):
     def _get_sms_rate():
         return {
             "rate": 0.0197,


### PR DESCRIPTION
On the long long road to https://trello.com/c/ORGrd1jn/498-upgrade-docker-images-for-our-ecs-apps-to-debian-bookworm

This should allow us to confidently upgrade to openssl 3.x without significant performance degradation.

As ever, I suggest reading the individual commits separately as they have their own extensive comments (yes, one of the commits is huge though)

See also https://github.com/alphagov/notifications-api/pull/4179