### PR TITLE
Make report titles which start and end on the same day less clunky

### DIFF
--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -60,7 +60,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             [
                 "Report Status",
                 "Today at 4:00pm 1 unsubscribe request Not downloaded",
-                "Today at midday to today at 2:17pm 1 unsubscribe request Not downloaded",
+                "Today from midday to 2:17pm 1 unsubscribe request Not downloaded",
                 "Today until midday 34 unsubscribe requests Downloaded",
                 "15 June to yesterday 200 unsubscribe requests Downloaded",
                 "7 December 2023 to 13 January 321 unsubscribe requests Completed",
@@ -139,7 +139,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             ],
             [
                 "Report Status",
-                "1 May at midday to 1 May at 2:17pm 1 unsubscribe request Completed",
+                "1 May from midday to 2:17pm 1 unsubscribe request Completed",
                 "30 April to 1 May at 10:00am 12,345,678 unsubscribe requests Completed",
             ],
             [],
@@ -210,8 +210,8 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             ],
             [
                 "Report Status",
-                "1 June at 11:22pm to 1 June at midnight 1,234 unsubscribe requests Downloaded",
-                "1 June at 2:17pm to 1 June at 2:18pm 4,567 unsubscribe requests Downloaded",
+                "1 June from 11:22pm to midnight 1,234 unsubscribe requests Downloaded",
+                "1 June from 2:17pm to 2:18pm 4,567 unsubscribe requests Downloaded",
                 "1 June until midday 7,890 unsubscribe requests Downloaded",
             ],
             [],


### PR DESCRIPTION
If the report starts and ends on the same day it’s a bit clunky to repeat the name of the day twice. Instead we can just present the times as a range.

# Before 

<img width="751" alt="image" src="https://github.com/user-attachments/assets/caaf291b-5c99-4092-bc3e-6b557327736b">

# After

<img width="755" alt="image" src="https://github.com/user-attachments/assets/b12a91a7-2dfa-4650-aa29-f59608e00d27">
