### PR TITLE
Show skiplink on CSV upload page when focussed

### DIFF
--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -20,11 +20,18 @@ $sticky-padding: govuk-spacing(4);
   }
 
   .back-to-top-link {
-    position: absolute;
-    top: govuk-spacing(6);
-    right: govuk-spacing(3);
+    &:focus {
+      opacity: 1;
+    }
+
     opacity: 0;
     transition: opacity 0.1s ease-in-out;
+
+    @include govuk-media-query($from: tablet) {
+      position: absolute;
+      top: govuk-spacing(6);
+      right: govuk-spacing(3);
+    }
   }
 
 }

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -48,7 +48,7 @@
         button_text='Upload your file again'
       ) }}
     </div>
-    <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
+    <a href="#main-content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
   </div>
 
   <div class="fullscreen-content" data-notify-module="fullscreen-table">

--- a/app/templates/views/uploads/contact-list/column-errors.html
+++ b/app/templates/views/uploads/contact-list/column-errors.html
@@ -54,7 +54,7 @@
         button_text='Upload your file again'
       ) }}
     </div>
-    <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
+    <a href="#main-content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
   </div>
 
     <h2 class="heading-medium" id="file-preview">{{ original_file_name }}</h2>

--- a/app/templates/views/uploads/contact-list/row-errors.html
+++ b/app/templates/views/uploads/contact-list/row-errors.html
@@ -48,7 +48,7 @@
         button_text='Upload your file again'
       ) }}
     </div>
-    <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
+    <a href="#main-content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
   </div>
 
   {% call(item, row_number) list_table(

--- a/app/templates/views/uploads/contact-list/too-many-columns.html
+++ b/app/templates/views/uploads/contact-list/too-many-columns.html
@@ -62,7 +62,7 @@
         button_text='Upload your file again'
       ) }}
     </div>
-    <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
+    <a href="#main-content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
   </div>
 
     {% set column_headers = recipients._raw_column_headers if recipients.duplicate_recipient_column_headers else recipients.column_headers %}

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -30,7 +30,7 @@
             button_text='Upload your file again'
           ) }}
         </div>
-        <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
+        <a href="#main-content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
       </div>
     </div>
   {% elif current_service.trial_mode %}


### PR DESCRIPTION
The skiplink on the page to upload a CSV file wasn't appearing when you tab to it, which is confusing for keyboard users who need to see the focus indicator to know where they are in the page.

This makes it visible by giving it an opacity of `1`. The current positioning would place the skiplink on top of the upload button on mobile, so now only applies to bigger screens.

### On larger screens
<img width="500" alt="Screenshot 2024-09-24 at 11 44 30" src="https://github.com/user-attachments/assets/8a81defb-61e2-4bc3-b9f1-9c25a55061a6">

### On mobile
<img width="325" alt="Screenshot 2024-09-24 at 11 44 16" src="https://github.com/user-attachments/assets/23eebc1f-3417-4373-bbe3-6117a3cad62f">