### PR TITLE
Announce successful letter template PDF attachment upload

### DIFF
--- a/app/assets/javascripts/esm/all-esm.mjs
+++ b/app/assets/javascripts/esm/all-esm.mjs
@@ -1,5 +1,5 @@
 // GOVUK Frontend modules
-import { createAll, Header, Button, Radios, ErrorSummary, SkipLink, Tabs } from 'govuk-frontend';
+import { createAll, Header, Button, Radios, ErrorSummary, SkipLink, Tabs, NotificationBanner } from 'govuk-frontend';
 
 import CollapsibleCheckboxes from './collapsible-checkboxes.mjs';
 import FocusBanner from './focus-banner.mjs';
@@ -13,6 +13,7 @@ createAll(Radios);
 createAll(ErrorSummary);
 createAll(SkipLink);
 createAll(Tabs);
+createAll(NotificationBanner);
 
 const $collapsibleCheckboxes = document.querySelector('[data-notify-module="collapsible-checkboxes"]');
 if ($collapsibleCheckboxes) {

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -24,6 +24,7 @@ $govuk-assets-path: "/static/";
 @import "govuk/components/tabs/index";
 @import "govuk/components/textarea/index";
 @import "govuk/components/summary-list/index";
+@import "govuk/components/notification-banner/index";
 
 @import "govuk/utilities";
 @import "govuk/overrides";

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1258,7 +1258,7 @@ def _process_letter_attachment_form(service_id, template, form, upload_id):
             "main.view_template",
             service_id=current_service.id,
             template_id=template.id,
-            _anchor="first-page-of-attachment",
+            upload_successful="yes",
         )
     )
 

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -4,6 +4,8 @@
 {% from "components/folder-path.html" import folder_path, page_title_folder_path %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+
 
 {% block service_page_title %}
   {{ page_title_folder_path(current_service.get_template_path(template._template)) }}
@@ -29,6 +31,19 @@
       {% endcall %}
     </div>
   {% else %}
+    {% if request.args.get("upload_successful") == 'yes' %}
+      {% set notification_banner_html %}
+        <h3 class="govuk-notification-banner__heading">
+          PDF attachment successfully uploaded
+        </h3>
+        <p class="govuk-body"><a class="govuk-notification-banner__link" href="#first-page-of-attachment">Go to the attachment</a></p>
+      {% endset %}
+    
+      {{ govukNotificationBanner({
+        "html": notification_banner_html,
+        "type": "success"
+      }) }}
+    {% endif %}
     <div class="govuk-grid-row">
       <div class="{% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %} govuk-grid-column-five-sixths {% else %} govuk-grid-column-full {% endif %}">
         {{ folder_path(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1407,7 +1407,7 @@ def test_post_attach_pages_redirects_to_template_view_when_validation_successful
                 "main.view_template",
                 service_id=SERVICE_ONE_ID,
                 template_id=template_id,
-                _anchor="first-page-of-attachment",
+                upload_successful="yes",
             ),
         )
 
@@ -1454,7 +1454,7 @@ def test_post_attach_pages_archives_existing_attachment_when_it_exists(
                 "main.view_template",
                 service_id=SERVICE_ONE_ID,
                 template_id=template_id,
-                _anchor="first-page-of-attachment",
+                upload_successful="yes",
             ),
         )
 


### PR DESCRIPTION
Currently, when an PDF attachment is successfully uploaded to a template, we redirect to a template preview and anchor to the first page of the attachment.

Visually that shows that the attachment was successfully uploaded (we do show an error if it wasn't), but screenreader users do not get informed.

This PR attaches a `upload_successful="yes"` query string to the URL, based on which we render the Notification banner component -  Success variant - https://design-system.service.gov.uk/components/notification-banner/

The template will then show the notification banner before the H1 with an anchor link to the first page of the attachment that already exists.

This way we indicate that the upload was successful for both visual and assistive tech users.

**Before**

https://github.com/user-attachments/assets/e49c6f1d-c495-4f2a-93da-986617177afe



**After**
(simulating successful upload as my local dev is broken)

https://github.com/user-attachments/assets/14e1c6b7-eb95-4889-a097-2e4df60898ef


