### PR TITLE
Copy common config files from utils in freeze step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,6 @@ var/
 .installed.cfg
 *.egg
 venv/
-pyproject.toml
-.pre-commit-config.yaml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# This file is automatically copied from notifications-utils@87.0.0
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: debug-statements
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: 'v0.3.7'
+  hooks:
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
+- repo: https://github.com/psf/black
+  rev: 24.4.0
+  hooks:
+    - id: black
+      name: black (python)

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,6 @@ PYTHON_EXECUTABLE_PREFIX := $(shell test -d "$${VIRTUALENV_ROOT}" && echo "$${VI
 
 .PHONY: bootstrap
 bootstrap: generate-version-file ## Set up everything to run the app
-	${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements.txt
-
-	python -c "from notifications_utils.version_tools import copy_config; copy_config()"
-
 	${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements_for_test.txt
 
 	source $(HOME)/.nvm/nvm.sh && nvm install && npm ci --no-audit
@@ -84,6 +80,7 @@ fix-imports: ## Fix imports using ruff
 freeze-requirements: ## create static requirements.txt
 	${PYTHON_EXECUTABLE_PREFIX}pip3 install --upgrade pip-tools
 	${PYTHON_EXECUTABLE_PREFIX}pip-compile requirements.in
+	${PYTHON_EXECUTABLE_PREFIX}python -c "from notifications_utils.version_tools import copy_config; copy_config()"
 
 .PHONY: bump-utils
 bump-utils:  # Bump notifications-utils package to latest version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -115,7 +115,7 @@ COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 RUN mkdir -p app
 
 # Install dev/test requirements
-COPY --chown=notify:notify Makefile requirements.txt requirements_for_test.txt package-lock.json package.json gulpfile.js ./
+COPY --chown=notify:notify Makefile requirements.txt requirements_for_test.txt requirements_for_test_common.txt package-lock.json package.json gulpfile.js ./
 RUN make bootstrap
 
 COPY --chown=notify:notify . .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+# This file is automatically copied from notifications-utils@87.0.0
+
+[tool.black]
+line-length = 120
+
+[tool.ruff]
+line-length = 120
+
+target-version = "py311"
+
+lint.select = [
+    "E",  # pycodestyle
+    "W",  # pycodestyle
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C90",  # mccabe cyclomatic complexity
+    "G",  # flake8-logging-format
+    "T20", # flake8-print
+    "UP",  # pyupgrade
+    "C4",  # flake8-comprehensions
+    "ISC",  # flake8-implicit-str-concat
+    "RSE",  # flake8-raise
+    "PIE",  # flake8-pie
+]
+lint.ignore = []
+exclude = [
+    "migrations/versions/",
+    "venv*",
+    "__pycache__",
+    "node_modules",
+    "cache",
+    "migrations",
+    "build",
+    "sample_cap_xml_documents.py",
+]


### PR DESCRIPTION
So that every time you bump the utils version you get the correct corresponding files and the build is more reproducible.

***

Duplicates https://github.com/alphagov/notifications-api/pull/4194