### PR TITLE
Update guidance-formatting.html

### DIFF
--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,20 +1,3 @@
-<h2 class="heading-medium">Unsubscribe links</h2>
-<p class="bottom-gutter-1-3">
-  Subscription emails must include an unsubscribe link in the body of the message.
-</p>
-<p class="bottom-gutter-1-3">
-  Transactional emails do not need to include an unsubscribe link.
-</p>
-<p class="bottom-gutter-1-3">
-  Use this example if you have a webpage for users to manage their email subscriptions:
-</p>
-<pre class="formatting-example"><code class="lang-md">[Unsubscribe](https://www.example.gov.uk/unsubscribe)
-</code></pre>
-<p class="bottom-gutter-1-3">
-  If you do not have your own webpage, you can add a ‘mailto’ link to let users send an email to your team instead. For example:
-</p>
-<pre class="formatting-example"><code class="lang-md">[Unsubscribe](mailto:example@gov.uk?subject=unsubscribe)
-</code></pre>
 <h2 class="heading-medium">Formatting</h2>
 <h3 class="heading-small">Headings and subheadings</h3>
 <p class="bottom-gutter-1-3">


### PR DESCRIPTION
removing content on unsub links - this has been moved to the 'Links and URLs section' see PR  https://github.com/alphagov/notifications-admin/pull/5201 This should be removed once the above PR is merged/deployed