### PR TITLE
Include accessibility statement page in the test_static_pages test

### DIFF
--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -87,6 +87,7 @@ def test_hiding_pages_from_search_engines(
 @pytest.mark.parametrize(
     "view",
     [
+        "accessibility_statement",
         "cookies",
         "guidance_api_documentation",
         "guidance_billing_details",


### PR DESCRIPTION
What

This PR adds a accessibility_statement to the list of static pages to test.

Why

We have a test that [tests for elements without a class](https://github.com/alphagov/notifications-admin/blob/708409d25000e5ff88e7cf8f1455ba2cbadc8bc7/tests/conftest.py#L3101)

This method is part of the `ClientRequest` class in the [client_request method](https://github.com/alphagov/notifications-admin/blob/708409d25000e5ff88e7cf8f1455ba2cbadc8bc7/tests/conftest.py#L2897)

Accessibillity page is very much a static page and we [have a test for them](https://github.com/alphagov/notifications-admin/blob/7a889e2c4de1ec1becba8682a783bdc1d7add8d5/tests/app/main/views/test_index.py#L90-L115) which utilises `client_request` and would have caught the missing class on the `a` tag that was [subsequently fixed](https://github.com/alphagov/notifications-admin/pull/5241)