### PR TITLE
Update sign out link to back to your service

### DIFF
--- a/app/templates/views/join-a-service/you-have-asked.html
+++ b/app/templates/views/join-a-service/you-have-asked.html
@@ -22,7 +22,7 @@
         You’ll get another email if your request is approved.
       </p>
       <p class="govuk-body">
-        <a href="{{ url_for('main.sign_out') }}" class="govuk-link govuk-link--no-visited-state">Sign out of GOV.UK Notify</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.your_services') }}">Back to your services</a>
       </p>
     </div>
   </div>

--- a/tests/app/main/views/test_join_service.py
+++ b/tests/app/main/views/test_join_service.py
@@ -257,9 +257,9 @@ def test_confirmation_page(
         "We have sent your request to 1 member of ‘service one’.",
         "We’ve also sent you a confirmation email.",
         "You’ll get another email if your request is approved.",
-        "Sign out of GOV.UK Notify",
+        "Back to your services",
     ]
 
     assert [(normalize_spaces(link.text), link["href"]) for link in page.select("main a")] == [
-        ("Sign out of GOV.UK Notify", url_for("main.sign_out"))
+        ("Back to your services", url_for("main.your_services"))
     ]


### PR DESCRIPTION
Update content for the `/services/<service_id>/join/you-have-asked?number_of_users_emailed=<#users>` to match R4 (https://docs.google.com/document/d/15jG6UW7aoCQ15E8uTVfpMG_lEYtCbJueEg-ww2O-6Nc/edit?tab=t.0#heading=h.s5o7dpucav8d)

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/15c3b59c-6d02-43b2-a005-182edb74c264">

