### PR TITLE
Send `user_created_at` field to Zendesk

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -141,6 +141,7 @@ def feedback(ticket_type):
             org_id=current_service.organisation_id if current_service else None,
             org_type=current_service.organisation_type if current_service else None,
             service_id=current_service.id if current_service else None,
+            user_created_at=get_user_created_at_for_ticket(current_user),
         )
         zendesk_ticket_id = zendesk_client.send_ticket_to_zendesk(ticket)
 
@@ -248,3 +249,10 @@ def get_zendesk_ticket_type(ticket_type):
         return NotifySupportTicket.TYPE_INCIDENT
 
     return NotifySupportTicket.TYPE_QUESTION
+
+
+def get_user_created_at_for_ticket(user) -> datetime | None:
+    if user.is_authenticated:
+        return datetime.strptime(user.created_at, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=pytz.utc)
+
+    return None

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -61,6 +61,7 @@ class User(BaseUser, UserMixin):
         "receives_new_features_email",
         "state",
         "take_part_in_research",
+        "created_at",
     }
 
     def __init__(self, _dict):

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==8.0.1
 fido2==1.1.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.2.0
 
 govuk-frontend-jinja==3.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.2.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,14 +1,14 @@
-# This file is automatically copied from notifications-utils@82.0.0
+# This file is automatically copied from notifications-utils@84.2.0
 
-beautifulsoup4==4.11.1
-pytest==7.2.0
-pytest-env==0.8.1
-pytest-mock==3.9.0
-pytest-xdist==3.0.2
-pytest-testmon==2.1.0
+beautifulsoup4==4.12.3
+pytest==8.3.2
+pytest-env==1.1.3
+pytest-mock==3.14.0
+pytest-xdist==3.6.1
+pytest-testmon==2.1.1
 pytest-watch==4.2.0
-requests-mock==1.10.0
-freezegun==1.2.2
+requests-mock==1.12.1
+freezegun==1.5.1
 
-black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
-ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes
+black==24.8.0  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.6.4  # Also update `.pre-commit-config.yaml` if this changes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3977,6 +3977,7 @@ def create_user(**overrides):
         "name": "Test User",
         "password": "somepassword",
         "email_address": "test@user.gov.uk",
+        "created_at": "2018-11-07T08:34:54.857402Z",
         "mobile_number": "07700 900762",
         "state": "active",
         "failed_login_count": 0,


### PR DESCRIPTION
We want to populate a new field on the Notify Zendesk form showing when
a Notify user account was created.

For users who are logged in when using the feedback form, we now pass
the UTC datetime that their Notify user account was created as an
argument to the support ticket. For non-logged in users we can just pass
`None` as the argument, which ensures the new date picker won't get
populated.

The `user_created_at` argument is optional.