### PR TITLE
Remove a reference to the ‘Terms of use’ from the Trial mode page

### DIFF
--- a/app/templates/views/guidance/using-notify/trial-mode.html
+++ b/app/templates/views/guidance/using-notify/trial-mode.html
@@ -46,7 +46,6 @@
     <li>add examples of the messages you want to send</li>
     <li>update your settings so you’re ready to send and receive messages</li>
     <li>accept our data processing and financial agreement</li>
-    <li>accept our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.terms_of_use') }}">terms of use</a></li>
   </ul>
 
 {% endblock %}


### PR DESCRIPTION
This PR removes a reference to the ‘Terms of use’ from the `Trial mode` page.

When we updated the terms of use earlier this year, we made clear that users accept the terms when they create an account, not when they request to go live.

This page was not updated to reflect that clarification - so we’re fixing that now. 