### PR TITLE
Update org domains min max list

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1256,8 +1256,8 @@ class AdminOrganisationDomainsForm(StripWhitespaceForm):
             ],
             default="",
         ),
-        min_entries=20,
-        max_entries=20,
+        min_entries=30,
+        max_entries=30,
         label="Domain names",
         thing="domain name",
     )

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1589,6 +1589,16 @@ def test_view_organisation_domains(
         None,
         None,
         None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
     ]
 
 


### PR DESCRIPTION
We have hardcoded min max for to show the list of organisation domains. Some of the organisations have more than 20 domains so increasing the limit so the list visible on admin UI.