### PR TITLE
Update guidance-links-urls-emails.html

### DIFF
--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,20 +1,3 @@
-<h2 class="heading-medium">Unsubscribe links</h2>
-<p class="bottom-gutter-1-3">
-  Subscription emails must include an unsubscribe link in the body of the message.
-</p>
-<p class="bottom-gutter-1-3">
-  Transactional emails do not need to include an unsubscribe link.
-</p>
-<p class="bottom-gutter-1-3">
-  Use this example if you have a webpage for users to manage their email subscriptions:
-</p>
-<pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.example.gov.uk/unsubscribe)
-</code></pre>
-<p class="bottom-gutter-1-3">
-  If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
-</p>
-<pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
-</code></pre>
 <h2 class="heading-medium">Formatting</h2>
 <h3 class="heading-small">Headings and subheadings</h3>
 <p class="bottom-gutter-1-3">

--- a/app/templates/partials/templates/guidance-links-urls-emails.html
+++ b/app/templates/partials/templates/guidance-links-urls-emails.html
@@ -14,4 +14,4 @@
 <p class="govuk-body">Select the 'Add an unsubscribe link' checkbox to let recipients request to opt out. </p>
 <p class="govuk-body">To add your own unsubscribe link, follow the instructions in our <a class="govuk-link govuk-link--no-visited-state"
     href="https://www.notifications.service.gov.uk/using-notify/api-documentation">API documentation</a>. This is an API only feature.</p>
-<p class="govuk-body">Read more on why you must add an <a class="govuk-link govuk-link--no-visited-state" href="Unsubscribe links – GOV.UK Notify">unsubscribe link</a>.</p>
+<p class="govuk-body">Find out why you need to add <a class="govuk-link govuk-link--no-visited-state" href="Unsubscribe links – GOV.UK Notify">unsubscribe links</a>.</p>

--- a/app/templates/partials/templates/guidance-links-urls-emails.html
+++ b/app/templates/partials/templates/guidance-links-urls-emails.html
@@ -9,3 +9,9 @@
 </p>
 <pre class="formatting-example"><code class="lang-md">[Apply now](https://www.gov.uk/example)
 </code></pre>
+<h3 class="govuk-heading-m">Unsubscribe links</h3>
+<p class="govuk-body">Subscription emails must include an unsubscribe link.</p>
+<p class="govuk-body">Select the 'Add an unsubscribe link' checkbox to let recipients request to opt out. </p>
+<p class="govuk-body">To add your own unsubscribe link, follow the instructions in our <a class="govuk-link govuk-link--no-visited-state"
+    href="https://www.notifications.service.gov.uk/using-notify/api-documentation">API documentation</a>. This is an API only feature.</p>
+<p class="govuk-body">Read more on why you must add an <a class="govuk-link govuk-link--no-visited-state" href="Unsubscribe links – GOV.UK Notify">unsubscribe link</a>.</p>

--- a/app/templates/partials/templates/guidance-links-urls-emails.html
+++ b/app/templates/partials/templates/guidance-links-urls-emails.html
@@ -12,6 +12,6 @@
 <h3 class="govuk-heading-m">Unsubscribe links</h3>
 <p class="govuk-body">Subscription emails must include an unsubscribe link.</p>
 <p class="govuk-body">Select the 'Add an unsubscribe link' checkbox to let recipients request to opt out. </p>
-<p class="govuk-body">To add your own unsubscribe link, follow the instructions in our <a class="govuk-link govuk-link--no-visited-state"
-    href="https://www.notifications.service.gov.uk/using-notify/api-documentation">API documentation</a>. This is an API only feature.</p>
+<p class="govuk-body">Use the Notify API to add your own unsubscribe link. Follow the instructions in our <a class="govuk-link govuk-link--no-visited-state"
+    href="https://www.notifications.service.gov.uk/using-notify/api-documentation">API documentation</a>.</p>
 <p class="govuk-body">Find out why you need to add <a class="govuk-link govuk-link--no-visited-state" href="Unsubscribe links – GOV.UK Notify">unsubscribe links</a>.</p>

--- a/app/templates/partials/templates/guidance-links-urls-emails.html
+++ b/app/templates/partials/templates/guidance-links-urls-emails.html
@@ -11,7 +11,7 @@
 </code></pre>
 <h3 class="govuk-heading-m">Unsubscribe links</h3>
 <p class="govuk-body">Subscription emails must include an unsubscribe link.</p>
-<p class="govuk-body">Select the 'Add an unsubscribe link' checkbox to let recipients request to opt out. </p>
+<p class="govuk-body">Select the ‘Add an unsubscribe link’ checkbox to let recipients request to opt out. </p>
 <p class="govuk-body">Use the Notify API to add your own unsubscribe link. Follow the instructions in our <a class="govuk-link govuk-link--no-visited-state"
     href="https://www.notifications.service.gov.uk/using-notify/api-documentation">API documentation</a>.</p>
 <p class="govuk-body">Find out why you need to add <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_unsubscribe_links') }}">unsubscribe links</a>.</p>

--- a/app/templates/partials/templates/guidance-links-urls-emails.html
+++ b/app/templates/partials/templates/guidance-links-urls-emails.html
@@ -14,4 +14,4 @@
 <p class="govuk-body">Select the 'Add an unsubscribe link' checkbox to let recipients request to opt out. </p>
 <p class="govuk-body">Use the Notify API to add your own unsubscribe link. Follow the instructions in our <a class="govuk-link govuk-link--no-visited-state"
     href="https://www.notifications.service.gov.uk/using-notify/api-documentation">API documentation</a>.</p>
-<p class="govuk-body">Find out why you need to add <a class="govuk-link govuk-link--no-visited-state" href="Unsubscribe links – GOV.UK Notify">unsubscribe links</a>.</p>
+<p class="govuk-body">Find out why you need to add <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_unsubscribe_links') }}">unsubscribe links</a>.</p>


### PR DESCRIPTION
Adding unsubscribe link instructions to guidance (removing section on unsub links as a separate instruction)

This should be merged/deployed at the same time as the PR to remove unusb content https://github.com/alphagov/notifications-admin/pull/5202