### PR TITLE
Remove duplicate ajax from view_notifications

### DIFF
--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -22,12 +22,15 @@
 {% block maincolumn_content %}
 
   {{ page_header(page_title) }}
-  {% if not message_type == "letter" %}
+
+  {# the blue pills only show for sms and email #}
+  {% if message_type != "letter" %}
 
     {{ ajax_block(
       partials,
-      url_for('json_updates.get_notifications_page_partials_as_json', service_id=current_service.id, message_type=message_type, status=status, search_query=search_query),
-      'counts'
+      url_for('json_updates.get_notifications_page_partials_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page, search_query=search_query),
+      'counts',
+      form='search-form'
     ) }}
 
   {% endif %}

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@86.2.0
+# This file is automatically copied from notifications-utils@87.0.0
 
 beautifulsoup4==4.11.1
 pytest==7.2.0


### PR DESCRIPTION
### make view_notifications ajax blocks have same URL/method

The URLs were different for the two ajax requests due to a missing pagination argument - as a result, we ended up with two different entries in the list of ajax calls, with two different requests to update their respective blocks. The ajax endpoint returns both blocks and updateContent.js is designed so that if two blocks request ajax content from the same URL, it'll just make one remote call and call the renderer for each block when it gets a response.

So to fix this, we could just add the pagination argument. But we also need the form to be defined in this block too - otherwise we'll end up in a weird and confusing state where one ajax block will make a GET request without the form search data, and one will make a POST request with the form search data (thus doing additional filtering). The first one to return would redraw both methods as it empties the queue. But both would also put on the timeout.

So if you have a GET and a POST with the same URL you could have theoretically end up with states where you were flip-flopping between filtered and non-filtered results - that said I think this wouldn't happen in practise due to the caching of the search results that we added recently.

(compare with the other ajax block at the bottom of the file)

https://github.com/alphagov/notifications-admin/blob/32353eba28d90ad0f9c4bd9d72cd2cd9855fbfd6/app/templates/views/notifications.html#L77-L82