### PR TITLE
notifications-utils: 87.1.0 -> 88.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@87.1.0
+# This file is automatically copied from notifications-utils@88.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from markupsafe import Markup
 from notifications_utils.template import (
-    EmailPreviewTemplate,
     LetterPreviewTemplate,
     SMSBodyPreviewTemplate,
 )
@@ -11,6 +10,7 @@ from notifications_utils.template import (
 from app.models import JSONModel, ModelList
 from app.notify_client.notification_api_client import notification_api_client
 from app.notify_client.service_api_client import service_api_client
+from app.utils.templates import EmailPreviewTemplate
 
 
 class Notification(JSONModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@87.1.0
+# This file is automatically copied from notifications-utils@88.0.1
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@87.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@88.0.1
 
 govuk-frontend-jinja==3.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@87.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@88.0.1
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@87.1.0
+# This file is automatically copied from notifications-utils@88.0.1
 
 beautifulsoup4==4.11.1
 pytest==7.2.0


### PR DESCRIPTION
Incorporating https://github.com/alphagov/notifications-utils/pull/1161

~@quis assuming this is safe in regards to https://github.com/alphagov/notifications-utils/pull/1159~