### PR TITLE
Put email and sms details in summary list

### DIFF
--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -1,4 +1,5 @@
-$email-message-gutter: govuk-spacing(9);
+$email-message-gutter-desktop: govuk-spacing(9);
+$email-message-gutter-mobile: govuk-spacing(3);
 
 // sass-lint:disable no-important
 
@@ -9,30 +10,67 @@ $email-message-gutter: govuk-spacing(9);
 
   &-meta {
 
-    @include govuk-font(19);
-    margin: 0;
-
-    td,
-    th {
-      @include govuk-font(19);
-      border-top: 0;
-      border-bottom: 1px solid $govuk-border-colour;
-      vertical-align: top;
+    // Persist table view on smaller screens
+    // The summary-list component stacks its content on smaller screens by default
+    &.govuk-summary-list {
+      display: table;
+      border-collapse: collapse;
+      margin-bottom: 0;
     }
 
-    th {
-      color: $govuk-secondary-text-colour;
-      padding-left: $email-message-gutter;
+    & > .govuk-summary-list__row {
+      display: table-row;
+
+      & > .govuk-summary-list__key,
+      & > .govuk-summary-list__value {
+        display: table-cell;
+        padding: govuk-spacing(2) $email-message-gutter-mobile;
+      }
+
+      & > .govuk-summary-list__key {
+        color: $govuk-secondary-text-colour;
+        font-weight: normal;
+        padding-right: govuk-spacing(3);
+        // set to max width of content (currently 'Reply to'), sized by character, with padding
+        width: 1em * ((55 + 5) / 16);
+
+        @include govuk-media-query($from: tablet) {
+          padding-left: $email-message-gutter-desktop;
+          padding-right: govuk-spacing(4);
+        }
+      }
+
+      & > .govuk-summary-list__value {
+        padding-left: 0;
+      }
+
+      // deal with long email addresses
+      & > .email-message-meta__reply-to {
+        word-break: break-word;
+      }
+
     }
 
-    td {
+    // Less hacky layout with more accurate and flexible first column, for browsers that support it (see https://caniuse.com/css-subgrid)
+    @supports(grid-template-columns: subgrid) {
 
-      width: 99%;
-      padding-right: $email-message-gutter;
-      word-break: break-word;
+      &.govuk-summary-list {
+        display: grid;
+        grid-template-columns: min-content 1fr;
 
-      &:last-child {
-        padding-right: $email-message-gutter;
+        & > .govuk-summary-list__row {
+          grid-column: span 2;
+          display: grid;
+          grid-template-columns: subgrid;
+          margin-bottom: 0;
+
+          & > .govuk-summary-list__key,
+          & > .govuk-summary-list__value {
+            width: auto;
+            margin-bottom: 0
+          }
+        }
+
       }
 
     }
@@ -47,11 +85,16 @@ $email-message-gutter: govuk-spacing(9);
 
     width: 100%;
     box-sizing: border-box;
-    padding: govuk-spacing(3) $email-message-gutter 0 $email-message-gutter;
+    padding: govuk-spacing(3) $email-message-gutter-mobile 0 $email-message-gutter-mobile;
     margin: 0 0 0 0;
     clear: both;
     position: relative;
     word-wrap: break-word;
+
+    @include govuk-media-query($from: tablet) {
+      padding-left: $email-message-gutter-desktop;
+      padding-right: $email-message-gutter-desktop;
+    }
 
     table {
       margin: 0 0 20px 0;

--- a/app/templates/partials/templates/email_preview_template.jinja2
+++ b/app/templates/partials/templates/email_preview_template.jinja2
@@ -1,0 +1,39 @@
+<div class="email-message">
+  <table class="email-message-meta">
+    <tbody>
+      {% if show_recipient %}
+        {% if from_name %}
+          <tr>
+            <th scope="row">From</th>
+            <td>
+              {{ from_name }}
+            </td>
+          </tr>
+        {% endif %}
+        {% if reply_to %}
+          <tr>
+            <th scope="row">Reply&nbsp;to</th>
+            <td>
+              {{ reply_to }}
+            </td>
+          </tr>
+        {% endif %}
+        <tr>
+          <th scope="row">To</th>
+          <td>
+            {{ recipient }}
+          </td>
+        </tr>
+      {% endif %}
+      <tr class="email-message-meta">
+        <th scope="row">Subject</th>
+        <td>
+          {{ subject }}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="email-message-body">
+    {{ body }}
+  </div>
+</div>

--- a/app/templates/partials/templates/email_preview_template.jinja2
+++ b/app/templates/partials/templates/email_preview_template.jinja2
@@ -1,38 +1,55 @@
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+
+{% set email_meta = [] %}
+
+{% if show_recipient %}
+  {% if from_name %}
+    {% do email_meta.append({
+      "key": {
+        "html": "From"
+      },
+      "value": {
+        "html": from_name
+      }
+    }) %}
+  {% endif %}
+
+  {% if reply_to %}
+    {% do email_meta.append({
+      "key": {
+        "html": "Reply&nbsp;to" | safe
+      },
+      "value": {
+        "classes": "email-message-meta__reply-to",
+        "html": reply_to
+      }
+    }) %}
+  {% endif %}
+{% endif %}
+
+{% do email_meta.append({
+    "key": {
+      "html": "To"
+    },
+    "value": {
+      "html": recipient
+    }
+}) %}
+
+{% do email_meta.append({
+    "key": {
+      "html": "Subject"
+    },
+    "value": {
+      "html": subject
+    }
+}) %}
+
 <div class="email-message">
-  <table class="email-message-meta">
-    <tbody>
-      {% if show_recipient %}
-        {% if from_name %}
-          <tr>
-            <th scope="row">From</th>
-            <td>
-              {{ from_name }}
-            </td>
-          </tr>
-        {% endif %}
-        {% if reply_to %}
-          <tr>
-            <th scope="row">Reply&nbsp;to</th>
-            <td>
-              {{ reply_to }}
-            </td>
-          </tr>
-        {% endif %}
-        <tr>
-          <th scope="row">To</th>
-          <td>
-            {{ recipient }}
-          </td>
-        </tr>
-      {% endif %}
-      <tr class="email-message-meta">
-        <th scope="row">Subject</th>
-        <td>
-          {{ subject }}
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  {{ govukSummaryList({
+    "classes": "email-message-meta",
+    "rows": email_meta
+  }) }}
   <div class="email-message-body">
     {{ body }}
   </div>

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -410,8 +410,8 @@ def test_should_show_page_for_email_template(
     )
 
     assert [
-        (normalize_spaces(row.select_one("th").text), normalize_spaces(row.select_one("td").text))
-        for row in page.select("table.email-message-meta tr")
+        (normalize_spaces(row.select_one("dt").text), normalize_spaces(row.select_one("dd").text))
+        for row in page.select(".email-message-meta .govuk-summary-list__row")
     ] == [
         ("From", expected_email_from),
         ("To", "email address"),

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -910,8 +910,8 @@ def test_email_preview_shows_from_name(extra_args):
     template = EmailPreviewTemplate(
         {"content": "content", "subject": "subject", "template_type": "email"}, **extra_args
     )
-    assert '<th scope="row">From</th>' in str(template)
-    assert "Example service" in str(template)
+    assert '<dt class="govuk-summary-list__key">\n      From\n    </dt>' in str(template)
+    assert '<dd class="govuk-summary-list__value">\n      Example service\n    </dd>' in str(template)
 
 
 def test_email_preview_escapes_html_in_from_name():
@@ -933,8 +933,12 @@ def test_email_preview_shows_reply_to_address(extra_args):
     template = EmailPreviewTemplate(
         {"content": "content", "subject": "subject", "template_type": "email"}, **extra_args
     )
-    assert '<th scope="row">Reply&nbsp;to</th>' in str(template)
-    assert "test@example.com" in str(template)
+    assert '<dt class="govuk-summary-list__key">\n      Reply&nbsp;to\n    </dt>' in str(template)
+    assert (
+        '    <dd class="govuk-summary-list__value email-message-meta__reply-to">\n'
+        "      test@example.com\n"
+        "    </dd>"
+    ) in str(template)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Change the metadata on the email template page from being wrapped in a table to [a summary list](https://design-system.service.gov.uk/components/summary-list/).

https://trello.com/c/DFMje2N6/975-fix-the-table-on-the-template-preview-page-wcag-22

The accessibility audit described the current table as being confusing, partly because it doesn't have a caption[^1]. We've either converted most other pages with lists of key:value pairs from tables to summary lists, on the recommendation of previous accessibility audits. So we decided to do the same here.

## Details of the changes

The HTML for this table is currently imported from notifications-utils, along with its rendering class and tests. But the admin app is the only user of this code so these changes move both into the admin app and make the changes there. If this pull request is merged, we will remove the then-redundant code from utils.

## Before

### Desktop

<img width="990" alt="email_template_desktop_before" src="https://github.com/user-attachments/assets/935e6836-206e-4de3-9792-fc2646020a38">

### Mobile

<img width="321" alt="email_template_mobile_before" src="https://github.com/user-attachments/assets/d3c2bb49-35d9-4e82-9c31-ed19e4eb51d1">

## After

### Desktop

<img width="990" alt="email_template_desktop_after" src="https://github.com/user-attachments/assets/7690796f-e7c0-4c8e-95ec-482a21e545ea">

### Mobile

<img width="321" alt="email_template_mobile_after" src="https://github.com/user-attachments/assets/65369bff-fc74-44f1-bf73-93315127dcdd">

## Notes for reviewers

This needs 2 types of review:
1. frontend code review, to compare with the existing (visual) UI
2. application code (python and Jinja) review, to ensure the class, jinja and tests still do what they did in their utils version
3. some 👀 from interaction design, to check the changes made to the mobile UI make sense

[^1]: See page 43 of [the audit report](https://drive.google.com/file/d/1qR8t3mcEka6sUVGqfhnjEpyhqqQhGNFi/view?usp=sharing)