### PR TITLE
Add `user_created_at` date to all Zendesk tickets a user can open

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -16,6 +16,7 @@ from app.models.feedback import (
     QUESTION_TICKET_TYPE,
 )
 from app.utils import hide_from_search_engines
+from app.utils.user import get_user_created_at_for_ticket
 
 bank_holidays = BankHolidays(use_cached_holidays=True)
 
@@ -249,10 +250,3 @@ def get_zendesk_ticket_type(ticket_type):
         return NotifySupportTicket.TYPE_INCIDENT
 
     return NotifySupportTicket.TYPE_QUESTION
-
-
-def get_user_created_at_for_ticket(user) -> datetime | None:
-    if user.is_authenticated:
-        return datetime.strptime(user.created_at, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=pytz.utc)
-
-    return None

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -29,7 +29,7 @@ from app.utils import service_belongs_to_org_type
 from app.utils.branding import get_email_choices as get_email_branding_choices
 from app.utils.branding import get_letter_choices as get_letter_branding_choices
 from app.utils.branding import letter_filename_for_db_from_logo_key
-from app.utils.user import user_has_permissions
+from app.utils.user import get_user_created_at_for_ticket, user_has_permissions
 
 from .index import THANKS_FOR_BRANDING_REQUEST_MESSAGE
 
@@ -53,6 +53,7 @@ def create_email_branding_zendesk_ticket(detail=None):
         org_type=current_service.organisation_type,
         service_id=current_service.id,
         notify_task_type="notify_task_email_branding",
+        user_created_at=get_user_created_at_for_ticket(current_user),
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 
@@ -216,6 +217,7 @@ def email_branding_enter_government_identity_logo_text(service_id):
             org_type=current_service.organisation_type,
             service_id=current_service.id,
             notify_task_type="notify_task_email_branding_gov",
+            user_created_at=get_user_created_at_for_ticket(current_user),
         )
         zendesk_client.send_ticket_to_zendesk(ticket)
         flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")
@@ -681,6 +683,7 @@ def letter_branding_request(service_id):
             org_type=current_service.organisation_type,
             service_id=current_service.id,
             notify_task_type="notify_task_letter_branding",
+            user_created_at=get_user_created_at_for_ticket(current_user),
         )
         zendesk_client.send_ticket_to_zendesk(ticket)
         flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -74,6 +74,7 @@ from app.utils import DELIVERED_STATUSES, FAILURE_STATUSES, SENDING_STATUSES
 from app.utils.constants import SIGN_IN_METHOD_TEXT_OR_EMAIL
 from app.utils.services import service_has_or_is_expected_to_send_x_or_more_notifications
 from app.utils.user import (
+    get_user_created_at_for_ticket,
     user_has_permissions,
     user_is_gov_user,
     user_is_platform_admin,
@@ -250,6 +251,7 @@ def submit_request_to_go_live(service_id):
         org_type=current_service.organisation_type,
         service_id=current_service.id,
         notify_task_type=notify_task_type,
+        user_created_at=get_user_created_at_for_ticket(current_user),
     )
     zendesk_client.send_ticket_to_zendesk(ticket)
 

--- a/app/utils/user.py
+++ b/app/utils/user.py
@@ -1,6 +1,8 @@
 import os
+from datetime import datetime
 from functools import wraps
 
+import pytz
 from flask import abort, current_app
 from flask_login import current_user, login_required
 
@@ -75,3 +77,10 @@ def normalise_email_address_aliases(email_address):
     local_part = local_part.split("+")[0].replace(".", "")
 
     return f"{local_part}@{domain}".lower()
+
+
+def get_user_created_at_for_ticket(user) -> datetime | None:
+    if user.is_authenticated:
+        return datetime.strptime(user.created_at, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=pytz.utc)
+
+    return None

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -1,3 +1,4 @@
+import datetime
 from io import BytesIO
 from textwrap import dedent
 from unittest import mock
@@ -5,6 +6,7 @@ from unittest.mock import ANY, PropertyMock
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+import pytz
 from flask import url_for
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket, NotifyTicketType
 
@@ -823,6 +825,7 @@ def test_email_branding_request_submit(
         org_type="nhs_local",
         service_id=SERVICE_ONE_ID,
         notify_task_type="notify_task_email_branding",
+        user_created_at=datetime.datetime(2018, 11, 7, 8, 34, 54, 857402).replace(tzinfo=pytz.utc),
     )
     mock_send_ticket_to_zendesk.assert_called_once()
     assert normalize_spaces(page.select_one(".banner-default").text) == (

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 from uuid import UUID, uuid4
 
 import pytest
+import pytz
 from flask import g, url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
@@ -2044,6 +2045,7 @@ def test_should_redirect_after_request_to_go_live(
         org_type="central",
         service_id=SERVICE_ONE_ID,
         notify_task_type="notify_task_go_live_request",
+        user_created_at=datetime(2018, 11, 7, 8, 34, 54, 857402).replace(tzinfo=pytz.utc),
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 
@@ -2147,6 +2149,7 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
         org_type="central",
         service_id=SERVICE_ONE_ID,
         notify_task_type=expected_zendesk_task_type,
+        user_created_at=datetime(2018, 11, 7, 8, 34, 54, 857402).replace(tzinfo=pytz.utc),
     )
     mock_send_ticket_to_zendesk.assert_called_once()
 

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -12,18 +12,13 @@ from notifications_utils.clients.zendesk.zendesk_client import (
     ZendeskError,
 )
 
-from app.main.views.feedback import (
-    ZENDESK_USER_LOGGED_OUT_NOTE,
-    get_user_created_at_for_ticket,
-    in_business_hours,
-)
+from app.main.views.feedback import ZENDESK_USER_LOGGED_OUT_NOTE, in_business_hours
 from app.models.feedback import (
     GENERAL_TICKET_TYPE,
     PROBLEM_TICKET_TYPE,
     QUESTION_TICKET_TYPE,
 )
-from app.models.user import AnonymousUser, User
-from tests.conftest import SERVICE_ONE_ID, create_user, normalize_spaces, set_config_values
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces, set_config_values
 
 
 def no_redirect():
@@ -831,25 +826,3 @@ def test_thanks(
         out_of_hours_emergency=out_of_hours_emergency,
     )
     assert normalize_spaces(page.select_one("main").find("p").text) == message
-
-
-def test_get_user_created_at_date_for_ticket_returns_none_for_unauthenticated_user():
-    unauthenticated_user = AnonymousUser()
-
-    assert get_user_created_at_for_ticket(unauthenticated_user) is None
-
-
-@pytest.mark.parametrize(
-    "user_created_at, expected_value",
-    [
-        ("2023-11-07T08:34:54.857402Z", datetime.datetime(2023, 11, 7, 8, 34, 54, 857402, tzinfo=datetime.UTC)),
-        ("2023-11-07T23:34:54.857402Z", datetime.datetime(2023, 11, 7, 23, 34, 54, 857402, tzinfo=datetime.UTC)),
-        ("2023-06-07T23:34:54.857402Z", datetime.datetime(2023, 6, 7, 23, 34, 54, 857402, tzinfo=datetime.UTC)),
-        ("2023-06-07T12:34:54.857402Z", datetime.datetime(2023, 6, 7, 12, 34, 54, 857402, tzinfo=datetime.UTC)),
-    ],
-)
-def test_get_user_created_at_for_ticket(client_request, user_created_at, expected_value):
-    user_json = create_user(created_at=user_created_at)
-    user = User(user_json)
-
-    assert get_user_created_at_for_ticket(user) == expected_value


### PR DESCRIPTION
This field had been added to tickets created by filling in the feedback form in https://github.com/alphagov/notifications-admin/pull/5209. But we also want it on other user tickets, so this adds it to the branding requests and requests to go live.