### PR TITLE
Give all folder icons alt text

### DIFF
--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -10,12 +10,13 @@
 ) %}
   <{{ root_element }} class="heading-medium folder-heading"{% if root_element == 'h1' %} id="page-header"{% endif %}>
     {% for folder in folders %}
+      {% set folder_id = 'folder_' ~ loop.index %}
       {% if loop.last and not link_current_item %}
         {% if folder.template_type or not folder.id %}
           <span class="folder-heading-template">{{ folder.name }}</span>
         {% else %}
           <span class="folder-heading-folder">
-            {{ svgs.folder(classes="folder-heading-folder__icon") }}
+            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
             {{ folder.name }}
           </span>
         {% endif %}
@@ -23,12 +24,12 @@
         {% if folder.id %}
           {% if current_user.has_template_folder_permission(folder, service=service) %}
             <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">
-              {{ svgs.folder(classes="folder-heading-folder__icon") }}
+              {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
               {{ folder.name }}
             </a>
           {% else %}
             <span class="folder-heading-folder">
-              {{ svgs.folder(classes="folder-heading-folder__icon") }}
+              {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
               {{ folder.name }}
             </span>
           {% endif %}
@@ -56,33 +57,34 @@
         {{ folder_path_separator() }}
       {% endif %}
       {% for folder in folder_path %}
+        {% set folder_id = 'folder_' ~ loop.index %}
         {% if loop.last %}
           <span class="folder-heading-folder">
-            {{ svgs.folder(classes="folder-heading-folder__icon") }}
+            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
             {{ folder.name if folder.id else from_service.name }}
           </span>
         {% else %}
           {% if folder.id %}
             {% if current_user.has_template_folder_permission(folder, service=from_service) %}
               <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
-                {{ svgs.folder(classes="folder-heading-folder__icon") }}
+                {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
                 {{ folder.name }}
               </a>
              {% else %}
               <span class="folder-heading-folder">
-                {{ svgs.folder(classes="folder-heading-folder__icon") }}
+                {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
                 {{ folder.name }}
               </span>
             {% endif %}
             {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% elif folder.parent_id == None %}
             <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
-              {{ svgs.folder(classes="folder-heading-folder__icon") }}
+              {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
               {{ from_service.name }}
             </a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% else %}
             <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, to_folder_id=to_folder_id) }}">
-              {{ svgs.folder(classes="folder-heading-folder__icon") }}
+              {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
               {{ from_service.name }}
             </a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% endif %}

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -15,17 +15,19 @@
     {% set checkboxes_data = [] %}
 
     {% for item in template_list %}
-
+      {% set item_num = loop.index %}
       {% set item_link_content %}
         {% for ancestor in item.ancestors %}
+          {% set folder_id = 'folder_' ~ item_num ~ '_ancestor_' ~ loop.index %}
           <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-            {{ svgs.folder(classes="template-list-folder__icon") }}
+            {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
             {{- format_template_name(ancestor.name) -}}
           </a> <span class="message-name-separator"></span>
         {% endfor %}
+        {% set folder_id = 'folder_' ~ item_num ~ '_ancestor_' ~ loop.index %}
         {% if item.is_folder %}
           <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-            {{ svgs.folder(classes="template-list-folder__icon") }}
+            {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
             <span class="live-search-relevant">{{- format_template_name(item.name) -}}</span>
           </a>
         {% else %}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -46,16 +46,19 @@
 
     <div id="template-list">
       {% for item in templates_and_folders %}
+        {% set item_num = loop.index %}
         <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
           {% for ancestor in item.ancestors %}
+              {% set folder_id = 'folder_' ~ item_num ~ '_ancestor_' ~ loop.index %}
               <a href="{{ url_for('main.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-              {{ svgs.folder(classes="template-list-folder__icon") }}
+              {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
               {{ ancestor.name }}
             </a> <span class="message-name-separator"></span>
           {% endfor %}
+          {% set folder_id = 'folder_' ~ item_num %}
           {% if item.is_folder %}
             <a href="{{ url_for('main.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-              {{ svgs.folder(classes="template-list-folder__icon") }}
+              {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
               <span class="live-search-relevant">{{ format_template_name(item.name) }}</span>
             </a>
           {% else %}

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -28,25 +28,28 @@
       ) }}
       <div id="template-list">
         {% for item in services_templates_and_folders %}
+          {% set item_num = loop.index %}
           <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
             {% for ancestor in item.ancestors %}
+              {% set folder_id = 'folder_' ~ item_num ~ '_ancestor_' ~ loop.index %}
               {% if ancestor.is_service %}
                 <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {% else %}
                 <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {% endif %}
-                {{ svgs.folder(classes="template-list-folder__icon") }}
+                {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
                 {{ ancestor.name }}
               </a> <span class="message-name-separator"></span>
             {% endfor %}
+            {% set folder_id = 'folder_' ~ item_num %}
             {% if item.is_service %}
               <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                {{ svgs.folder(classes="template-list-folder__icon") }}
+                {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% elif item.is_folder %}
               <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                {{ svgs.folder(classes="template-list-folder__icon") }}
+                {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% else %}

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -303,7 +303,7 @@ def test_conversation_reply_shows_templates(
     )
 
     link = page.select(".template-list-item-without-ancestors")
-    assert normalize_spaces(link[0].text) == "Parent 2 - visible 1 template"
+    assert normalize_spaces(link[0].text) == "Folder Parent 2 - visible 1 template"
     assert normalize_spaces(link[1].text) == "sms_template_two Text message template"
 
     assert link[0].select_one("a")["href"] == url_for(

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -55,25 +55,25 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             {},
             ["Email", "Text message", "Letter"],
             [
-                "folder_one folder_one 2 folders",
-                "folder_one folder_one_one folder_one folder_one_one 1 template, 1 folder",
+                "folder_one Folder folder_one 2 folders",
+                "folder_one folder_one_one Folder folder_one Folder folder_one_one 1 template, 1 folder",
                 (
                     "folder_one folder_one_one folder_one_one_one "
-                    "folder_one folder_one_one folder_one_one_one "
+                    "Folder folder_one Folder folder_one_one Folder folder_one_one_one "
                     "1 template"
                 ),
                 (
                     "folder_one folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested "
+                    "Folder folder_one Folder folder_one_one Folder folder_one_one_one sms_template_nested "
                     "Text message template"
                 ),
                 (
                     "folder_one folder_one_one letter_template_nested "
-                    "folder_one folder_one_one letter_template_nested "
+                    "Folder folder_one Folder folder_one_one letter_template_nested "
                     "Letter template"
                 ),
-                "folder_one folder_one_two folder_one folder_one_two Empty",
-                "folder_two folder_two Empty",
+                "folder_one folder_one_two Folder folder_one Folder folder_one_two Empty",
+                "folder_two Folder folder_two Empty",
                 "sms_template_one sms_template_one Text message template",
                 "sms_template_two sms_template_two Text message template",
                 "email_template_one email_template_one Email template",
@@ -82,8 +82,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
                 "letter_template_two letter_template_two Letter template",
             ],
             [
-                "folder_one folder_one 2 folders",
-                "folder_two folder_two Empty",
+                "folder_one Folder folder_one 2 folders",
+                "folder_two Folder folder_two Empty",
                 "sms_template_one sms_template_one Text message template",
                 "sms_template_two sms_template_two Text message template",
                 "email_template_one email_template_one Email template",
@@ -115,25 +115,25 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             {"template_type": "all"},
             ["Email", "Text message", "Letter"],
             [
-                "folder_one folder_one 2 folders",
-                "folder_one folder_one_one folder_one folder_one_one 1 template, 1 folder",
+                "folder_one Folder folder_one 2 folders",
+                "folder_one folder_one_one Folder folder_one Folder folder_one_one 1 template, 1 folder",
                 (
                     "folder_one folder_one_one folder_one_one_one "
-                    "folder_one folder_one_one folder_one_one_one "
+                    "Folder folder_one Folder folder_one_one Folder folder_one_one_one "
                     "1 template"
                 ),
                 (
                     "folder_one folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested "
+                    "Folder folder_one Folder folder_one_one Folder folder_one_one_one sms_template_nested "
                     "Text message template"
                 ),
                 (
                     "folder_one folder_one_one letter_template_nested "
-                    "folder_one folder_one_one letter_template_nested "
+                    "Folder folder_one Folder folder_one_one letter_template_nested "
                     "Letter template"
                 ),
-                "folder_one folder_one_two folder_one folder_one_two Empty",
-                "folder_two folder_two Empty",
+                "folder_one folder_one_two Folder folder_one Folder folder_one_two Empty",
+                "folder_two Folder folder_two Empty",
                 "sms_template_one sms_template_one Text message template",
                 "sms_template_two sms_template_two Text message template",
                 "email_template_one email_template_one Email template",
@@ -142,8 +142,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
                 "letter_template_two letter_template_two Letter template",
             ],
             [
-                "folder_one folder_one 2 folders",
-                "folder_two folder_two Empty",
+                "folder_one Folder folder_one 2 folders",
+                "folder_two Folder folder_two Empty",
                 "sms_template_one sms_template_one Text message template",
                 "sms_template_two sms_template_two Text message template",
                 "email_template_one email_template_one Email template",
@@ -175,23 +175,23 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             {"template_type": "sms"},
             ["All", "Email", "Letter"],
             [
-                "folder_one folder_one 1 folder",
-                "folder_one folder_one_one folder_one folder_one_one 1 folder",
+                "folder_one Folder folder_one 1 folder",
+                "folder_one folder_one_one Folder folder_one Folder folder_one_one 1 folder",
                 (
                     "folder_one folder_one_one folder_one_one_one "
-                    "folder_one folder_one_one folder_one_one_one "
+                    "Folder folder_one Folder folder_one_one Folder folder_one_one_one "
                     "1 template"
                 ),
                 (
                     "folder_one folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one folder_one_one folder_one_one_one sms_template_nested "
+                    "Folder folder_one Folder folder_one_one Folder folder_one_one_one sms_template_nested "
                     "Text message template"
                 ),
                 "sms_template_one sms_template_one Text message template",
                 "sms_template_two sms_template_two Text message template",
             ],
             [
-                "folder_one folder_one 1 folder",
+                "folder_one Folder folder_one 1 folder",
                 "sms_template_one sms_template_one Text message template",
                 "sms_template_two sms_template_two Text message template",
             ],
@@ -207,24 +207,24 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_one – Templates – service one – GOV.UK Notify",
-            "Templates folder_one",
+            "Templates Folder folder_one",
             [{"template_type": "all"}],
             {"template_folder_id": PARENT_FOLDER_ID},
             ["Email", "Text message", "Letter"],
             [
-                "folder_one_one folder_one_one 1 template, 1 folder",
-                "folder_one_one folder_one_one_one folder_one_one folder_one_one_one 1 template",
+                "folder_one_one Folder folder_one_one 1 template, 1 folder",
+                "folder_one_one folder_one_one_one Folder folder_one_one Folder folder_one_one_one 1 template",
                 (
                     "folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one_one folder_one_one_one sms_template_nested "
+                    "Folder folder_one_one Folder folder_one_one_one sms_template_nested "
                     "Text message template"
                 ),
-                "folder_one_one letter_template_nested folder_one_one letter_template_nested Letter template",
-                "folder_one_two folder_one_two Empty",
+                "folder_one_one letter_template_nested Folder folder_one_one letter_template_nested Letter template",
+                "folder_one_two Folder folder_one_two Empty",
             ],
             [
-                "folder_one_one folder_one_one 1 template, 1 folder",
-                "folder_one_two folder_one_two Empty",
+                "folder_one_one Folder folder_one_one 1 template, 1 folder",
+                "folder_one_two Folder folder_one_two Empty",
             ],
             [
                 "folder_one_one",
@@ -237,21 +237,21 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_one – Templates – service one – GOV.UK Notify",
-            "Templates folder_one",
+            "Templates Folder folder_one",
             [{"template_type": "sms"}],
             {"template_type": "sms", "template_folder_id": PARENT_FOLDER_ID},
             ["All", "Email", "Letter"],
             [
-                "folder_one_one folder_one_one 1 folder",
-                "folder_one_one folder_one_one_one folder_one_one folder_one_one_one 1 template",
+                "folder_one_one Folder folder_one_one 1 folder",
+                "folder_one_one folder_one_one_one Folder folder_one_one Folder folder_one_one_one 1 template",
                 (
                     "folder_one_one folder_one_one_one sms_template_nested "
-                    "folder_one_one folder_one_one_one sms_template_nested "
+                    "Folder folder_one_one Folder folder_one_one_one sms_template_nested "
                     "Text message template"
                 ),
             ],
             [
-                "folder_one_one folder_one_one 1 folder",
+                "folder_one_one Folder folder_one_one 1 folder",
             ],
             [
                 "folder_one_one",
@@ -262,7 +262,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_one – Templates – service one – GOV.UK Notify",
-            "Templates folder_one",
+            "Templates Folder folder_one",
             [{"template_type": "email"}],
             {"template_type": "email", "template_folder_id": PARENT_FOLDER_ID},
             ["All", "Text message", "Letter"],
@@ -273,7 +273,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_one_one – folder_one – Templates – service one – GOV.UK Notify",
-            "Templates folder_one folder_one_one",
+            "Templates Folder folder_one Folder folder_one_one",
             [
                 {"template_type": "all"},
                 {"template_type": "all", "template_folder_id": PARENT_FOLDER_ID},
@@ -281,16 +281,16 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             {"template_folder_id": CHILD_FOLDER_ID},
             ["Email", "Text message", "Letter"],
             [
-                "folder_one_one_one folder_one_one_one 1 template",
+                "folder_one_one_one Folder folder_one_one_one 1 template",
                 (
                     "folder_one_one_one sms_template_nested "
-                    "folder_one_one_one sms_template_nested "
+                    "Folder folder_one_one_one sms_template_nested "
                     "Text message template"
                 ),
                 "letter_template_nested letter_template_nested Letter template",
             ],
             [
-                "folder_one_one_one folder_one_one_one 1 template",
+                "folder_one_one_one Folder folder_one_one_one 1 template",
                 "letter_template_nested letter_template_nested Letter template",
             ],
             [
@@ -302,7 +302,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_one_one_one – folder_one_one – folder_one – Templates – service one – GOV.UK Notify",
-            "Templates folder_one folder_one_one folder_one_one_one",
+            "Templates Folder folder_one Folder folder_one_one Folder folder_one_one_one",
             [
                 {"template_type": "all"},
                 {"template_type": "all", "template_folder_id": PARENT_FOLDER_ID},
@@ -323,7 +323,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_one_one_one – folder_one_one – folder_one – Templates – service one – GOV.UK Notify",
-            "Templates folder_one folder_one_one folder_one_one_one",
+            "Templates Folder folder_one Folder folder_one_one Folder folder_one_one_one",
             [
                 {"template_type": "email"},
                 {"template_type": "email", "template_folder_id": PARENT_FOLDER_ID},
@@ -341,7 +341,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_two – Templates – service one – GOV.UK Notify",
-            "Templates folder_two",
+            "Templates Folder folder_two",
             [{"template_type": "all"}],
             {"template_folder_id": FOLDER_TWO_ID},
             ["Email", "Text message", "Letter"],
@@ -352,7 +352,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_two – Templates – service one – GOV.UK Notify",
-            "Templates folder_two",
+            "Templates Folder folder_two",
             [{"template_type": "sms"}],
             {"template_folder_id": FOLDER_TWO_ID, "template_type": "sms"},
             ["All", "Email", "Letter"],
@@ -363,7 +363,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_two – Templates – service one – GOV.UK Notify",
-            "Templates folder_two",
+            "Templates Folder folder_two",
             [{"template_type": "all"}],
             {"template_folder_id": FOLDER_TWO_ID, "template_type": "all"},
             ["Email", "Text message", "Letter"],
@@ -516,7 +516,7 @@ def test_template_id_is_searchable_for_services_with_api_keys(
             ".template-list-item:not(.template-list-item-hidden-by-default)"
         )
     ] == [
-        "folder one folder one 1 template",
+        "folder one Folder folder one 1 template",
         f'template one {template_1["id"]} template one Text message template',
     ]
 
@@ -1538,19 +1538,28 @@ def test_show_custom_error_message(
         (
             {},
             [
-                ["folder_A", "folder_A", "1 template, 2 folders"],
-                ["folder_E folder_F folder_G", "folder_E", "folder_F", "folder_G", "1 template"],
+                ["folder_A", "Folder", "folder_A", "1 template, 2 folders"],
+                ["folder_E folder_F folder_G", "Folder", "folder_E", "folder_F", "folder_G", "1 template"],
                 ["email_template_root", "email_template_root", "Email template"],
             ],
             [
-                ["folder_A", "folder_A", "1 template, 2 folders"],
-                ["folder_A folder_C", "folder_A", "folder_C", "1 template"],
-                ["folder_A folder_C sms_template_C", "folder_A", "folder_C", "sms_template_C", "Text message template"],
-                ["folder_A folder_D", "folder_A", "folder_D", "Empty"],
-                ["folder_A sms_template_A", "folder_A", "sms_template_A", "Text message template"],
-                ["folder_E folder_F folder_G", "folder_E", "folder_F", "folder_G", "1 template"],
+                ["folder_A", "Folder", "folder_A", "1 template, 2 folders"],
+                ["folder_A folder_C", "Folder", "folder_A", "Folder", "folder_C", "1 template"],
+                [
+                    "folder_A folder_C sms_template_C",
+                    "Folder",
+                    "folder_A",
+                    "Folder",
+                    "folder_C",
+                    "sms_template_C",
+                    "Text message template",
+                ],
+                ["folder_A folder_D", "Folder", "folder_A", "Folder", "folder_D", "Empty"],
+                ["folder_A sms_template_A", "Folder", "folder_A", "sms_template_A", "Text message template"],
+                ["folder_E folder_F folder_G", "Folder", "folder_E", "folder_F", "folder_G", "1 template"],
                 [
                     "folder_E folder_F folder_G email_template_G",
+                    "Folder",
                     "folder_E",
                     "folder_F",
                     "folder_G",
@@ -1564,13 +1573,14 @@ def test_show_custom_error_message(
         (
             {"template_type": "email"},
             [
-                ["folder_E folder_F folder_G", "folder_E", "folder_F", "folder_G", "1 template"],
+                ["folder_E folder_F folder_G", "Folder", "folder_E", "folder_F", "folder_G", "1 template"],
                 ["email_template_root", "email_template_root", "Email template"],
             ],
             [
-                ["folder_E folder_F folder_G", "folder_E", "folder_F", "folder_G", "1 template"],
+                ["folder_E folder_F folder_G", "Folder", "folder_E", "folder_F", "folder_G", "1 template"],
                 [
                     "folder_E folder_F folder_G email_template_G",
+                    "Folder",
                     "folder_E",
                     "folder_F",
                     "folder_G",
@@ -1584,13 +1594,21 @@ def test_show_custom_error_message(
         (
             {"template_type": "sms"},
             [
-                ["folder_A", "folder_A", "1 template, 1 folder"],
+                ["folder_A", "Folder", "folder_A", "1 template, 1 folder"],
             ],
             [
-                ["folder_A", "folder_A", "1 template, 1 folder"],
-                ["folder_A folder_C", "folder_A", "folder_C", "1 template"],
-                ["folder_A folder_C sms_template_C", "folder_A", "folder_C", "sms_template_C", "Text message template"],
-                ["folder_A sms_template_A", "folder_A", "sms_template_A", "Text message template"],
+                ["folder_A", "Folder", "folder_A", "1 template, 1 folder"],
+                ["folder_A folder_C", "Folder", "folder_A", "Folder", "folder_C", "1 template"],
+                [
+                    "folder_A folder_C sms_template_C",
+                    "Folder",
+                    "folder_A",
+                    "Folder",
+                    "folder_C",
+                    "sms_template_C",
+                    "Text message template",
+                ],
+                ["folder_A sms_template_A", "Folder", "folder_A", "sms_template_A", "Text message template"],
             ],
             None,
         ),

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2275,20 +2275,20 @@ def test_choose_a_template_to_copy(
     assert page.select(".folder-heading") == []
 
     expected = [
-        "Service 1 6 templates",
-        "Service 1 sms_template_one Text message template",
-        "Service 1 sms_template_two Text message template",
-        "Service 1 email_template_one Email template",
-        "Service 1 email_template_two Email template",
-        "Service 1 letter_template_one Letter template",
-        "Service 1 letter_template_two Letter template",
-        "Service 2 6 templates",
-        "Service 2 sms_template_one Text message template",
-        "Service 2 sms_template_two Text message template",
-        "Service 2 email_template_one Email template",
-        "Service 2 email_template_two Email template",
-        "Service 2 letter_template_one Letter template",
-        "Service 2 letter_template_two Letter template",
+        "Folder Service 1 6 templates",
+        "Folder Service 1 sms_template_one Text message template",
+        "Folder Service 1 sms_template_two Text message template",
+        "Folder Service 1 email_template_one Email template",
+        "Folder Service 1 email_template_two Email template",
+        "Folder Service 1 letter_template_one Letter template",
+        "Folder Service 1 letter_template_two Letter template",
+        "Folder Service 2 6 templates",
+        "Folder Service 2 sms_template_one Text message template",
+        "Folder Service 2 sms_template_two Text message template",
+        "Folder Service 2 email_template_one Email template",
+        "Folder Service 2 email_template_two Email template",
+        "Folder Service 2 letter_template_one Letter template",
+        "Folder Service 2 letter_template_two Letter template",
     ]
     actual = page.select(".template-list-item")
 
@@ -2332,20 +2332,20 @@ def test_choose_a_template_to_copy_passes_through_folder_id(
     assert page.select(".folder-heading") == []
 
     expected = [
-        "Service 1 6 templates",
-        "Service 1 sms_template_one Text message template",
-        "Service 1 sms_template_two Text message template",
-        "Service 1 email_template_one Email template",
-        "Service 1 email_template_two Email template",
-        "Service 1 letter_template_one Letter template",
-        "Service 1 letter_template_two Letter template",
-        "Service 2 6 templates",
-        "Service 2 sms_template_one Text message template",
-        "Service 2 sms_template_two Text message template",
-        "Service 2 email_template_one Email template",
-        "Service 2 email_template_two Email template",
-        "Service 2 letter_template_one Letter template",
-        "Service 2 letter_template_two Letter template",
+        "Folder Service 1 6 templates",
+        "Folder Service 1 sms_template_one Text message template",
+        "Folder Service 1 sms_template_two Text message template",
+        "Folder Service 1 email_template_one Email template",
+        "Folder Service 1 email_template_two Email template",
+        "Folder Service 1 letter_template_one Letter template",
+        "Folder Service 1 letter_template_two Letter template",
+        "Folder Service 2 6 templates",
+        "Folder Service 2 sms_template_one Text message template",
+        "Folder Service 2 sms_template_two Text message template",
+        "Folder Service 2 email_template_one Email template",
+        "Folder Service 2 email_template_two Email template",
+        "Folder Service 2 letter_template_one Letter template",
+        "Folder Service 2 letter_template_two Letter template",
     ]
     actual = page.select(".template-list-item")
 
@@ -2454,7 +2454,7 @@ def test_choose_a_template_to_copy_from_folder_within_service(
         from_folder=PARENT_FOLDER_ID,
     )
 
-    assert normalize_spaces(page.select_one(".folder-heading").text) == "service one Parent folder"
+    assert normalize_spaces(page.select_one(".folder-heading").text) == "Folder service one Folder Parent folder"
     breadcrumb_links = page.select(".folder-heading a")
     assert len(breadcrumb_links) == 1
     assert breadcrumb_links[0]["href"] == url_for(
@@ -2464,9 +2464,9 @@ def test_choose_a_template_to_copy_from_folder_within_service(
     )
 
     expected = [
-        "Child folder empty Empty",
-        "Child folder non-empty 1 template",
-        "Child folder non-empty Should appear in list (nested) Text message template",
+        "Folder Child folder empty Empty",
+        "Folder Child folder non-empty 1 template",
+        "Folder Child folder non-empty Should appear in list (nested) Text message template",
         "Should appear in list (at same level) Text message template",
     ]
     actual = page.select(".template-list-item")


### PR DESCRIPTION
Their purpose in the visual interface is to show the thing they are next to is a folder. We need this information in the semantic interface too, so users of assistive tech can access it. We made the Jinja SVG macro so the `<svg>` shape can have an accessible name but never set it.

Note: this doesn't change the folder on the team member page because it adds no extra information to the following text ('X of X folders').

## Before

<img width="854" alt="template_list_item_with_folder_before" src="https://github.com/user-attachments/assets/abf9940a-3dfc-4477-85c7-1d79cf2495d0" alt="image of link with folder icon in and a devtools panel showing its label in the accessibility tree as just containing the link text">

## After

<img width="904" alt="template_list_item_with_folder_after" src="https://github.com/user-attachments/assets/e698f66c-3c7e-4717-b6e5-21c564bd23bc" alt="image of link with folder icon in and a devtools panel showing its label in the accessibility tree containing the link text prefixed by 'Folder'">
