### PR TITLE
Notifications csv report timeout

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -6,7 +6,6 @@ from flask import (
     redirect,
     render_template,
     request,
-    stream_with_context,
     url_for,
 )
 from markupsafe import Markup
@@ -86,17 +85,16 @@ def view_job_csv(service_id, job_id):
     filter_args = parse_filter_args(request.args)
     filter_args["status"] = set_status_filters(filter_args)
 
+    data = generate_notifications_csv(
+        service_id=service_id,
+        job_id=job_id,
+        status=filter_args.get("status"),
+        page=request.args.get("page", 1),
+        page_size=5000,
+        template_type=job.template_type,
+    )
     return Response(
-        stream_with_context(
-            generate_notifications_csv(
-                service_id=service_id,
-                job_id=job_id,
-                status=filter_args.get("status"),
-                page=request.args.get("page", 1),
-                page_size=5000,
-                template_type=job.template_type,
-            )
-        ),
+        list(data),
         mimetype="text/csv",
         headers={
             "Content-Disposition": 'inline; filename="{} - {}.csv"'.format(

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -14,7 +14,6 @@ from flask import (
     render_template,
     request,
     send_file,
-    stream_with_context,
     url_for,
 )
 from notifications_python_client.errors import APIError, HTTPError
@@ -288,23 +287,23 @@ def download_notifications_csv(service_id):
         abort(404)
 
     service_data_retention_days = current_service.get_days_of_retention(message_type)
+
+    data = generate_notifications_csv(
+        service_id=service_id,
+        status=filter_args.get("status"),
+        page=request.args.get("page", 1),
+        page_size=10000,
+        template_type=message_type,
+        limit_days=service_data_retention_days,
+    )
     return Response(
-        stream_with_context(
-            generate_notifications_csv(
-                service_id=service_id,
-                status=filter_args.get("status"),
-                page=request.args.get("page", 1),
-                page_size=10000,
-                template_type=message_type,
-                limit_days=service_data_retention_days,
-            )
-        ),
+        list(data),
         mimetype="text/csv",
         headers={
             "Content-Disposition": 'inline; filename="{} - {} - {} report.csv"'.format(
                 format_date_numeric(datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")),
                 message_type,
                 current_service.name,
-            )
+            ),
         },
     )

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -36,7 +36,7 @@
           </p>
         {% elif notifications %}
           <p class="{% if job.template_type != 'letter' %}bottom-gutter{% endif %}">
-            <a href="{{ download_link }}" download class="govuk-link govuk-link--no-visited-state heading-small">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
+            <a href="{{ download_link }}" id="download-job-report" class="govuk-link govuk-link--no-visited-state heading-small">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
             &emsp;
             <span id="time-left">{{ time_left }}</span>
           </p>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -72,7 +72,7 @@
   {% if current_user.has_permissions('view_activity') %}
     <p class="bottom-gutter">
         {% if can_download %}
-            <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">
+            <a href="{{ download_link }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">
                 Download this report (<abbr title="Comma separated values">CSV</abbr>)
             </a>
 

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -303,7 +303,7 @@ def test_link_to_download_notifications(
 
     client_request.login(user)
     page = client_request.get("main.view_notifications", service_id=SERVICE_ONE_ID, **query_parameters)
-    download_link = page.select_one("a[download=download]")
+    download_link = page.select_one("a[href*='download-notifications.csv']")
     assert (download_link["href"] if download_link else None) == expected_download_link(service_id=SERVICE_ONE_ID)
 
 
@@ -924,7 +924,7 @@ def test_view_notifications_can_download(
     page = client_request.get("main.view_notifications", service_id=SERVICE_ONE_ID)
 
     # check download link
-    download_link = page.select_one("a[download=download]")
+    download_link = page.select_one("a[href*='download-notifications.csv']")
     if test_case.expected_download_link_present:
         assert download_link is not None
     else:

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -104,7 +104,7 @@ def test_should_show_page_for_one_job(
         job_id=fake_uuid,
         status=status_argument,
     )
-    csv_link = page.select_one("a[download]")
+    csv_link = page.select_one("a[id=download-job-report]")
     assert csv_link["href"] == url_for(
         "main.view_job_csv", service_id=SERVICE_ONE_ID, job_id=fake_uuid, status=status_argument
     )
@@ -322,7 +322,7 @@ def test_should_show_letter_job(
     )
     assert normalize_spaces(page.select(".keyline-block")[0].text) == "1 Letter"
     assert normalize_spaces(page.select(".keyline-block")[1].text) == "6 January Estimated delivery date"
-    assert page.select_one("a[download]")["href"] == url_for(
+    assert page.select_one("a[id=download-job-report]")["href"] == url_for(
         "main.view_job_csv",
         service_id=SERVICE_ONE_ID,
         job_id=fake_uuid,


### PR DESCRIPTION
There is 30s timeout error set for eventlet which is causing issue for large csv file. Remove stream_with_context and download csv without streaming and raise timeout error if request takes > 30s. More info on [this card](https://trello.com/c/pnDkObaV/1062-streaming-csv-responses-silently-fail-due-to-eventlet-timeout).
