### PR TITLE
WIP: Fix truncated text on pages

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -255,7 +255,7 @@ a {
 
   .govuk-grid-row & {
     margin: govuk-spacing(3) 0 20px 0;
-    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   a,
@@ -273,25 +273,6 @@ a {
     padding: 0 0 0 40px;
   }
 
-  &-folder-truncated {
-    width: 0;
-    padding: 0 0 0 30px;
-    white-space: nowrap;
-    overflow: hidden;
-    top: -2px; // adjust for effect of inline-block on content-height
-
-    @include govuk-media-query($from: tablet) {
-      top: auto;
-    }
-  }
-
-  &-folder-root-truncated {
-    max-width: 1.4em;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
   a {
 
     display: inline-block;
@@ -300,13 +281,8 @@ a {
     &.folder-heading-folder {
 
       display: inline;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      overflow-wrap: break-word;
 
-    }
-
-    &.folder-heading-folder-truncated {
-      display: inline-block;
     }
 
     &:hover {

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -1,6 +1,28 @@
 .table {
   margin-bottom: govuk-spacing(6);
   width: 100%;
+
+  th, td {
+    position: relative;
+  }
+
+  th:has(.govuk-link:focus), td:has(.govuk-link:focus) {
+    background-color: $govuk-focus-colour;
+    box-shadow: inset 0 -4px 0 0 $govuk-focus-text-colour;
+    .govuk-link:focus {
+      box-shadow: none;
+    }
+  }
+
+  .table-row th .govuk-link::before,
+  .table-row td .govuk-link::before {
+    content: " ";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 }
 
 .table-heading {

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -39,13 +39,6 @@
       display: table-cell;
       width: 52.5%;
       font-weight: normal;
-
-      .hint,
-      p {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
     }
   }
 
@@ -75,13 +68,7 @@
       display: table-cell;
       width: 52.5%;
       font-weight: normal;
-
-      .hint,
-      p {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
+      overflow-wrap: break-word;
     }
   }
 
@@ -89,28 +76,14 @@
 
     @include govuk-font(24, $weight: bold);
     display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    padding: 10px 0 32px 0;
-    margin: -10px 0 -32px 0;
-
-    &:focus {
-
-      color: $govuk-text-colour;
-
-      & + .template-statistics-table-hint {
-        color: $govuk-text-colour;
-      }
-
-    }
-
+    overflow-wrap: break-word;
   }
 
   &-hint {
     @include govuk-font(19);
     color: $govuk-secondary-text-colour;
     pointer-events: none;
+    overflow-wrap: break-word;
   }
 
 }
@@ -435,9 +408,7 @@ a.table-show-more-link {
 .wide-left-hand-column {
   display: block;
   max-width: 560px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: break-word;
 }
 
 .truncate-text {

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -410,9 +410,3 @@ a.table-show-more-link {
   max-width: 560px;
   overflow-wrap: break-word;
 }
-
-.truncate-text {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -146,12 +146,6 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
   color: $govuk-secondary-text-colour;
 }
 
-.govuk-summary-list__value--truncate {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .notify-hint--paragraph {
   color: $govuk-text-colour;
   padding-top: govuk-spacing(3);

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -95,25 +95,13 @@
   &-filename {
     @include govuk-font(19, $weight: bold);
     display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    padding-bottom: 30px;
-    padding-top: 10px;
-    margin-bottom: -30px;
-    margin-top: -10px;
+    overflow-wrap: break-word;
   }
 
   &-filename-large {
     @include govuk-font(24, $weight: bold);
     display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    padding-bottom: 30px;
-    padding-top: 10px;
-    margin-bottom: -30px;
-    margin-top: -10px;
+    overflow-wrap: break-word;
   }
 
   &-filename-large-no-hint {
@@ -132,45 +120,20 @@
     @include govuk-font(16);
     display: block;
     color: $govuk-secondary-text-colour;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
     max-width: 580px;
+    overflow-wrap: break-word;
   }
 
   &-hint-large {
     @include govuk-font(19);
     display: block;
     color: $govuk-secondary-text-colour;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
     max-width: 580px;
+    overflow-wrap: break-word;
   }
 
   &-status {
     text-align: right;
-  }
-
-}
-
-/* The focus state for sibling links overlaps the hint so the hint's text colour needs to adapt */
-.govuk-link:focus {
-
-  &.file-list-filename,
-  &.file-list-filename-large {
-    /* override box-shadow to push underline down a bit */
-    box-shadow: 0 -2px $govuk-focus-colour, 0 5px $govuk-focus-text-colour;
-
-    // File-list items contained by keyline-blocks have more spacing at the top so adapt to cover it
-    .keyline-block > .file-list & {
-      box-shadow: 0 -5px $govuk-focus-colour, 0 5px $govuk-focus-text-colour;
-    }
-  }
-
-  & + .file-list-hint,
-  & + .file-list-hint-large {
-    color: $govuk-focus-text-colour;
   }
 
 }

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -147,3 +147,11 @@
   display: block;
   margin-top: govuk-spacing(5);
 }
+
+/* The focus state overlaps the hint so the hint's text colour needs to adapt */
+.govuk-link:focus {
+  & + .file-list-hint,
+  & + .file-list-hint-large {
+    color: $govuk-focus-text-colour;
+  }
+}

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -22,7 +22,7 @@
       {% else %}
         {% if folder.id %}
           {% if current_user.has_template_folder_permission(folder, service=service) %}
-            <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">
+            <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder" title="{{ folder.name }}">
               {{ svgs.folder(classes="folder-heading-folder__icon") }}
               {{ folder.name }}
             </a>
@@ -33,7 +33,7 @@
             </span>
           {% endif %}
         {% else %}
-          <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type) }}" title="Templates" class="govuk-link govuk-link--no-visited-state {% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
+          <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type) }}" title="Templates" class="govuk-link govuk-link--no-visited-state">Templates</a>
         {% endif %}
         {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
       {% endif %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -90,7 +90,7 @@
   </td>
 {%- endmacro %}
 
-{% macro text_field(text, status='', truncate=false, wrap=False) -%}
+{% macro text_field(text, status='', wrap=False) -%}
   {% call field(status=status, wrap=wrap) %}
     {% if text is iterable and text is not string %}
       <ul>
@@ -101,25 +101,20 @@
         {% endfor %}
       </ul>
     {% else %}
-      {% if truncate %}
-        <div class="truncate-text" title="{{ text }}">{{text}}</div>
-      {% else %}
-        {{ text }}
-      {% endif %}
+      {{ text }}
     {% endif %}
   {% endcall %}
 {%- endmacro %}
 
-{% macro callable_text_field(status='', truncate=false, wrap=False) %}
-  {{ text_field(caller(), status=status, truncate=truncate, wrap=wrap) }}
+{% macro callable_text_field(status='', wrap=False) %}
+  {{ text_field(caller(), status=status, wrap=wrap) }}
 {% endmacro %}
 
 
-{% macro optional_text_field(text, default='Not set', truncate=false, wrap=False) -%}
+{% macro optional_text_field(text, default='Not set', wrap=False) -%}
   {{ text_field(
     text or default,
     status='' if text else 'default',
-    truncate=truncate,
     wrap=wrap
   ) }}
 {%- endmacro %}

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -22,13 +22,13 @@
 	  ) %}
 	    {% call row() %}
 	      {{ text_field('Delivery receipts') }}
-	      {{ optional_text_field(delivery_status_callback, truncate=true) }}
+	      {{ optional_text_field(delivery_status_callback) }}
 	      {{ edit_field('Change', url_for('main.delivery_status_callback', service_id=current_service.id)) }}
 	    {% endcall %}
 
 	    {% call row() %}
 	      {{ text_field('Received text messages') }}
-          {{ optional_text_field(received_text_messages_callback, truncate=true) }}
+          {{ optional_text_field(received_text_messages_callback) }}
 	   	  {{ edit_field('Change', url_for('main.received_text_messages_callback', service_id=current_service.id)) }}
 	    {% endcall %}
 	  {% endcall %}

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -139,8 +139,7 @@
             "text": "Data processing and financial agreement"
           },
           "value": {
-            "text": "Not signed (but we have some service-specific agreements in place)" if current_org.agreement_signed is none else "Signed" if current_org.agreement_signed else "Not signed",
-            "classes": "govuk-summary-list__value--truncate" if current_org.agreement_signed is none
+            "text": "Not signed (but we have some service-specific agreements in place)" if current_org.agreement_signed is none else "Signed" if current_org.agreement_signed else "Not signed"
           },
           "actions": {
             "items": [
@@ -160,7 +159,7 @@
           },
           "value": {
             "text": current_org.request_to_go_live_notes or "None",
-            "classes": "govuk-summary-list__value--default" if current_org.request_to_go_live_notes is none else "govuk-summary-list__value--truncate"
+            "classes": "govuk-summary-list__value--default" if current_org.request_to_go_live_notes is none
           },
           "actions": {
             "items": [

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -28,8 +28,7 @@
               "text": "Service name"
             },
             "value": {
-              "text": current_service.name,
-              "classes": "govuk-summary-list__value--truncate"
+              "text": current_service.name
             },
             "actions": {
               "items": [
@@ -130,8 +129,7 @@
               "text": "Email sender name"
             },
             "value": {
-              "html": email_sender_html,
-              "classes": "govuk-summary-list__value--truncate"
+              "html": email_sender_html
             },
             "actions": {
               "items": [
@@ -150,7 +148,7 @@
               "text": "Reply-to email addresses"
             },
             "value": {
-              "classes": "govuk-summary-list__value--default" if current_service.default_email_reply_to_address is none else "govuk-summary-list__value--truncate",
+              "classes": "govuk-summary-list__value--default" if current_service.default_email_reply_to_address is none,
               "html": reply_to_email_addresses_html
             },
             "actions": {
@@ -190,7 +188,7 @@
             },
             "value": {
               "text": current_service.contact_link or 'Not set up',
-              "classes": "govuk-summary-list__value--default" if current_service.contact_link is none else "govuk-summary-list__value--truncate"
+              "classes": "govuk-summary-list__value--default" if current_service.contact_link is none
             },
             "actions": {
               "items": [
@@ -259,8 +257,7 @@
               "text": "Text message sender IDs"
             },
             "value": {
-              "text": text_message_sender_ids_html,
-              "classes": "govuk-summary-list__value--truncate"
+              "text": text_message_sender_ids_html
             },
             "actions": {
               "items": [
@@ -411,7 +408,7 @@
             },
             "value": {
               "html": sender_addresses_html,
-              "classes": "govuk-summary-list__value--default" if current_service.count_letter_contact_details == 0 else "govuk-summary-list__value--truncate"
+              "classes": "govuk-summary-list__value--default" if current_service.count_letter_contact_details == 0
             },
             "actions": {
               "items": [


### PR DESCRIPTION
## What 
Remove truncated text from our pages by removing CSS styles that prevent the text to wrap and associated HTML classes. Text in such scenarios now flows and wraps. 

## Why
Content must be presented without loss of information or functionality.
This fails [the reflow WCAG success criterion](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html).

## How to review
- see individual commits

These changes affect many pages that include affected components. 
- `file-list` component
   - services/serviceID>/inbox
   - services/serviceID>/notifications
   - services/serviceID>/uploads
   - services/serviceID>unsubscribe-requests
   - services/serviceID>/contact-list/<id>
   - services/serviceID>/api/keys
   - services/serviceID>/jobs/<id>
   - send-contact-list, returned-letters
- `dashboard-table`
   - services/serviceID>api/callback
   - services/serviceID>template-usage
   - /features/performance
   - notifications table
- settings summary list
   - service settings
   - organisation settings
- template folder path heading
  - a template in nested folder: services/serviceID>templates/id
  
  ## Visual changes
  
  There are changes in listed page that, instead of a single line of truncated text, now show all the text that wraps into multiple line as required. 
  
  ### Example: Notifications table
  

https://github.com/user-attachments/assets/dd6dafe0-c673-4dd7-9185-5f61a0f8cb72


https://github.com/user-attachments/assets/6c5ebb4a-1c5e-457e-991f-7f53d4d50ba1


  
  
  
