### PR TITLE
Make add reply-to address flow work with screen readers

### DIFF
--- a/app/assets/javascripts/esm/all-esm.mjs
+++ b/app/assets/javascripts/esm/all-esm.mjs
@@ -2,6 +2,7 @@
 import { createAll, Header, Button, Radios, ErrorSummary, SkipLink, Tabs } from 'govuk-frontend';
 
 import CollapsibleCheckboxes from './collapsible-checkboxes.mjs';
+import FocusBanner from './focus-banner.mjs';
 
 // Modules from 3rd party vendors
 import morphdom from 'morphdom';
@@ -18,9 +19,10 @@ if ($collapsibleCheckboxes) {
   new CollapsibleCheckboxes($collapsibleCheckboxes);
 }
 
+const focusBanner = new FocusBanner();
 
 // ES modu;es do not export to global so in order to
-// reuse some of teh import here in our other 
+// reuse some of teh import here in our other
 // global functions, we need to explicitly attach them to window
 // this will be removed when we migrate out files
 // to ES modules

--- a/app/assets/javascripts/esm/focus-banner.mjs
+++ b/app/assets/javascripts/esm/focus-banner.mjs
@@ -1,0 +1,39 @@
+// This new way of writing Javascript components is based on the GOV.UK Frontend skeleton Javascript coding standard
+// that uses ES 015 Classes -
+// https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/js.md#skeleton
+//
+// It replaces the previously used way of setting methods on the component's `prototype`.
+// We use a class declaration way of defining classes -
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/class
+//
+// More on ES2015 Classes at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
+
+// Focus banners that do not use the GOVUK Design System Error Summary component but still need to
+// match its behaviour when they appear
+class FocusBanner {
+  constructor() {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      return this;
+    }
+
+    // focus any error banners when the page loads
+    this.focusBanner($('.banner-dangerous'));
+
+    // focus success and error banners when they appear in any content updates
+    $(document).on("updateContent.onafterupdate", function(evt, el) {
+      this.focusBanner($(".banner-dangerous, .banner-default-with-tick", el));
+    }.bind(this));
+  }
+
+  focusBanner ($bannerEl) {
+    if ($bannerEl.length === 0) { return; }
+
+    $bannerEl.attr('tabindex', '-1');
+    $bannerEl.trigger('focus');
+    $bannerEl.on('blur', () => {
+      $bannerEl.removeAttr('tabindex');
+    });
+  }
+}
+
+export default FocusBanner;

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -12,20 +12,6 @@ if (document.body.classList.contains('govuk-frontend-supported')) {
 
   $(() => $('.error-message, .govuk-error-message').eq(0).parent('label').next('input').trigger('focus'));
 
-  function focusBanner ($bannerEl) {
-    if ($bannerEl.length === 0) { return }
-
-    $bannerEl.attr('tabindex', '-1');
-    $bannerEl.on('blur', () => $(this).removeAttr('tabindex'));
-    $bannerEl.trigger('focus');
-  };
-
-  $(() => focusBanner($('.banner-dangerous')))
-
-  $(document).on("updateContent.onafterupdate", function(evt, el) {
-    focusBanner($(".banner-dangerous, .banner-default-with-tick", el));
-  });
-
   $(() => $('.govuk-header__container').on('click', function() {
     $(this).css('border-color', '#1d70b8');
   }));

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -12,7 +12,19 @@ if (document.body.classList.contains('govuk-frontend-supported')) {
 
   $(() => $('.error-message, .govuk-error-message').eq(0).parent('label').next('input').trigger('focus'));
 
-  $(() => $('.banner-dangerous').eq(0).trigger('focus'));
+  function focusBanner ($bannerEl) {
+    if ($bannerEl.length === 0) { return }
+
+    $bannerEl.attr('tabindex', '-1');
+    $bannerEl.on('blur', () => $(this).removeAttr('tabindex'));
+    $bannerEl.trigger('focus');
+  };
+
+  $(() => focusBanner($('.banner-dangerous')))
+
+  $(document).on("updateContent.onafterupdate", function(evt, el) {
+    focusBanner($(".banner-dangerous, .banner-default-with-tick", el));
+  });
 
   $(() => $('.govuk-header__container').on('click', function() {
     $(this).css('border-color', '#1d70b8');

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -58,13 +58,29 @@
   };
 
   var getRenderer = ($contents, key, classesPersister) => response => {
+    var contents = $contents.get(0);
+    var contentHasUpdated = false;
     classesPersister.remove();
     window.Morphdom(
-      $contents.get(0),
-      $(response[key]).get(0)
+      contents,
+      $(response[key]).get(0),
+      {
+        onBeforeElUpdated: function(fromEl, toEl) {
+          // spec - https://dom.spec.whatwg.org/#concept-node-equals
+          if (fromEl.isEqualNode(toEl)) {
+            return false;
+          } else if (fromEl === contents) { // if root node is different, updates will apply
+            contentHasUpdated = true;
+          }
+
+          return true;
+        }
+      }
     );
-    $(document).trigger("updateContent.onafterupdate", [$contents.get(0)]);
     classesPersister.replace();
+    if (contentHasUpdated === true) {
+      $(document).trigger("updateContent.onafterupdate", [contents]);
+    }
   };
 
   var getQueue = resource => (

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -63,6 +63,7 @@
       $contents.get(0),
       $(response[key]).get(0)
     );
+    $(document).trigger("updateContent.onafterupdate", [$contents.get(0)]);
     classesPersister.replace();
   };
 

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -12,6 +12,10 @@
   clear: both;
   border: 5px solid $govuk-success-colour;
 
+  &:focus {
+    outline: 3px solid $govuk-focus-colour;
+  }
+
   &-title {
     @include govuk-font(24, $weight: bold);
   }
@@ -57,10 +61,6 @@
   border: 5px solid $govuk-error-colour;
   margin: 15px 0;
   text-align: left;
-
-  &:focus {
-    outline: 3px solid $govuk-focus-colour;
-  }
 
   .list {
     margin-bottom: 0;

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -458,7 +458,6 @@ def service_verify_reply_to_address(service_id, notification_id):
         service_id=service_id,
         notification_id=notification_id,
         partials=get_service_verify_reply_to_address_partials(service_id, notification_id),
-        verb=("Change" if replace else "Add"),
         replace=replace,
         is_default=is_default,
     )

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -7,7 +7,6 @@
     class='banner{% if type %}-{{ type }}{% endif %}{% if with_tick %}-with-tick{% endif %}'
     {% if type == 'dangerous' %}
     role='group'
-    tabindex='-1'
     {% endif %}
     {% if id %}
     id={{ id }}

--- a/app/templates/views/service-settings/email-reply-to/_verify-updates.html
+++ b/app/templates/views/service-settings/email-reply-to/_verify-updates.html
@@ -1,10 +1,12 @@
 {% from "components/banner.html" import banner, banner_wrapper %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
 <div class="ajax-block-container">
   {% if verification_status == "pending" %}
+    {{ page_header('Checking email reply-to address') }}
     <p class="govuk-body">
       We’re checking that ‘{{ reply_to_email_address }}’ is a real email address.
     </p>
@@ -17,6 +19,8 @@
     </p>
   {% elif verification_status == "success" %}
     {{ banner("‘{}’ is ready to use".format(reply_to_email_address), type='default', with_tick=True) }}
+
+    {{ page_header('Checking email reply-to address') }}
     <div class="js-stick-at-bottom-when-scrolling">
       {{ govukButton({
         "element": "a",
@@ -38,6 +42,7 @@
         </p>
       {% endcall %}
     </div>
+    {{ page_header('Checking email reply-to address') }}
     {% if replace %}
       {% set form_url = url_for('main.service_edit_email_reply_to', service_id=service_id, reply_to_email_id=replace) %}
     {% else %}

--- a/app/templates/views/service-settings/email-reply-to/verify.html
+++ b/app/templates/views/service-settings/email-reply-to/verify.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
@@ -18,7 +17,6 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ page_header('Checking email reply-to address') }}
   {{ ajax_block(
       partials,
       url_for('json_updates.service_verify_reply_to_address_updates', service_id=service_id, notification_id=notification_id, is_default=is_default, replace=replace),

--- a/app/templates/views/service-settings/email-reply-to/verify.html
+++ b/app/templates/views/service-settings/email-reply-to/verify.html
@@ -4,7 +4,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
-  {{ verb }} email reply-to address
+  Checking email reply-to address
 {% endblock %}
 
 {% block backLink %}
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ page_header('{} email reply-to address'.format(verb)) }}
+  {{ page_header('Checking email reply-to address') }}
   {{ ajax_block(
       partials,
       url_for('json_updates.service_verify_reply_to_address_updates', service_id=service_id, notification_id=notification_id, is_default=is_default, replace=replace),

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2833,7 +2833,7 @@ def test_service_add_reply_to_email_address_without_verification_for_platform_ad
     mock_update.assert_called_once_with(SERVICE_ONE_ID, email_address="test@example.gov.uk", is_default=True)
 
 
-@pytest.mark.parametrize("is_default,replace,expected_header", [(True, "&replace=123", "Change"), (False, "", "Add")])
+@pytest.mark.parametrize("is_default,replace", [(True, "&replace=123"), (False, "")])
 @pytest.mark.parametrize(
     "status,expected_failure,expected_success",
     [
@@ -2853,7 +2853,6 @@ def test_service_verify_reply_to_address(
     expected_success,
     is_default,
     replace,
-    expected_header,
 ):
     notification = {
         "id": fake_uuid,
@@ -2874,7 +2873,7 @@ def test_service_verify_reply_to_address(
         notification_id=notification["id"],
         _optional_args=f"?is_default={is_default}{replace}",
     )
-    assert page.select_one("h1").text == f"{expected_header} email reply-to address"
+    assert page.select_one("h1").text == "Checking email reply-to address"
     back_link = page.select_one(".govuk-back-link")
     assert back_link.text.strip() == "Back"
     if replace:

--- a/tests/javascripts/focus-banner.test.mjs
+++ b/tests/javascripts/focus-banner.test.mjs
@@ -1,0 +1,90 @@
+import FocusBanner from '../../app/assets/javascripts/esm/focus-banner.mjs'
+
+describe('Focus banner', () => {
+
+  beforeAll(() => {
+    document.body.classList.add('govuk-frontend-supported');
+  });
+
+  test('It focuses any div.banner-dangerous elements when the page loads', () => {
+
+    document.body.innerHTML = `
+      <div class="banner-dangerous">
+        <h2>This is a problem with your upload</h2>
+        <p>The file uploaded needs to be a PNG</p>
+      </div>`;
+
+    (new FocusBanner());
+
+    const bannerEl = document.querySelector('.banner-dangerous');
+
+    expect(document.activeElement).toBe(bannerEl);
+
+    $(bannerEl).trigger('blur');
+
+    expect(bannerEl.hasAttribute('tabindex')).toBe(false);
+
+  });
+
+  describe('It focuses banner elements when they appear in content updated by AJAX', () => {
+
+    test('If there is a div.banner-dangerous in the updated content, it should be focused', () => {
+
+      document.body.innerHTML = `
+        <div class="ajax-block-container">
+        </div>`;
+
+      const ajaxBlockContainer = document.querySelector('.ajax-block-container');
+
+      (new FocusBanner());
+
+      // simulate a content update event
+      ajaxBlockContainer.innerHTML = `
+        <div class="banner-dangerous">
+          <h2>This is a problem with your upload</h2>
+          <p>The file uploaded needs to be a PNG</p>
+        </div>`;
+      $(document).trigger('updateContent.onafterupdate', ajaxBlockContainer);
+
+      const bannerEl = document.querySelector('.banner-dangerous');
+
+      expect(document.activeElement).toBe(bannerEl);
+
+      $(bannerEl).trigger('blur');
+
+      expect(bannerEl.hasAttribute('tabindex')).toBe(false);
+
+    });
+
+    test('If there is a div.banner-default-with-tick in the updated content, it should be focused', () => {
+
+      document.body.innerHTML = `
+        <div class="ajax-block-container">
+        </div>`;
+
+      const ajaxBlockContainer = document.querySelector('.ajax-block-container');
+
+      (new FocusBanner());
+
+      ajaxBlockContainer.innerHTML = `
+        <div class="banner-default-with-tick">
+          <h2>This is a problem with your upload</h2>
+          <p>The file uploaded needs to be a PNG</p>
+        </div>`;
+
+      // simulate a content update event
+      $(document).trigger('updateContent.onafterupdate', ajaxBlockContainer);
+
+      const bannerEl = document.querySelector('.banner-default-with-tick');
+
+      expect(document.activeElement).toBe(bannerEl);
+
+      $(bannerEl).trigger('blur');
+
+      expect(bannerEl.hasAttribute('tabindex')).toBe(false);
+
+    });
+
+  });
+
+});

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -366,10 +366,13 @@ describe('Update content', () => {
 
     });
 
-    test("If the response contains no changes, the DOM should stay the same", () => {
+    test("If the response contains no changes, the DOM should stay the same and no update event should fire", () => {
 
       // send the done callback a response with updates included
       responseObj[updateKey] = getPartial(partialData);
+
+      const updateEventCallbackSpy = jest.fn();
+      $(document).on('updateContent.onafterupdate', updateEventCallbackSpy);
 
       // start the module
       window.GOVUK.notifyModules.start();
@@ -383,10 +386,13 @@ describe('Update content', () => {
 
       // check a sample DOM node is unchanged
       expect(document.querySelectorAll('.big-number-number')[0].textContent.trim()).toEqual("0");
-
+      expect(updateEventCallbackSpy).not.toHaveBeenCalled()
     });
 
-    test("If the response contains changes, it should update the DOM with them", () => {
+    test("If the response contains changes, it should update the DOM with them and fire an update event", () => {
+
+      const updateEventCallbackSpy = jest.fn();
+      $(document).on('updateContent.onafterupdate', updateEventCallbackSpy);
 
       partialData[0].count = 1;
 
@@ -405,6 +411,9 @@ describe('Update content', () => {
 
       // check the right DOM node is updated
       expect(document.querySelectorAll('.big-number-number')[0].textContent.trim()).toEqual("1");
+      // check the event was triggered with the updated DOM node (the 2nd argument, after the event object)
+      expect(updateEventCallbackSpy).toHaveBeenCalled();
+      expect(updateEventCallbackSpy.mock.calls[0][1]).toEqual(document.querySelector('.ajax-block-container'));
 
     });
 
@@ -666,37 +675,6 @@ describe('Update content', () => {
       expect(partialsInPage[1].querySelectorAll('.file-list h2')[0].classList.contains('js-child-has-focus')).toBe(false);
 
     });
-
-  });
-
-  test('After any updates it should fire the updateContent.onafterupdate event', () => {
-
-    function getPartial() {
-        return `<div class="ajax-block-container">
-                  <p>12 Emails</p>
-                </div>`;
-    };
-
-    document.body.innerHTML = getInitialHTMLString(getPartial());
-
-    // spy on event we want to track
-    const eventSpy = jest.fn()
-    $(document).on('updateContent.onafterupdate', eventSpy);
-
-    // make a response with no changes
-    responseObj[updateKey] = getPartial();
-
-    // start the module
-    window.GOVUK.notifyModules.start();
-
-    // move to the time the first request is fired
-    jest.advanceTimersByTime(2000);
-
-    // simulate a 200 response
-    jest.advanceTimersByTime(serverResponse.responseTimeInMilliseconds);
-    serverResponse.complete();
-
-    expect(eventSpy).toHaveBeenCalled();
 
   });
 

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -669,6 +669,37 @@ describe('Update content', () => {
 
   });
 
+  test('After any updates it should fire the updateContent.onafterupdate event', () => {
+
+    function getPartial() {
+        return `<div class="ajax-block-container">
+                  <p>12 Emails</p>
+                </div>`;
+    };
+
+    document.body.innerHTML = getInitialHTMLString(getPartial());
+
+    // spy on event we want to track
+    const eventSpy = jest.fn()
+    $(document).on('updateContent.onafterupdate', eventSpy);
+
+    // make a response with no changes
+    responseObj[updateKey] = getPartial();
+
+    // start the module
+    window.GOVUK.notifyModules.start();
+
+    // move to the time the first request is fired
+    jest.advanceTimersByTime(2000);
+
+    // simulate a 200 response
+    jest.advanceTimersByTime(serverResponse.responseTimeInMilliseconds);
+    serverResponse.complete();
+
+    expect(eventSpy).toHaveBeenCalled();
+
+  });
+
   afterEach(() => {
 
     document.body.innerHTML = '';


### PR DESCRIPTION
Fixes the add reply-to address flow so updates are announced to screen readers.

https://trello.com/c/2JfcApXt/999-page-for-checking-a-reply-to-email-address-has-problems-for-screen-reader-users

All changes paired on by @klssmith and me.

## Explanation of changes

### Changing the H1 and title

We changed the title and H1 of the page that checks and confirms/rejects the email address to 'Checking reply-to address' so it isn't the same as the previous page and explains the page better.

### Move the banners before the H1

We moved the banners you see if the email address is confirmed or rejected to be above the H1, to match existing error summary behaviour.

### Focus the banners

We added some JS to focus either banner when it appears to match the behaviour of error summaries and ensure the banner text is announced to screen readers.

## Before

https://github.com/user-attachments/assets/075eb9e2-f9e2-4905-b058-ab5f0ac3c290

## After

https://github.com/user-attachments/assets/c9e4e91e-fd0d-441e-b755-3acd5f27c2ec

Both examples use the JAWS screen reader. Neither video has audio so use the text descriptions at the bottom to see what JAWS is announcing.

## Notes for reviewers

Worth reviewing commit by commit.

If you don't feel comfortable testing with screen readers, just review the code because this work was paired on throughout so 2 pairs of 👀s have seen it working already.

If you have access to a assistivelabs, it's worth testing with JAWS or NVDA. If you're testing with Voiceover, bear in mind you might need to turn 'Automatically speak the web page' off and turn 'Speak web page summary' so it announces the title when the page loads. In Safari too, Chrome doesn't seem to respect that setting.

Testing is loads easier if you hack it by:
- setting the `REPLY_TO_EMAIL_ADDRESS_VALIDATION_TIMEOUT` to 5 in `app/config.py`
- changing the conditional logic in `app/templates/views/service-settings/email-reply-to/_verify-updates.html` so you see the banner you want, because the flow on local will always fail