### PR TITLE
Update service navigation to show full service and organisation name

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -8,14 +8,7 @@
 
   &-service-name,
   &-organisation-link {
-    display: inline-block;
-    overflow: hidden;
-    // aligning to the baseline with overflow: hidden adds to the parent's height
-    // aligning to the top doesn't
-    // see: https://stackoverflow.com/questions/23529369/why-does-x-overflowhidden-cause-extra-space-below#answer-51088033
-    vertical-align: top;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    float: left;
   }
 
   &-service-type {
@@ -36,9 +29,8 @@
 
   }
 
-  &-service-switch,
   &-service-back-to,
-  &-organisation-link {
+  &-service-switch {
 
     &:focus {
       text-decoration: none; // override the :hover style (the focus style has its own underline)
@@ -54,25 +46,19 @@
     border-bottom: 1px solid $govuk-border-colour;
     margin: 0 0 10px;
     position: relative;
+    display: flex;
 
-    &-name {
-
-      padding: $padding-top 0 $padding-bottom 0;
-      max-width: 50%;
-
+    &__container {
+      flex-basis: 75%;
+      padding-top: $padding-top;
+      padding-bottom: $padding-bottom;
     }
 
     &-switch {
 
       text-align: right;
-      position: absolute;
-      top: 0;
-      right: 0;
-      padding: $padding-top 0 $padding-bottom govuk-spacing(3);
-
-      &:focus {
-        padding: $padding-top 0px $padding-bottom + 1px govuk-spacing(3) + 10;
-      }
+      margin-left: auto;
+      padding-top: $padding-top;
 
     }
 
@@ -82,24 +68,30 @@
       display: inline-block;
 
     }
-
   }
 
   &-organisation-link {
 
-    max-width: 25%;
-    padding: $padding-top 20px $padding-bottom 0;
-    margin-right: 3px;
     box-sizing: border-box;
+    margin-bottom: govuk-spacing(1);
+    
+    &:focus:before {
+      border-color: $govuk-focus-text-colour;
+    }
+
+  }
+
+  &-organisation-link + &-service-name {
+    padding-left: govuk-spacing(3);
+    margin-left: govuk-spacing(2);
     position: relative;
 
     &:before {
       content: "";
       display: block;
       position: absolute;
-      top: 4px;
-      bottom: 1px;
-      right: 5px;
+      top:  6px;
+      left: -3px;
       width: 7px;
       height: 7px;
       margin: auto 0;
@@ -109,13 +101,12 @@
       border: solid;
       border-width: 1px 1px 0 0;
       border-color: $govuk-secondary-text-colour;
+      @include govuk-media-query($from: tablet) {
+        top: 10px;
+      }
     }
-
-    &:focus:before {
-      border-color: $govuk-focus-text-colour;
-    }
-
   }
+
 
   a {
     display: block;

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -9,11 +9,13 @@
 {% block main %}
   <div class="govuk-width-container">
     <div class="navigation-service">
-      {% if current_user.platform_admin %}
-        <a href="{{ url_for('main.organisations') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-organisation-link">Organisations</a>
-      {% endif %}
-      <div class="navigation-service-name govuk-!-font-weight-bold">
-        {{ current_org.name }}
+      <div class="navigation-service__container">
+        {% if current_user.platform_admin %}
+          <a href="{{ url_for('main.organisations') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-organisation-link">Organisations</a>
+        {% endif %}
+        <div class="navigation-service-name govuk-!-font-weight-bold">
+          {{ current_org.name }}
+        </div>
       </div>
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-switch">Switch service</a>
     </div>

--- a/app/templates/service_navigation.html
+++ b/app/templates/service_navigation.html
@@ -9,13 +9,15 @@
 
 {% macro service_navigation(user, service) %}
 <div class="navigation-service">
-  {% if service.organisation_id %}
-    {% if user.platform_admin or
-      (user.belongs_to_organisation(service.organisation_id) and service.live) %}
-      <a href="{{ url_for('main.organisation_dashboard', org_id=service.organisation_id) }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-organisation-link">{{ service.organisation_name }}</a>
+  <div class="navigation-service__container">
+    {% if service.organisation_id %}
+      {% if user.platform_admin or
+        (user.belongs_to_organisation(service.organisation_id) and service.live) %}
+        <a href="{{ url_for('main.organisation_dashboard', org_id=service.organisation_id) }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-organisation-link">{{ service.organisation_name }}</a>
+      {% endif %}
     {% endif %}
-  {% endif %}
-  {{ navigation_service_name(service) }}
+    {{ navigation_service_name(service) }}
+  </div>
   <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-switch">Switch service</a>
 </div>
 {% endmacro %}

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -5,8 +5,10 @@
 {% block main %}
 <div class="govuk-width-container {{ mainClasses }}">
     <div class="navigation-service">
-      <div class="navigation-service-name govuk-!-font-weight-bold">
-        Platform admin
+      <div class="navigation-service__container">
+        <div class="navigation-service-name govuk-!-font-weight-bold">
+          Platform admin
+        </div>
       </div>
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-switch">Switch service</a>
     </div>


### PR DESCRIPTION
## What

Update the service navigation design to 
- display full name of the organisation (if allowed to see)
- display full name of the service

regardless of the viewport size or text zoom level. 
For this we mimicked the gov.uk breadcrumb pattern, where a long item drops onto the next line with a chevron preceding it. 

Fixes https://trello.com/c/UkFnJkCH/997-service-navigation-has-visual-issues-on-smaller-screens

## Why
Organisation and service names were being truncated if they were too long of their container, which fails 1.4.10 Reflow

## How to review

- see individual commits for detailed logic. Once reviewed I'll combine CSS changes into one commit and add all the messages into it.
- test locally with a users that can/cannot see the org link

## Visual examples

**Short names**
<img width="940" alt="desktop-long-names" src="https://github.com/user-attachments/assets/9c217c4d-48f1-4f67-803e-3210fd7d8ab1">

**Long names**
<img width="939" alt="desktop-short-names" src="https://github.com/user-attachments/assets/2b05b72b-6a5a-42ea-ad9f-4309eb6c7678">

**400% zoom**
<img width="1061" alt="Screenshot 2024-10-21 at 13 11 02" src="https://github.com/user-attachments/assets/fb0afa3d-6c82-4b10-b640-cdd8c34d8e6d">

**IE11**
<img width="1013" alt="Screenshot 2024-10-21 at 12 37 07" src="https://github.com/user-attachments/assets/149c8662-3837-4ff6-99ed-b805e707a689">


