### PR TITLE
Fix sticky footer overlapping some focused elements

### DIFF
--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -68,6 +68,7 @@
   };
   ScrollArea.prototype.scrollToRevealElement = function ($el) {
     var nodeName = $el.get(0).nodeName.toLowerCase();
+    var nodeType =  $el.get(0).getAttribute('type');
     var endOfFurthestEl = focusOverlap.endOfFurthestEl(this._els, this.edge);
     var isInSticky = function () {
       return $el.closest(this.selector).length > 0;
@@ -78,7 +79,13 @@
     // if textarea is focused, we care about checking the caret, not the whole element
     if (nodeName === 'textarea') {
       focused = this.getFocusedDetails.forCaret($el);
-    } else {
+    }
+    // if checkbox or radio are focused we take the parent element
+    // and adjust for all of its height
+    else if (nodeType === 'checkbox' || nodeType === 'radio') {
+      focused = this.getFocusedDetails.forElement($el.parent());
+    }
+    else {
       if (isInSticky()) { return; }
       focused = this.getFocusedDetails.forElement($el);
     }

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -356,11 +356,23 @@ describe("Stick to top/bottom of window when scrolling", () => {
 
         const inputFormBottom = getScreenItemBottomPosition(inputForm);
 
-        inputForm.insertAdjacentHTML('afterEnd', '<input type="checkbox" name="confirm" value="yes" />');
+        inputForm.insertAdjacentHTML('afterEnd', 
+          `<div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="id" name="confirm" type="checkbox" value="yes">
+            <label class="govuk-label govuk-checkboxes__label" for="id">Yes</label>
+          </div>`
+        );
         checkbox = document.querySelector('input[type=checkbox]');
 
         screenMock.mockPositionAndDimension('checkbox', checkbox, {
           offsetHeight: 50, // 118px smaller than the sticky
+          offsetWidth: 727,
+          offsetTop: inputFormBottom
+        });
+
+        // also mock offeset for the parent containing element div
+        screenMock.mockPositionAndDimension('checkboxParent', checkbox.parentNode, {
+          offsetHeight: 50,
           offsetWidth: 727,
           offsetTop: inputFormBottom
         });
@@ -1089,7 +1101,12 @@ describe("Stick to top/bottom of window when scrolling", () => {
 
         const contentBottom = getScreenItemBottomPosition(content);
 
-        content.insertAdjacentHTML('afterEnd', '<input type="checkbox" name="confirm" value="yes" />');
+        content.insertAdjacentHTML('afterEnd', 
+          `<div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="id" name="confirm" type="checkbox" value="yes">
+            <label class="govuk-label govuk-checkboxes__label" for="id">Yes</label>
+          </div>`
+        );
         checkbox = document.querySelector('input[type=checkbox]');
 
         screenMock.mockPositionAndDimension('checkbox', checkbox, {
@@ -1098,7 +1115,7 @@ describe("Stick to top/bottom of window when scrolling", () => {
           offsetTop: contentBottom
         });
 
-        checkboxBottom = getScreenItemBottomPosition(checkbox);
+        checkboxBottom = getScreenItemBottomPosition(checkbox.parentNode);
 
         // move the sticky over the checkbox. It's 50px high so this position will cause it to overlap.
         screenMock.scrollTo((checkboxBottom - windowHeight) + 5);


### PR DESCRIPTION
Fixes: https://trello.com/c/wPRphm25/998-the-sticky-footer-sometimes-overlaps-focused-elements

## What
Add a condition that checks for the type of focused element and if it's either a checkbox or radio then take the parent element (which will be `govuk-checkboxes__item` or `govuk-radios__item`) and adjust the scroll for its height.

This fixes an issue where checkboxes on templates page were not brought into view when focused if the sticky footer happens to overlap them.

While that's due to them having a minimal height for visual composition, it also helps to now fully show the hint text as that is usually lower than the height of the checkbox itself.

## Changes

https://github.com/user-attachments/assets/872c7739-7a3e-492a-a914-acb077b9a85d

https://github.com/user-attachments/assets/4a0e1df2-2bae-4eee-9be7-37caf2ec9d87

https://github.com/user-attachments/assets/45706fb7-e960-4f95-a7de-89697f88bb86

https://github.com/user-attachments/assets/a8be0e1b-e9ba-42c2-9287-e3458503c056





# 