### PR TITLE
Update date and style links in accessibility statement

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -12,8 +12,8 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "4 October 2024",
-      "Next review due": "4 December 2024"
+      "Last updated": "7 October 2024",
+      "Next review due": "7 December 2024"
     }
     ) }}
     {# Last non-functional changes: 4 June 2024 #}
@@ -111,22 +111,22 @@
 
   <ol class="govuk-list govuk-list--number">
     <li>
-      The footer containing the ‘New template’ and ‘New Folder’ buttons on the templates page sometimes obscures links or checkboxes in the page when they are tabbed to. This means keyboard-only users can lose sight of what is currently in focus and breaks <a href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">success criterion 2.4.11: focus obscured (minimum)</a>.
+      The footer containing the ‘New template’ and ‘New Folder’ buttons on the templates page sometimes obscures links or checkboxes in the page when they are tabbed to. This means keyboard-only users can lose sight of what is currently in focus and breaks <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html">success criterion 2.4.11: focus obscured (minimum)</a>.
     </li>
     <li>
-      The navigation showing your current organisation and service has visual problems on smaller screens. This makes it hard to use on mobile devices or at 400% zoom on a 1280 pixel screen and breaks <a href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html">success criterion 1.4.10: Reflow</a>.
+      The navigation showing your current organisation and service has visual problems on smaller screens. This makes it hard to use on mobile devices or at 400% zoom on a 1280 pixel screen and breaks <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html">success criterion 1.4.10: Reflow</a>.
     </li>
     <li>
-      Content on the inbox page needs horizontal scrolling on smaller screens. This makes it harder to access on mobile devices or at 400% zoom on a 1280 pixel screen and breaks <a href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html">success criterion 1.4.10: Reflow</a>.
+      Content on the inbox page needs horizontal scrolling on smaller screens. This makes it harder to access on mobile devices or at 400% zoom on a 1280 pixel screen and breaks <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html">success criterion 1.4.10: Reflow</a>.
     </li>
     <li>
-      The design of the letter template page does not work on smaller screens. This makes it harder to access on mobile devices or at 400% zoom on a 1280 pixel screen and breaks <a href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html">success criterion 1.4.10: Reflow</a>.
+      The design of the letter template page does not work on smaller screens. This makes it harder to access on mobile devices or at 400% zoom on a 1280 pixel screen and breaks <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html">success criterion 1.4.10: Reflow</a>.
     </li>
     <li>
-      The page for adding a reply-to email address gives progress updates that are only communicated visually. This is confusing for screen reader users and breaks <a href="https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html">success criterion 4.1.3: Status messages</a>.
+      The page for adding a reply-to email address gives progress updates that are only communicated visually. This is confusing for screen reader users and breaks <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html">success criterion 4.1.3: Status messages</a>.
     </li>
     <li>
-      Links in the text messages shown on the conversation page do not have enough contrast with their background. This makes them harder to read for low vision users and breaks <a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html">success criterion 1.4.3: Contrast (minimum)</a>.
+      Links in the text messages shown on the conversation page do not have enough contrast with their background. This makes them harder to read for low vision users and breaks <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html">success criterion 1.4.3: Contrast (minimum)</a>.
     </li>
   </ol>
 


### PR DESCRIPTION
Add missing `govuk-link` class to links in "Non-accessible content" list and update date to today.

Before

![www notify works_accessibility-statement](https://github.com/user-attachments/assets/da006ff6-78fc-404e-a690-610547aa054c)

After
<img width="681" alt="Screenshot 2024-10-07 at 14 16 36" src="https://github.com/user-attachments/assets/ffcbe68c-1212-4f1c-ad20-bf3bd656a0c7">
