### PR TITLE
Update approve join request template when user exists

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -46,6 +46,8 @@ def invite_user(service_id, user_id=None):
         folder_permissions=[f["id"] for f in current_service.all_template_folders],
     )
 
+    is_join_request = False if user_id is None else True
+
     if user_id:
         user_to_invite = User.from_id(user_id)
         if user_to_invite.belongs_to_service(current_service.id):
@@ -78,6 +80,7 @@ def invite_user(service_id, user_id=None):
             form.permissions,
             form.login_authentication.data,
             form.folder_permissions.data,
+            is_join_request,
         )
 
         flash(f"Invite sent to {invited_user.email_address}", "default_with_tick")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -489,22 +489,11 @@ class InvitedUser(BaseUser):
 
     @classmethod
     def create(
-        cls,
-        invite_from_id,
-        service_id,
-        email_address,
-        permissions,
-        auth_type,
-        folder_permissions,
+        cls, invite_from_id, service_id, email_address, permissions, auth_type, folder_permissions, is_join_request
     ):
         return cls(
             invite_api_client.create_invite(
-                invite_from_id,
-                service_id,
-                email_address,
-                permissions,
-                auth_type,
-                folder_permissions,
+                invite_from_id, service_id, email_address, permissions, auth_type, folder_permissions, is_join_request
             )
         )
 

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -11,7 +11,9 @@ class InviteApiClient(NotifyAdminAPIClient):
 
         self.admin_url = app.config["ADMIN_BASE_URL"]
 
-    def create_invite(self, invite_from_id, service_id, email_address, permissions, auth_type, folder_permissions):
+    def create_invite(
+        self, invite_from_id, service_id, email_address, permissions, auth_type, folder_permissions, is_join_request
+    ):
         data = {
             "service": service_id,
             "email_address": email_address,
@@ -20,6 +22,7 @@ class InviteApiClient(NotifyAdminAPIClient):
             "auth_type": auth_type,
             "invite_link_host": self.admin_url,
             "folder_permissions": folder_permissions,
+            "is_join_request": is_join_request,
         }
         data = _attach_current_user(data)
         resp = self.post(url=f"/service/{service_id}/invite", data=data)

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1067,7 +1067,7 @@ def test_invite_user(
     expected_permissions = {"manage_api_keys", "manage_service", "manage_templates", "send_messages", "view_activity"}
 
     app.invite_api_client.create_invite.assert_called_once_with(
-        sample_invite["from_user"], sample_invite["service"], email_address, expected_permissions, "sms_auth", []
+        sample_invite["from_user"], sample_invite["service"], email_address, expected_permissions, "sms_auth", [], False
     )
 
 
@@ -1109,6 +1109,7 @@ def test_invite_user_when_email_address_is_prefilled(
         {"send_messages"},
         "sms_auth",
         [],
+        True,
     )
 
 
@@ -1159,7 +1160,13 @@ def test_invite_user_with_email_auth_service(
     expected_permissions = {"manage_api_keys", "manage_service", "manage_templates", "send_messages", "view_activity"}
 
     app.invite_api_client.create_invite.assert_called_once_with(
-        sample_invite["from_user"], sample_invite["service"], email_address, expected_permissions, auth_type, []
+        sample_invite["from_user"],
+        sample_invite["service"],
+        email_address,
+        expected_permissions,
+        auth_type,
+        [],
+        False,
     )
 
 

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -32,7 +32,9 @@ def test_client_creates_invite(
         },
     )
 
-    invite_api_client.create_invite("12345", "67890", "test@example.com", {"send_messages"}, "sms_auth", [fake_uuid])
+    invite_api_client.create_invite(
+        "12345", "67890", "test@example.com", {"send_messages"}, "sms_auth", [fake_uuid], False
+    )
 
     mock_post.assert_called_once_with(
         url="/service/67890/invite",
@@ -45,6 +47,7 @@ def test_client_creates_invite(
             "permissions": "send_emails,send_letters,send_texts",
             "invite_link_host": current_app.config["ADMIN_BASE_URL"],
             "folder_permissions": [fake_uuid],
+            "is_join_request": False,
         },
     )
 


### PR DESCRIPTION
When a user successfully requests to join a service they should get an email request has been approved. More details on [this card](https://trello.com/c/FHhogwve/904-send-a-different-invite-email-if-the-user-has-requested-to-join-a-service).