### PR TITLE
Persist notification search

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -243,7 +243,11 @@ def view_notifications(service_id, message_type=None):
     if request.method == "POST" and not search_term:
         return redirect_to_main_view_notification(current_service, message_type, None)
 
-    if search_query_hash and search_query_hash != cached_search_query_hash:
+    if cached_search_query_hash and search_query_hash != cached_search_query_hash:
+        return redirect_to_main_view_notification(current_service, message_type, cached_search_query_hash)
+
+    if not cached_search_query_hash and search_query_hash:
+        cached_search_query_hash = None
         return redirect_to_main_view_notification(current_service, message_type, cached_search_query_hash)
 
     return render_template(

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -352,6 +352,7 @@ def _get_notifications_dashboard_partials_data(service_id, message_type):
                 "main.view_notification",
                 service_id=current_service.id,
                 from_statuses=request.args.get("status"),
+                from_search_query=request.args.get("search_query"),
             ),
         ),
     }

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -139,6 +139,7 @@ def view_notification(service_id, notification_id):  # noqa: C901
             service_id=current_service.id,
             message_type=template.template_type,
             status=request.args.get("from_statuses", "sending,delivered,failed"),
+            search_query=request.args.get("from_search_query", None),
         )
 
     if notification["notification_type"] == "letter":

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -26,7 +26,7 @@
 
     {{ ajax_block(
       partials,
-      url_for('json_updates.get_notifications_page_partials_as_json', service_id=current_service.id, message_type=message_type, status=status),
+      url_for('json_updates.get_notifications_page_partials_as_json', service_id=current_service.id, message_type=message_type, status=status, search_query=search_query),
       'counts'
     ) }}
 
@@ -34,7 +34,7 @@
 
   <div class="govuk-grid-column-full {% if message_type == 'sms' %}extra-tracking{% endif %}">
   {% call form_wrapper(
-    action=url_for('main.view_notifications', service_id=current_service.id, message_type=message_type),
+    action=url_for('main.view_notifications', service_id=current_service.id, message_type=message_type, search_query=search_query),
     class="govuk-grid-row notify-simple-search-form"
   ) %}
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -85,7 +85,7 @@
 
   {{ ajax_block(
     partials,
-    url_for('json_updates.get_notifications_page_partials_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),
+    url_for('json_updates.get_notifications_page_partials_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page, search_query=search_query),
     'notifications',
     form='search-form'
   ) }}

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,3 +1,5 @@
+import hashlib
+from datetime import timedelta
 from functools import wraps
 from itertools import chain
 
@@ -21,6 +23,8 @@ FAILURE_STATUSES = [
 REQUESTED_STATUSES = SENDING_STATUSES + DELIVERED_STATUSES + FAILURE_STATUSES
 
 NOTIFICATION_TYPES = ["sms", "email", "letter"]
+
+SEVEN_DAYS_TTL = int(timedelta(days=28).total_seconds())
 
 
 def service_has_permission(permission):
@@ -162,3 +166,7 @@ def format_provider(provider):
         return provider.title()
 
     return provider.upper()
+
+
+def get_sha512_hashed(str):
+    return hashlib.sha512(str.encode()).hexdigest()

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -24,7 +24,7 @@ REQUESTED_STATUSES = SENDING_STATUSES + DELIVERED_STATUSES + FAILURE_STATUSES
 
 NOTIFICATION_TYPES = ["sms", "email", "letter"]
 
-SEVEN_DAYS_TTL = int(timedelta(days=28).total_seconds())
+SEVEN_DAYS_TTL = int(timedelta(days=7).total_seconds())
 
 
 def service_has_permission(permission):

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -202,6 +202,13 @@ def test_can_show_notifications(
         for view_notification_link in view_notification_links
     )
 
+    if hash_search_query:
+        assert all(
+            parse_qs(urlparse(view_notification_link["href"]).query, keep_blank_values=True)["from_search_query"]
+            == [hash_search_query]
+            for view_notification_link in view_notification_links
+        )
+
 
 def test_can_show_notifications_if_data_retention_not_available(
     client_request,

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -164,6 +164,12 @@ def test_notification_status_page_respects_redaction(
             partial(url_for, "main.view_notifications", message_type="sms", status="failed"),
         ),
         (
+            {"from_statuses": "failed", "from_search_query": "test-hash-1234"},
+            partial(
+                url_for, "main.view_notifications", message_type="sms", status="failed", search_query="test-hash-1234"
+            ),
+        ),
+        (
             {"from_job": "job_id"},
             partial(url_for, "main.view_job", job_id="job_id"),
         ),


### PR DESCRIPTION
If user search for a notification on the emails/sms/letters dashboard pages, click through to one of the notification and go back, the search term doesn’t persist. More details on [this card](https://trello.com/c/rsHVv64U/903-live-search-on-notification-dashboards-doesnt-persist-search-terms).