### PR TITLE
fix: join service user list crashes if user never logged in

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2877,8 +2877,18 @@ class JoinServiceForm(StripWhitespaceForm):
         super().__init__(*args, **kwargs)
 
         self.users.choices = [(user.id, user.name) for user in users]
+
         self.users.param_extensions["items"] = [
-            {"hint": {"text": f"Last used Notify {format_date_human(user.logged_in_at)}"}} for user in users
+            {
+                "hint": {
+                    "text": (
+                        f"Last used Notify {format_date_human(user.logged_in_at)}"
+                        if user.logged_in_at
+                        else "Never used Notify"
+                    )
+                }
+            }
+            for user in users
         ]
 
     users = GovukCheckboxesField(

--- a/tests/app/main/views/test_join_service.py
+++ b/tests/app/main/views/test_join_service.py
@@ -125,10 +125,13 @@ def test_page_lists_team_members_of_service(
 
     manage_service_user_1 = create_active_user_with_permissions()
     manage_service_user_2 = create_active_user_with_permissions()
+    manage_service_user_3 = create_active_user_with_permissions()
     manage_service_user_1["name"] = "Manage service user 1"
     manage_service_user_2["name"] = "Manage service user 2"
+    manage_service_user_3["name"] = "Manage service user 3"
     manage_service_user_1["logged_in_at"] = "2023-01-02 01:00"
     manage_service_user_2["logged_in_at"] = "2023-02-03 01:00"
+    manage_service_user_3["logged_in_at"] = None
 
     mock_get_users = mocker.patch(
         "app.models.user.Users._get_items",
@@ -140,6 +143,7 @@ def test_page_lists_team_members_of_service(
             # These two users should appear on the page
             manage_service_user_1,
             manage_service_user_2,
+            manage_service_user_3,
         ],
     )
 
@@ -170,6 +174,11 @@ def test_page_lists_team_members_of_service(
             manage_service_user_2["id"],
             "Manage service user 2",
             "Last used Notify today",
+        ),
+        (
+            manage_service_user_3["id"],
+            "Manage service user 3",
+            "Never used Notify",
         ),
     ]
 


### PR DESCRIPTION
this can happen for users with type email_auth - their status will be set to active even before they've ever logged in

i noticed this on preview, but on prod we have 1000 users created in 2024 alone that are in a state like this