### PR TITLE
Tweak content of template-level unsubscribe link setting

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1458,7 +1458,17 @@ class LetterAddressForm(StripWhitespaceForm):
 
 class EmailTemplateForm(BaseTemplateForm, TemplateNameMixin):
     subject = GovukTextareaField("Subject", validators=[NotifyDataRequired(thing="the subject of the email")])
-    has_unsubscribe_link = GovukCheckboxField("Allow users to unsubscribe")
+    has_unsubscribe_link = GovukCheckboxField(
+        "Add an unsubscribe link",
+        param_extensions={
+            "items": [
+                {
+                    "hint": {"text": "You will see unsubscribe requests on the dashboard"},
+                    "classes": "govuk-checkboxes__item--single-with-hint",
+                }
+            ],
+        },
+    )
 
 
 class LetterTemplateForm(BaseTemplateForm, TemplateNameMixin):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -558,8 +558,12 @@ def test_edit_email_template_should_have_unsubscribe_checkbox(
         template_id=fake_uuid,
     )
     assert page.select_one("form input[type=checkbox]")["name"] == "has_unsubscribe_link"
+    assert normalize_spaces(page.select_one("form label[for=has_unsubscribe_link]").text) == "Add an unsubscribe link"
     assert (
-        normalize_spaces(page.select_one("form label[for=has_unsubscribe_link]").text) == "Allow users to unsubscribe"
+        normalize_spaces(
+            page.select_one(".govuk-checkboxes__item--single-with-hint #has_unsubscribe_link-item-hint").text
+        )
+        == "You will see unsubscribe requests on the dashboard"
     )
 
 
@@ -629,8 +633,12 @@ def test_add_email_template_should_have_unsubscribe_checkbox(
         template_type=template_type,
     )
     assert page.select_one("form input[type=checkbox]")["name"] == "has_unsubscribe_link"
+    assert normalize_spaces(page.select_one("form label[for=has_unsubscribe_link]").text) == "Add an unsubscribe link"
     assert (
-        normalize_spaces(page.select_one("form label[for=has_unsubscribe_link]").text) == "Allow users to unsubscribe"
+        normalize_spaces(
+            page.select_one(".govuk-checkboxes__item--single-with-hint #has_unsubscribe_link-item-hint").text
+        )
+        == "You will see unsubscribe requests on the dashboard"
     )
 
 


### PR DESCRIPTION
This makes it clearer what will happen when the user ticks this box.

Story: https://trello.com/c/gN0W0DYD/91-update-content-on-allow-users-to-unsubscribe-checkbox

Content doc here: https://docs.google.com/document/d/1XvU9KAfkzJCQ8oJA3gOS0Su1nguaBZStxNWW8ud0aZI/edit?pli=1

# Before
<img width="652" alt="image" src="https://github.com/user-attachments/assets/4955e547-c254-49a7-b10e-c724d46f7a3c">

# After 
<img width="667" alt="image" src="https://github.com/user-attachments/assets/b105aaa1-7cc2-4ebd-86c3-398b92bbdcea">
