### PR TITLE
Fix the `change` link on the profile page (WCAG 2.2 issues)

### DIFF
--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -118,7 +118,7 @@
           {
           "href": url_for('main.user_profile_take_part_in_user_research'),
           "text": "Change",
-          "visuallyHiddenText": "consent to user research",
+          "visuallyHiddenText": "consent to take part in user research",
           "classes": "govuk-link--no-visited-state"
           }
         ]


### PR DESCRIPTION
This PR makes the purpose of the `Change` user research preferences link more explicit for non-visual users, by updating the `visuallyHiddenText`.

## Why

DAC identified the following issue in the latest WCAG 2.2 audit:

The full 'Change' link text on the profile page doesn't match the name of the field you would change.

This makes it hard to guess what you should call it when you want to select it by voice when using speech recognition software.