### PR TITLE
Check for non-smart quotes when testing pages

### DIFF
--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -152,7 +152,7 @@
     London SW1A 2AS
     </p>
 
-    <p class="govuk-body">If you have a complaint, you can also contact the <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/">Information Commissioner's Office</a> (ICO). The ICO is an independent regulator set up to uphold information rights.</p>
+    <p class="govuk-body">If you have a complaint, you can also contact the <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/">Information Commissioner’s Office</a> (ICO). The ICO is an independent regulator set up to uphold information rights.</p>
 
     <p class="govuk-body">
     Information Commissioner’s Office<br>

--- a/app/templates/views/service-settings/set-auth-type-for-users.html
+++ b/app/templates/views/service-settings/set-auth-type-for-users.html
@@ -35,7 +35,7 @@
         }}
 
         <p class="govuk-body">
-        If you need to change someone's sign-in method later, go to the team members page.
+        If you need to change someone’s sign-in method later, go to the team members page.
         </p>
 
         <div class="js-stick-at-bottom-when-scrolling">

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -209,31 +209,32 @@ def test_register_with_existing_email_sends_emails(
 
 
 @pytest.mark.parametrize(
-    "email_address, expected_value",
+    "email_address, expected_value, extra_args",
     [
-        ("first.last@example.com", "First Last"),
-        ("first.middle.last@example.com", "First Middle Last"),
-        ("first.m.last@example.com", "First Last"),
-        ("first.last-last@example.com", "First Last-Last"),
-        ("first.o'last@example.com", "First O’Last"),
-        ("first.last+testing@example.com", "First Last"),
-        ("first.last+testing+testing@example.com", "First Last"),
-        ("first.last6@example.com", "First Last"),
-        ("first.last.212@example.com", "First Last"),
-        ("first.2.last@example.com", "First Last"),
-        ("first.2b.last@example.com", "First Last"),
-        ("first.1.2.3.last@example.com", "First Last"),
-        ("first.last.1.2.3@example.com", "First Last"),
+        ("first.last@example.com", "First Last", {}),
+        ("first.middle.last@example.com", "First Middle Last", {}),
+        ("first.m.last@example.com", "First Last", {}),
+        ("first.last-last@example.com", "First Last-Last", {}),
+        ("first.o'last@example.com", "First O’Last", {"_test_for_non_smart_quotes": False}),
+        ("first.last+testing@example.com", "First Last", {}),
+        ("first.last+testing+testing@example.com", "First Last", {}),
+        ("first.last6@example.com", "First Last", {}),
+        ("first.last.212@example.com", "First Last", {}),
+        ("first.2.last@example.com", "First Last", {}),
+        ("first.2b.last@example.com", "First Last", {}),
+        ("first.1.2.3.last@example.com", "First Last", {}),
+        ("first.last.1.2.3@example.com", "First Last", {}),
         # Instances where we can’t make a good-enough guess:
-        ("example123@example.com", None),
-        ("f.last@example.com", None),
-        ("f.m.last@example.com", None),
+        ("example123@example.com", None, {}),
+        ("f.last@example.com", None, {}),
+        ("f.m.last@example.com", None, {}),
     ],
 )
 def test_shows_name_on_registration_page_from_invite(
     client_request,
     email_address,
     expected_value,
+    extra_args,
     sample_invite,
     mock_get_invited_user_by_id,
 ):
@@ -241,7 +242,10 @@ def test_shows_name_on_registration_page_from_invite(
     with client_request.session_transaction() as session:
         session["invited_user_id"] = sample_invite
 
-    page = client_request.get("main.register_from_invite")
+    page = client_request.get(
+        "main.register_from_invite",
+        **extra_args,
+    )
     assert page.select_one("input[name=name]").get("value") == expected_value
 
 
@@ -303,7 +307,7 @@ def test_register_from_invite(
             service=sample_invite["service"],
             password="somreallyhardthingtoguess",
             auth_type="sms_auth",
-            **extra_data
+            **extra_data,
         ),
         _expected_redirect=url_for("main.verify"),
     )

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -1659,7 +1659,13 @@ def test_should_filter_templates_folder_page_based_on_user_permissions(
         },
     )
 
-    page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID, _test_page_title=False, **extra_args)
+    page = client_request.get(
+        "main.choose_template",
+        service_id=SERVICE_ONE_ID,
+        _test_page_title=False,
+        _test_for_non_smart_quotes=False,
+        **extra_args,
+    )
 
     displayed_page_items = page.select(".template-list-item:not(.template-list-item-hidden-by-default)")
     assert [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2928,6 +2928,7 @@ def client_request(request, _logged_in_client, mocker, service_one):  # noqa (C9
             _test_page_title=True,
             _test_for_elements_without_class=True,
             _test_forms_have_an_action_set=True,
+            _test_for_non_smart_quotes=True,
             _optional_args="",
             **endpoint_kwargs,
         ):
@@ -2939,6 +2940,7 @@ def client_request(request, _logged_in_client, mocker, service_one):  # noqa (C9
                 _test_page_title=_test_page_title,
                 _test_for_elements_without_class=_test_for_elements_without_class,
                 _test_forms_have_an_action_set=_test_forms_have_an_action_set,
+                _test_for_non_smart_quotes=_test_for_non_smart_quotes,
             )
 
         @staticmethod
@@ -2950,6 +2952,7 @@ def client_request(request, _logged_in_client, mocker, service_one):  # noqa (C9
             _test_page_title=True,
             _test_for_elements_without_class=True,
             _test_forms_have_an_action_set=True,
+            _test_for_non_smart_quotes=True,
             **endpoint_kwargs,
         ):
             from flask.templating import _render
@@ -2995,6 +2998,9 @@ def client_request(request, _logged_in_client, mocker, service_one):  # noqa (C9
 
             if _test_forms_have_an_action_set and _expected_status not in (301, 302):
                 ClientRequest.test_forms_have_an_action_set(page)
+
+            if _test_for_non_smart_quotes:
+                ClientRequest.test_for_non_smart_quotes(page)
 
             return page
 
@@ -3130,6 +3136,13 @@ def client_request(request, _logged_in_client, mocker, service_one):  # noqa (C9
             ), (  # forms hidden when js is enabled, or by default are exempt
                 "Forms that POST need an action set, even if posting to the same page"
             )
+
+        @staticmethod
+        def test_for_non_smart_quotes(page):
+            for el in page.select("h1, h2, h3, h4, h5, h6, p, li"):
+                assert not (
+                    "'" in el.text or '"' in el.text
+                ), f"Non-smart quote or apostrophe found in <{el.name}>: {normalize_spaces(el.text)}"
 
     return ClientRequest
 


### PR DESCRIPTION
We want to always want to use smart quotes

Rather than leave this up to people to catch at the PR review stage, let’s automate it with a test.