### PR TITLE
Give checkboxes height again & fix other visual bugs

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -58,18 +58,22 @@ a {
 .template-list {
 
   &-item {
+    display: block;
     margin-bottom: 0;
 
     &-with-checkbox {
+      padding-left: $govuk-touch-target-size + $govuk-checkboxes-label-padding-left-right;
+      min-height: $govuk-touch-target-size;
 
       .template-list-item-hint {
+        width: 100%;
         margin-top: 0;
-        padding-left: ($govuk-checkboxes-label-padding-left-right + $govuk-touch-target-size);
       }
 
       input {
-        margin-right: $govuk-checkboxes-label-padding-left-right;
-        height: 1px;
+        position: absolute;
+        top: 0;
+        left: 0;
       }
     }
 
@@ -84,7 +88,7 @@ a {
         display: block;
         // block focus state for items that have no ancestors
         // our version of dart-sass (< 1.4.0 still parses calc() as a special function
-        // so we need to interpolate it 
+        // so we need to interpolate it
         // https://sass-lang.com/documentation/syntax/special-functions/#element-progid-and-expression
         width: calc(100% - #{$govuk-touch-target-size + $govuk-checkboxes-label-padding-left-right});
 
@@ -194,6 +198,11 @@ a {
 
     @include govuk-media-query($from: tablet) {
       padding-left: 40px;
+    }
+
+    &:focus {
+      -webkit-box-decoration-break: inherit;
+      box-decoration-break: inherit;
     }
 
     &__icon {


### PR DESCRIPTION
Includes changes to the template list CSS to:
- give the checkbox element has height again
- fix an issue caused by the 'new' design system links styles setting the `box-decoration-break` value to assume all lines a link wraps to inherit the initial padding
- add padding-left to stop content from the template list item wrapping underneath the checkbox

The checkboxes currently have a height of 1px, which interferes with the logic browsers use to scroll them into view when mostly off-screen. Because only their first 1px was considered by the layout, you would often see checkboxes that were
mostly off-screen focused without being scrolled into view.

The `box-decoration-break` change interferred with us having padding at the start of links to folders, to make space for the folder icon. It was only visible when the links were focused.

## Before - unfocused

<img width="678" alt="template_list_path_wrapping_text_before" src="https://github.com/user-attachments/assets/cb82ee36-45a1-45f9-8974-4acebc5d9178">

## Before - focused

<img width="693" alt="template_list_path_wrapping_text_focused_before" src="https://github.com/user-attachments/assets/3d48c2e3-6300-40b8-a62a-21b60c7f0b3f">

## After - unfocused

<img width="691" alt="template_list_path_wrapping_text_after" src="https://github.com/user-attachments/assets/756173d8-f5e2-43ff-9b02-c0d01a4ba79f">

## After - focused

<img width="681" alt="template_list_path_wrapping_text_focused_after" src="https://github.com/user-attachments/assets/0e4aeb2c-213f-4cb9-b091-01cee320e8b6">

## Notes for reviewers

It's worth testing with the following pages:
- templates
- templates with a search
- templates > copy an existing template > Choose an existing template
- reply to an inbound sms > Choose a template