### PR TITLE
Add a `Notification` model

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -6,11 +6,11 @@ from notifications_utils.safe_string import make_string_safe
 from app import (
     api_key_api_client,
     current_service,
-    notification_api_client,
     service_api_client,
 )
 from app.main import main
 from app.main.forms import CallbackForm, CreateKeyForm, GuestList
+from app.models.notification import APINotifications
 from app.notify_client.api_key_api_client import (
     KEY_TYPE_NORMAL,
     KEY_TYPE_TEAM,
@@ -28,7 +28,7 @@ def api_integration(service_id):
     return render_template(
         "views/api/index.html",
         callbacks_link=callbacks_link,
-        api_notifications=notification_api_client.get_api_notifications_for_service(service_id),
+        api_notifications=APINotifications(service_id),
     )
 
 

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -95,11 +95,8 @@ def get_user_number(service_id, notification_id):
 
 def get_sms_thread(service_id, user_number):
     for notification in sorted(
-        (
-            Notifications(service_id, to=user_number, template_type="sms")
-            + InboundSMSMessages(service_id, user_number=user_number)
-        ),
-        key=lambda notification: notification.created_at,
+        Notifications(service_id, to=user_number, template_type="sms")
+        + InboundSMSMessages(service_id, user_number=user_number)
     ):
         is_inbound = isinstance(notification, InboundSMSMessage)
 

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -102,10 +102,6 @@ def get_sms_thread(service_id, user_number):
         key=lambda notification: notification.created_at,
     ):
         is_inbound = isinstance(notification, InboundSMSMessage)
-        redact_personalisation = not is_inbound and notification.template["redact_personalisation"]
-
-        if redact_personalisation:
-            notification.personalisation = {}
 
         yield {
             "inbound": is_inbound,
@@ -116,7 +112,7 @@ def get_sms_thread(service_id, user_number):
                 },
                 notification.personalisation,
                 downgrade_non_sms_characters=(not is_inbound),
-                redact_missing_personalisation=redact_personalisation,
+                redact_missing_personalisation=notification.redact_personalisation,
             ),
             "created_at": notification.created_at,
             "status": notification.status,

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -7,6 +7,7 @@ from notifications_utils.template import SMSPreviewTemplate
 from app import current_service, notification_api_client, service_api_client
 from app.main import json_updates, main
 from app.main.forms import SearchByNameForm
+from app.models.notification import Notifications
 from app.models.template_list import UserTemplateList
 from app.utils.user import user_has_permissions
 
@@ -95,9 +96,8 @@ def get_user_number(service_id, notification_id):
 def get_sms_thread(service_id, user_number):
     for notification in sorted(
         (
-            notification_api_client.get_notifications_for_service(service_id, to=user_number, template_type="sms")[
-                "notifications"
-            ]
+            # Still need to use the `dict` here until we also have a model for inbound messages
+            Notifications(service_id, to=user_number, template_type="sms").items
             + service_api_client.get_inbound_sms(service_id, user_number=user_number)["data"]
         ),
         key=lambda notification: notification["created_at"],

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -5,9 +5,7 @@ from itertools import groupby
 
 from flask import Response, abort, jsonify, render_template, request, session, url_for
 from flask_login import current_user
-from markupsafe import Markup
 from notifications_utils.recipient_validation.phone_number import format_phone_number_human_readable
-from notifications_utils.template import EmailPreviewTemplate, LetterPreviewTemplate, SMSBodyPreviewTemplate
 from werkzeug.utils import redirect
 
 from app import (
@@ -22,6 +20,7 @@ from app.extensions import redis_client
 from app.formatters import format_date_numeric, format_datetime_numeric
 from app.main import json_updates, main
 from app.main.forms import SearchNotificationsForm
+from app.models.notification import Notifications
 from app.statistics_utils import get_formatted_percentage
 from app.utils import (
     DELIVERED_STATUSES,
@@ -242,7 +241,7 @@ def _get_notifications_dashboard_partials_data(service_id, message_type):
     if message_type is not None:
         service_data_retention_days = current_service.get_days_of_retention(message_type)
 
-    notifications = notification_api_client.get_notifications_for_service(
+    notifications = Notifications(
         service_id=service_id,
         page=page,
         template_type=[message_type] if message_type else [],
@@ -257,11 +256,11 @@ def _get_notifications_dashboard_partials_data(service_id, message_type):
     }
     prev_page = None
 
-    if "links" in notifications and notifications["links"].get("prev", None):
+    if notifications.prev:
         prev_page = generate_previous_dict("main.view_notifications", service_id, page, url_args=url_args)
     next_page = None
 
-    if "links" in notifications and notifications["links"].get("next", None):
+    if notifications.next:
         next_page = generate_next_dict("main.view_notifications", service_id, page, url_args)
 
     return {
@@ -278,7 +277,7 @@ def _get_notifications_dashboard_partials_data(service_id, message_type):
         ),
         "notifications": render_template(
             "views/activity/notifications.html",
-            notifications=list(add_preview_of_content_to_notifications(notifications["notifications"])),
+            notifications=notifications,
             limit_days=service_data_retention_days,
             prev_page=prev_page,
             next_page=next_page,
@@ -328,44 +327,6 @@ def get_status_filters(service, message_type, statistics, search_query):
         )
         for key, label, option in filters
     ]
-
-
-def add_preview_of_content_to_notifications(notifications):
-    for notification in notifications:
-        yield dict(preview_of_content=get_preview_of_content(notification), **notification)
-
-
-def get_preview_of_content(notification):
-    if notification["template"].get("redact_personalisation"):
-        notification["personalisation"] = {}
-
-    if notification["template"]["is_precompiled_letter"]:
-        return notification["client_reference"]
-
-    if notification["template"]["template_type"] == "sms":
-        return str(
-            SMSBodyPreviewTemplate(
-                notification["template"],
-                notification["personalisation"],
-            )
-        )
-
-    if notification["template"]["template_type"] == "email":
-        return Markup(
-            EmailPreviewTemplate(
-                notification["template"],
-                notification["personalisation"],
-                redact_missing_personalisation=True,
-            ).subject
-        )
-
-    if notification["template"]["template_type"] == "letter":
-        return Markup(
-            LetterPreviewTemplate(
-                notification["template"],
-                notification["personalisation"],
-            ).subject
-        )
 
 
 @main.route("/services/<uuid:service_id>/usage")

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -20,7 +20,7 @@ from app.extensions import redis_client
 from app.formatters import format_date_numeric, format_datetime_numeric
 from app.main import json_updates, main
 from app.main.forms import SearchNotificationsForm
-from app.models.notification import Notifications
+from app.models.notification import InboundSMSMessages, Notifications
 from app.statistics_utils import get_formatted_percentage
 from app.utils import (
     DELIVERED_STATUSES,
@@ -401,11 +401,11 @@ def inbox_download(service_id):
             ]
             + [
                 [
-                    format_phone_number_human_readable(message["user_number"]),
-                    message["content"].lstrip("=+-@"),
-                    format_datetime_numeric(message["created_at"]),
+                    format_phone_number_human_readable(message.user_number),
+                    message.content.lstrip("=+-@"),
+                    format_datetime_numeric(message.created_at),
                 ]
-                for message in service_api_client.get_inbound_sms(service_id)["data"]
+                for message in InboundSMSMessages(service_id)
             ]
         ).as_csv_data,
         mimetype="text/csv",

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -20,7 +20,6 @@ from app import (
 )
 from app.formatters import get_time_left, message_count_noun
 from app.main import json_updates, main
-from app.main.views.dashboard import add_preview_of_content_to_notifications
 from app.models.job import Job
 from app.s3_client.s3_csv_client import s3download
 from app.utils import parse_filter_args, set_status_filters
@@ -228,7 +227,7 @@ def get_job_partials(job):
             "partials/count.html",
             counts=_get_job_counts(job),
             status=filter_args["status"],
-            notifications_deleted=(job.status == "finished" and not notifications["notifications"]),
+            notifications_deleted=(job.status == "finished" and not notifications),
         )
     service_data_retention_days = current_service.get_days_of_retention(job.template_type)
 
@@ -236,8 +235,8 @@ def get_job_partials(job):
         "counts": counts,
         "notifications": render_template(
             "partials/jobs/notifications.html",
-            notifications=list(add_preview_of_content_to_notifications(notifications["notifications"])),
-            more_than_one_page=bool(notifications.get("links", {}).get("next")),
+            notifications=notifications,
+            more_than_one_page=notifications.next,
             download_link=url_for(
                 "main.view_job_csv", service_id=current_service.id, job_id=job.id, status=request.args.get("status")
             ),

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -24,7 +24,13 @@ class SortingAndEqualityMixin(ABC):
         return f"{self.__class__.__name__}(<{self.id}>)"
 
     def __lt__(self, other):
-        return (getattr(self, self.__sort_attribute__).lower()) < (getattr(other, self.__sort_attribute__).lower())
+        self_attr = getattr(self, self.__sort_attribute__)
+        other_attr = getattr(other, self.__sort_attribute__)
+
+        if isinstance(self_attr, str) and isinstance(other_attr, str):
+            return self_attr.lower() < other_attr.lower()
+
+        return self_attr < other_attr
 
     def __eq__(self, other):
         return self.id == other.id

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -27,7 +27,6 @@ class Notification(JSONModel):
     job_row_number: int
     service: Any
     template_version: int
-    personalisation: dict
     postage: str
     notification_type: str
     reply_to_text: str
@@ -48,10 +47,17 @@ class Notification(JSONModel):
         return self.template["content"]
 
     @property
-    def preview_of_content(self):
-        if self.template.get("redact_personalisation"):
-            self.personalisation = {}
+    def redact_personalisation(self):
+        return self.template.get("redact_personalisation")
 
+    @property
+    def personalisation(self):
+        if self.redact_personalisation:
+            return {}
+        return self._dict["personalisation"]
+
+    @property
+    def preview_of_content(self):
         if self.template["is_precompiled_letter"]:
             return self.client_reference
 
@@ -147,6 +153,7 @@ class InboundSMSMessage(JSONModel):
     __sort_attribute__ = "created_at"
 
     personalisation = None
+    redact_personalisation = False
     status = None
 
 

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -1,0 +1,132 @@
+from datetime import datetime
+from typing import Any
+
+from markupsafe import Markup
+from notifications_utils.template import (
+    EmailPreviewTemplate,
+    LetterPreviewTemplate,
+    SMSBodyPreviewTemplate,
+)
+
+from app.models import JSONModel, ModelList
+from app.notify_client.notification_api_client import notification_api_client
+
+
+class Notification(JSONModel):
+    id: Any
+    to: str
+    recipient: str
+    template: Any
+    job: Any
+    sent_at: datetime
+    created_at: datetime
+    created_by: Any
+    updated_at: datetime
+    row_number: int
+    job_row_number: int
+    service: Any
+    template_version: int
+    personalisation: dict
+    postage: str
+    notification_type: str
+    reply_to_text: str
+    client_reference: str
+    created_by_name: str
+    created_by_email_address: str
+    job_name: str
+    api_key_name: str
+
+    __sort_attribute__ = "created_at"
+
+    @property
+    def status(self):
+        return self._dict["status"]
+
+    @property
+    def preview_of_content(self):
+        if self.template.get("redact_personalisation"):
+            self.personalisation = {}
+
+        if self.template["is_precompiled_letter"]:
+            return self.client_reference
+
+        if self.template["template_type"] == "sms":
+            return str(
+                SMSBodyPreviewTemplate(
+                    self.template,
+                    self.personalisation,
+                )
+            )
+
+        if self.template["template_type"] == "email":
+            return Markup(
+                EmailPreviewTemplate(
+                    self.template,
+                    self.personalisation,
+                    redact_missing_personalisation=True,
+                ).subject
+            )
+
+        if self.template["template_type"] == "letter":
+            return Markup(
+                LetterPreviewTemplate(
+                    self.template,
+                    self.personalisation,
+                ).subject
+            )
+
+
+class APINotification(Notification):
+    key_name: str
+
+    @property
+    def status(self):
+        if self.notification_type == "letter":
+            if self._dict["status"] in ("created", "sending"):
+                return "accepted"
+
+            if self._dict["status"] in ("delivered", "returned-letter"):
+                return "received"
+
+        return self._dict["status"]
+
+
+class Notifications(ModelList):
+    model = Notification
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return notification_api_client.get_notifications_for_service(*args, **kwargs)
+
+    def __init__(self, *args, **kwargs):
+        resp = self._get_items(*args, **kwargs)
+        self.items = resp["notifications"]
+        self.prev = resp.get("links", {}).get("prev", None)
+        self.next = resp.get("links", {}).get("next", None)
+
+
+class NotificationForCSV(Notification):
+    created_at: str  # API returns this field pre-formatted in Europe/London timezone
+    template_name: str
+    template_type: str
+
+
+class NotificationsForCSV(Notifications):
+    model = NotificationForCSV
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return notification_api_client.get_notifications_for_service_for_csv(*args, **kwargs)
+
+
+class APINotifications(Notifications):
+    model = APINotification
+
+    def __init__(self, service_id):
+        super().__init__(
+            service_id,
+            include_jobs=False,
+            include_from_test_key=True,
+            include_one_off=False,
+            count_pages=False,
+        )

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -10,6 +10,7 @@ from notifications_utils.template import (
 
 from app.models import JSONModel, ModelList
 from app.notify_client.notification_api_client import notification_api_client
+from app.notify_client.service_api_client import service_api_client
 
 
 class Notification(JSONModel):
@@ -41,6 +42,10 @@ class Notification(JSONModel):
     @property
     def status(self):
         return self._dict["status"]
+
+    @property
+    def content(self):
+        return self.template["content"]
 
     @property
     def preview_of_content(self):
@@ -130,3 +135,27 @@ class APINotifications(Notifications):
             include_one_off=False,
             count_pages=False,
         )
+
+
+class InboundSMSMessage(JSONModel):
+    user_number: str
+    notify_number: str
+    content: str
+    created_at: datetime
+    id: Any
+
+    __sort_attribute__ = "created_at"
+
+    personalisation = None
+    status = None
+
+
+class InboundSMSMessages(ModelList):
+    model = InboundSMSMessage
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return service_api_client.get_inbound_sms(*args, **kwargs)
+
+    def __init__(self, *args, **kwargs):
+        self.items = self._get_items(*args, **kwargs)["data"]

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -99,23 +99,6 @@ class NotificationApiClient(NotifyAdminAPIClient):
     def get_notification(self, service_id, notification_id):
         return self.get(url=f"/service/{service_id}/notifications/{notification_id}")
 
-    def get_api_notifications_for_service(self, service_id):
-        ret = self.get_notifications_for_service(
-            service_id, include_jobs=False, include_from_test_key=True, include_one_off=False, count_pages=False
-        )
-        return self.map_letters_to_accepted(ret)
-
-    @staticmethod
-    def map_letters_to_accepted(notifications):
-        for notification in notifications["notifications"]:
-            if notification["notification_type"] == "letter":
-                if notification["status"] in ("created", "sending"):
-                    notification["status"] = "accepted"
-
-                if notification["status"] in ("delivered", "returned-letter"):
-                    notification["status"] = "received"
-        return notifications
-
     def get_notification_letter_preview(self, service_id, notification_id, file_type, page=None):
         get_url = "/service/{}/template/preview/{}/{}{}".format(
             service_id, notification_id, file_type, f"?page={page}" if page else ""

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -46,7 +46,7 @@
         {% endif %}
       </div>
     {% endif %}
-    {% for notification in api_notifications.notifications %}
+    {% for notification in api_notifications %}
       {% set summary_html %}
       <h3>
         <span class="api-notifications-item__recipient">
@@ -54,7 +54,7 @@
         </span>
         <span class="govuk-grid-row api-notifications-item__meta">
           <span class="govuk-grid-column-one-half api-notifications-item__meta-key">
-            {{notification.key_name}}
+            {{ notification.key_name }}
           </span>
           <span class="govuk-grid-column-one-half api-notifications-item__meta-time">
             <time class="timeago" datetime="{{ notification.created_at }}">
@@ -87,9 +87,9 @@
         "classes": "api-notifications-item govuk-details govuk-!-margin-bottom-0"
       }) }}
     {% endfor %}
-    {% if api_notifications.notifications %}
+    {% if api_notifications %}
       <div class="api-notifications-item">
-        {% if api_notifications.notifications|length == 50 %}
+        {% if api_notifications|length == 50 %}
           <p class="api-notifications-item__meta">
             Only showing the first 50 messages.
           </p>

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -356,7 +356,7 @@ def test_letters_with_status_virus_scan_failed_shows_a_failure_description(
         is_precompiled_letter=True,
         client_reference="client reference",
     )
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     page = client_request.get(
         "main.view_notifications",
@@ -383,7 +383,7 @@ def test_should_not_show_preview_link_for_precompiled_letters_in_virus_states(
     notifications = create_notifications(
         template_type="letter", status=letter_status, is_precompiled_letter=True, client_reference="ref"
     )
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     page = client_request.get(
         "main.view_notifications",
@@ -714,7 +714,7 @@ def test_html_contains_links_for_failed_notifications(
     mocker,
 ):
     notifications = create_notifications(status="technical-failure")
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     response = client_request.get(
         "main.view_notifications", service_id=SERVICE_ONE_ID, message_type="sms", status="sending%2Cdelivered%2Cfailed"
@@ -758,7 +758,7 @@ def test_redacts_templates_that_should_be_redacted(
         redact_personalisation=True,
         template_type=notification_type,
     )
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     page = client_request.get(
         "main.view_notifications",
@@ -836,7 +836,7 @@ def test_sending_status_hint_displays_correctly_on_notifications_page(
     mocker,
 ):
     notifications = create_notifications(template_type=message_type, status=status)
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     page = client_request.get("main.view_notifications", service_id=service_one["id"], message_type=message_type)
 
@@ -870,7 +870,7 @@ def test_should_show_address_and_hint_for_letters(
         client_reference=expected_hint,
         to=expected_address,
     )
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     page = client_request.get(
         "main.view_notifications",

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -207,7 +207,7 @@ def test_letter_notifications_should_have_link_to_view_letter(
     link_text,
 ):
     notifications = create_notifications(template_type=template_type)
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
     page = client_request.get(
         "main.api_integration",
         service_id=SERVICE_ONE_ID,
@@ -226,7 +226,7 @@ def test_should_not_have_link_to_view_letter_for_precompiled_letters_in_virus_st
     status,
 ):
     notifications = create_notifications(status=status)
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     page = client_request.get(
         "main.api_integration",
@@ -253,7 +253,7 @@ def test_letter_notifications_should_show_client_reference(
     shows_ref,
 ):
     notifications = create_notifications(client_reference=client_reference)
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     page = client_request.get(
         "main.api_integration",

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -84,7 +84,7 @@ def test_view_conversation(
         personalisation={"name": "Jo"},
         redact_personalisation=outbound_redacted,
     )
-    mock = mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mock = mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     page = client_request.get(
         "main.conversation",

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -202,7 +202,7 @@ def test_view_conversation_with_empty_inbound(
     fake_uuid,
 ):
     mock_get_inbound_sms = mocker.patch(
-        "app.main.views.conversation.service_api_client.get_inbound_sms",
+        "app.models.notification.InboundSMSMessages._get_items",
         return_value={
             "has_next": False,
             "data": [

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -459,7 +459,7 @@ def test_download_inbox_strips_formulae(
     mocker,
 ):
     mocker.patch(
-        "app.service_api_client.get_inbound_sms",
+        "app.models.notification.InboundSMSMessages._get_items",
         return_value={
             "has_next": False,
             "data": [

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -304,7 +304,7 @@ def test_should_show_letter_job(
 ):
     notifications = create_notifications(template_type="letter", subject="template subject")
     get_notifications = mocker.patch(
-        "app.notification_api_client.get_notifications_for_service",
+        "app.models.notification.Notifications._get_items",
         return_value=notifications,
     )
 
@@ -360,7 +360,7 @@ def test_should_show_letter_job_with_banner_after_sending_before_1730(
     mocker,
 ):
     mocker.patch(
-        "app.notification_api_client.get_notifications_for_service",
+        "app.models.notification.Notifications._get_items",
         return_value=create_notifications(template_type="letter", postage="second"),
     )
 
@@ -388,7 +388,7 @@ def test_should_show_letter_job_with_banner_when_there_are_multiple_CSV_rows(
     mocker,
 ):
     mocker.patch(
-        "app.notification_api_client.get_notifications_for_service",
+        "app.models.notification.Notifications._get_items",
         return_value=create_notifications(template_type="letter", postage="second"),
     )
 
@@ -415,7 +415,7 @@ def test_should_show_letter_job_with_banner_after_sending_after_1730(
     mocker,
 ):
     mocker.patch(
-        "app.notification_api_client.get_notifications_for_service",
+        "app.models.notification.Notifications._get_items",
         return_value=create_notifications(template_type="letter", postage="second"),
     )
 
@@ -579,7 +579,7 @@ def test_should_cancel_letter_job(
     mocker.patch("app.job_api_client.get_job", side_effect=[{"data": job}])
     notifications_json = notification_json(SERVICE_ONE_ID, job=job, status="created", template_type="letter")
     mocker.patch("app.job_api_client.get_job", side_effect=[{"data": job}])
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications_json)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications_json)
     mocker.patch("app.notification_api_client.get_notification_count_for_job_id", return_value=5)
     mock_cancel = mocker.patch("app.job_api_client.cancel_letter_job", return_value=5)
     client_request.post(
@@ -617,7 +617,7 @@ def test_should_not_show_cancel_link_for_letter_job_if_too_late(
     job = job_json(SERVICE_ONE_ID, active_user_with_permissions, job_id=job_id, created_at=job_created_at)
     notifications_json = notification_json(SERVICE_ONE_ID, job=job, status="created", template_type="letter")
     mocker.patch("app.job_api_client.get_job", side_effect=[{"data": job}])
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications_json)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications_json)
 
     page = client_request.get("main.view_job", service_id=SERVICE_ONE_ID, job_id=str(job_id))
 
@@ -646,7 +646,7 @@ def test_should_show_cancel_link_for_letter_job(
     notifications_json = notification_json(SERVICE_ONE_ID, job=job, status="created", template_type="letter")
     mocker.patch("app.job_api_client.get_job", side_effect=[{"data": job}])
     mocker.patch(
-        "app.notification_api_client.get_notifications_for_service",
+        "app.models.notification.Notifications._get_items",
         return_value=notifications_json,
     )
 
@@ -683,7 +683,7 @@ def test_dont_cancel_letter_job_when_to_early_to_cancel(
     notifications_json = notification_json(
         SERVICE_ONE_ID, job=job, status="created", template_type="letter", rows=number_of_processed_notifications
     )
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications_json)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications_json)
     mocker.patch(
         "app.notification_api_client.get_notification_count_for_job_id", return_value=number_of_processed_notifications
     )
@@ -835,7 +835,7 @@ def test_should_show_letter_job_with_first_class_if_notifications_are_first_clas
     mocker,
 ):
     notifications = create_notifications(template_type="letter", postage="first")
-    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notifications)
 
     page = client_request.get(
         "main.view_job",

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 import pytest
 
+from app.models.notification import APINotifications
 from app.notify_client.notification_api_client import NotificationApiClient
 from tests import notification_json, single_notification_json
 
@@ -178,16 +179,16 @@ def test_get_api_notifications_changes_letter_statuses(mocker, letter_status, ex
     notis = notification_json(service_id=service_id, rows=0)
     notis["notifications"] = [sms_notification, email_notification, letter_notification]
 
-    mocker.patch("app.notify_client.notification_api_client.NotificationApiClient.get", return_value=notis)
+    mocker.patch("app.models.notification.Notifications._get_items", return_value=notis)
 
-    ret = NotificationApiClient(mocker.MagicMock()).get_api_notifications_for_service(service_id)
+    ret = APINotifications(service_id)
 
-    assert ret["notifications"][0]["notification_type"] == "sms"
-    assert ret["notifications"][1]["notification_type"] == "email"
-    assert ret["notifications"][2]["notification_type"] == "letter"
-    assert ret["notifications"][0]["status"] == "created"
-    assert ret["notifications"][1]["status"] == "created"
-    assert ret["notifications"][2]["status"] == expected_status
+    assert ret[0].notification_type == "sms"
+    assert ret[1].notification_type == "email"
+    assert ret[2].notification_type == "letter"
+    assert ret[0].status == "created"
+    assert ret[1].status == "created"
+    assert ret[2].status == expected_status
 
 
 def test_update_notification_to_cancelled(mocker):

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -16,7 +16,7 @@ def _get_notifications_csv(
     template_type="sms",
     job_name="bar.csv",
     status="Delivered",
-    created_at="1943-04-19 12:00:00",
+    created_at="2023-04-19 12:00:00",
     rows=1,
     job_id=fake_uuid,
     created_by_name=None,
@@ -76,7 +76,7 @@ def _get_notifications_csv_mock(
             "my-key-name",
             [
                 "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time,API key name\n",
-                "foo@bar.com,ref 1234,foo,sms,,sender@email.gov.uk,,Delivered,1943-04-19 12:00:00,my-key-name\r\n",
+                "foo@bar.com,ref 1234,foo,sms,,sender@email.gov.uk,,Delivered,2023-04-19 12:00:00,my-key-name\r\n",
             ],
         ),
         (
@@ -84,7 +84,7 @@ def _get_notifications_csv_mock(
             None,
             [
                 "Recipient,Reference,Template,Type,Sent by,Sent by email,Job,Status,Time,API key name\n",
-                "foo@bar.com,ref 1234,foo,sms,Anne Example,sender@email.gov.uk,,Delivered,1943-04-19 12:00:00,\r\n",
+                "foo@bar.com,ref 1234,foo,sms,Anne Example,sender@email.gov.uk,,Delivered,2023-04-19 12:00:00,\r\n",
             ],
         ),
     ],
@@ -126,7 +126,7 @@ def test_generate_notifications_csv_without_job(
             07700900123
         """,
             ["Row number", "phone_number", "Template", "Type", "Job", "Status", "Time"],
-            ["1", "07700900123", "foo", "sms", "bar.csv", "Delivered", "1943-04-19 12:00:00"],
+            ["1", "07700900123", "foo", "sms", "bar.csv", "Delivered", "2023-04-19 12:00:00"],
         ),
         (
             """
@@ -134,7 +134,7 @@ def test_generate_notifications_csv_without_job(
             07700900123,  🐜,🐝,🦀
         """,
             ["Row number", "phone_number", "a", "b", "c", "Template", "Type", "Job", "Status", "Time"],
-            ["1", "07700900123", "🐜", "🐝", "🦀", "foo", "sms", "bar.csv", "Delivered", "1943-04-19 12:00:00"],
+            ["1", "07700900123", "🐜", "🐝", "🦀", "foo", "sms", "bar.csv", "Delivered", "2023-04-19 12:00:00"],
         ),
         (
             """
@@ -142,7 +142,7 @@ def test_generate_notifications_csv_without_job(
             "07700900123","🐜,🐜","🐝,🐝","🦀"
         """,
             ["Row number", "phone_number", "a", "b", "c", "Template", "Type", "Job", "Status", "Time"],
-            ["1", "07700900123", "🐜,🐜", "🐝,🐝", "🦀", "foo", "sms", "bar.csv", "Delivered", "1943-04-19 12:00:00"],
+            ["1", "07700900123", "🐜,🐜", "🐝,🐝", "🦀", "foo", "sms", "bar.csv", "Delivered", "2023-04-19 12:00:00"],
         ),
     ],
 )

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -63,9 +63,7 @@ def _get_notifications_csv_mock(
     mocker,
     api_user_active,
 ):
-    return mocker.patch(
-        "app.notification_api_client.get_notifications_for_service_for_csv", side_effect=_get_notifications_csv()
-    )
+    return mocker.patch("app.models.notification.NotificationsForCSV._get_items", side_effect=_get_notifications_csv())
 
 
 @pytest.mark.parametrize(
@@ -97,7 +95,7 @@ def test_generate_notifications_csv_without_job(
     expected_content,
 ):
     mocker.patch(
-        "app.notification_api_client.get_notifications_for_service_for_csv",
+        "app.models.notification.NotificationsForCSV._get_items",
         side_effect=_get_notifications_csv(
             created_by_name=created_by_name,
             created_by_email_address="sender@email.gov.uk",
@@ -203,7 +201,7 @@ def test_generate_notifications_csv_calls_twice_if_notifications_batch_equals_pa
     response_2 = _get_notifications_csv(rows=3, row_number=8)
 
     mock_get_notifications = mocker.patch(
-        "app.notification_api_client.get_notifications_for_service_for_csv",
+        "app.models.notification.NotificationsForCSV._get_items",
         side_effect=[
             response_1(service_id),
             response_2(service_id),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2079,7 +2079,7 @@ def mock_get_inbound_sms(notify_admin, mocker):
         return inbound_sms_json()
 
     return mocker.patch(
-        "app.service_api_client.get_inbound_sms",
+        "app.models.notification.InboundSMSMessages._get_items",
         side_effect=_get_inbound_sms,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2030,7 +2030,7 @@ def mock_get_notifications(
             created_by_name="Firstname Lastname",
         )
 
-    return mocker.patch("app.notification_api_client.get_notifications_for_service", side_effect=_get_notifications)
+    return mocker.patch("app.models.notification.Notifications._get_items", side_effect=_get_notifications)
 
 
 @pytest.fixture(scope="function")
@@ -2050,7 +2050,7 @@ def mock_get_notifications_with_previous_next(notify_admin, mocker):
     ):
         return notification_json(service_id, rows=50, with_links=True if count_pages is None else count_pages)
 
-    return mocker.patch("app.notification_api_client.get_notifications_for_service", side_effect=_get_notifications)
+    return mocker.patch("app.models.notification.Notifications._get_items", side_effect=_get_notifications)
 
 
 @pytest.fixture(scope="function")
@@ -2070,7 +2070,7 @@ def mock_get_notifications_with_no_notifications(notify_admin, mocker):
     ):
         return notification_json(service_id, rows=0)
 
-    return mocker.patch("app.notification_api_client.get_notifications_for_service", side_effect=_get_notifications)
+    return mocker.patch("app.models.notification.Notifications._get_items", side_effect=_get_notifications)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Best reviewed commit-by-commit.

***

Notifications are one of the last database objects in the admin app that we are still passing around as raw JSON, rather than wrapping them in a proper Python object.

This is a bit fiddly because the fields present are different depending which API endpoint the list of notifications is coming from. So I’ve made multiple models instead of trying to overload one.

I’ve also made a model for inbound text messages, so they can be sorted and combined with outgoing ones.