### PR TITLE
Make back links work when sending a messages from the inbound SMS flow

### DIFF
--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -42,6 +42,17 @@ def conversation_reply(
     notification_id,
     from_folder=None,
 ):
+    if from_folder:
+        parent_folder_id = current_service.get_template_folder(from_folder)["parent_id"]
+        back_link = url_for(
+            "main.conversation_reply",
+            service_id=service_id,
+            notification_id=notification_id,
+            from_folder=parent_folder_id,
+        )
+    else:
+        back_link = url_for("main.conversation", service_id=service_id, notification_id=notification_id)
+
     return render_template(
         "views/templates/choose-reply.html",
         templates_and_folders=UserTemplateList(
@@ -51,6 +62,7 @@ def conversation_reply(
         _search_form=SearchByNameForm(),
         notification_id=notification_id,
         template_type="sms",
+        back_link=back_link,
     )
 
 

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -1,4 +1,4 @@
-from flask import jsonify, redirect, render_template, session, url_for
+from flask import jsonify, redirect, render_template, request, session, url_for
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils.recipient_validation.phone_number import format_phone_number_human_readable
@@ -59,6 +59,7 @@ def conversation_reply(
             service=current_service, template_folder_id=from_folder, user=current_user, template_type="sms"
         ),
         template_folder_path=current_service.get_template_folder_path(from_folder),
+        from_folder=from_folder,
         _search_form=SearchByNameForm(),
         notification_id=notification_id,
         template_type="sms",
@@ -75,6 +76,10 @@ def conversation_reply_with_template(
 ):
     session["recipient"] = get_user_number(service_id, notification_id)
     session["placeholders"] = {"phone number": session["recipient"]}
+    session["from_inbound_sms_details"] = {
+        "notification_id": notification_id,
+        "from_folder": request.args.get("from_folder"),
+    }
 
     return redirect(
         url_for(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -864,6 +864,20 @@ def get_back_link(service_id, template, step_index, placeholders=None):
         else:
             return _get_set_sender_back_link(service_id, template)
 
+    if step_index == 1 and template.template_type == "sms" and "from_inbound_sms_details" in session:
+        notification_id = session["from_inbound_sms_details"]["notification_id"]
+        from_folder = session["from_inbound_sms_details"]["from_folder"]
+
+        if from_folder:
+            return url_for(
+                "main.conversation_reply",
+                service_id=service_id,
+                notification_id=notification_id,
+                from_folder=from_folder,
+            )
+        else:
+            return url_for("main.conversation_reply", service_id=service_id, notification_id=notification_id)
+
     if template.template_type == "letter" and placeholders:
         # Make sure we’re not redirecting users to a page which will
         # just redirect them forwards again
@@ -1026,6 +1040,7 @@ def send_notification(service_id, template_id):
     session.pop("placeholders")
     session.pop("recipient")
     session.pop("sender_id", None)
+    session.pop("from_inbound_sms_details", None)
 
     return redirect(
         url_for(

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -106,3 +106,18 @@
 {% macro folder_path_separator() %}
   <span class="folder-heading-separator"></span>
 {% endmacro %}
+
+
+{% macro format_template_name(name, separators=True) -%}
+  {%- if name is string -%}
+    {{- name -}}
+  {%- else -%}
+    {%- for part in name -%}
+      {{- format_template_name(part, separators) -}}
+      {%- if not loop.last -%}
+        {%- if separators %}
+        <span class="message-name-separator"></span>{%- else %} {% endif -%}
+      {% endif -%}
+    {%- endfor -%}
+  {% endif %}
+{%- endmacro %}

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -1,18 +1,6 @@
-{% import "components/svgs.html" as svgs %}
+{% from "components/folder-path.html" import format_template_name %}
 
-{% macro format_item_name(name, separators=True) -%}
-  {%- if name is string -%}
-    {{- name -}}
-  {%- else -%}
-    {%- for part in name -%}
-      {{- format_item_name(part, separators) -}}
-      {%- if not loop.last -%}
-        {%- if separators %}
-        <span class="message-name-separator"></span>{%- else %} {% endif -%}
-      {% endif -%}
-    {%- endfor -%}
-  {% endif %}
-{%- endmacro %}
+{% import "components/svgs.html" as svgs %}
 
 {% if template_list.template_folder_id and not template_list.templates_to_show %}
   <p class="template-list-empty">
@@ -32,13 +20,13 @@
         {% for ancestor in item.ancestors %}
           <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
             {{ svgs.folder(classes="template-list-folder__icon") }}
-            {{- format_item_name(ancestor.name) -}}
+            {{- format_template_name(ancestor.name) -}}
           </a> <span class="message-name-separator"></span>
         {% endfor %}
         {% if item.is_folder %}
           <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
             {{ svgs.folder(classes="template-list-folder__icon") }}
-            <span class="live-search-relevant">{{- format_item_name(item.name) -}}</span>
+            <span class="live-search-relevant">{{- format_template_name(item.name) -}}</span>
           </a>
         {% else %}
           <a href="{{ url_for('main.view_template', service_id=current_service.id, template_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-template">
@@ -46,7 +34,7 @@
               {%- if current_service.api_keys -%}
                 <span class="govuk-!-display-none">{{ item.id }} </span>
               {%- endif -%}
-              {{- format_item_name(item.name) -}}
+              {{- format_template_name(item.name) -}}
             </span>
           </a>
         {% endif %}
@@ -54,8 +42,8 @@
 
       {% set label_content %}
         <span class="govuk-visually-hidden">
-          {%- for ancestor in item.ancestors %}{{ format_item_name(ancestor.name, separators=False) }} {% endfor -%}
-          {{ format_item_name(item.name, separators=False) -}}
+          {%- for ancestor in item.ancestors %}{{ format_template_name(ancestor.name, separators=False) }} {% endfor -%}
+          {{ format_template_name(item.name, separators=False) -}}
         </span>
       {% endset %}
 

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -1,5 +1,5 @@
 {% from "components/live-search.html" import live_search %}
-{% from "components/folder-path.html" import folder_path %}
+{% from "components/folder-path.html" import folder_path, format_template_name %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% import "components/svgs.html" as svgs %}
 
@@ -50,7 +50,7 @@
           {% if item.is_folder %}
             <a href="{{ url_for('main.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {{ svgs.folder(classes="template-list-folder__icon") }}
-              <span class="live-search-relevant">{{ item.name }}</span>
+              <span class="live-search-relevant">{{ format_template_name(item.name) }}</span>
             </a>
           {% else %}
             <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('main.conversation_reply_with_template', service_id=current_service.id, template_id=item.id, notification_id=notification_id) }}">

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -1,12 +1,18 @@
 {% from "components/live-search.html" import live_search %}
 {% from "components/folder-path.html" import folder_path, format_template_name %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
 {% import "components/svgs.html" as svgs %}
 
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
   Choose a template
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({ "href": back_link }) }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -59,7 +59,7 @@
               <span class="live-search-relevant">{{ format_template_name(item.name) }}</span>
             </a>
           {% else %}
-            <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('main.conversation_reply_with_template', service_id=current_service.id, template_id=item.id, notification_id=notification_id) }}">
+            <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('main.conversation_reply_with_template', service_id=current_service.id, template_id=item.id, notification_id=notification_id, from_folder=from_folder)  }}">
               <span class="live-search-relevant">{{ item.name }}</span>
             </a>
           {% endif %}


### PR DESCRIPTION
When sending from the inbound SMS flow we didn't have a back link on the page to choose a template. Once you had started sending a message, the back links took you to the "standard journey" of sending a message after clicking on a template. This change adds in back links to the "Choose a template page" and makes the back links when sending work for all scenarios. More details in the individual commit messages.

This also fixes a bug with how templates in folders appeared when sending from an inbound SMS:

**Before**
![Screenshot 2024-10-29 at 11 30 10](https://github.com/user-attachments/assets/42e9f3a5-e632-4514-b788-3c9a6215922a)

**After**
![Screenshot 2024-10-29 at 11 30 31](https://github.com/user-attachments/assets/7493d4df-0c19-464c-bbd4-7c2bae38289d)

