### PR TITLE
Bump utils to 85.0.0

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,15 +1,11 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
 from functools import total_ordering
-from typing import Any
 
-import pytz
 from flask import abort
 from notifications_utils.serialised_model import (
     SerialisedModel,
     SerialisedModelCollection,
 )
-from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 
 
 @total_ordering
@@ -39,13 +35,6 @@ class SortingAndEqualityMixin(ABC):
 
 class JSONModel(SerialisedModel, SortingAndEqualityMixin):
 
-    ALLOWED_PROPERTIES = set()  # This is deprecated
-
-    def __new__(cls, *args, **kwargs):
-        for parent in cls.__mro__:
-            cls.__annotations__ = getattr(parent, "__annotations__", {}) | cls.__annotations__
-        return super().__new__(cls)
-
     def __init__(self, _dict):
         # in the case of a bad request _dict may be `None`
         self._dict = _dict or {}
@@ -62,16 +51,6 @@ class JSONModel(SerialisedModel, SortingAndEqualityMixin):
             return next(thing for thing in things if thing["id"] == str(id))
         except StopIteration:
             abort(404)
-
-    @staticmethod
-    def coerce_value_to_type(value, type_):
-        if type_ is Any or value is None:
-            return value
-
-        if issubclass(type_, datetime):
-            return utc_string_to_aware_gmt_datetime(value).astimezone(pytz.utc)
-
-        return type_(value)
 
 
 class ModelList(SerialisedModelCollection):

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==8.0.1
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@85.0.0
 
 govuk-frontend-jinja==3.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@85.0.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,14 +1,14 @@
-# This file is automatically copied from notifications-utils@84.2.0
+# This file is automatically copied from notifications-utils@85.0.0
 
-beautifulsoup4==4.12.3
-pytest==8.3.2
-pytest-env==1.1.3
-pytest-mock==3.14.0
-pytest-xdist==3.6.1
-pytest-testmon==2.1.1
+beautifulsoup4==4.11.1
+pytest==7.2.0
+pytest-env==0.8.1
+pytest-mock==3.9.0
+pytest-xdist==3.0.2
+pytest-testmon==2.1.0
 pytest-watch==4.2.0
-requests-mock==1.12.1
-freezegun==1.5.1
+requests-mock==1.10.0
+freezegun==1.2.2
 
-black==24.8.0  # Also update `.pre-commit-config.yaml` if this changes
-ruff==0.6.4  # Also update `.pre-commit-config.yaml` if this changes
+black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes

--- a/tests/app/models/test_base_model.py
+++ b/tests/app/models/test_base_model.py
@@ -41,7 +41,6 @@ def test_model_raises_for_unknown_attributes(json_response):
         __sort_attribute__ = None
 
     model = Custom(json_response)
-    assert model.ALLOWED_PROPERTIES == set()
 
     with pytest.raises(AttributeError) as e:
         model.foo  # noqa: B018


### PR DESCRIPTION
 ## 85.0.0

* Removes `SerialisedModel.ALLOWED_PROPERTIES` in favour of annotations syntax

 ## 84.3.0

* Reverts 84.1.0

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/84.2.0...85.0.0