### PR TITLE
Fix the `Reject the request` text field label and hint text

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2858,7 +2858,7 @@ class UniqueServiceForm(StripWhitespaceForm):
 
 
 class ServiceGoLiveDecisionForm(OnOffSettingForm):
-    rejection_reason = GovukTextareaField("Rejection reason")
+    rejection_reason = GovukTextareaField("Enter the reason for your decision")
 
     def validate(self, *args, **kwargs):
         if self.enabled.data is False:

--- a/app/templates/views/organisations-admin/approve-service-decision.html
+++ b/app/templates/views/organisations-admin/approve-service-decision.html
@@ -31,7 +31,7 @@
             "items": [
               {"disabled": cannot_approve},
               {
-                "hint": {"html": "Enter the reason for your decision. Notify will share this with the person that made the request to go live."},
+                "hint": {"html": "Notify will share this with the person that made the request to go live."},
                 "conditional": { "html": form.rejection_reason(param_extensions={ "label": { "classes": "govuk-visually-hidden" }, "hint": None }) }
               },
             ]


### PR DESCRIPTION
This PR:

* renames the `Reject the request` text field label
* makes the text field label visible
* updates the hint text to remove any repetition

## Why

DAC identified the following issue in the latest WCAG 2.2 audit:

The accessible name of the reason given for rejecting a request to go live doesn't match the text above its textbox in the visual interface.