### PR TITLE
Add a new school email domain

### DIFF
--- a/app/utils/email_domains.txt
+++ b/app/utils/email_domains.txt
@@ -10,3 +10,4 @@ hscni.net
 llyw.cymru
 nhs.wales
 judiciary.uk
+kirkleeseducation.uk


### PR DESCRIPTION
We need to add a new school email domain to this list to handle schools covered by the kirkleeseducation.uk domain.