### PR TITLE
Conditionally focus template page forms

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -289,7 +289,7 @@
       // make sticky JS recalculate its cache of the element's position
       GOVUK.stickAtBottomWhenScrolling.recalculate();
 
-      if (currentStateObj && ('setFocus' in currentStateObj)) {
+      if (currentStateObj && ('setFocus' in currentStateObj) && !this.formHasError()) {
         scrollTop = $(window).scrollTop();
         currentStateObj.setFocus();
         $(window).scrollTop(scrollTop);
@@ -327,6 +327,10 @@
         </div>
       </div>
     `).get(0);
+
+    this.formHasError = function() {
+      return Boolean(document.querySelector('.govuk-error-summary'));
+    };
   };
 
 })(window.GOVUK.NotifyModules);

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -217,6 +217,13 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
   }
 }
 
+// mobile only variant of the static spacing class
+.govuk-\!-margin-top-3--mobile-only {
+  @include govuk-media-query($until: tablet) {
+    margin-top: govuk-spacing(6);
+  }
+}
+
 // variants of govuk-frontend width override classes 
 // that remains static across all breakpoiunts
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -208,6 +208,9 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
         single_notification_channel=single_notification_channel,
         option_hints=option_hints,
         error_summary_enabled=True,
+        error_summary_extra_params={
+            "classes": "govuk-!-margin-top-3--mobile-only",
+        },
     )
 
 

--- a/app/templates/components/error-summary.html
+++ b/app/templates/components/error-summary.html
@@ -14,7 +14,7 @@
   {%- endfor -%}
 {%- endmacro -%}
 
-{% macro errorSummary(form) %}
+{% macro errorSummary(form, error_summary_extra_params=false) %}
   {% if form.errors %}
     {% set errors = [] %}
     {% for field_name, error_list in form.errors.items() %}
@@ -35,9 +35,12 @@
       {% endif %}
     {% endfor %}
 
-    {{ govukErrorSummary({
+    {% set extra_params = error_summary_extra_params if error_summary_extra_params else {} %}
+    {% set required_params =  {
       "titleText": "There is a problem",
       "errorList": errors
-    }) }}
+    }%}
+    {% set all_params = dict(required_params, **extra_params) %}
+    {{ govukErrorSummary(all_params) }}
   {% endif %}
 {% endmacro %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -33,7 +33,9 @@
           {% include 'flash_messages.html' %}
           {% block errorSummary %}
             {% if error_summary_enabled %}
-              {% if form and form.errors %}{{ errorSummary(form) }}{% endif %}
+              {% if form and form.errors %}
+                {{ errorSummary(form, error_summary_extra_params) }}
+              {% endif %}
             {% endif %}
           {% endblock %}
           {% block maincolumn_content %}{% endblock %}

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -1478,6 +1478,7 @@ def test_radio_button_with_no_value_shows_custom_error_message(
     assert mock_move_to_template_folder.called is False
     assert mock_create_template_folder.called is False
 
+    assert "govuk-!-margin-top-3--mobile-only" in page.select_one(".govuk-error-summary").get("class")
     assert page.select_one(".govuk-error-message").text.strip() == "Error: Select the type of template you want to add"
 
 

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -980,4 +980,43 @@ describe('TemplateFolderForm', () => {
 
   });
 
+  describe("When a form is submitted without a selection and page renders with an error-summary", () => {
+    beforeEach(() => {
+      const errorSummary = 
+        `<div class="govuk-error-summary" data-module="govuk-error-summary">
+            <div role="alert">
+              <h2 class="govuk-error-summary__title">
+                There is a problem
+              </h2>
+              <div class="govuk-error-summary__body">
+                <ul class="govuk-list govuk-error-summary__list">
+                  <li>
+                    <a href="#">Error</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        `;
+      
+      // fake page refresh that sets a state of last submitted form
+      templateFolderForm.setAttribute('data-prev-state',"add-new-template" );
+      // append the error summary to fake an error
+      $(errorSummary).insertBefore(templateFolderForm);
+      // start module
+      window.GOVUK.notifyModules.start();
+
+      formControls = templateFolderForm.querySelector('#sticky_template_forms');
+
+    });
+    test("region should not be focused", () => {
+      // we can't import govuk-frontend in here for it to focus the error summary
+      // as it's an ES Module, but as this module checks for the presence 
+      // of error summary to determine whether or not to focus the form
+      // we can just check whether the form is focussed or not
+      expect(document.activeElement).not.toBe(formControls.querySelector('#add_new_template_form'));
+
+    });
+  });
+
 });


### PR DESCRIPTION
Fixes: https://trello.com/c/Dg0mE6e5/1041-validation-for-new-template-form-doesnt-focus-the-error-summary

When a user clicks say "add a new template" button, we show and focus that form. Should then a user submit that form without any selection, we reload the page, show the error-summary banner, check which form they submitted and then show it and focus it.

This caused an issue for screenreader users, which expected the error summary to be focused.

This PR amends the javascript module logic to check if the rendered page contains an error summary. 
If it does, we don't focus the form and let Design System Javascript handle error-summary focus.

As the error-summary contains the link to the errored form, users can then make changes quickly.