### PR TITLE
Give all error banners the role of 'alert'

### DIFF
--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -6,7 +6,7 @@
   <div
     class='banner{% if type %}-{{ type }}{% endif %}{% if with_tick %}-with-tick{% endif %}'
     {% if type == 'dangerous' %}
-    role='group'
+    role='alert'
     {% endif %}
     {% if id %}
     id={{ id }}


### PR DESCRIPTION
So the semantics match the visuals and behaviour.

https://trello.com/c/gqzledqm/1014-attach-pages-upload-doesnt-let-screen-reader-users-know-when-the-upload-works

This was the proposed solution for the error banner used when you attach pages to a letter template, in the report for the recent accessibility audit. It makes sense to make this change to all error banners.