### PR TITLE
Announce January 2025 international letter price increase

### DIFF
--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -20,6 +20,10 @@
       }
     ) }}
 
+  <div class="govuk-inset-text">
+    International letter prices will go up on 2 January 2025. This is because Royal Mail is increasing its rates.
+  </div>
+
   <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
   <p class="govuk-body">Prices include:</p>


### PR DESCRIPTION
Royal Mail will increase the cost of sending international letters on 2 January 2025.

We do not yet know how this will affect our rates.

While we wait for confirmation from our print provider, we need to add an announcement to the letter pricing page.