### PR TITLE
Bump govuk-frontend to v5.7.1 and govuk-frontend-jinja to v3.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cbor-js": "0.1.0",
-        "govuk-frontend": "5.4.1",
+        "govuk-frontend": "5.7.1",
         "hogan": "1.0.2",
         "jquery": "3.5.0",
         "morphdom": "2.6.1",
@@ -5875,9 +5875,9 @@
       "dev": true
     },
     "node_modules/govuk-frontend": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.1.tgz",
-      "integrity": "sha512-Gmd8LV++TRh9OF6tA+9KQTpwvlsLcri7qRjViz9ji4YuwZvX+c9TD7tyE+dnJcqsQsJfhr9Fp38m3Hu3H7EIcQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
+      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor-js": "0.1.0",
-    "govuk-frontend": "5.4.1",
+    "govuk-frontend": "5.7.1",
     "hogan": "1.0.2",
     "jquery": "3.5.0",
     "morphdom": "2.6.1",

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ fido2==1.1.3
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@88.1.0
 
-govuk-frontend-jinja==3.1.0
+govuk-frontend-jinja==3.4.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 govuk-bank-holidays==0.14
     # via notifications-utils
-govuk-frontend-jinja==3.1.0
+govuk-frontend-jinja==3.4.0
     # via -r requirements.in
 greenlet==3.0.3
     # via eventlet

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -12,8 +12,8 @@ def test_govuk_frontend_jinja_overrides_on_design_system_v3():
     govuk_frontend_jinja_version = Version(metadata.version("govuk-frontend-jinja"))
 
     # Compatibility between these two libs is defined at https://github.com/LandRegistry/govuk-frontend-jinja/
-    correct_govuk_frontend_version = Version("5.4.1") == govuk_frontend_version
-    correct_govuk_frontend_jinja_version = Version("3.1.0") == govuk_frontend_jinja_version
+    correct_govuk_frontend_version = Version("5.7.1") == govuk_frontend_version
+    correct_govuk_frontend_jinja_version = Version("3.4.0") == govuk_frontend_jinja_version
 
     assert correct_govuk_frontend_version and correct_govuk_frontend_jinja_version, (
         "After upgrading either of the Design System packages, you must validate that "


### PR DESCRIPTION
Fixes: https://trello.com/c/zDuS5nzZ/1015-update-admin-and-document-download-apps-to-latest-design-system

Current latest, with new coat of arms.
Bumps [govuk-frontend-jinja to v3.4.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.4.0) that supports [govuk-frontend v5.7.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.1)

Top: before 
Bottom: after
<img width="183" alt="Screenshot 2024-11-01 at 07 52 56" src="https://github.com/user-attachments/assets/cf51ac47-4699-4705-8c62-4820bfba344c">
