### PR TITLE
Add validator to restrict sender ids like NHSNoReply

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -70,6 +70,7 @@ from app.main.validators import (
     IsAUKMobileNumberOrShortCode,
     IsNotAGenericSenderID,
     IsNotAPotentiallyMaliciousSenderID,
+    IsNotLikeNHSNoReply,
     Length,
     MustContainAlphanumericCharacters,
     NoCommasInPlaceHolders,
@@ -1832,6 +1833,7 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
             IsNotAGenericSenderID(),
             IsNotAPotentiallyMaliciousSenderID(),
             IsAUKMobileNumberOrShortCode(),
+            IsNotLikeNHSNoReply(),
         ],
     )
     is_default = GovukCheckboxField("Make this text message sender ID the default")

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -193,6 +193,18 @@ class IsNotAGenericSenderID:
             raise ValidationError(self.message)
 
 
+class IsNotLikeNHSNoReply:
+
+    def __call__(self, form, field):
+        lower_cased_data = field.data.lower()
+        if (
+            field.data
+            and ("nhs" in lower_cased_data and "no" in lower_cased_data and "reply" in lower_cased_data)
+            and field.data != "NHSNoReply"
+        ):
+            raise ValidationError("Text message sender ID must match other NHS services - change it to ‘NHSNoReply’")
+
+
 def create_phishing_senderid_zendesk_ticket(senderID=None):
     ticket_message = render_template(
         "support-tickets/phishing-senderid.txt",

--- a/tests/app/main/forms/test_service_sms_senders_form.py
+++ b/tests/app/main/forms/test_service_sms_senders_form.py
@@ -45,6 +45,14 @@ from app.models.service import Service
             True,
             True,
         ),  # Evri is a user id that will be set in the
+        ("NHSNoReply", False, None, False, False),  # NHSNoReply is allowed
+        (
+            "NHSno Reply",
+            True,
+            "Text message sender ID must match other NHS services - change it to ‘NHSNoReply’",
+            False,
+            False,
+        ),  # NHS-No Reply and variants are not allowed
         pytest.param(
             "'UC'", False, None, False, False, marks=pytest.mark.xfail
         ),  # Apostrophes can cause SMS delivery issues


### PR DESCRIPTION
NCSC are trying to reduce the number of sender IDs in use to help people know they are coming from a legitimate place.

One of the sender ids with lots of variation is NHSNoReply

This PR stops new people  registering new sender ids with nhs and no and reply in any order, apart from NHSNoReply