### PR TITLE
application: use `EventletTimeoutMiddleware` if using eventlet

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,6 +24,7 @@ from itsdangerous import BadSignature
 from notifications_python_client.errors import HTTPError
 from notifications_utils import logging, request_helper
 from notifications_utils.asset_fingerprinter import asset_fingerprinter
+from notifications_utils.eventlet import EventletTimeout
 from notifications_utils.formatters import (
     formatted_list,
     get_lines_with_normalised_whitespace,
@@ -494,6 +495,11 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
         if current_app.config.get("DEBUG", None):
             raise error
         return _error_response(500)
+
+    @application.errorhandler(EventletTimeout)
+    def eventlet_timeout(error):
+        application.logger.exception(error)
+        return _error_response(504, error_page_template=500)
 
 
 def setup_blueprints(application):

--- a/application.py
+++ b/application.py
@@ -5,6 +5,11 @@ init_performance_monitoring()
 from flask import Flask  # noqa
 from app import create_app  # noqa
 
+from notifications_utils.eventlet import EventletTimeoutMiddleware, using_eventlet  # noqa
+
 application = Flask("app")
 
 create_app(application)
+
+if using_eventlet:
+    application = EventletTimeoutMiddleware(application, timeout_seconds=60)


### PR DESCRIPTION
Also catch `EventletTimeout` exceptions, turning these into 504s, which are the closest thing to an application timeout standard codes seem to cover.

60s timeout to start with as this matches our cloudfront/ALB timeouts and so should present the same behaviour to users.

In `EventletTimeoutMiddleware`'s current implementation, the timeout gets cancelled as soon as the initial status response is returned, so streaming responses shouldn't be affected any more than normal responses.

See https://github.com/alphagov/notifications-api/pull/4209 for the same addition to the api

Successfully tested on dev-a https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/45.