### PR TITLE
Updates utils to 84.0.0 to fix a validation bug with the phone_numbes library preventing sending to certain Jersey phone numbers

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==8.0.1
 fido2==1.1.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.5.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
 
 govuk-frontend-jinja==3.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.5.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx
@@ -115,7 +115,7 @@ ordered-set==4.1.0
     # via notifications-utils
 packaging==23.1
     # via gunicorn
-phonenumbers==8.13.18
+phonenumbers==8.13.45
     # via notifications-utils
 pillow==10.3.0
     # via -r requirements.in


### PR DESCRIPTION
It was discovered that a subset of valid Jersey phone numbers were being incorrectly invalidated by the phone_numberslibrary code due to a bug in the regex phone numbers were being validated against for the Jersey region. The latest version  provides a fix