### PR TITLE
`EventletTimeoutMiddleware`: wrap `application.wsgi_app`, get value from env var

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,3 +1,5 @@
+import os
+
 from app.performance import init_performance_monitoring
 
 init_performance_monitoring()
@@ -12,4 +14,7 @@ application = Flask("app")
 create_app(application)
 
 if using_eventlet:
-    application = EventletTimeoutMiddleware(application, timeout_seconds=60)
+    application.wsgi_app = EventletTimeoutMiddleware(
+        application.wsgi_app,
+        timeout_seconds=int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30)),
+    )

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,9 +1,11 @@
+import os
+
 from gds_metrics.gunicorn import child_exit  # noqa
 from notifications_utils.gunicorn_defaults import set_gunicorn_defaults
-
 
 set_gunicorn_defaults(globals())
 
 workers = 5
 worker_class = "eventlet"
 keepalive = 90
+timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class


### PR DESCRIPTION
Wrapping `application.wsgi_app` is more correct than wrapping `application` itself, as it preserves flasky behaviours of the outer `application` object.

Also control the timeout time with a `HTTP_SERVE_TIMEOUT_SECONDS` config/env var that we can control from e.g. terraform, unifying this with the value we use for gunicorn's `timeout` (which has little effect on the eventlet `worker_class`, but controls a similar behaviour on non-async workers), with the intention we start to respect this across all our apps.

Also default to 30s is what we've decided to set our cloudfront timeouts to.

See also https://github.com/alphagov/notifications-api/pull/4219

Passes dev-a @ https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/53