### PR TITLE
Delete cached statistics when processing report

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -508,6 +508,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.get(f"service/{service_id}/unsubscribe-request-reports-summary")
 
     @cache.delete("service-{service_id}-unsubscribe-request-reports-summary")
+    @cache.delete("service-{service_id}-unsubscribe-request-statistics")
     def process_unsubscribe_request_report(self, service_id, batch_id, data):
         return self.post(f"service/{service_id}/process-unsubscribe-request-report/{batch_id}", data=data)
 


### PR DESCRIPTION
Marking a report as completed now removes its requests from the count returned to the dashboard: https://github.com/alphagov/notifications-api/pull/4184/files

However the actual number does not update because the previous value is being cached in Redis.

This commit deletes the Redis cache any time we mark a report as completed/not completed.