### PR TITLE
Adjust link text colour in inbound text messages

### DIFF
--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -44,6 +44,10 @@ $tail-angle: 20deg;
       transform: rotate(-$tail-angle);
     }
 
+    .govuk-link {
+      color: $link-colour-on-grey-background;
+    }
+
   }
 
 }

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -3,6 +3,12 @@
 $notify-secondary-button-colour: govuk-shade(govuk-colour("light-grey"), 7%);
 $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 18%);
 
+// adjusted link colour on grey to satisfy WCAG criterion
+// on govuk-shade(govuk-colour("light-grey"), 7%) this 
+// now has a contrast ratio of 5.67
+// this HEX is lighter than $govuk-link-hover-colour
+$link-colour-on-grey-background: #1852ab;
+
 // Additional padding-bottom override, following the GOV.UK Frontend spacing scale:
 // https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale
 .govuk-\!-padding-bottom-12 {


### PR DESCRIPTION
## What 
Introduce a variable for a slightly darker blue shade of the link colour. This has a bigger contrast ratio on a grey background, satisfying minimum contrast ratio required by WCAG.

This fixes an issue with links on inbound message conversations.

Fixes https://trello.com/c/v4f15js9/996-links-in-messages-on-the-conversation-page-dont-have-enough-contrast-with-their-background

## Visual change
Link 1 - current colour
Link 2 - new colour
![image](https://github.com/user-attachments/assets/9f288d6b-faa1-432e-9c0c-f2e452767d04)
