### PR TITLE
Reorder buttons on letter template view

### DIFF
--- a/app/templates/partials/templates/letter_image_template.jinja2
+++ b/app/templates/partials/templates/letter_image_template.jinja2
@@ -1,10 +1,5 @@
 {% if template.include_letter_edit_ui_overlay %}
 <div class="template-container template-container--with-attach-pages-button">
-  {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not template.too_many_pages %}
-    <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-get-ready-to-send">
-      Get ready to send<span class="govuk-visually-hidden"> a letter using this template</span>
-    </a>
-  {% endif %}
   {% if current_user.has_permissions('manage_service') %}
     {% if not current_service.letter_branding_id %}
       <a href="{{ url_for(".letter_branding_options", service_id=current_service.id, from_template=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-branding">Add logo</a>
@@ -12,15 +7,26 @@
   {% endif %}
   {% if current_user.has_permissions('manage_templates') %}
     <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-postage">Change postage</a>
-    {% if template.welsh_page_count %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh body text</span></a>
-    {% else %}
-      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> body text</span></a>
-    {% endif %}
+  {% endif %}
+  {#
+    we break the permissions block here to to be able to add the get ready to send button,
+    so that it appears in a more logical keyboard tab order
+  #}
+  {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not template.too_many_pages %}
+    <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-get-ready-to-send">
+      Get ready to send<span class="govuk-visually-hidden"> a letter using this template</span>
+    </a>
+  {% endif %}
+  {% if current_user.has_permissions('manage_templates') %}
     {% if current_service.count_letter_contact_details %}
       <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Change your contact details</a>
     {% else %}
       <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-contact">Add your contact details</a>
+    {% endif %}
+    {% if template.welsh_page_count %}
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id, language='welsh') }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> Welsh body text</span></a>
+    {% else %}
+      <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-button govuk-button--secondary edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> body text</span></a>
     {% endif %}
   {% endif %}
 {% endif %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -909,8 +909,8 @@ def test_letter_with_default_branding_has_add_logo_button(
     )
 
     edit_links = page.select(".template-container a")
-    assert edit_links[1]["href"] == expected_link(service_id=SERVICE_ONE_ID)
-    assert edit_links[1].text == expected_link_text
+    assert edit_links[0]["href"] == expected_link(service_id=SERVICE_ONE_ID)
+    assert edit_links[0].text == expected_link_text
 
 
 @pytest.mark.parametrize(
@@ -1813,14 +1813,6 @@ def test_should_be_able_to_view_a_letter_template_with_links(
     assert [(link["href"], normalize_spaces(link.text)) for link in page.select("a[class*=edit-template-link]")] == [
         (
             url_for(
-                "main.set_sender",
-                service_id=SERVICE_ONE_ID,
-                template_id=fake_uuid,
-            ),
-            "Get ready to send a letter using this template",
-        ),
-        (
-            url_for(
                 "main.letter_branding_options",
                 service_id=SERVICE_ONE_ID,
                 from_template=fake_uuid,
@@ -1837,11 +1829,11 @@ def test_should_be_able_to_view_a_letter_template_with_links(
         ),
         (
             url_for(
-                "main.edit_service_template",
+                "main.set_sender",
                 service_id=SERVICE_ONE_ID,
                 template_id=fake_uuid,
             ),
-            "Edit body text",
+            "Get ready to send a letter using this template",
         ),
         (
             url_for(
@@ -1850,6 +1842,14 @@ def test_should_be_able_to_view_a_letter_template_with_links(
                 template_id=fake_uuid,
             ),
             "Change your contact details",
+        ),
+        (
+            url_for(
+                "main.edit_service_template",
+                service_id=SERVICE_ONE_ID,
+                template_id=fake_uuid,
+            ),
+            "Edit body text",
         ),
         (
             url_for(


### PR DESCRIPTION
Fixes https://trello.com/c/7IYHVqM5/947-visual-order-of-buttons-on-letter-template-page-doesnt-match-the-html

Accessibility audit raised an issue with the focus order of buttons on the letter template.

Cited as "The tab order is unpredictable, as it
moves in the following order:
- Get ready to send
- Add logo
- Change postage
- Edit
- Change your contact details

It is not the expected tab order of moving from top to bottom, left to right", it affects keyboard-only users."

This PR moves the "Get ready to send" but to the suggested order of:

- Add logo
- Change postage
- Get ready to send
- Change your contact details
- Edit

There is extra complexity as not all buttons exist for all users, so a decision was made to break-up the existing `if user has "manage templates"` block to add the button.

Tests needed to also be updated to match the changed button order.

## Before

https://github.com/user-attachments/assets/6b9451e4-b40d-4d0e-83d6-26315a2ec6df


## After

https://github.com/user-attachments/assets/10372974-000c-44a8-9bbd-38be43f6b867


