### PR TITLE
Approver service join request approver page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1031,6 +1031,18 @@ class PermissionsForm(StripWhitespaceForm):
         return form
 
 
+class JoinServiceRequestApproveForm(StripWhitespaceForm):
+    join_service_approval_request = GovukRadiosField(
+        "",
+        choices=[
+            ("approved", "Yes"),
+            ("rejected", "No"),
+        ],
+        thing="one option",
+        param_extensions={"fieldset": {"legend": {"classes": ""}}},
+    )
+
+
 class OrganisationUserPermissionsForm(StripWhitespaceForm):
     permissions_field = GovukCheckboxesField(
         "Permissions",

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1032,14 +1032,15 @@ class PermissionsForm(StripWhitespaceForm):
 
 
 class JoinServiceRequestApproveForm(StripWhitespaceForm):
-    join_service_approval_request = GovukRadiosField(
+    join_service_approve_request = GovukRadiosField(
         "",
         choices=[
             ("approved", "Yes"),
             ("rejected", "No"),
         ],
-        thing="one option",
+        thing="an option",
         param_extensions={"fieldset": {"legend": {"classes": ""}}},
+        default="approved",
     )
 
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -104,6 +104,9 @@ def service_join_request_manage(service_id, request_id):
     request_changed_by = service_join_request.status_changed_by
     requested_service = service_api_client.get_service(service_join_request.service_id)
 
+    if current_user.id not in service_join_request.contacted_service_users:
+        abort(403)
+
     if service_join_request.is_approved:
         return render_template(
             "views/service-join-request-already-approved.html",

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -119,6 +119,11 @@ def service_join_request_manage(service_id, request_id):
             requested_by=requested_by,
             rejected_at=service_join_request.created_at,
         )
+    if service_id in requested_by["belongs_to_service"]:
+        return render_template(
+            "views/service-join-request-user-already-joined.html",
+            user_to_invite=requested_by,
+        )
 
     return render_template(
         "views/join-service-request-approver.html",

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -19,7 +19,7 @@ from app.main.forms import (
     PermissionsForm,
     SearchUsersForm,
 )
-from app.models.service import ServiceJoinRequest
+from app.models.service import Service, ServiceJoinRequest
 from app.models.user import InvitedUser, User
 from app.utils.user import is_gov_user, user_has_permissions
 from app.utils.user_permissions import permission_options
@@ -96,13 +96,13 @@ def invite_user(service_id, user_id=None):
 
 @main.route("/services/<uuid:service_id>/join-request/<uuid:request_id>/approve", methods=["GET", "POST"])
 @user_has_permissions("manage_service")
-def service_join_request_manage(service_id, request_id):
+def service_join_request_approve(service_id, request_id):
     form = JoinServiceRequestApproveForm()
 
     service_join_request = ServiceJoinRequest.from_id(request_id)
     requested_by = service_join_request.requester
     request_changed_by = service_join_request.status_changed_by
-    requested_service = service_api_client.get_service(service_join_request.service_id)
+    requested_service = Service.from_id(service_join_request.service_id)
 
     if current_user.id not in service_join_request.contacted_service_users:
         abort(403)
@@ -129,14 +129,14 @@ def service_join_request_manage(service_id, request_id):
         )
 
     # if form.validate_on_submit():
-    # (form.join_service_approval_request.data)
+    # (form.join_service_approve_request.data)
     # Once permissions/reject template created, redirect from here
 
     return render_template(
         "views/join-service-request-approver.html",
         form=form,
-        mobile_number=True,
         requester=requested_by,
+        requested_service=requested_service,
         error_summary_enabled=True,
     )
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -15,9 +15,11 @@ from app.main.forms import (
     ChangeMobileNumberForm,
     ChangeNonGovEmailForm,
     InviteUserForm,
+    JoinServiceRequestApproveForm,
     PermissionsForm,
     SearchUsersForm,
 )
+from app.models.service import ServiceJoinRequest
 from app.models.user import InvitedUser, User
 from app.utils.user import is_gov_user, user_has_permissions
 from app.utils.user_permissions import permission_options
@@ -88,6 +90,23 @@ def invite_user(service_id, user_id=None):
         form=form,
         mobile_number=True,
         user_to_invite=user_to_invite,
+        error_summary_enabled=True,
+    )
+
+
+@main.route("/services/<uuid:service_id>/join-request/<uuid:request_id>/approve", methods=["GET", "POST"])
+@user_has_permissions("manage_service")
+def service_join_request_manage(service_id, request_id):
+    form = JoinServiceRequestApproveForm()
+
+    service_join_request = ServiceJoinRequest.from_id(request_id)
+    requested_by = service_join_request.requester
+
+    return render_template(
+        "views/join-service-request-approver.html",
+        form=form,
+        mobile_number=True,
+        requester=requested_by,
         error_summary_enabled=True,
     )
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -101,6 +101,17 @@ def service_join_request_manage(service_id, request_id):
 
     service_join_request = ServiceJoinRequest.from_id(request_id)
     requested_by = service_join_request.requester
+    request_changed_by = service_join_request.status_changed_by
+    requested_service = service_api_client.get_service(service_join_request.service_id)
+
+    if service_join_request.is_approved:
+        return render_template(
+            "views/service-join-request-already-approved.html",
+            approved_by=request_changed_by,
+            requested_by=requested_by,
+            approved_at=service_join_request.created_at,
+            requested_service=requested_service,
+        )
 
     return render_template(
         "views/join-service-request-approver.html",

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -112,6 +112,13 @@ def service_join_request_manage(service_id, request_id):
             approved_at=service_join_request.created_at,
             requested_service=requested_service,
         )
+    if service_join_request.is_rejected:
+        return render_template(
+            "views/service-join-request-rejected.html",
+            rejected_by=request_changed_by,
+            requested_by=requested_by,
+            rejected_at=service_join_request.created_at,
+        )
 
     return render_template(
         "views/join-service-request-approver.html",

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -112,7 +112,7 @@ def service_join_request_manage(service_id, request_id):
             "views/service-join-request-already-approved.html",
             approved_by=request_changed_by,
             requested_by=requested_by,
-            approved_at=service_join_request.created_at,
+            approved_at=service_join_request.status_changed_at,
             requested_service=requested_service,
         )
     if service_join_request.is_rejected:
@@ -120,13 +120,17 @@ def service_join_request_manage(service_id, request_id):
             "views/service-join-request-rejected.html",
             rejected_by=request_changed_by,
             requested_by=requested_by,
-            rejected_at=service_join_request.created_at,
+            rejected_at=service_join_request.status_changed_at,
         )
     if service_id in requested_by["belongs_to_service"]:
         return render_template(
             "views/service-join-request-user-already-joined.html",
             user_to_invite=requested_by,
         )
+
+    # if form.validate_on_submit():
+    # (form.join_service_approval_request.data)
+    # Once permissions/reject template created, redirect from here
 
     return render_template(
         "views/join-service-request-approver.html",

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -638,3 +638,34 @@ class Service(JSONModel):
 
 class Services(SerialisedModelCollection):
     model = Service
+
+
+class ServiceJoinRequest(JSONModel):
+    service_join_request_id: Any
+    requester: Any
+    service_id: Any
+    created_at: datetime
+    status_changed_at: datetime
+    status_changed_by: Any
+    reason: str
+    status: str
+    contacted_service_users: list[str]
+    requested_service: Any
+
+    __sort_attribute__ = "id"
+
+    @property
+    def is_pending(self):
+        return self.status == "pending"
+
+    @property
+    def is_approved(self):
+        return self.status == "approved"
+
+    @property
+    def is_rejected(self):
+        return self.status == "rejected"
+
+    @classmethod
+    def from_id(cls, request_id):
+        return cls(service_api_client.get_service_join_requests(request_id))

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -542,5 +542,8 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
         return None
 
+    def get_service_join_requests(self, request_id):
+        return self.get(f"/service/service-join-request/{request_id}")
+
 
 service_api_client = ServiceAPIClient()

--- a/app/templates/views/join-service-request-approver.html
+++ b/app/templates/views/join-service-request-approver.html
@@ -1,0 +1,21 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+
+{% block service_page_title %}
+  {{ '{} wants to join your service'.format(requester.name) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header('{} wants to join your service'.format(requester.name)) }}
+
+  {% call form_wrapper() %}
+    {{ form.join_service_approval_request }}
+
+    {{ page_footer('Confirm') }}
+
+  {% endcall %}
+
+{% endblock %}

--- a/app/templates/views/join-service-request-approver.html
+++ b/app/templates/views/join-service-request-approver.html
@@ -12,9 +12,14 @@
   {{ page_header('{} wants to join your service'.format(requester.name)) }}
 
   {% call form_wrapper() %}
-    {{ form.join_service_approval_request }}
-
-    {{ page_footer('Confirm') }}
+    {{ form.join_service_approve_request(param_extensions={
+      "fieldset": {
+        "legend": {
+          "text": "Do you want to let {} join ‘{}’?".format(requester.name, requested_service.name),
+        },
+      },
+    }) }}
+    {{ page_footer('Continue') }}
 
   {% endcall %}
 

--- a/app/templates/views/service-join-request-already-approved.html
+++ b/app/templates/views/service-join-request-already-approved.html
@@ -1,0 +1,18 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+
+{% block service_page_title %}
+  {{ requested_by.name }} has already joined your service
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header('{} has already joined your service'.format(requested_by.name)) }}
+
+  <p class="govuk-body">
+    {{ approved_by.name }} approved their request on {{ approved_at|format_date_short }}.
+  </p>
+
+  <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_account') }}">Back to your services</a>
+
+{% endblock %}

--- a/app/templates/views/service-join-request-already-approved.html
+++ b/app/templates/views/service-join-request-already-approved.html
@@ -10,7 +10,7 @@
   {{ page_header('{} has already joined your service'.format(requested_by.name)) }}
 
   <p class="govuk-body">
-    {{ approved_by.name }} approved their request on {{ approved_at|format_date_short }}.
+    {{ approved_by.name }} approved this request on {{ approved_at|format_date_short }}.
   </p>
 
   <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_account') }}">Back to your services</a>

--- a/app/templates/views/service-join-request-rejected.html
+++ b/app/templates/views/service-join-request-rejected.html
@@ -1,0 +1,18 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+
+{% block service_page_title %}
+  You cannot let {{requested_by.name}} join your service
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header('You cannot let {} join your service'.format(requested_by.name)) }}
+
+  <p class="govuk-body">
+    {{ rejected_by.name }} already refused their request on {{ rejected_at|format_date_short }}.
+  </p>
+
+  <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_account') }}">Back to your services</a>
+
+{% endblock %}

--- a/app/templates/views/service-join-request-rejected.html
+++ b/app/templates/views/service-join-request-rejected.html
@@ -10,7 +10,7 @@
   {{ page_header('You cannot let {} join your service'.format(requested_by.name)) }}
 
   <p class="govuk-body">
-    {{ rejected_by.name }} already refused their request on {{ rejected_at|format_date_short }}.
+    {{ rejected_by.name }} already refused this request on {{ rejected_at|format_date_short }}.
   </p>
 
   <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_account') }}">Back to your services</a>

--- a/app/templates/views/service-join-request-user-already-joined.html
+++ b/app/templates/views/service-join-request-user-already-joined.html
@@ -10,7 +10,7 @@
   {{ page_header('This person is already a team member') }}
 
   <p class="govuk-body">
-    {{ user_to_invite.name }} is already member of '{{ current_service.name }}'.
+    {{ user_to_invite.name }} is already member of ‘{{ current_service.name }}‘.
   </p>
 
   <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_account') }}">Back to your services</a>

--- a/app/templates/views/service-join-request-user-already-joined.html
+++ b/app/templates/views/service-join-request-user-already-joined.html
@@ -1,0 +1,18 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+
+{% block service_page_title %}
+  This person is already a team member
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header('This person is already a team member') }}
+
+  <p class="govuk-body">
+    {{ user_to_invite.name }} is already member of '{{ current_service.name }}'.
+  </p>
+
+  <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_account') }}">Back to your services</a>
+
+{% endblock %}

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -2034,7 +2034,7 @@ def test_service_join_request_already_joined(
     )
     assert "This person is already a team member" in page.text.strip()
     assert "This person is already a team member" in page.select_one("h1").text.strip()
-    assert "Test User With Empty Permissions is already member of ‘service one‘" in page.select_one("p").text.strip()
+    assert "Test User With Empty Permissions is already member of ‘service one‘." in page.select_one("p").text.strip()
 
 
 def test_service_join_request_should_return_403_when_approver_is_not_logged_in_user(

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -170,6 +170,7 @@ EXCLUDED_ENDPOINTS = set(
             "index",
             "invite_org_user",
             "invite_user",
+            "service_join_request_manage",
             "json_updates.conversation_updates",
             "json_updates.get_notifications_page_partials_as_json",
             "json_updates.inbox_updates",

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -170,7 +170,7 @@ EXCLUDED_ENDPOINTS = set(
             "index",
             "invite_org_user",
             "invite_user",
-            "service_join_request_manage",
+            "service_join_request_approve",
             "json_updates.conversation_updates",
             "json_updates.get_notifications_page_partials_as_json",
             "json_updates.inbox_updates",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -176,7 +176,7 @@
     "/services/<uuid:service_id>/jobs/<uuid:job_id>.json",
     "/services/<uuid:service_id>/jobs/<uuid:job_id>/cancel",
     "/services/<uuid:service_id>/jobs/<uuid:job_id>/original.csv",
-    "/services/<uuid:service_id>/join-request/<uuid:request_id>",
+    "/services/<uuid:service_id>/join-request/<uuid:request_id>/approve",
     "/services/<uuid:service_id>/make-service-live",
     "/services/<uuid:service_id>/make-service-live/contact-user",
     "/services/<uuid:service_id>/make-service-live/decision",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -176,6 +176,7 @@
     "/services/<uuid:service_id>/jobs/<uuid:job_id>.json",
     "/services/<uuid:service_id>/jobs/<uuid:job_id>/cancel",
     "/services/<uuid:service_id>/jobs/<uuid:job_id>/original.csv",
+    "/services/<uuid:service_id>/join-request/<uuid:request_id>",
     "/services/<uuid:service_id>/make-service-live",
     "/services/<uuid:service_id>/make-service-live/contact-user",
     "/services/<uuid:service_id>/make-service-live/decision",


### PR DESCRIPTION
When approver gets service-join-request, they would approver page or request status page. More details on [this card](https://trello.com/c/pQovKftH/976-create-new-approver-flow-for-request-to-join-a-service).

Request approve page:
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/4f8e73bb-268e-479a-9c38-1ab178ce6604">

Request approved page:
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/6f49262b-8f76-43fd-a5fa-29c0320f9f30">

Request refused page:
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/1becd049-3f9c-40fa-9c9f-24b9cf54b8b4">


Requester already member:
<img width="1243" alt="image" src="https://github.com/user-attachments/assets/7cd01cae-cd78-4d41-8129-fa37b9c28add">
