### PR TITLE
Remove notification id hash from the link to inbound text messages

### DIFF
--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -21,7 +21,7 @@
     {% call field() %}
       <a
         class="govuk-link govuk-link--no-visited-state file-list-filename"
-        href="{{ url_for('main.conversation', service_id=current_service.id, notification_id=item.id) }}#n{{ item.id }}"
+        href="{{ url_for('main.conversation', service_id=current_service.id, notification_id=item.id) }}"
       >
         {{ item.user_number | format_phone_number_human_readable }}
       </a>


### PR DESCRIPTION
Fixes https://trello.com/c/ERqZpZTl/965-first-link-in-messages-on-conversation-page-is-focused-on-page-load

## What
If a service has inbound text messages, they are able to view those messages from the the link on the "inbox" page (services/<id>/inbox.

That link is made out of the notification id and a hash of the latest message id, so that the link takes you directly to that content.

This was raised as an accessibility issue where "This can be disorientating for blind users because content above this such as the h1 and other important messages may be missed, or it may be time-consuming for the user to orient themselves on the page.
This issue will affect screen reader users and keyboard-only users that use the tab key to navigate.

This PR removes the notification ID hash from the link, so that now on page load, focus is naturally taken to the top of the page.

Functional tests
![Screenshot 2024-09-27 at 09 24 59](https://github.com/user-attachments/assets/5e676667-e6f5-40b9-825f-be3d745fde82)

## How to test locally

You'll need to add an inbound message to the DB first. It's important that:
- the number isn't already in the table
- you don't assign it to a service (why we set this to null below)

Check what numbers are already in the table:

`select * from inbound_numbers;`

Add a number: 

- increment existing number's last digit by 1

```
insert into inbound_numbers values(uuid_generate_v4(), [a new phone number], 'mmg', null, 't', current_timestamp, current_timestamp);

```
Enable inbound sms in your service's settings and platform admin settings

Send some messages to that number
Tom has a script to add inbound messages - https://github.com/tombye/notifications_custom_api_calls

Check link from dashboard to message conversation doesn't contain a hash that would take you to a specific message

