### PR TITLE
Don’t let non-team-members create unsubscribe request reports

### DIFF
--- a/app/main/views/unsubscribe_requests.py
+++ b/app/main/views/unsubscribe_requests.py
@@ -77,7 +77,7 @@ def download_unsubscribe_request_report(service_id, batch_id=None):
 
 
 @main.route("/services/<uuid:service_id>/unsubscribe-requests/reports/batch-report")
-@user_has_permissions("view_activity")
+@user_has_permissions("view_activity", restrict_admin_usage=True)
 def create_unsubscribe_request_report(service_id):
     created_report_id = current_service.unsubscribe_request_reports_summary.batch_unbatched(service_id)
     return redirect(

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -534,6 +534,19 @@ def test_create_unsubscribe_request_report_creates_batched_report(client_request
     )
 
 
+def test_create_unsubscribe_request_report_blocks_platform_admin(
+    client_request,
+    platform_admin_user,
+    fake_uuid,
+):
+    client_request.login(platform_admin_user)
+    client_request.get(
+        "main.create_unsubscribe_request_report",
+        service_id=fake_uuid,
+        _expected_status=403,
+    )
+
+
 def test_download_unsubscribe_request_report(client_request, mocker):
     report_data = {
         "batch_id": "3d466625-6ea4-414f-ac48-add30d895c43",


### PR DESCRIPTION
We let platform admins do almost anything a regular user who is a member of a team can do.

However it would be bad if a platform admin, when clicking around, created an unsubscribe request report for a team they are not a member of because:
- it’s not reversible
- it triggers the 7 day deletion countdown