### PR TITLE
Move guidance pages side nav out of main content

### DIFF
--- a/app/templates/content_template.html
+++ b/app/templates/content_template.html
@@ -1,4 +1,4 @@
-{% extends "withoutnav_template.html" %}
+{% extends "admin_template.html" %}
 
 {% from "components/sub-navigation.html" import sub_navigation %}
 
@@ -6,23 +6,31 @@
   {{ content_page_title }}
 {% endblock %}
 
-{% block maincolumn_content %}
-
-  <div class="govuk-grid-row">
-
-    {% if navigation_links and navigation_label_prefix %}
+{% block main %}
+  <div class="govuk-width-container">
+    {% block beforeContent %}
+      {% if current_service and current_service.active and current_user.is_authenticated and current_user.belongs_to_service(current_service.id) %}
+      <div class="navigation-service">
+        <a href="{{ url_for('main.show_accounts_or_dashboard') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-back-to">Back to {{ current_service.name }}</a>
+      </div>
+      {% endif %}
+      {% block backLink %}{% endblock %}
+    {% endblock %}
+    <div class="govuk-grid-row">
+      {% if navigation_links and navigation_label_prefix %}
       <div class="govuk-grid-column-one-quarter">
         {{ sub_navigation(navigation_links, navigation_label_prefix) }}
       </div>
       <div class="govuk-grid-column-{% if content_column_width %}{{ content_column_width }}{% else %}five-eighths{% endif %}">
-    {% else %}
+      {% else %}
       <div class="govuk-grid-column-two-thirds">
-    {% endif %}
-
-    {% block content_column_content %}
-    {% endblock %}
-
+      {% endif %}
+        <main class="govuk-main-wrapper govuk-!-padding-top-0 govuk-!-padding-bottom-12" id="main-content">
+        {% block content %}
+          {% block content_column_content %}{% endblock %}
+        {% endblock %}
+        </main>
+      </div>
     </div>
   </div>
-
 {% endblock %}


### PR DESCRIPTION
Means using the skiplink will jump you straight to the main content area, as on other pages.

https://trello.com/c/wv0h4he6/966-side-navigation-isnt-bypassed-by-skiplink-on-guidance-pages?filter=label:Sept%202%202024%20accessibility%20audit

This also includes some tidying up of the `content_template.html` code. Details of which are in the commit.