### PR TITLE
feat: Add permission-based filters for platform admins on manage users page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2223,6 +2223,12 @@ class SearchByNameForm(StripWhitespaceForm):
 class SearchUsersForm(StripWhitespaceForm):
     search = GovukSearchField("Search by name or email address")
 
+    permissions_field = GovukCheckboxesField(
+        "Permissions",
+        filters=[partial(filter_by_permissions, permissions=permission_options)],
+        choices=list(permission_options),
+    )
+
 
 class SearchNotificationsForm(StripWhitespaceForm):
     to = GovukSearchField()

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -75,6 +75,16 @@
               {% endif %}
               </span>
             </h2>
+
+            <br>
+              {% if user.logged_in_at %}
+                  <p class="govuk-body">Last logged in
+                      <time class="timeago" datetime="{{ user.logged_in_at }}">
+                          {{ user.logged_in_at|format_delta }}
+                      </time>
+                  </p>
+              {% endif %}
+
             <ul class="tick-cross__list">
               {% for permission, label in permissions %}
                 {{ tick_cross(

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -2,6 +2,8 @@
 {% from "components/tick-cross.html" import tick_cross %}
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/checkboxes/macro.html" import govukCheckboxes %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {% block service_page_title %}
   Team members
@@ -17,6 +19,31 @@
     <div data-notify-module="autofocus">
       {{ live_search(target_selector='.user-list-item', show=True, form=form) }}
     </div>
+
+    {% if current_user.platform_admin %}
+        {% set details_content %}
+            <form method="GET" action="{{ url_for('main.manage_users', service_id=current_service.id) }}">
+                <h2 class="heading-small">Permissions</h2>
+                {{ govukCheckboxes({
+                    'idPrefix': 'permissions',
+                    'name': 'permissions',
+                    'items': [
+                      { 'value': 'manage_service', 'text': 'Manage settings, team and usage' },
+                      { 'value': 'manage_api_keys', 'text': 'Manage API integration' },
+                    ]
+                  }) }}
+                <br>
+                {{ govukButton({ "text": "Apply Filters" }) }}
+            </form>
+        {% endset %}
+
+        {{ govukDetails({
+            "summaryText": "Apply Filters",
+            "html": details_content,
+            "open": form.errors | convert_to_boolean
+          }) }}
+
+    {% endif %}
   {% endif %}
 
   <div class="user-list">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2281,6 +2281,27 @@ def mock_get_invites_without_manage_permission(mocker, service_one, sample_invit
 
 
 @pytest.fixture(scope="function")
+def mock_get_invites_without_permissions(mocker, service_one, sample_invite):
+    def _get_invites(service_id):
+        return [
+            invite_json(
+                id_=str(sample_uuid()),
+                from_user=service_one["users"][0],
+                email_address=f"invited_user_{i}@test.gov.uk",
+                service_id=service_one["id"],
+                permissions="",  # No permissions for the invites
+                created_at=str(datetime.utcnow()),
+                auth_type="sms_auth",
+                folder_permissions=[],
+                status="pending",
+            )
+            for i in range(5)
+        ]
+
+    return mocker.patch("app.models.user.InvitedUsers.client_method", side_effect=_get_invites)
+
+
+@pytest.fixture(scope="function")
 def mock_accept_invite(mocker, sample_invite):
     def _accept(service_id, invite_id):
         return sample_invite


### PR DESCRIPTION
## Summary
- Introduced permission-based filters on the manage users page, visible only to platform admins.
- Platform admins can filter team members by specific permissions, such as "Manage settings, team and usage" and "Manage API integration."
- Updated tests to verify the visibility of the filter section and the "Apply Filters" button for platform admins.
Added asserts to ensure the filter section is hidden for non-platform admins.
- Added Last Login field on each team member


## Task:
[Add a filter/sort by function and 'last logged in' for ‘manage service‘ users on the 'team members' page
](https://trello.com/c/BxoOjSiF/58-add-a-filter-sort-by-function-and-last-logged-in-for-manage-service-users-on-the-team-members-page)


### Manual Testing:
**Default behaviour**
- Less than 7 users on services  = No search box and filters showing
![Screenshot 2024-10-04 at 15 27 13](https://github.com/user-attachments/assets/c08eddf4-0a60-40c7-bfef-3c109c2ddf3c)

**Search box present with no Filters for users who are not platform admins**
![Screenshot 2024-10-04 at 15 29 02](https://github.com/user-attachments/assets/72d30d43-200d-42e7-b265-dadf4ca324b1)

**Filters present for Platform admins**
![Screenshot 2024-10-04 at 15 31 40](https://github.com/user-attachments/assets/eed24d45-efcc-4e9a-a6fb-0ef3d557ab90)

**Last Login details for each member**
![Screenshot 2024-10-08 at 14 30 11](https://github.com/user-attachments/assets/7d85c721-b4f8-420c-9dae-ef518a05caf2)
