### PR TITLE
Fix sticky footer overlapping some focused elements

### DIFF
--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -68,6 +68,7 @@
   };
   ScrollArea.prototype.scrollToRevealElement = function ($el) {
     var nodeName = $el.get(0).nodeName.toLowerCase();
+    var nodeType =  $el.get(0).getAttribute('type');
     var endOfFurthestEl = focusOverlap.endOfFurthestEl(this._els, this.edge);
     var isInSticky = function () {
       return $el.closest(this.selector).length > 0;
@@ -78,7 +79,13 @@
     // if textarea is focused, we care about checking the caret, not the whole element
     if (nodeName === 'textarea') {
       focused = this.getFocusedDetails.forCaret($el);
-    } else {
+    }
+    // if checkbox or radio are focused and not in strick footer we take the parent element
+    // and adjust for all of its height
+    else if (!isInSticky() && (nodeType === 'checkbox' || nodeType === 'radio')) {
+      focused = this.getFocusedDetails.forElement($el.parent());
+    }
+    else {
       if (isInSticky()) { return; }
       focused = this.getFocusedDetails.forElement($el);
     }

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -356,11 +356,23 @@ describe("Stick to top/bottom of window when scrolling", () => {
 
         const inputFormBottom = getScreenItemBottomPosition(inputForm);
 
-        inputForm.insertAdjacentHTML('afterEnd', '<input type="checkbox" name="confirm" value="yes" />');
+        inputForm.insertAdjacentHTML('afterEnd', 
+          `<div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="id" name="confirm" type="checkbox" value="yes">
+            <label class="govuk-label govuk-checkboxes__label" for="id">Yes</label>
+          </div>`
+        );
         checkbox = document.querySelector('input[type=checkbox]');
 
         screenMock.mockPositionAndDimension('checkbox', checkbox, {
           offsetHeight: 50, // 118px smaller than the sticky
+          offsetWidth: 727,
+          offsetTop: inputFormBottom
+        });
+
+        // also mock offeset for the parent containing element div
+        screenMock.mockPositionAndDimension('checkboxParent', checkbox.parentNode, {
+          offsetHeight: 50,
           offsetWidth: 727,
           offsetTop: inputFormBottom
         });
@@ -1089,7 +1101,12 @@ describe("Stick to top/bottom of window when scrolling", () => {
 
         const contentBottom = getScreenItemBottomPosition(content);
 
-        content.insertAdjacentHTML('afterEnd', '<input type="checkbox" name="confirm" value="yes" />');
+        content.insertAdjacentHTML('afterEnd', 
+          `<div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="id" name="confirm" type="checkbox" value="yes">
+            <label class="govuk-label govuk-checkboxes__label" for="id">Yes</label>
+          </div>`
+        );
         checkbox = document.querySelector('input[type=checkbox]');
 
         screenMock.mockPositionAndDimension('checkbox', checkbox, {
@@ -1098,7 +1115,7 @@ describe("Stick to top/bottom of window when scrolling", () => {
           offsetTop: contentBottom
         });
 
-        checkboxBottom = getScreenItemBottomPosition(checkbox);
+        checkboxBottom = getScreenItemBottomPosition(checkbox.parentNode);
 
         // move the sticky over the checkbox. It's 50px high so this position will cause it to overlap.
         screenMock.scrollTo((checkboxBottom - windowHeight) + 5);


### PR DESCRIPTION
Reintroduction of https://github.com/alphagov/notifications-admin/pull/5256 that's already been reviewed and merged, but needed to be [reverted](https://github.com/alphagov/notifications-admin/pull/5260) due to a failing functional test.

With a [fix](https://github.com/alphagov/notifications-functional-tests/pull/526) to make sure sticky footer javascript runs in the tests, this resulted in tests passing
-  locally
![Screenshot 2024-10-25 at 14 49 07](https://github.com/user-attachments/assets/085b162f-f966-490e-b5e5-0c27522f2164)
- when run on dev-a
![Screenshot 2024-10-25 at 16 16 32](https://github.com/user-attachments/assets/9bc5fcae-3da7-43bf-b87d-b9d2eefb3d9d)

