### PR TITLE
Update the guidance for short URLs

### DIFF
--- a/app/templates/views/guidance/using-notify/links-and-URLs.html
+++ b/app/templates/views/guidance/using-notify/links-and-URLs.html
@@ -19,9 +19,7 @@
 
   <p class="govuk-body">URLs should be easy to read.</p>
 
-  <p class="govuk-body">If you have a long, complex web address, you may want to set up a short URL. Find out <a class="govuk-link govuk-link--no-visited-state"
-    href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">how to set up a short URL if you have a GOV.UK domain</a>.
-  </p>
+  <p class="govuk-body">If you have a long, complex web address, you may want to set up a short URL.</p>
 
   <p class="govuk-body">We do not recommend using a third-party link shortening service because:</p>
 
@@ -30,6 +28,10 @@
     <li>your link might stop working if there’s a service outage</li>
     <li>you can no longer control where the redirect goes</li>
   </ul>
+
+  <p class="govuk-body">If your webpage is published on GOV.UK, you can contact <abbr title="Government Digital Service">GDS</abbr> to <a class="govuk-link govuk-link--no-visited-state"
+    href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">request a short URL</a>.
+  </p>
 
   <h2 class="heading-medium" id="link-text-in-emails">Link text in emails</h2>
 


### PR DESCRIPTION
Our guidance incorrectly says that anyone with a `gov.uk` domain can request a short URL from GDS.

We’ve had a couple of support tickets asking about this – so we need to correct the guidance to avoid misleading anyone.