### PR TITLE
Improve the report title for single unsubscribe requests

### DIFF
--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -70,7 +70,11 @@ class UnsubscribeRequestsReport(JSONModel):
     @property
     def latest(self):
         if self.is_first_of_several_reports_on_the_same_day:
-            return format_datetime_human(self.latest_timestamp, date_prefix="", separator="until")
+            return format_datetime_human(
+                self.latest_timestamp,
+                date_prefix="",
+                separator="at" if self.count == 1 else "until",
+            )
 
         if self.starts_on_a_day_another_report_ends or self.ends_on_a_day_another_report_starts:
             return format_datetime_human(self.latest_timestamp, date_prefix="")

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -91,6 +91,33 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             ],
         ),
         (
+            # Two single requests on the same day
+            [
+                {
+                    "count": 1,
+                    "earliest_timestamp": "2024-01-01T13:18:00+00:00",
+                    "latest_timestamp": "2024-01-01T13:18:00+00:00",
+                    "processed_by_service_at": None,
+                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
+                    "is_a_batched_report": True,
+                },
+                {
+                    "count": 1,
+                    "earliest_timestamp": "2024-01-01T12:17:00+00:00",
+                    "latest_timestamp": "2024-01-01T12:17:00+00:00",
+                    "processed_by_service_at": None,
+                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
+                    "is_a_batched_report": True,
+                },
+            ],
+            [
+                "Report Status",
+                "1 January at 1:18pm 1 unsubscribe request Downloaded",
+                "1 January at 12:17pm 1 unsubscribe request Downloaded",
+            ],
+            [],
+        ),
+        (
             # Two reports with overlapping days
             [
                 {


### PR DESCRIPTION
It doesn’t make sense to talk about a range of time (‘until’) when there’s only a single request in the report. As in other cases we should talk about a specific time (‘at’).

This is something we might see as people are testing the feature and download the report immediately after unsubscribing themselves.

# Before

<img width="761" alt="image" src="https://github.com/user-attachments/assets/42bb26d3-38a0-4b3b-b6a3-d5f155b120a4">

# After 

<img width="764" alt="image" src="https://github.com/user-attachments/assets/ed94ac47-9a49-48b4-ac1e-9391c604c009">
