### PR TITLE
Don’t coerce `row_number` in CSV download

### DIFF
--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -23,7 +23,6 @@ class Notification(JSONModel):
     created_at: datetime
     created_by: Any
     updated_at: datetime
-    row_number: int
     job_row_number: int
     service: Any
     template_version: int
@@ -117,6 +116,7 @@ class Notifications(ModelList):
 
 
 class NotificationForCSV(Notification):
+    row_number: Any  # Can be an empty string so can’t cast to `int`
     created_at: str  # API returns this field pre-formatted in Europe/London timezone
     template_name: str
     template_type: str

--- a/tests/app/utils/test_csv.py
+++ b/tests/app/utils/test_csv.py
@@ -31,7 +31,7 @@ def _get_notifications_csv(
             "notifications": [
                 {
                     "id": sample_uuid(),
-                    "row_number": row_number + i,
+                    "row_number": (row_number + i) if row_number else "",
                     "to": recipient,
                     "recipient": recipient,
                     "client_reference": "ref 1234",
@@ -102,6 +102,7 @@ def test_generate_notifications_csv_without_job(
             job_id=None,
             job_name=None,
             api_key_name=api_key_name,
+            row_number="",
         ),
     )
     assert (


### PR DESCRIPTION
The `row_number` that the API returns for a CSV download can be either an empty string or a number.

When we deserialise the JSON from the API we check for `None` values before trying to cast to another type, but we don’t check for empty string.

Therefore marking a field as `int` causes an exception because empty string cannot be coerced to an integer.

This commit change the type to `Any`, which means no coercion will be attempted.

This also moves the field to the `NotificationForCSV` model, since it’s only returned when getting notifications to download and not from the morre general `GET /notifications` endpoint.

***

Comes from: https://github.com/alphagov/notifications-api/blob/8d787fcfca5e6e68720bace6204465b7e963e3c9/app/models.py#L1590