### PR TITLE
Use the `Notification` model when viewing a single notification

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -27,7 +27,6 @@ from app import (
 )
 from app.main import json_updates, main
 from app.models.notification import Notification
-from app.notify_client.api_key_api_client import KEY_TYPE_TEST
 from app.utils import (
     DELIVERED_STATUSES,
     FAILURE_STATUSES,
@@ -138,7 +137,6 @@ def view_notification(service_id, notification_id):  # noqa: C901
         partials=get_single_notification_partials(notification),
         help=get_help_argument(),
         can_receive_inbound=(current_service.has_permission("inbound_sms")),
-        sent_with_test_key=(notification.key_type == KEY_TYPE_TEST),
         back_link=back_link,
     )
 
@@ -218,7 +216,6 @@ def get_single_notification_partials(notification):
         "status": render_template(
             "partials/notifications/status.html",
             notification=notification,
-            sent_with_test_key=(notification.key_type == KEY_TYPE_TEST),
         ),
     }
 

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -50,7 +50,7 @@ def view_notification(service_id, notification_id):  # noqa: C901
     error_message = None
     page_count = None
 
-    if notification.template["is_precompiled_letter"]:
+    if notification.is_precompiled_letter:
         try:
             file_contents, metadata = get_letter_file_data(service_id, notification_id, "pdf", with_metadata=True)
             page_count = (
@@ -144,7 +144,7 @@ def view_notification(service_id, notification_id):  # noqa: C901
         estimated_letter_delivery_date=notification.estimated_letter_delivery_date,
         notification_id=notification.id,
         can_receive_inbound=(current_service.has_permission("inbound_sms")),
-        is_precompiled_letter=notification.template["is_precompiled_letter"],
+        is_precompiled_letter=notification.is_precompiled_letter,
         letter_print_day=notification.letter_print_day,
         show_cancel_button=notification.letter_can_be_cancelled,
         sent_with_test_key=(notification.key_type == KEY_TYPE_TEST),
@@ -180,7 +180,7 @@ def get_preview_error_image():
 @user_has_permissions("view_activity", "send_messages")
 def view_letter_notification_as_preview(service_id, notification_id, filetype, with_metadata=False):
     notification = Notification.from_id_and_service_id(notification_id, service_id)
-    if not notification.template["is_precompiled_letter"]:
+    if not notification.is_precompiled_letter:
         return template_preview_client.get_preview_for_templated_letter(
             db_template=notification.template,
             filetype=filetype,

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -81,7 +81,7 @@ def view_notification(service_id, notification_id):  # noqa: C901
         email_reply_to=notification.reply_to_text,
     )
     template.values = notification.personalisation
-    template.postage = None if notification.status == "validation-failed" else notification.postage
+    template.postage = notification.displayed_postage
 
     if template.template_type == "letter" and template.too_many_pages:
         # We check page count here to show the right error message for a letter that is too long.

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -41,7 +41,7 @@ from app.utils.user import user_has_permissions
 
 @main.route("/services/<uuid:service_id>/notification/<uuid:notification_id>")
 @user_has_permissions("view_activity", "send_messages")
-def view_notification(service_id, notification_id):  # noqa: C901
+def view_notification(service_id, notification_id):
     notification = Notification.from_id_and_service_id(str(notification_id), service_id)
 
     error_message = None

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -133,7 +133,6 @@ def view_notification(service_id, notification_id):
         ),
         partials=get_single_notification_partials(notification),
         help=get_help_argument(),
-        can_receive_inbound=(current_service.has_permission("inbound_sms")),
         back_link=back_link,
     )
 

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -28,8 +28,6 @@ from app import (
 from app.main import json_updates, main
 from app.models.notification import Notification
 from app.utils import (
-    DELIVERED_STATUSES,
-    FAILURE_STATUSES,
     NOTIFICATION_TYPES,
     get_help_argument,
     parse_filter_args,
@@ -123,7 +121,6 @@ def view_notification(service_id, notification_id):  # noqa: C901
     return render_template(
         "views/notifications/notification.html",
         notification=notification,
-        finished=(notification.status in (DELIVERED_STATUSES + FAILURE_STATUSES)),
         message=error_message,
         uploaded_file_name="Report",
         template=template,

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -17,7 +17,6 @@ from flask import (
 )
 from notifications_python_client.errors import APIError, HTTPError
 from notifications_utils.letter_timings import (
-    get_letter_timings,
     letter_can_be_cancelled,
 )
 from notifications_utils.pdf import pdf_page_count
@@ -131,13 +130,6 @@ def view_notification(service_id, notification_id):  # noqa: C901
             search_query=request.args.get("from_search_query", None),
         )
 
-    if notification.notification_type == "letter":
-        estimated_letter_delivery_date = get_letter_timings(
-            notification.created_at.replace(tzinfo=None), postage=notification.postage
-        ).earliest_delivery
-    else:
-        estimated_letter_delivery_date = None
-
     return render_template(
         "views/notifications/notification.html",
         finished=(notification.status in (DELIVERED_STATUSES + FAILURE_STATUSES)),
@@ -158,7 +150,7 @@ def view_notification(service_id, notification_id):  # noqa: C901
         created_at=notification.created_at,
         updated_at=notification.updated_at,
         help=get_help_argument(),
-        estimated_letter_delivery_date=estimated_letter_delivery_date,
+        estimated_letter_delivery_date=notification.estimated_letter_delivery_date,
         notification_id=notification.id,
         can_receive_inbound=(current_service.has_permission("inbound_sms")),
         is_precompiled_letter=notification.template["is_precompiled_letter"],

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -26,7 +26,6 @@ from pypdf.errors import PdfReadError
 from app import (
     current_service,
     format_date_numeric,
-    job_api_client,
     notification_api_client,
     template_preview_client,
 )
@@ -100,11 +99,6 @@ def view_notification(service_id, notification_id):  # noqa: C901
         # fully processed yet.
         error_message = get_letter_validation_error("letter-too-long", [1], template.page_count)
 
-    if notification.job:
-        job = job_api_client.get_job(service_id, notification.job["id"])["data"]
-    else:
-        job = None
-
     letter_print_day = get_letter_printing_statement(notification.status, notification.created_at)
 
     show_cancel_button = notification.notification_type == "letter" and letter_can_be_cancelled(
@@ -151,7 +145,7 @@ def view_notification(service_id, notification_id):  # noqa: C901
         message=error_message,
         uploaded_file_name="Report",
         template=template,
-        job=job,
+        job=notification.job,
         updates_url=url_for(
             "json_updates.view_notification_updates",
             service_id=service_id,

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -122,7 +122,6 @@ def view_notification(service_id, notification_id):
         "views/notifications/notification.html",
         notification=notification,
         message=error_message,
-        uploaded_file_name="Report",
         template=template,
         updates_url=url_for(
             "json_updates.view_notification_updates",

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -16,9 +16,6 @@ from flask import (
     url_for,
 )
 from notifications_python_client.errors import APIError, HTTPError
-from notifications_utils.letter_timings import (
-    letter_can_be_cancelled,
-)
 from notifications_utils.pdf import pdf_page_count
 from pypdf.errors import PdfReadError
 
@@ -100,10 +97,6 @@ def view_notification(service_id, notification_id):  # noqa: C901
 
     letter_print_day = get_letter_printing_statement(notification.status, notification.created_at)
 
-    show_cancel_button = notification.notification_type == "letter" and letter_can_be_cancelled(
-        notification.status, notification.created_at.replace(tzinfo=None)
-    )
-
     if get_help_argument() or request.args.get("help") == "0":
         # help=0 is set when you’ve just sent a notification. We
         # only want to show the back link when you’ve navigated to a
@@ -155,7 +148,7 @@ def view_notification(service_id, notification_id):  # noqa: C901
         can_receive_inbound=(current_service.has_permission("inbound_sms")),
         is_precompiled_letter=notification.template["is_precompiled_letter"],
         letter_print_day=letter_print_day,
-        show_cancel_button=show_cancel_button,
+        show_cancel_button=notification.letter_can_be_cancelled,
         sent_with_test_key=(notification.key_type == KEY_TYPE_TEST),
         back_link=back_link,
     )

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -123,12 +123,11 @@ def view_notification(service_id, notification_id):  # noqa: C901
 
     return render_template(
         "views/notifications/notification.html",
+        notification=notification,
         finished=(notification.status in (DELIVERED_STATUSES + FAILURE_STATUSES)),
-        notification_status=notification.status,
         message=error_message,
         uploaded_file_name="Report",
         template=template,
-        job=notification.job,
         updates_url=url_for(
             "json_updates.view_notification_updates",
             service_id=service_id,
@@ -137,16 +136,8 @@ def view_notification(service_id, notification_id):  # noqa: C901
             help=get_help_argument(),
         ),
         partials=get_single_notification_partials(notification),
-        created_by=notification.created_by,
-        created_at=notification.created_at,
-        updated_at=notification.updated_at,
         help=get_help_argument(),
-        estimated_letter_delivery_date=notification.estimated_letter_delivery_date,
-        notification_id=notification.id,
         can_receive_inbound=(current_service.has_permission("inbound_sms")),
-        is_precompiled_letter=notification.is_precompiled_letter,
-        letter_print_day=notification.letter_print_day,
-        show_cancel_button=notification.letter_can_be_cancelled,
         sent_with_test_key=(notification.key_type == KEY_TYPE_TEST),
         back_link=back_link,
     )

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -37,7 +37,7 @@ from app.utils import (
     set_status_filters,
 )
 from app.utils.csv import generate_notifications_csv
-from app.utils.letters import get_letter_printing_statement, get_letter_validation_error
+from app.utils.letters import get_letter_validation_error
 from app.utils.templates import get_template
 from app.utils.user import user_has_permissions
 
@@ -95,8 +95,6 @@ def view_notification(service_id, notification_id):  # noqa: C901
         # fully processed yet.
         error_message = get_letter_validation_error("letter-too-long", [1], template.page_count)
 
-    letter_print_day = get_letter_printing_statement(notification.status, notification.created_at)
-
     if get_help_argument() or request.args.get("help") == "0":
         # help=0 is set when you’ve just sent a notification. We
         # only want to show the back link when you’ve navigated to a
@@ -147,7 +145,7 @@ def view_notification(service_id, notification_id):  # noqa: C901
         notification_id=notification.id,
         can_receive_inbound=(current_service.has_permission("inbound_sms")),
         is_precompiled_letter=notification.template["is_precompiled_letter"],
-        letter_print_day=letter_print_day,
+        letter_print_day=notification.letter_print_day,
         show_cancel_button=notification.letter_can_be_cancelled,
         sent_with_test_key=(notification.key_type == KEY_TYPE_TEST),
         back_link=back_link,

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -13,6 +13,7 @@ from app.models import JSONModel, ModelList
 from app.notify_client.api_key_api_client import KEY_TYPE_TEST
 from app.notify_client.notification_api_client import notification_api_client
 from app.notify_client.service_api_client import service_api_client
+from app.utils import DELIVERED_STATUSES, FAILURE_STATUSES
 from app.utils.letters import get_letter_printing_statement
 from app.utils.templates import EmailPreviewTemplate
 
@@ -146,6 +147,10 @@ class Notification(JSONModel):
         if self.status == "validation-failed":
             return None
         return self.postage
+
+    @property
+    def finished(self):
+        return self.status in (DELIVERED_STATUSES + FAILURE_STATUSES)
 
 
 class APINotification(Notification):

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -127,6 +127,12 @@ class Notification(JSONModel):
         if self.notification_type == "letter":
             return letter_can_be_cancelled(self.status, self.created_at.replace(tzinfo=None))
 
+    @property
+    def displayed_postage(self):
+        if self.status == "validation-failed":
+            return None
+        return self.postage
+
 
 class APINotification(Notification):
     key_name: str

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -133,6 +133,10 @@ class Notification(JSONModel):
         return get_letter_printing_statement(self.status, self.created_at)
 
     @property
+    def is_precompiled_letter(self):
+        return self.template["is_precompiled_letter"]
+
+    @property
     def displayed_postage(self):
         if self.status == "validation-failed":
             return None

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any
 
 from markupsafe import Markup
+from notifications_utils.letter_timings import get_letter_timings
 from notifications_utils.template import (
     LetterPreviewTemplate,
     SMSBodyPreviewTemplate,
@@ -115,6 +116,11 @@ class Notification(JSONModel):
 
         if self._dict["job"]:
             return Job.from_id(self._dict["job"]["id"], self.service_id)
+
+    @property
+    def estimated_letter_delivery_date(self):
+        if self.notification_type == "letter":
+            return get_letter_timings(self.created_at.replace(tzinfo=None), postage=self.postage).earliest_delivery
 
 
 class APINotification(Notification):

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -43,9 +43,7 @@ class Notification(JSONModel):
 
     @classmethod
     def from_id_and_service_id(cls, id, service_id):
-        instance = cls(notification_api_client.get_notification(service_id, str(id)))
-        instance.template["reply_to_text"] = instance.reply_to_text
-        return instance
+        return cls(notification_api_client.get_notification(service_id, str(id)))
 
     @property
     def status(self):

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any
 
 from markupsafe import Markup
-from notifications_utils.letter_timings import get_letter_timings
+from notifications_utils.letter_timings import get_letter_timings, letter_can_be_cancelled
 from notifications_utils.template import (
     LetterPreviewTemplate,
     SMSBodyPreviewTemplate,
@@ -121,6 +121,11 @@ class Notification(JSONModel):
     def estimated_letter_delivery_date(self):
         if self.notification_type == "letter":
             return get_letter_timings(self.created_at.replace(tzinfo=None), postage=self.postage).earliest_delivery
+
+    @property
+    def letter_can_be_cancelled(self):
+        if self.notification_type == "letter":
+            return letter_can_be_cancelled(self.status, self.created_at.replace(tzinfo=None))
 
 
 class APINotification(Notification):

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -10,6 +10,7 @@ from notifications_utils.template import (
 from werkzeug.utils import cached_property
 
 from app.models import JSONModel, ModelList
+from app.notify_client.api_key_api_client import KEY_TYPE_TEST
 from app.notify_client.notification_api_client import notification_api_client
 from app.notify_client.service_api_client import service_api_client
 from app.utils.letters import get_letter_printing_statement
@@ -60,6 +61,10 @@ class Notification(JSONModel):
     @property
     def key_type(self):
         return self._dict.get("key_type")
+
+    @property
+    def sent_with_test_key(self):
+        return self.key_type == KEY_TYPE_TEST
 
     @property
     def sent_by(self):

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -6,6 +6,7 @@ from notifications_utils.template import (
     LetterPreviewTemplate,
     SMSBodyPreviewTemplate,
 )
+from werkzeug.utils import cached_property
 
 from app.models import JSONModel, ModelList
 from app.notify_client.notification_api_client import notification_api_client
@@ -18,7 +19,6 @@ class Notification(JSONModel):
     to: str
     recipient: str
     template: Any
-    job: Any
     sent_at: datetime
     created_at: datetime
     created_by: Any
@@ -108,6 +108,13 @@ class Notification(JSONModel):
                     self.personalisation,
                 ).subject
             )
+
+    @cached_property
+    def job(self):
+        from app.models.job import Job
+
+        if self._dict["job"]:
+            return Job.from_id(self._dict["job"]["id"], self.service_id)
 
 
 class APINotification(Notification):

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -12,6 +12,7 @@ from werkzeug.utils import cached_property
 from app.models import JSONModel, ModelList
 from app.notify_client.notification_api_client import notification_api_client
 from app.notify_client.service_api_client import service_api_client
+from app.utils.letters import get_letter_printing_statement
 from app.utils.templates import EmailPreviewTemplate
 
 
@@ -126,6 +127,10 @@ class Notification(JSONModel):
     def letter_can_be_cancelled(self):
         if self.notification_type == "letter":
             return letter_can_be_cancelled(self.status, self.created_at.replace(tzinfo=None))
+
+    @property
+    def letter_print_day(self):
+        return get_letter_printing_statement(self.status, self.created_at)
 
     @property
     def displayed_postage(self):

--- a/app/templates/partials/notifications/status.html
+++ b/app/templates/partials/notifications/status.html
@@ -23,7 +23,7 @@
       #}
       via {{ notification.sent_by | format_provider }}
     {% endif %}
-    {% if sent_with_test_key %}
+    {% if notification.sent_with_test_key %}
       (test)
     {% endif %}
   </p>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -19,8 +19,8 @@
       1|message_count_label(template.template_type, suffix='') | capitalize
     ) }}
     <p class="govuk-body">
-      {% if is_precompiled_letter %}
-        {% if created_by %}
+      {% if notification.is_precompiled_letter %}
+        {% if notification.created_by %}
           Uploaded
         {% else %}
           Provided as PDF
@@ -33,38 +33,38 @@
         {% endif %}
         was sent
       {% endif %}
-      {% if job and job.original_file_name != 'Report' %}
+      {% if notification.job and notification.job.original_file_name != 'Report' %}
         {% set destination =
           {'letter': 'an address', 'email': 'an email address', 'sms': 'a phone number'} %}
         to {{ destination[template.template_type] }} from
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.view_job', service_id=current_service.id, job_id=job.id) }}">{{ job.original_file_name }}</a>
-      {% elif created_by %}
-        by {{ created_by.name }}
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.view_job', service_id=current_service.id, job_id=notification.job.id) }}">{{ notification.job.original_file_name }}</a>
+      {% elif notification.created_by %}
+        by {{ notification.created_by.name }}
       {% endif %}
-      {{ created_at|format_datetime_human }}
+      {{ notification.created_at|format_datetime_human }}
     </p>
 
     {% if template.template_type == 'letter' %}
-      {% if notification_status == 'cancelled' %}
+      {% if notification.status == 'cancelled' %}
         <p class="notification-status-cancelled">
-          Cancelled {{ updated_at|format_datetime_short }}
+          Cancelled {{ notification.updated_at|format_datetime_short }}
         </p>
-      {% elif notification_status == 'validation-failed' %}
+      {% elif notification.status == 'validation-failed' %}
         <p class="notification-status-cancelled">
           {{ message.summary | safe }}
         </p>
-      {% elif notification_status == 'permanent-failure' %}
+      {% elif notification.status == 'permanent-failure' %}
          <p class="notification-status-cancelled">
           Permanent failure – The provider cannot print the letter. Your letter will not be dispatched.
          </p>
-      {% elif notification_status == 'technical-failure' %}
+      {% elif notification.status == 'technical-failure' %}
         <p class="notification-status-cancelled">
           Technical failure – Notify will resend once the team have
           fixed the problem
         </p>
       {% else %}
         {% if sent_with_test_key %}
-          {% if is_precompiled_letter %}
+          {% if notification.is_precompiled_letter %}
             <p class="govuk-body">
               This letter passed our checks, but we will not print it because you used a test key.
             </p>
@@ -75,10 +75,10 @@
           {% endif %}
         {% else %}
           <p class="govuk-body">
-            {{ letter_print_day }}
+            {{ notification.letter_print_day }}
           </p>
           <p class="govuk-body">
-            Estimated delivery date: {{ estimated_letter_delivery_date|format_day_of_week }} {{ estimated_letter_delivery_date|format_date_short }}
+            Estimated delivery date: {{ notification.estimated_letter_delivery_date|format_day_of_week }} {{ notification.estimated_letter_delivery_date|format_date_short }}
           </p>
         {% endif %}
       {% endif %}
@@ -91,14 +91,14 @@
     {% if template.template_type == 'letter' %}
       <div class="js-stick-at-bottom-when-scrolling">
         <div class="page-footer">
-          {% if show_cancel_button %}
+          {% if notification.letter_can_be_cancelled %}
             <span class="page-footer-delete-link page-footer-delete-link-without-button">
-              <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.cancel_letter', service_id=current_service.id, notification_id=notification_id) }}">Cancel sending this letter</a>
+              <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.cancel_letter', service_id=current_service.id, notification_id=notification.id) }}">Cancel sending this letter</a>
             </span>
           {% else %}
             <div>&nbsp;</div>
           {% endif %}
-          <a class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link-without-button" href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification_id, filetype='pdf') }}" download>Download as a PDF</a>
+          <a class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link-without-button" href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification.id, filetype='pdf') }}" download>Download as a PDF</a>
         </div>
       </div>
     {% elif template.template_type == 'email' %}
@@ -111,7 +111,7 @@
 
     {% if current_user.has_permissions('send_messages') and current_user.has_permissions('view_activity') and template.template_type == 'sms' and can_receive_inbound %}
       <p class="govuk-body">
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.conversation', service_id=current_service.id, notification_id=notification_id, _anchor='n{}'.format(notification_id)) }}">See all text messages sent to this phone number</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.conversation', service_id=current_service.id, notification_id=notification.id, _anchor='n{}'.format(notification.id)) }}">See all text messages sent to this phone number</a>
       </p>
     {% endif %}
 

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -103,10 +103,10 @@
       </div>
     {% elif template.template_type == 'email' %}
       <div class="js-stick-at-bottom-when-scrolling">
-        {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
+        {{ ajax_block(partials, updates_url, 'status', finished=notification.finished) }}
       </div>
     {% elif template.template_type == 'sms' %}
-      {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
+      {{ ajax_block(partials, updates_url, 'status', finished=notification.finished) }}
     {% endif %}
 
     {% if current_user.has_permissions('send_messages') and current_user.has_permissions('view_activity') and template.template_type == 'sms' and can_receive_inbound %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -109,7 +109,7 @@
       {{ ajax_block(partials, updates_url, 'status', finished=notification.finished) }}
     {% endif %}
 
-    {% if current_user.has_permissions('send_messages') and current_user.has_permissions('view_activity') and template.template_type == 'sms' and can_receive_inbound %}
+    {% if current_user.has_permissions('send_messages') and current_user.has_permissions('view_activity') and template.template_type == 'sms' and current_service.has_permission("inbound_sms") %}
       <p class="govuk-body">
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.conversation', service_id=current_service.id, notification_id=notification.id, _anchor='n{}'.format(notification.id)) }}">See all text messages sent to this phone number</a>
       </p>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -63,7 +63,7 @@
           fixed the problem
         </p>
       {% else %}
-        {% if sent_with_test_key %}
+        {% if notification.sent_with_test_key %}
           {% if notification.is_precompiled_letter %}
             <p class="govuk-body">
               This letter passed our checks, but we will not print it because you used a test key.


### PR DESCRIPTION
This continues the work done in https://github.com/alphagov/notifications-admin/pull/5232

Notifications are one of the last database objects in the admin app that we are still passing around as raw JSON, rather than wrapping them in a proper Python object.