### PR TITLE
Dockerfile: use debian bookworm-based base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye as base
+FROM python:3.11-slim-bookworm as base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
https://trello.com/c/ORGrd1jn/498-upgrade-docker-images-for-our-ecs-apps-to-debian-bookworm

Because it's 2024

See also https://github.com/alphagov/notifications-api/pull/4243

Passed dev-a @ https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/112