### PR TITLE
Replace autofocus logic for sending notifications

### DIFF
--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -18,7 +18,7 @@
 
   {% call form_wrapper(
     class='js-stick-at-top-when-scrolling send-one-off-form' if template.template_type != 'sms' else 'send-one-off-form',
-    module="autofocus" if not form.errors else None,
+    module="autofocus" if not form.errors and form.placeholder_value.label.text not in ['email address', 'phone number'] else None,
     data_kwargs={'force-focus': True}
   ) %}
     <div class="govuk-grid-row">


### PR DESCRIPTION
Replaces logic we added to only make textboxes **after** the first one focus on load in the 'send a single email or sms notification' flow.

To fix this accessibility issue: https://trello.com/c/ey6X6AQe/946-recipient-textbox-is-focused-on-page-load

The logic to not apply autofocus for the first textboxes in the 'send a single email or sms' flows was stripped out in https://github.com/alphagov/notifications-admin/commit/54b55e46c2025f747d2804dd329ed58f8dd6facd

This replaces it. It is needed because the autofocus causes more problems than it fixes when entering the email address or phone number but seems ok when entering placeholders. This finding came from a previous accessibility audit, as described in https://github.com/alphagov/notifications-admin/commit/826b04282b982d36b6b0e55d467e949252b29a6d (before it was removed).