### PR TITLE
Bump `fido2` and `cryptography` to latest versions

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ pyexcel-xls==0.7.0
 pyexcel-xlsx==0.6.0
 pyexcel-ods3==0.6.1
 notifications-python-client==8.0.1
-fido2==1.1.0
+fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via flask
-cryptography==39.0.1
+cryptography==43.0.1
     # via fido2
 dnspython==2.6.1
     # via eventlet
@@ -45,7 +45,7 @@ et-xmlfile==1.1.0
     # via openpyxl
 eventlet==0.35.2
     # via gunicorn
-fido2==1.1.0
+fido2==1.1.3
     # via -r requirements.in
 flask==3.0.0
     # via


### PR DESCRIPTION
Resolves https://github.com/alphagov/notifications-admin/security/dependabot/56

`fido2` needs bumping because the current version is incompatible with the latest version of `cryptography`