### PR TITLE
Refactor already-signed-in check into a decorator

### DIFF
--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 from flask import abort, redirect, render_template, session, url_for
-from flask_login import current_user
 
 from app.main import main
 from app.main.forms import (
@@ -12,14 +11,13 @@ from app.main.forms import (
 from app.main.views.verify import activate_user
 from app.models.user import InvitedOrgUser, InvitedUser, User
 from app.utils import hide_from_search_engines
+from app.utils.login import redirect_if_logged_in
 
 
 @main.route("/register", methods=["GET", "POST"])
 @hide_from_search_engines
+@redirect_if_logged_in
 def register():
-    if current_user and current_user.is_authenticated:
-        return redirect(url_for("main.show_accounts_or_dashboard"))
-
     form = RegisterUserForm()
     if form.validate_on_submit():
         _do_registration(form, send_sms=False)

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -19,17 +19,14 @@ from app.main.forms import LoginForm
 from app.models.user import InvitedUser, User
 from app.utils import hide_from_search_engines
 from app.utils.constants import JSON_UPDATES_BLUEPRINT_NAME
-from app.utils.login import is_safe_redirect_url
+from app.utils.login import redirect_if_logged_in
 
 
 @main.route("/sign-in", methods=(["GET", "POST"]))
 @hide_from_search_engines
+@redirect_if_logged_in
 def sign_in():  # noqa: C901
     redirect_url = request.args.get("next")
-    if current_user and current_user.is_authenticated:
-        if redirect_url and is_safe_redirect_url(redirect_url):
-            return redirect(redirect_url)
-        return redirect(url_for("main.show_accounts_or_dashboard"))
 
     form = LoginForm()
     password_reset_url = url_for(".forgot_password", next=request.args.get("next"))

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -25,7 +25,7 @@ from app.utils.login import redirect_if_logged_in
 @main.route("/sign-in", methods=(["GET", "POST"]))
 @hide_from_search_engines
 @redirect_if_logged_in
-def sign_in():  # noqa: C901
+def sign_in():
     redirect_url = request.args.get("next")
 
     form = LoginForm()

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -7,7 +7,6 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user
 from itsdangerous import SignatureExpired
 from notifications_utils.url_safe_token import check_token
 
@@ -19,8 +18,8 @@ from app.models.user import User
 from app.utils.login import (
     email_needs_revalidating,
     log_in_user,
+    redirect_if_logged_in,
     redirect_to_sign_in,
-    redirect_when_logged_in,
 )
 
 
@@ -36,10 +35,9 @@ def two_factor_email_interstitial(token):
 
 
 @main.route("/email-auth/<string:token>", methods=["POST"])
+@redirect_if_logged_in
 def two_factor_email(token):
     redirect_url = request.args.get("next")
-    if current_user.is_authenticated:
-        return redirect_when_logged_in(platform_admin=current_user.platform_admin)
 
     # checks url is valid, and hasn't timed out
     try:

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -32,15 +32,28 @@ def log_in_user(user_id):
         session.pop("user_details", None)
         session.pop("file_uploads", None)
 
-    return redirect_when_logged_in(platform_admin=user.platform_admin)
+    return redirect_when_logged_in()
 
 
-def redirect_when_logged_in(platform_admin):
+def redirect_when_logged_in():
     next_url = request.args.get("next")
     if next_url and is_safe_redirect_url(next_url):
         return redirect(next_url)
 
     return redirect(url_for("main.show_accounts_or_dashboard"))
+
+
+def redirect_if_logged_in(f):
+    from app import current_user
+
+    @wraps(f)
+    def wrapped(*args, **kwargs):
+        if current_user and current_user.is_authenticated:
+            return redirect_when_logged_in()
+        else:
+            return f(*args, **kwargs)
+
+    return wrapped
 
 
 def email_needs_revalidating(user):


### PR DESCRIPTION
It makes sense for this check-and-redirect code to be a decorator because:
- it’s checking a similar, generic thing to other decorators like `is_platform_admin`
- it’s repeated [3 times](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)) and by making it a decorator we can reuse it