### PR TITLE
Use returned service ID inside unsubscribe model

### DIFF
--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -79,7 +79,7 @@ def download_unsubscribe_request_report(service_id, batch_id=None):
 @main.route("/services/<uuid:service_id>/unsubscribe-requests/reports/batch-report")
 @user_has_permissions("view_activity", restrict_admin_usage=True)
 def create_unsubscribe_request_report(service_id):
-    created_report_id = current_service.unsubscribe_request_reports_summary.batch_unbatched(service_id)
+    created_report_id = current_service.unsubscribe_request_reports_summary.batch_unbatched()
     return redirect(
         url_for(
             "main.unsubscribe_request_report",

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -10,6 +10,7 @@ from app.utils.time import to_utc_string
 
 
 class UnsubscribeRequestsReport(JSONModel):
+    service_id: Any
     count: int
     batch_id: Any
     is_a_batched_report: bool
@@ -113,10 +114,10 @@ class UnsubscribeRequestsReports(ModelList):
                 return report
         abort(404)
 
-    def batch_unbatched(self, service_id):
+    def batch_unbatched(self):
         unbatched = self.get_unbatched_report()
         created = service_api_client.create_unsubscribe_request_report(
-            service_id,
+            unbatched.service_id,
             {
                 "count": unbatched.count,
                 "earliest_timestamp": to_utc_string(unbatched.earliest_timestamp),

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -16,45 +16,40 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
         (
             # A mixture of reports from different dates
             [
-                create_unsubscribe_request_report(**{
-                    "service_id": SERVICE_ONE_ID,
-                    "count": 1,
-                    "earliest_timestamp": "2024-06-22T15:00:00+00:00",
-                    "latest_timestamp": "2024-06-22T15:00:00+00:00",
-                    "batch_id": "1629dada-9777-4d0a-aa5a-a8b6e3c7ff7b",
-                }),
-                create_unsubscribe_request_report(**{
-                    "service_id": SERVICE_ONE_ID,
-                    "count": 1,
-                    "earliest_timestamp": "2024-06-22T11:00:00+00:00",
-                    "latest_timestamp": "2024-06-22T13:17:00+00:00",
-                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
-                }),
-                create_unsubscribe_request_report(**{
-                    "service_id": SERVICE_ONE_ID,
-                    "count": 34,
-                    "earliest_timestamp": "2024-06-22T10:00:00+00:00",
-                    "latest_timestamp": "2024-06-22T11:00:00+00:00",
-                    "batch_id": "5e2b05ef-7552-49ef-a77f-96d46ab2b9bb",
-                    "is_a_batched_report": True,
-                }),
-                create_unsubscribe_request_report(**{
-                    "service_id": SERVICE_ONE_ID,
-                    "count": 200,
-                    "earliest_timestamp": "2024-06-15T18:00:00+00:00",
-                    "latest_timestamp": "2024-06-21T08:00:00+00:00",
-                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
-                    "is_a_batched_report": True,
-                }),
-                create_unsubscribe_request_report(**{
-                    "service_id": SERVICE_ONE_ID,
-                    "count": 321,
-                    "earliest_timestamp": "2023-12-8T00:00:00+00:00",
-                    "latest_timestamp": "2024-01-14T00:00:00+00:00",
-                    "processed_by_service_at": "2024-06-10T00:00:00+00:00",
-                    "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
-                    "is_a_batched_report": True,
-                }),
+                create_unsubscribe_request_report(
+                    count=1,
+                    earliest_timestamp="2024-06-22T15:00:00+00:00",
+                    latest_timestamp="2024-06-22T15:00:00+00:00",
+                    batch_id="1629dada-9777-4d0a-aa5a-a8b6e3c7ff7b",
+                ),
+                create_unsubscribe_request_report(
+                    count=1,
+                    earliest_timestamp="2024-06-22T11:00:00+00:00",
+                    latest_timestamp="2024-06-22T13:17:00+00:00",
+                    batch_id="af5f5e86-528b-475e-8be1-012988987775",
+                ),
+                create_unsubscribe_request_report(
+                    count=34,
+                    earliest_timestamp="2024-06-22T10:00:00+00:00",
+                    latest_timestamp="2024-06-22T11:00:00+00:00",
+                    batch_id="5e2b05ef-7552-49ef-a77f-96d46ab2b9bb",
+                    is_a_batched_report=True,
+                ),
+                create_unsubscribe_request_report(
+                    count=200,
+                    earliest_timestamp="2024-06-15T18:00:00+00:00",
+                    latest_timestamp="2024-06-21T08:00:00+00:00",
+                    batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
+                    is_a_batched_report=True,
+                ),
+                create_unsubscribe_request_report(
+                    count=321,
+                    earliest_timestamp="2023-12-8T00:00:00+00:00",
+                    latest_timestamp="2024-01-14T00:00:00+00:00",
+                    processed_by_service_at="2024-06-10T00:00:00+00:00",
+                    batch_id="e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
+                    is_a_batched_report=True,
+                ),
             ],
             [
                 "Report Status",
@@ -72,13 +67,13 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
         (
             # A single report spanning a long time period
             [
-                create_unsubscribe_request_report(**{
-                    "service_id": SERVICE_ONE_ID,
-                    "count": 1,
-                    "earliest_timestamp": "2020-01-01T10:00:00+00:00",
-                    "latest_timestamp": "2024-06-01T12:17:00+00:00",
-                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
-                }),
+                create_unsubscribe_request_report(
+                    service_id=SERVICE_ONE_ID,
+                    count=1,
+                    earliest_timestamp="2020-01-01T10:00:00+00:00",
+                    latest_timestamp="2024-06-01T12:17:00+00:00",
+                    batch_id="af5f5e86-528b-475e-8be1-012988987775",
+                ),
             ],
             [
                 "Report Status",
@@ -91,20 +86,20 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
         (
             # Two single requests on the same day
             [
-                create_unsubscribe_request_report(**{
-                    "count": 1,
-                    "earliest_timestamp": "2024-01-01T13:18:00+00:00",
-                    "latest_timestamp": "2024-01-01T13:18:00+00:00",
-                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
-                    "is_a_batched_report": True,
-                }),
-                create_unsubscribe_request_report(**{
-                    "count": 1,
-                    "earliest_timestamp": "2024-01-01T12:17:00+00:00",
-                    "latest_timestamp": "2024-01-01T12:17:00+00:00",
-                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
-                    "is_a_batched_report": True,
-                }),
+                create_unsubscribe_request_report(
+                    count=1,
+                    earliest_timestamp="2024-01-01T13:18:00+00:00",
+                    latest_timestamp="2024-01-01T13:18:00+00:00",
+                    batch_id="af5f5e86-528b-475e-8be1-012988987775",
+                    is_a_batched_report=True,
+                ),
+                create_unsubscribe_request_report(
+                    count=1,
+                    earliest_timestamp="2024-01-01T12:17:00+00:00",
+                    latest_timestamp="2024-01-01T12:17:00+00:00",
+                    batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
+                    is_a_batched_report=True,
+                ),
             ],
             [
                 "Report Status",
@@ -116,22 +111,22 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
         (
             # Two reports with overlapping days
             [
-                create_unsubscribe_request_report(**{
-                    "count": 1,
-                    "earliest_timestamp": "2024-05-01T11:00:00+00:00",
-                    "latest_timestamp": "2024-05-01T13:17:00+00:00",
-                    "processed_by_service_at": "2024-06-22T13:14:00+00:00",
-                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
-                    "is_a_batched_report": True,
-                }),
-                create_unsubscribe_request_report(**{
-                    "count": 12345678,
-                    "earliest_timestamp": "2024-04-30T03:00:00+00:00",
-                    "latest_timestamp": "2024-05-01T09:00:00+00:00",
-                    "processed_by_service_at": "2024-06-22T13:14:00+00:00",
-                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
-                    "is_a_batched_report": True,
-                }),
+                create_unsubscribe_request_report(
+                    count=1,
+                    earliest_timestamp="2024-05-01T11:00:00+00:00",
+                    latest_timestamp="2024-05-01T13:17:00+00:00",
+                    processed_by_service_at="2024-06-22T13:14:00+00:00",
+                    batch_id="af5f5e86-528b-475e-8be1-012988987775",
+                    is_a_batched_report=True,
+                ),
+                create_unsubscribe_request_report(
+                    count=12345678,
+                    earliest_timestamp="2024-04-30T03:00:00+00:00",
+                    latest_timestamp="2024-05-01T09:00:00+00:00",
+                    processed_by_service_at="2024-06-22T13:14:00+00:00",
+                    batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
+                    is_a_batched_report=True,
+                ),
             ],
             [
                 "Report Status",
@@ -143,27 +138,27 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
         (
             # Three reports on independent, consecutive days
             [
-                create_unsubscribe_request_report(**{
-                    "count": 1234,
-                    "earliest_timestamp": "2024-06-22T11:00:00+00:00",
-                    "latest_timestamp": "2024-06-22T13:17:00+00:00",
-                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
-                    "is_a_batched_report": True,
-                }),
-                create_unsubscribe_request_report(**{
-                    "count": 4567,
-                    "earliest_timestamp": "2024-06-21T11:00:00+00:00",
-                    "latest_timestamp": "2024-06-21T13:17:00+00:00",
-                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
-                    "is_a_batched_report": True,
-                }),
-                create_unsubscribe_request_report(**{
-                    "count": 7890,
-                    "earliest_timestamp": "2024-06-20T11:00:00+00:00",
-                    "latest_timestamp": "2024-06-20T13:17:00+00:00",
-                    "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
-                    "is_a_batched_report": True,
-                }),
+                create_unsubscribe_request_report(
+                    count=1234,
+                    earliest_timestamp="2024-06-22T11:00:00+00:00",
+                    latest_timestamp="2024-06-22T13:17:00+00:00",
+                    batch_id="af5f5e86-528b-475e-8be1-012988987775",
+                    is_a_batched_report=True,
+                ),
+                create_unsubscribe_request_report(
+                    count=4567,
+                    earliest_timestamp="2024-06-21T11:00:00+00:00",
+                    latest_timestamp="2024-06-21T13:17:00+00:00",
+                    batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
+                    is_a_batched_report=True,
+                ),
+                create_unsubscribe_request_report(
+                    count=7890,
+                    earliest_timestamp="2024-06-20T11:00:00+00:00",
+                    latest_timestamp="2024-06-20T13:17:00+00:00",
+                    batch_id="e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
+                    is_a_batched_report=True,
+                ),
             ],
             [
                 "Report Status",
@@ -176,27 +171,27 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
         (
             # Three reports on the same day
             [
-                create_unsubscribe_request_report(**{
-                    "count": 1234,
-                    "earliest_timestamp": "2024-06-01T22:22:00+00:00",
-                    "latest_timestamp": "2024-06-01T23:00:00+00:00",
-                    "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
-                    "is_a_batched_report": True,
-                }),
-                create_unsubscribe_request_report(**{
-                    "count": 4567,
-                    "earliest_timestamp": "2024-06-01T13:17:00+00:00",
-                    "latest_timestamp": "2024-06-01T13:18:00+00:00",
-                    "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
-                    "is_a_batched_report": True,
-                }),
-                create_unsubscribe_request_report(**{
-                    "count": 7890,
-                    "earliest_timestamp": "2024-06-01T08:00:00+00:00",
-                    "latest_timestamp": "2024-06-01T11:00:00+00:00",
-                    "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
-                    "is_a_batched_report": True,
-                }),
+                create_unsubscribe_request_report(
+                    count=1234,
+                    earliest_timestamp="2024-06-01T22:22:00+00:00",
+                    latest_timestamp="2024-06-01T23:00:00+00:00",
+                    batch_id="af5f5e86-528b-475e-8be1-012988987775",
+                    is_a_batched_report=True,
+                ),
+                create_unsubscribe_request_report(
+                    count=4567,
+                    earliest_timestamp="2024-06-01T13:17:00+00:00",
+                    latest_timestamp="2024-06-01T13:18:00+00:00",
+                    batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
+                    is_a_batched_report=True,
+                ),
+                create_unsubscribe_request_report(
+                    count=7890,
+                    earliest_timestamp="2024-06-01T08:00:00+00:00",
+                    latest_timestamp="2024-06-01T11:00:00+00:00",
+                    batch_id="e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
+                    is_a_batched_report=True,
+                ),
             ],
             [
                 "Report Status",
@@ -241,14 +236,14 @@ def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocke
 @freeze_time("2024-06-22 12:00")
 def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_request, mocker):
     test_data = [
-        create_unsubscribe_request_report(**{
-            "count": 200,
-            "earliest_timestamp": "2024-06-15",
-            "latest_timestamp": "2024-06-21",
-            "batch_id": "a8a526f9-84be-44a6-b751-62c95c4b9329",
-            "is_a_batched_report": True,
-            "will_be_archived_at": "2024-06-29 23:59",
-        }),
+        create_unsubscribe_request_report(
+            count=200,
+            earliest_timestamp="2024-06-15",
+            latest_timestamp="2024-06-21",
+            batch_id="a8a526f9-84be-44a6-b751-62c95c4b9329",
+            is_a_batched_report=True,
+            will_be_archived_at="2024-06-29 23:59",
+        ),
     ]
 
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
@@ -281,11 +276,11 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
 @freeze_time("2024-07-02")
 def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker):
     test_data = [
-        create_unsubscribe_request_report(**{
-            "count": 34,
-            "earliest_timestamp": "2024-06-22 10:00",
-            "latest_timestamp": "2024-07-01 12:00",
-        }),
+        create_unsubscribe_request_report(
+            count=34,
+            earliest_timestamp="2024-06-22 10:00",
+            latest_timestamp="2024-07-01 12:00",
+        ),
     ]
 
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
@@ -320,15 +315,15 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
 @freeze_time("2024-01-01")
 def test_unsubscribe_request_report_for_processed_batched_reports(client_request, mocker):
     test_data = [
-        create_unsubscribe_request_report(**{
-            "count": 321,
-            "earliest_timestamp": "2023-06-8",
-            "latest_timestamp": "2023-06-14",
-            "processed_by_service_at": "2024-06-10",
-            "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
-            "is_a_batched_report": True,
-            "will_be_archived_at": "2024-01-08 23:00",
-        }),
+        create_unsubscribe_request_report(
+            count=321,
+            earliest_timestamp="2023-06-8",
+            latest_timestamp="2023-06-14",
+            processed_by_service_at="2024-06-10",
+            batch_id="e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
+            is_a_batched_report=True,
+            will_be_archived_at="2024-01-08 23:00",
+        ),
     ]
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
     page = client_request.get(
@@ -363,14 +358,14 @@ def test_unsubscribe_request_report_with_forced_download(
         UnsubscribeRequestsReports,
         "client_method",
         return_value=[
-            create_unsubscribe_request_report(**{
-                "count": 321,
-                "earliest_timestamp": "2023-06-8",
-                "latest_timestamp": "2023-06-14",
-                "batch_id": fake_uuid,
-                "is_a_batched_report": True,
-                "will_be_archived_at": "2024-01-08 23:00",
-            }),
+            create_unsubscribe_request_report(
+                count=321,
+                earliest_timestamp="2023-06-8",
+                latest_timestamp="2023-06-14",
+                batch_id=fake_uuid,
+                is_a_batched_report=True,
+                will_be_archived_at="2024-01-08 23:00",
+            ),
         ],
     )
     page = client_request.get(
@@ -395,11 +390,11 @@ def test_cannot_force_download_for_unbatched_unsubscribe_request_report(
         UnsubscribeRequestsReports,
         "client_method",
         return_value=[
-            create_unsubscribe_request_report(**{
-                "count": 321,
-                "earliest_timestamp": "2023-06-8",
-                "latest_timestamp": "2023-06-14",
-            }),
+            create_unsubscribe_request_report(
+                count=321,
+                earliest_timestamp="2023-06-8",
+                latest_timestamp="2023-06-14",
+            ),
         ],
     )
     page = client_request.get(
@@ -430,13 +425,13 @@ def test_mark_report_as_completed(client_request, mocker, fake_uuid):
         UnsubscribeRequestsReports,
         "client_method",
         return_value=[
-            create_unsubscribe_request_report(**{
-                "count": 321,
-                "earliest_timestamp": "2024-08-06",
-                "latest_timestamp": "2024-08-07",
-                "batch_id": fake_uuid,
-                "is_a_batched_report": True,
-            }),
+            create_unsubscribe_request_report(
+                count=321,
+                earliest_timestamp="2024-08-06",
+                latest_timestamp="2024-08-07",
+                batch_id=fake_uuid,
+                is_a_batched_report=True,
+            ),
         ],
     )
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
@@ -481,11 +476,11 @@ def test_download_unsubscribe_request_report_redirects_to_batch_unsubscribe_requ
 
 def test_create_unsubscribe_request_report_creates_batched_report(client_request, mocker):
     summary_data = [
-        create_unsubscribe_request_report(**{
-            "count": 34,
-            "earliest_timestamp": "2024-07-18T16:32:28.000000Z",
-            "latest_timestamp": "2024-07-20T19:22:11.000000Z",
-        }),
+        create_unsubscribe_request_report(
+            count=34,
+            earliest_timestamp="2024-07-18T16:32:28.000000Z",
+            latest_timestamp="2024-07-20T19:22:11.000000Z",
+        ),
     ]
     test_batch_id = "daaa3f82-faf0-4199-82da-15ec6aa8abe8"
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=summary_data)

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -7,7 +7,7 @@ from notifications_python_client.errors import HTTPError
 
 from app import service_api_client
 from app.models.unsubscribe_requests_report import UnsubscribeRequestsReports
-from tests.conftest import SERVICE_ONE_ID, normalize_spaces
+from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, normalize_spaces
 
 
 @pytest.mark.parametrize(
@@ -16,43 +16,37 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
         (
             # A mixture of reports from different dates
             [
-                {
+                create_unsubscribe_request_report(**{
                     "service_id": SERVICE_ONE_ID,
                     "count": 1,
                     "earliest_timestamp": "2024-06-22T15:00:00+00:00",
                     "latest_timestamp": "2024-06-22T15:00:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "1629dada-9777-4d0a-aa5a-a8b6e3c7ff7b",
-                    "is_a_batched_report": False,
-                },
-                {
+                }),
+                create_unsubscribe_request_report(**{
                     "service_id": SERVICE_ONE_ID,
                     "count": 1,
                     "earliest_timestamp": "2024-06-22T11:00:00+00:00",
                     "latest_timestamp": "2024-06-22T13:17:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
-                    "is_a_batched_report": False,
-                },
-                {
+                }),
+                create_unsubscribe_request_report(**{
                     "service_id": SERVICE_ONE_ID,
                     "count": 34,
                     "earliest_timestamp": "2024-06-22T10:00:00+00:00",
                     "latest_timestamp": "2024-06-22T11:00:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "5e2b05ef-7552-49ef-a77f-96d46ab2b9bb",
                     "is_a_batched_report": True,
-                },
-                {
+                }),
+                create_unsubscribe_request_report(**{
                     "service_id": SERVICE_ONE_ID,
                     "count": 200,
                     "earliest_timestamp": "2024-06-15T18:00:00+00:00",
                     "latest_timestamp": "2024-06-21T08:00:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
                     "is_a_batched_report": True,
-                },
-                {
+                }),
+                create_unsubscribe_request_report(**{
                     "service_id": SERVICE_ONE_ID,
                     "count": 321,
                     "earliest_timestamp": "2023-12-8T00:00:00+00:00",
@@ -60,7 +54,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "processed_by_service_at": "2024-06-10T00:00:00+00:00",
                     "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
                     "is_a_batched_report": True,
-                },
+                }),
             ],
             [
                 "Report Status",
@@ -78,15 +72,13 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
         (
             # A single report spanning a long time period
             [
-                {
+                create_unsubscribe_request_report(**{
                     "service_id": SERVICE_ONE_ID,
                     "count": 1,
                     "earliest_timestamp": "2020-01-01T10:00:00+00:00",
                     "latest_timestamp": "2024-06-01T12:17:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
-                    "is_a_batched_report": False,
-                },
+                }),
             ],
             [
                 "Report Status",
@@ -99,24 +91,20 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
         (
             # Two single requests on the same day
             [
-                {
-                    "service_id": SERVICE_ONE_ID,
+                create_unsubscribe_request_report(**{
                     "count": 1,
                     "earliest_timestamp": "2024-01-01T13:18:00+00:00",
                     "latest_timestamp": "2024-01-01T13:18:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
                     "is_a_batched_report": True,
-                },
-                {
-                    "service_id": SERVICE_ONE_ID,
+                }),
+                create_unsubscribe_request_report(**{
                     "count": 1,
                     "earliest_timestamp": "2024-01-01T12:17:00+00:00",
                     "latest_timestamp": "2024-01-01T12:17:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
                     "is_a_batched_report": True,
-                },
+                }),
             ],
             [
                 "Report Status",
@@ -128,24 +116,22 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
         (
             # Two reports with overlapping days
             [
-                {
-                    "service_id": SERVICE_ONE_ID,
+                create_unsubscribe_request_report(**{
                     "count": 1,
                     "earliest_timestamp": "2024-05-01T11:00:00+00:00",
                     "latest_timestamp": "2024-05-01T13:17:00+00:00",
                     "processed_by_service_at": "2024-06-22T13:14:00+00:00",
                     "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
                     "is_a_batched_report": True,
-                },
-                {
-                    "service_id": SERVICE_ONE_ID,
+                }),
+                create_unsubscribe_request_report(**{
                     "count": 12345678,
                     "earliest_timestamp": "2024-04-30T03:00:00+00:00",
                     "latest_timestamp": "2024-05-01T09:00:00+00:00",
                     "processed_by_service_at": "2024-06-22T13:14:00+00:00",
                     "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
                     "is_a_batched_report": True,
-                },
+                }),
             ],
             [
                 "Report Status",
@@ -157,33 +143,27 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
         (
             # Three reports on independent, consecutive days
             [
-                {
-                    "service_id": SERVICE_ONE_ID,
+                create_unsubscribe_request_report(**{
                     "count": 1234,
                     "earliest_timestamp": "2024-06-22T11:00:00+00:00",
                     "latest_timestamp": "2024-06-22T13:17:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
                     "is_a_batched_report": True,
-                },
-                {
-                    "service_id": SERVICE_ONE_ID,
+                }),
+                create_unsubscribe_request_report(**{
                     "count": 4567,
                     "earliest_timestamp": "2024-06-21T11:00:00+00:00",
                     "latest_timestamp": "2024-06-21T13:17:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
                     "is_a_batched_report": True,
-                },
-                {
-                    "service_id": SERVICE_ONE_ID,
+                }),
+                create_unsubscribe_request_report(**{
                     "count": 7890,
                     "earliest_timestamp": "2024-06-20T11:00:00+00:00",
                     "latest_timestamp": "2024-06-20T13:17:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
                     "is_a_batched_report": True,
-                },
+                }),
             ],
             [
                 "Report Status",
@@ -196,33 +176,27 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
         (
             # Three reports on the same day
             [
-                {
-                    "service_id": SERVICE_ONE_ID,
+                create_unsubscribe_request_report(**{
                     "count": 1234,
                     "earliest_timestamp": "2024-06-01T22:22:00+00:00",
                     "latest_timestamp": "2024-06-01T23:00:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "af5f5e86-528b-475e-8be1-012988987775",
                     "is_a_batched_report": True,
-                },
-                {
-                    "service_id": SERVICE_ONE_ID,
+                }),
+                create_unsubscribe_request_report(**{
                     "count": 4567,
                     "earliest_timestamp": "2024-06-01T13:17:00+00:00",
                     "latest_timestamp": "2024-06-01T13:18:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "c2d11916-ee82-419e-99a8-7e38163e756f",
                     "is_a_batched_report": True,
-                },
-                {
-                    "service_id": SERVICE_ONE_ID,
+                }),
+                create_unsubscribe_request_report(**{
                     "count": 7890,
                     "earliest_timestamp": "2024-06-01T08:00:00+00:00",
                     "latest_timestamp": "2024-06-01T11:00:00+00:00",
-                    "processed_by_service_at": None,
                     "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
                     "is_a_batched_report": True,
-                },
+                }),
             ],
             [
                 "Report Status",
@@ -267,16 +241,14 @@ def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocke
 @freeze_time("2024-06-22 12:00")
 def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_request, mocker):
     test_data = [
-        {
-            "service_id": SERVICE_ONE_ID,
+        create_unsubscribe_request_report(**{
             "count": 200,
             "earliest_timestamp": "2024-06-15",
             "latest_timestamp": "2024-06-21",
-            "processed_by_service_at": None,
             "batch_id": "a8a526f9-84be-44a6-b751-62c95c4b9329",
             "is_a_batched_report": True,
             "will_be_archived_at": "2024-06-29 23:59",
-        }
+        }),
     ]
 
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
@@ -309,15 +281,11 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
 @freeze_time("2024-07-02")
 def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker):
     test_data = [
-        {
-            "service_id": SERVICE_ONE_ID,
+        create_unsubscribe_request_report(**{
             "count": 34,
             "earliest_timestamp": "2024-06-22 10:00",
             "latest_timestamp": "2024-07-01 12:00",
-            "processed_by_service_at": None,
-            "batch_id": None,
-            "is_a_batched_report": False,
-        }
+        }),
     ]
 
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
@@ -352,8 +320,7 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
 @freeze_time("2024-01-01")
 def test_unsubscribe_request_report_for_processed_batched_reports(client_request, mocker):
     test_data = [
-        {
-            "service_id": SERVICE_ONE_ID,
+        create_unsubscribe_request_report(**{
             "count": 321,
             "earliest_timestamp": "2023-06-8",
             "latest_timestamp": "2023-06-14",
@@ -361,7 +328,7 @@ def test_unsubscribe_request_report_for_processed_batched_reports(client_request
             "batch_id": "e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
             "is_a_batched_report": True,
             "will_be_archived_at": "2024-01-08 23:00",
-        },
+        }),
     ]
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=test_data)
     page = client_request.get(
@@ -396,16 +363,14 @@ def test_unsubscribe_request_report_with_forced_download(
         UnsubscribeRequestsReports,
         "client_method",
         return_value=[
-            {
-                "service_id": SERVICE_ONE_ID,
+            create_unsubscribe_request_report(**{
                 "count": 321,
                 "earliest_timestamp": "2023-06-8",
                 "latest_timestamp": "2023-06-14",
-                "processed_by_service_at": None,
                 "batch_id": fake_uuid,
                 "is_a_batched_report": True,
                 "will_be_archived_at": "2024-01-08 23:00",
-            },
+            }),
         ],
     )
     page = client_request.get(
@@ -430,15 +395,11 @@ def test_cannot_force_download_for_unbatched_unsubscribe_request_report(
         UnsubscribeRequestsReports,
         "client_method",
         return_value=[
-            {
-                "service_id": SERVICE_ONE_ID,
+            create_unsubscribe_request_report(**{
                 "count": 321,
                 "earliest_timestamp": "2023-06-8",
                 "latest_timestamp": "2023-06-14",
-                "processed_by_service_at": None,
-                "batch_id": None,
-                "is_a_batched_report": False,
-            },
+            }),
         ],
     )
     page = client_request.get(
@@ -469,15 +430,13 @@ def test_mark_report_as_completed(client_request, mocker, fake_uuid):
         UnsubscribeRequestsReports,
         "client_method",
         return_value=[
-            {
-                "service_id": SERVICE_ONE_ID,
+            create_unsubscribe_request_report(**{
                 "count": 321,
                 "earliest_timestamp": "2024-08-06",
                 "latest_timestamp": "2024-08-07",
-                "processed_by_service_at": None,
                 "batch_id": fake_uuid,
                 "is_a_batched_report": True,
-            },
+            }),
         ],
     )
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
@@ -522,15 +481,11 @@ def test_download_unsubscribe_request_report_redirects_to_batch_unsubscribe_requ
 
 def test_create_unsubscribe_request_report_creates_batched_report(client_request, mocker):
     summary_data = [
-        {
-            "service_id": SERVICE_ONE_ID,
+        create_unsubscribe_request_report(**{
             "count": 34,
             "earliest_timestamp": "2024-07-18T16:32:28.000000Z",
             "latest_timestamp": "2024-07-20T19:22:11.000000Z",
-            "processed_by_service_at": None,
-            "batch_id": None,
-            "is_a_batched_report": False,
-        }
+        }),
     ]
     test_batch_id = "daaa3f82-faf0-4199-82da-15ec6aa8abe8"
     mocker.patch.object(UnsubscribeRequestsReports, "client_method", return_value=summary_data)

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -20,13 +20,13 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     count=1,
                     earliest_timestamp="2024-06-22T15:00:00+00:00",
                     latest_timestamp="2024-06-22T15:00:00+00:00",
-                    batch_id="1629dada-9777-4d0a-aa5a-a8b6e3c7ff7b",
                 ),
                 create_unsubscribe_request_report(
                     count=1,
                     earliest_timestamp="2024-06-22T11:00:00+00:00",
                     latest_timestamp="2024-06-22T13:17:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
+                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=34,
@@ -54,13 +54,12 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
             [
                 "Report Status",
                 "Today at 4:00pm 1 unsubscribe request Not downloaded",
-                "Today from midday to 2:17pm 1 unsubscribe request Not downloaded",
+                "Today from midday to 2:17pm 1 unsubscribe request Downloaded",
                 "Today until midday 34 unsubscribe requests Downloaded",
                 "15 June to yesterday 200 unsubscribe requests Downloaded",
                 "7 December 2023 to 13 January 321 unsubscribe requests Completed",
             ],
             [
-                "Not downloaded",
                 "Not downloaded",
             ],
         ),
@@ -73,15 +72,14 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     earliest_timestamp="2020-01-01T10:00:00+00:00",
                     latest_timestamp="2024-06-01T12:17:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
+                    is_a_batched_report=True,
                 ),
             ],
             [
                 "Report Status",
-                "1 January 2020 to 1 June 1 unsubscribe request Not downloaded",
+                "1 January 2020 to 1 June 1 unsubscribe request Downloaded",
             ],
-            [
-                "Not downloaded",
-            ],
+            [],
         ),
         (
             # Two single requests on the same day

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -26,21 +26,18 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     earliest_timestamp="2024-06-22T11:00:00+00:00",
                     latest_timestamp="2024-06-22T13:17:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
-                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=34,
                     earliest_timestamp="2024-06-22T10:00:00+00:00",
                     latest_timestamp="2024-06-22T11:00:00+00:00",
                     batch_id="5e2b05ef-7552-49ef-a77f-96d46ab2b9bb",
-                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=200,
                     earliest_timestamp="2024-06-15T18:00:00+00:00",
                     latest_timestamp="2024-06-21T08:00:00+00:00",
                     batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
-                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=321,
@@ -48,7 +45,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     latest_timestamp="2024-01-14T00:00:00+00:00",
                     processed_by_service_at="2024-06-10T00:00:00+00:00",
                     batch_id="e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
-                    is_a_batched_report=True,
                 ),
             ],
             [
@@ -72,7 +68,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     earliest_timestamp="2020-01-01T10:00:00+00:00",
                     latest_timestamp="2024-06-01T12:17:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
-                    is_a_batched_report=True,
                 ),
             ],
             [
@@ -89,14 +84,12 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     earliest_timestamp="2024-01-01T13:18:00+00:00",
                     latest_timestamp="2024-01-01T13:18:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
-                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=1,
                     earliest_timestamp="2024-01-01T12:17:00+00:00",
                     latest_timestamp="2024-01-01T12:17:00+00:00",
                     batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
-                    is_a_batched_report=True,
                 ),
             ],
             [
@@ -115,7 +108,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     latest_timestamp="2024-05-01T13:17:00+00:00",
                     processed_by_service_at="2024-06-22T13:14:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
-                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=12345678,
@@ -123,7 +115,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     latest_timestamp="2024-05-01T09:00:00+00:00",
                     processed_by_service_at="2024-06-22T13:14:00+00:00",
                     batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
-                    is_a_batched_report=True,
                 ),
             ],
             [
@@ -141,21 +132,18 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     earliest_timestamp="2024-06-22T11:00:00+00:00",
                     latest_timestamp="2024-06-22T13:17:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
-                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=4567,
                     earliest_timestamp="2024-06-21T11:00:00+00:00",
                     latest_timestamp="2024-06-21T13:17:00+00:00",
                     batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
-                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=7890,
                     earliest_timestamp="2024-06-20T11:00:00+00:00",
                     latest_timestamp="2024-06-20T13:17:00+00:00",
                     batch_id="e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
-                    is_a_batched_report=True,
                 ),
             ],
             [
@@ -174,21 +162,18 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                     earliest_timestamp="2024-06-01T22:22:00+00:00",
                     latest_timestamp="2024-06-01T23:00:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
-                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=4567,
                     earliest_timestamp="2024-06-01T13:17:00+00:00",
                     latest_timestamp="2024-06-01T13:18:00+00:00",
                     batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
-                    is_a_batched_report=True,
                 ),
                 create_unsubscribe_request_report(
                     count=7890,
                     earliest_timestamp="2024-06-01T08:00:00+00:00",
                     latest_timestamp="2024-06-01T11:00:00+00:00",
                     batch_id="e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
-                    is_a_batched_report=True,
                 ),
             ],
             [
@@ -239,7 +224,6 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
             earliest_timestamp="2024-06-15",
             latest_timestamp="2024-06-21",
             batch_id="a8a526f9-84be-44a6-b751-62c95c4b9329",
-            is_a_batched_report=True,
             will_be_archived_at="2024-06-29 23:59",
         ),
     ]
@@ -319,7 +303,6 @@ def test_unsubscribe_request_report_for_processed_batched_reports(client_request
             latest_timestamp="2023-06-14",
             processed_by_service_at="2024-06-10",
             batch_id="e5aed7fe-b649-43b0-9c2b-1cdeb315f724",
-            is_a_batched_report=True,
             will_be_archived_at="2024-01-08 23:00",
         ),
     ]
@@ -361,7 +344,6 @@ def test_unsubscribe_request_report_with_forced_download(
                 earliest_timestamp="2023-06-8",
                 latest_timestamp="2023-06-14",
                 batch_id=fake_uuid,
-                is_a_batched_report=True,
                 will_be_archived_at="2024-01-08 23:00",
             ),
         ],
@@ -428,7 +410,6 @@ def test_mark_report_as_completed(client_request, mocker, fake_uuid):
                 earliest_timestamp="2024-08-06",
                 latest_timestamp="2024-08-07",
                 batch_id=fake_uuid,
-                is_a_batched_report=True,
             ),
         ],
     )

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -17,12 +17,10 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
             # A mixture of reports from different dates
             [
                 create_unsubscribe_request_report(
-                    count=1,
                     earliest_timestamp="2024-06-22T15:00:00+00:00",
                     latest_timestamp="2024-06-22T15:00:00+00:00",
                 ),
                 create_unsubscribe_request_report(
-                    count=1,
                     earliest_timestamp="2024-06-22T11:00:00+00:00",
                     latest_timestamp="2024-06-22T13:17:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
@@ -64,7 +62,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
             [
                 create_unsubscribe_request_report(
                     service_id=SERVICE_ONE_ID,
-                    count=1,
                     earliest_timestamp="2020-01-01T10:00:00+00:00",
                     latest_timestamp="2024-06-01T12:17:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
@@ -80,13 +77,11 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
             # Two single requests on the same day
             [
                 create_unsubscribe_request_report(
-                    count=1,
                     earliest_timestamp="2024-01-01T13:18:00+00:00",
                     latest_timestamp="2024-01-01T13:18:00+00:00",
                     batch_id="af5f5e86-528b-475e-8be1-012988987775",
                 ),
                 create_unsubscribe_request_report(
-                    count=1,
                     earliest_timestamp="2024-01-01T12:17:00+00:00",
                     latest_timestamp="2024-01-01T12:17:00+00:00",
                     batch_id="c2d11916-ee82-419e-99a8-7e38163e756f",
@@ -103,7 +98,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
             # Two reports with overlapping days
             [
                 create_unsubscribe_request_report(
-                    count=1,
                     earliest_timestamp="2024-05-01T11:00:00+00:00",
                     latest_timestamp="2024-05-01T13:17:00+00:00",
                     processed_by_service_at="2024-06-22T13:14:00+00:00",

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -17,6 +17,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             # A mixture of reports from different dates
             [
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 1,
                     "earliest_timestamp": "2024-06-22T15:00:00+00:00",
                     "latest_timestamp": "2024-06-22T15:00:00+00:00",
@@ -25,6 +26,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": False,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 1,
                     "earliest_timestamp": "2024-06-22T11:00:00+00:00",
                     "latest_timestamp": "2024-06-22T13:17:00+00:00",
@@ -33,6 +35,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": False,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 34,
                     "earliest_timestamp": "2024-06-22T10:00:00+00:00",
                     "latest_timestamp": "2024-06-22T11:00:00+00:00",
@@ -41,6 +44,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": True,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 200,
                     "earliest_timestamp": "2024-06-15T18:00:00+00:00",
                     "latest_timestamp": "2024-06-21T08:00:00+00:00",
@@ -49,6 +53,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": True,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 321,
                     "earliest_timestamp": "2023-12-8T00:00:00+00:00",
                     "latest_timestamp": "2024-01-14T00:00:00+00:00",
@@ -74,6 +79,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             # A single report spanning a long time period
             [
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 1,
                     "earliest_timestamp": "2020-01-01T10:00:00+00:00",
                     "latest_timestamp": "2024-06-01T12:17:00+00:00",
@@ -94,6 +100,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             # Two single requests on the same day
             [
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 1,
                     "earliest_timestamp": "2024-01-01T13:18:00+00:00",
                     "latest_timestamp": "2024-01-01T13:18:00+00:00",
@@ -102,6 +109,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": True,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 1,
                     "earliest_timestamp": "2024-01-01T12:17:00+00:00",
                     "latest_timestamp": "2024-01-01T12:17:00+00:00",
@@ -121,6 +129,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             # Two reports with overlapping days
             [
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 1,
                     "earliest_timestamp": "2024-05-01T11:00:00+00:00",
                     "latest_timestamp": "2024-05-01T13:17:00+00:00",
@@ -129,6 +138,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": True,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 12345678,
                     "earliest_timestamp": "2024-04-30T03:00:00+00:00",
                     "latest_timestamp": "2024-05-01T09:00:00+00:00",
@@ -148,6 +158,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             # Three reports on independent, consecutive days
             [
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 1234,
                     "earliest_timestamp": "2024-06-22T11:00:00+00:00",
                     "latest_timestamp": "2024-06-22T13:17:00+00:00",
@@ -156,6 +167,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": True,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 4567,
                     "earliest_timestamp": "2024-06-21T11:00:00+00:00",
                     "latest_timestamp": "2024-06-21T13:17:00+00:00",
@@ -164,6 +176,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": True,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 7890,
                     "earliest_timestamp": "2024-06-20T11:00:00+00:00",
                     "latest_timestamp": "2024-06-20T13:17:00+00:00",
@@ -184,6 +197,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             # Three reports on the same day
             [
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 1234,
                     "earliest_timestamp": "2024-06-01T22:22:00+00:00",
                     "latest_timestamp": "2024-06-01T23:00:00+00:00",
@@ -192,6 +206,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": True,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 4567,
                     "earliest_timestamp": "2024-06-01T13:17:00+00:00",
                     "latest_timestamp": "2024-06-01T13:18:00+00:00",
@@ -200,6 +215,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                     "is_a_batched_report": True,
                 },
                 {
+                    "service_id": SERVICE_ONE_ID,
                     "count": 7890,
                     "earliest_timestamp": "2024-06-01T08:00:00+00:00",
                     "latest_timestamp": "2024-06-01T11:00:00+00:00",
@@ -252,6 +268,7 @@ def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocke
 def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_request, mocker):
     test_data = [
         {
+            "service_id": SERVICE_ONE_ID,
             "count": 200,
             "earliest_timestamp": "2024-06-15",
             "latest_timestamp": "2024-06-21",
@@ -293,6 +310,7 @@ def test_unsubscribe_request_report_for_unprocessed_batched_reports(client_reque
 def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker):
     test_data = [
         {
+            "service_id": SERVICE_ONE_ID,
             "count": 34,
             "earliest_timestamp": "2024-06-22 10:00",
             "latest_timestamp": "2024-07-01 12:00",
@@ -335,6 +353,7 @@ def test_unsubscribe_request_report_for_unbatched_reports(client_request, mocker
 def test_unsubscribe_request_report_for_processed_batched_reports(client_request, mocker):
     test_data = [
         {
+            "service_id": SERVICE_ONE_ID,
             "count": 321,
             "earliest_timestamp": "2023-06-8",
             "latest_timestamp": "2023-06-14",
@@ -378,6 +397,7 @@ def test_unsubscribe_request_report_with_forced_download(
         "client_method",
         return_value=[
             {
+                "service_id": SERVICE_ONE_ID,
                 "count": 321,
                 "earliest_timestamp": "2023-06-8",
                 "latest_timestamp": "2023-06-14",
@@ -411,6 +431,7 @@ def test_cannot_force_download_for_unbatched_unsubscribe_request_report(
         "client_method",
         return_value=[
             {
+                "service_id": SERVICE_ONE_ID,
                 "count": 321,
                 "earliest_timestamp": "2023-06-8",
                 "latest_timestamp": "2023-06-14",
@@ -449,6 +470,7 @@ def test_mark_report_as_completed(client_request, mocker, fake_uuid):
         "client_method",
         return_value=[
             {
+                "service_id": SERVICE_ONE_ID,
                 "count": 321,
                 "earliest_timestamp": "2024-08-06",
                 "latest_timestamp": "2024-08-07",
@@ -501,6 +523,7 @@ def test_download_unsubscribe_request_report_redirects_to_batch_unsubscribe_requ
 def test_create_unsubscribe_request_report_creates_batched_report(client_request, mocker):
     summary_data = [
         {
+            "service_id": SERVICE_ONE_ID,
             "count": 34,
             "earliest_timestamp": "2024-07-18T16:32:28.000000Z",
             "latest_timestamp": "2024-07-20T19:22:11.000000Z",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4230,7 +4230,6 @@ def create_unsubscribe_request_report(
     service_id=SERVICE_ONE_ID,
     processed_by_service_at=None,
     batch_id=None,
-    is_a_batched_report=False,
     will_be_archived_at=None,
     count,
     earliest_timestamp,
@@ -4243,7 +4242,7 @@ def create_unsubscribe_request_report(
         "latest_timestamp": latest_timestamp,
         "processed_by_service_at": processed_by_service_at,
         "batch_id": batch_id,
-        "is_a_batched_report": is_a_batched_report,
+        "is_a_batched_report": bool(batch_id),
         "will_be_archived_at": will_be_archived_at,
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4231,7 +4231,7 @@ def create_unsubscribe_request_report(
     processed_by_service_at=None,
     batch_id=None,
     will_be_archived_at=None,
-    count,
+    count=1,
     earliest_timestamp,
     latest_timestamp,
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4225,6 +4225,29 @@ def create_template(
     )
 
 
+def create_unsubscribe_request_report(
+    *,
+    service_id=SERVICE_ONE_ID,
+    processed_by_service_at=None,
+    batch_id=None,
+    is_a_batched_report=False,
+    will_be_archived_at=None,
+    count,
+    earliest_timestamp,
+    latest_timestamp,
+):
+    return {
+        "service_id": service_id,
+        "count": count,
+        "earliest_timestamp": earliest_timestamp,
+        "latest_timestamp": latest_timestamp,
+        "processed_by_service_at": processed_by_service_at,
+        "batch_id": batch_id,
+        "is_a_batched_report": is_a_batched_report,
+        "will_be_archived_at": will_be_archived_at,
+    }
+
+
 @pytest.fixture
 def mock_get_invited_user_by_id(mocker, sample_invite):
     def _get(invited_user_id):


### PR DESCRIPTION
We won’t ever want to have one service batching up unsubscribe requests for another.

As of https://github.com/alphagov/notifications-api/pull/4191 we are serialising the service ID so the method on the model doesn’t need to take it as an argument any more.

***

I’ve also done a bunch of refactoring of the test data to use a common fixture and be less verbose (see separate commits).