### PR TITLE
Get notifications for CSV reports through separate endpoint

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -109,7 +109,6 @@ def view_job_csv(service_id, job_id):
                 status=filter_args.get("status"),
                 page=request.args.get("page", 1),
                 page_size=5000,
-                format_for_csv=True,
                 template_type=job.template_type,
             )
         ),

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -290,11 +290,9 @@ def download_notifications_csv(service_id):
         stream_with_context(
             generate_notifications_csv(
                 service_id=service_id,
-                job_id=None,
                 status=filter_args.get("status"),
                 page=request.args.get("page", 1),
                 page_size=10000,
-                format_for_csv=True,
                 template_type=message_type,
                 limit_days=service_data_retention_days,
             )

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -8,28 +8,22 @@ class NotificationApiClient(NotifyAdminAPIClient):
         job_id=None,
         template_type=None,
         status=None,
-        paginate_by_older_than=None,
-        older_than=None,
         page=None,
         page_size=None,
         count_pages=None,
         limit_days=None,
         include_jobs=None,
         include_from_test_key=None,
-        format_for_csv=None,
         to=None,
         include_one_off=None,
     ):
         params = {
-            "paginate_by_older_than": paginate_by_older_than,
-            "older_than": older_than,
             "page": page,
             "page_size": page_size,
             "template_type": template_type,
             "status": status,
             "include_jobs": include_jobs,
             "include_from_test_key": include_from_test_key,
-            "format_for_csv": format_for_csv,
             "to": to,
             "include_one_off": include_one_off,
             "count_pages": count_pages,
@@ -48,6 +42,35 @@ class NotificationApiClient(NotifyAdminAPIClient):
             if limit_days is not None:
                 params["limit_days"] = limit_days
             return method(url=f"/service/{service_id}/notifications", **kwargs)
+
+    def get_notifications_for_service_for_csv(
+        self,
+        service_id,
+        job_id=None,
+        template_type=None,
+        status=None,
+        older_than=None,
+        page=None,
+        page_size=None,
+        limit_days=None,
+    ):
+        params = {
+            "older_than": older_than,
+            "page": page,
+            "page_size": page_size,
+            "template_type": template_type,
+            "status": status,
+        }
+
+        params = {k: v for k, v in params.items() if v is not None}
+        kwargs = {"params": params}
+
+        if job_id:
+            return self.get(url=f"/service/{service_id}/job/{job_id}/notifications", **kwargs)
+        else:
+            if limit_days is not None:
+                params["limit_days"] = limit_days
+            return self.get(url=f"/service/{service_id}/notifications/csv", **kwargs)
 
     def send_notification(self, service_id, *, template_id, recipient, personalisation, sender_id):
         data = {

--- a/app/utils/csv.py
+++ b/app/utils/csv.py
@@ -72,12 +72,10 @@ def generate_notifications_csv(**kwargs):
             "API key name",
         ]
 
-    kwargs["paginate_by_older_than"] = True
-
     yield ",".join(fieldnames) + "\n"
 
     while True:
-        notifications_batch = notification_api_client.get_notifications_for_service(**kwargs)
+        notifications_batch = notification_api_client.get_notifications_for_service_for_csv(**kwargs)
 
         for notification in notifications_batch["notifications"]:
             if kwargs.get("job_id"):

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -11,13 +11,6 @@ from tests import notification_json, single_notification_json
     [
         ({}, {"url": "/service/abcd1234/notifications", "params": {}}),
         ({"page": 99}, {"url": "/service/abcd1234/notifications", "params": {"page": 99}}),
-        (
-            {"page": 99, "paginate_by_older_than": True, "older_than": "5678"},
-            {
-                "url": "/service/abcd1234/notifications",
-                "params": {"page": 99, "paginate_by_older_than": True, "older_than": "5678"},
-            },
-        ),
         ({"include_jobs": False}, {"url": "/service/abcd1234/notifications", "params": {"include_jobs": False}}),
         (
             {"include_from_test_key": True},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2007,7 +2007,6 @@ def mock_get_notifications(
         include_from_test_key=None,
         to=None,
         include_one_off=None,
-        format_for_csv=None,
     ):
         job = None
         if job_id is not None:


### PR DESCRIPTION
We had one endpoint doing too much, so it became complex and hard to follow. So now we will use two separate endpoints for getting notifications for CSV.

Needs to go in after https://github.com/alphagov/notifications-api/pull/4192