### PR TITLE
Use `format_thousands` template filter consistently

### DIFF
--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -8,7 +8,7 @@
             {% if currency %}
               {{ "{}{:,.2f}".format(currency, number) | insert_wbr }}
             {% else %}
-              {{ "{:,}".format(number) | insert_wbr }}
+              {{ number | format_thousands | insert_wbr }}
             {% endif %}
           {% else %}
             {{ number }}
@@ -43,11 +43,11 @@
         {% if failures %}
           {% if failure_link %}
             <a class="govuk-link govuk-link--inverse" href="{{ failure_link }}">
-              {{ "{:,}".format(failures) | insert_wbr }}
+              {{ failures | format_thousands | insert_wbr  }}
               failed – {{ failure_percentage }}%
             </a>
           {% else %}
-            {{ "{:,}".format(failures) | insert_wbr  }}
+            {{ failures | format_thousands | insert_wbr  }}
             failed – {{ failure_percentage }}%
           {% endif %}
         {% else %}
@@ -63,7 +63,7 @@
   <span class="big-number-dark bottom-gutter-2-3">
     <span class="big-number-number">
       {% if number is number %}
-        {{ "{:,}".format(number) | insert_wbr  }}
+        {{ number | format_thousands | insert_wbr  }}
       {% else %}
         {{ number }}
       {% endif %}

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -24,8 +24,8 @@
         </h1>
         <p class="govuk-body">
           Notify can process up to
-          {{ "{:,}".format(recipients.max_rows) }} rows at once. Your
-          file has {{ "{:,}".format(recipients|length) }} rows.
+          {{ recipients.max_rows|format_thousands }} rows at once. Your
+          file has {{ recipients|length|format_thousands }} rows.
         </p>
 
       {% elif not count_of_recipients %}

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -53,7 +53,7 @@
               ) }}
               {% if counts.requested %}
                 <span class="{{ 'failure-highlight' if counts.show_warning else '' }}">
-                  {{ "{:,}".format(counts.failed) }} failed
+                  {{ counts.failed|format_thousands }} failed
                 </span>
               {% else %}
                 –

--- a/app/templates/views/platform-admin/index.html
+++ b/app/templates/views/platform-admin/index.html
@@ -55,7 +55,7 @@
     {% for noti_type in global_stats %}
       <div class="govuk-grid-column-one-third">
         <div class="bordered-text-box">
-          <span class="big-number-number">{{ "{:,}".format(noti_type.test_data.number) }}</span>
+          <span class="big-number-number">{{ noti_type.test_data.number|format_thousands }}</span>
           {{ noti_type.test_data.label }}
         </div>
       </div>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -674,7 +674,7 @@
             "text": "Rate limit"
           },
           "value": {
-            "text": "{:,} per minute".format(current_service.rate_limit)
+            "text": "{} per minute".format(current_service.rate_limit|format_thousands)
           },
           "actions": {
             "items": [
@@ -693,7 +693,7 @@
             "text": "{} limit".format('email'|format_notification_type)
           },
           "value": {
-            "text": "{:,} per day".format(current_service.get_message_limit('email'))
+            "text": "{} per day".format(current_service.get_message_limit('email')|format_thousands)
           },
           "actions": {
             "items": [
@@ -712,7 +712,7 @@
             "text": "{} limit".format('sms'|format_notification_type)
           },
           "value": {
-            "text": "{:,} per day".format(current_service.get_message_limit('sms'))
+            "text": "{} per day".format(current_service.get_message_limit('sms')|format_thousands)
           },
           "actions": {
             "items": [
@@ -731,7 +731,7 @@
             "text": "{} limit".format('letter'|format_notification_type)
           },
           "value": {
-            "text": "{:,} per day".format(current_service.get_message_limit('letter'))
+            "text": "{} per day".format(current_service.get_message_limit('letter')|format_thousands)
           },
           "actions": {
             "items": [
@@ -750,7 +750,7 @@
             "text": "Free text message allowance"
           },
           "value": {
-            "text": "{:,} per year".format(current_service.free_sms_fragment_limit)
+            "text": "{} per year".format(current_service.free_sms_fragment_limit|format_thousands)
           },
           "actions": {
             "items": [

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -19,7 +19,7 @@
       {{ page_header('Send text messages') }}
       <p class="govuk-body">
         You have a free allowance of
-        {{ '{:,}'.format(current_service.free_sms_fragment_limit) }} text messages each
+        {{ current_service.free_sms_fragment_limit|format_thousands }} text messages each
         financial year.
       </p>
       <p class="govuk-body">

--- a/app/templates/views/uploads/contact-list/column-errors.html
+++ b/app/templates/views/uploads/contact-list/column-errors.html
@@ -24,8 +24,8 @@
         </h1>
         <p class="govuk-body">
           Notify can store files up to
-          {{ "{:,}".format(recipients.max_rows) }} rows in size. Your
-          file has {{ "{:,}".format(recipients|length) }} rows.
+          {{ recipients.max_rows|format_thousands }} rows in size. Your
+          file has {{ recipients|length|format_thousands }} rows.
         </p>
 
       {% elif not recipients.allowed_to_send_to %}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -116,7 +116,7 @@
               {% endfor %}
               {% for letter in item.letter_breakdown %}
                 {% if letter.sent %}
-                  <li class="tabular-numbers">{{ "{:,} {}".format(letter.sent, letter.postage_description) }} {{ letter.sent|message_count_label('letter', suffix='') }} at
+                  <li class="tabular-numbers">{{ letter.sent|format_thousands}} {{ letter.postage_description }} {{ letter.sent|message_count_label('letter', suffix='') }} at
                   {{ letter.rate | format_pounds_as_currency }}</li>
                 {% endif %}
               {% endfor %}


### PR DESCRIPTION
This is easier to read and requires less arcane Python string formatting knowledge