### PR TITLE
Add error summary on error for ask-to-join-a-service

### DIFF
--- a/app/main/views/join_service.py
+++ b/app/main/views/join_service.py
@@ -53,6 +53,10 @@ def join_service_ask(service_to_join_id):
         "views/join-a-service/ask.html",
         service=service,
         form=form,
+        error_summary_enabled=True,
+        error_summary_extra_params={
+            "classes": "govuk-!-width-two-thirds",
+        },
     )
 
 

--- a/app/templates/views/join-a-service/ask.html
+++ b/app/templates/views/join-a-service/ask.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-header.html" import page_header %}
+{% from "components/govuk-page-header.html" import govuk_page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
@@ -15,18 +15,18 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    {{ page_header(heading) }}
-    <p class="govuk-body">
-      You’re asking to join ‘{{ service.name }}’.
-    </p>
-    {% call form_wrapper() %}
-      {{ form.users }}
-      {{ form.reason }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govuk_page_header(heading) }}
+      <p class="govuk-body">
+        You’re asking to join ‘{{ service.name }}’.
+      </p>
+      {% call form_wrapper() %}
+        {{ form.users }}
+        {{ form.reason }}
       {{ page_footer('Ask to join this service') }}
-    {% endcall %}
+      {% endcall %}
+    </div>
   </div>
-</div>
 
 {% endblock %}

--- a/app/templates/withoutnav_template.html
+++ b/app/templates/withoutnav_template.html
@@ -17,7 +17,7 @@
     {% include 'flash_messages.html' %}
     {% block errorSummary %}
       {% if error_summary_enabled %}
-        {% if form and form.errors %}{{ errorSummary(form) }}{% endif %}
+        {% if form and form.errors %}{{ errorSummary(form, error_summary_extra_params) }}{% endif %}
       {% endif %}
     {% endblock %}
     {% block maincolumn_content %}{% endblock %}


### PR DESCRIPTION
Adding error summary when submitting ask to join a live service form without requester. More details on [this card](https://trello.com/c/kOPFdylE/1053-ask-to-join-a-service-request-form-is-missing-error-summary-on-error).

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/203e9893-68bf-4b04-b260-42c264c3283a">

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/204be888-a083-4a62-b132-c85729ba82c3">
