### PR TITLE
Split breadcrumb HTML off from h1

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -303,25 +303,26 @@ a {
 
   &-breadcrumb,
   & {
-    display: inline-block;
+    display: inline;
   }
 
   &-container {
     margin: govuk-spacing(3) 0 govuk-spacing(4);
-
-    & > .folder-heading {
-      margin: 0;
-    }
   }
 
   &-breadcrumb {
     list-style: none;
-    display: inline-block;
-    min-height: 30px; // set min-height to line-height with folder icons
     @include govuk-font(24, $weight: "bold");
 
-    li {
-      display: inline;
+    > li {
+      display: inline-block;
+      vertical-align: top;
+      // contains the first <a> when it has overflow:hidden and so gets extra height compared to the others
+      max-height: 30px;
+
+      > a {
+        display: inline-block;
+      }
     }
   }
 

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -301,6 +301,30 @@ a {
     text-overflow: ellipsis;
   }
 
+  &-breadcrumb,
+  & {
+    display: inline-block;
+  }
+
+  &-container {
+    margin: govuk-spacing(3) 0 govuk-spacing(4);
+
+    & > .folder-heading {
+      margin: 0;
+    }
+  }
+
+  &-breadcrumb {
+    list-style: none;
+    display: inline-block;
+    min-height: 30px; // set min-height to line-height with folder icons
+    @include govuk-font(24, $weight: "bold");
+
+    li {
+      display: inline;
+    }
+  }
+
   a {
 
     display: inline-block;

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -8,48 +8,52 @@
   link_current_item=False,
   root_element='h1'
 ) %}
-  <ol class="folder-heading-breadcrumb">
-  {% for folder in folders %}
-    {% if not loop.last %}
-    <li>
-      {% if folder.id %}
-        {% if current_user.has_template_folder_permission(folder, service=service) %}
-          <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">
-            {{ svgs.folder(classes="folder-heading-folder__icon") }}
-            {{ folder.name }}
-          </a>
+  <div class="folder-heading-container">
+  {% if folders | length > 1 %}
+    <ol class="folder-heading-breadcrumb">
+    {% for folder in folders %}
+      {% if not loop.last %}
+      <li>
+        {% if folder.id %}
+          {% if current_user.has_template_folder_permission(folder, service=service) %}
+            <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder{% if loop.index < (loop.length - 1) %} folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">
+              {{ svgs.folder(classes="folder-heading-folder__icon") }}
+              {{ folder.name }}
+            </a>
+          {% else %}
+            <span class="folder-heading-folder">
+              {{ svgs.folder(classes="folder-heading-folder__icon") }}
+              {{ folder.name }}
+            </span>
+          {% endif %}
+        {% else %}
+          <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type) }}" title="Templates" class="govuk-link govuk-link--no-visited-state {% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
+        {% endif %}
+        {{ folder_path_separator() }}
+      </li>
+      {% endif %}
+    {% endfor %}
+    </ol>
+  {% endif %}
+    {% set folder = folders | last %}
+    <{{ root_element }} class="heading-medium folder-heading"{% if root_element == 'h1' %} id="page-header"{% endif %}>
+      {% if link_current_item and current_user.has_template_folder_permission(folder, service=service) %}
+        <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder" title="{{ folder.name }}">
+          {{ svgs.folder(classes="folder-heading-folder__icon") }}
+          {{ folder.name }}
+        </a>
+      {% else %}
+        {% if folder.template_type or not folder.id %}
+          <span class="folder-heading-template">{{ folder.name }}</span>
         {% else %}
           <span class="folder-heading-folder">
             {{ svgs.folder(classes="folder-heading-folder__icon") }}
             {{ folder.name }}
           </span>
         {% endif %}
-      {% else %}
-        <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type) }}" title="Templates" class="govuk-link govuk-link--no-visited-state {% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
       {% endif %}
-      {{ folder_path_separator() }}
-    </li>
-    {% endif %}
-  {% endfor %}
-  </ol>
-  {% set folder = folders | last %}
-  <{{ root_element }} class="heading-medium folder-heading"{% if root_element == 'h1' %} id="page-header"{% endif %}>
-    {% if link_current_item and current_user.has_template_folder_permission(folder, service=service) %}
-      <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder" title="{{ folder.name }}">
-        {{ svgs.folder(classes="folder-heading-folder__icon") }}
-        {{ folder.name }}
-      </a>
-    {% else %}
-      {% if folder.template_type or not folder.id %}
-        <span class="folder-heading-template">{{ folder.name }}</span>
-      {% else %}
-        <span class="folder-heading-folder">
-          {{ svgs.folder(classes="folder-heading-folder__icon") }}
-          {{ folder.name }}
-        </span>
-      {% endif %}
-    {% endif %}
-  </{{ root_element }}>
+    </{{ root_element }}>
+  </div>
 {% endmacro %}
 
 
@@ -61,12 +65,13 @@
   to_folder_id
 ) %}
   {% if folder_path %}
+  <div class="folder-heading-container">
     <ol class="folder-heading-breadcrumb">
     {% if folder_path|length == 1 %}
       <li>
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, to_folder_id=to_folder_id) }}">Services</a>
+        {{ folder_path_separator() }}
       </li>
-      {{ folder_path_separator() }}
     {% endif %}
     {% for folder in folder_path %}
       {% if not loop.last %}
@@ -106,12 +111,13 @@
         {{ folder.name if folder.id else from_service.name }}
       </span>
     </h2>
+  </div>
   {% endif %}
 {% endmacro %}
 
 
 {% macro page_title_folder_path(folders) %}
-{{ folders[-1].name }}{% if folders | length > 1 %} - {{ folders[-2].name }}{% endif %}
+{{ folders[-1].name }}{% if folders | length > 1 %} – {{ folders[-2].name }}{% endif %}
 {% endmacro %}
 
 

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -8,12 +8,17 @@
   link_current_item=False,
   root_element='h1'
 ) %}
-  <{{ root_element }} class="heading-medium folder-heading"{% if root_element == 'h1' %} id="page-header"{% endif %}>
-    {% for folder in folders %}
-      {% set folder_id = 'folder_' ~ loop.index %}
-      {% if loop.last and not link_current_item %}
-        {% if folder.template_type or not folder.id %}
-          <span class="folder-heading-template">{{ folder.name }}</span>
+  <ol class="folder-heading-breadcrumb">
+  {% for folder in folders %}
+    {% set folder_id = 'folder_' ~ loop.index %}
+    {% if not loop.last %}
+    <li>
+      {% if folder.id %}
+        {% if current_user.has_template_folder_permission(folder, service=service) %}
+          <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">
+            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+            {{ folder.name }}
+          </a>
         {% else %}
           <span class="folder-heading-folder">
             {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
@@ -21,24 +26,31 @@
           </span>
         {% endif %}
       {% else %}
-        {% if folder.id %}
-          {% if current_user.has_template_folder_permission(folder, service=service) %}
-            <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">
-              {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
-              {{ folder.name }}
-            </a>
-          {% else %}
-            <span class="folder-heading-folder">
-              {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
-              {{ folder.name }}
-            </span>
-          {% endif %}
-        {% else %}
-          <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type) }}" title="Templates" class="govuk-link govuk-link--no-visited-state {% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
-        {% endif %}
-        {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
+        <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type) }}" title="Templates" class="govuk-link govuk-link--no-visited-state {% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
       {% endif %}
-    {% endfor %}
+      {{ folder_path_separator() }}
+    </li>
+    {% endif %}
+  {% endfor %}
+  </ol>
+  {% set folder_id = 'folder_' ~ folders | length %}
+  {% set folder = folders | last %}
+  <{{ root_element }} class="heading-medium folder-heading"{% if root_element == 'h1' %} id="page-header"{% endif %}>
+    {% if link_current_item and current_user.has_template_folder_permission(folder, service=service) %}
+      <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder" title="{{ folder.name }}">
+        {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+        {{ folder.name }}
+      </a>
+    {% else %}
+      {% if folder.template_type or not folder.id %}
+        <span class="folder-heading-template">{{ folder.name }}</span>
+      {% else %}
+        <span class="folder-heading-folder">
+          {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+          {{ folder.name }}
+        </span>
+      {% endif %}
+    {% endif %}
   </{{ root_element }}>
 {% endmacro %}
 
@@ -51,45 +63,52 @@
   to_folder_id
 ) %}
   {% if folder_path %}
-    <h2 class="heading-medium folder-heading">
-      {% if folder_path|length == 1 %}
+    <ol class="folder-heading-breadcrumb">
+    {% if folder_path|length == 1 %}
+      <li>
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, to_folder_id=to_folder_id) }}">Services</a>
-        {{ folder_path_separator() }}
-      {% endif %}
-      {% for folder in folder_path %}
+      </li>
+      {{ folder_path_separator() }}
+    {% endif %}
+    {% for folder in folder_path %}
+      {% if not loop.last %}
+        <li>
         {% set folder_id = 'folder_' ~ loop.index %}
-        {% if loop.last %}
-          <span class="folder-heading-folder">
-            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
-            {{ folder.name if folder.id else from_service.name }}
-          </span>
-        {% else %}
-          {% if folder.id %}
-            {% if current_user.has_template_folder_permission(folder, service=from_service) %}
-              <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
-                {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
-                {{ folder.name }}
-              </a>
-             {% else %}
-              <span class="folder-heading-folder">
-                {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
-                {{ folder.name }}
-              </span>
-            {% endif %}
-            {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
-          {% elif folder.parent_id == None %}
+        {% if folder.id %}
+          {% if current_user.has_template_folder_permission(folder, service=from_service) %}
             <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
               {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
-              {{ from_service.name }}
-            </a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
-          {% else %}
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, to_folder_id=to_folder_id) }}">
+              {{ folder.name }}
+            </a>
+            {% else %}
+            <span class="folder-heading-folder">
               {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
-              {{ from_service.name }}
-            </a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
+              {{ folder.name }}
+            </span>
           {% endif %}
+        {% elif folder.parent_id == None %}
+          <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
+            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+            {{ from_service.name }}
+          </a>
+        {% else %}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, to_folder_id=to_folder_id) }}">
+            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+            {{ from_service.name }}
+          </a>
         {% endif %}
-      {% endfor %}
+        {{ folder_path_separator() }}
+        </li>
+      {% endif %}
+    {% endfor %}
+    </ol>
+    {% set folder = folder_path|last %}
+    {% set folder_id = 'folder_' ~ folder_path|length %}
+    <h2 class="heading-medium folder-heading">
+      <span class="folder-heading-folder">
+        {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+        {{ folder.name if folder.id else from_service.name }}
+      </span>
     </h2>
   {% endif %}
 {% endmacro %}

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -111,12 +111,7 @@
 
 
 {% macro page_title_folder_path(folders) %}
-  {% for folder in folders|reverse %}
-    {{ folder.name }}
-    {% if not loop.last %}
-      –
-    {% endif %}
-  {% endfor %}
+{{ folders[-1].name }}{% if folders | length > 1 %} - {{ folders[-2].name }}{% endif %}
 {% endmacro %}
 
 

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -10,18 +10,17 @@
 ) %}
   <ol class="folder-heading-breadcrumb">
   {% for folder in folders %}
-    {% set folder_id = 'folder_' ~ loop.index %}
     {% if not loop.last %}
     <li>
       {% if folder.id %}
         {% if current_user.has_template_folder_permission(folder, service=service) %}
           <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">
-            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+            {{ svgs.folder(classes="folder-heading-folder__icon") }}
             {{ folder.name }}
           </a>
         {% else %}
           <span class="folder-heading-folder">
-            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+            {{ svgs.folder(classes="folder-heading-folder__icon") }}
             {{ folder.name }}
           </span>
         {% endif %}
@@ -33,12 +32,11 @@
     {% endif %}
   {% endfor %}
   </ol>
-  {% set folder_id = 'folder_' ~ folders | length %}
   {% set folder = folders | last %}
   <{{ root_element }} class="heading-medium folder-heading"{% if root_element == 'h1' %} id="page-header"{% endif %}>
     {% if link_current_item and current_user.has_template_folder_permission(folder, service=service) %}
       <a href="{{ url_for('main.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder" title="{{ folder.name }}">
-        {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+        {{ svgs.folder(classes="folder-heading-folder__icon") }}
         {{ folder.name }}
       </a>
     {% else %}
@@ -46,7 +44,7 @@
         <span class="folder-heading-template">{{ folder.name }}</span>
       {% else %}
         <span class="folder-heading-folder">
-          {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+          {{ svgs.folder(classes="folder-heading-folder__icon") }}
           {{ folder.name }}
         </span>
       {% endif %}
@@ -73,27 +71,26 @@
     {% for folder in folder_path %}
       {% if not loop.last %}
         <li>
-        {% set folder_id = 'folder_' ~ loop.index %}
         {% if folder.id %}
           {% if current_user.has_template_folder_permission(folder, service=from_service) %}
             <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
-              {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+              {{ svgs.folder(classes="folder-heading-folder__icon") }}
               {{ folder.name }}
             </a>
             {% else %}
             <span class="folder-heading-folder">
-              {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+              {{ svgs.folder(classes="folder-heading-folder__icon") }}
               {{ folder.name }}
             </span>
           {% endif %}
         {% elif folder.parent_id == None %}
           <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">
-            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+            {{ svgs.folder(classes="folder-heading-folder__icon") }}
             {{ from_service.name }}
           </a>
         {% else %}
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, to_folder_id=to_folder_id) }}">
-            {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+            {{ svgs.folder(classes="folder-heading-folder__icon") }}
             {{ from_service.name }}
           </a>
         {% endif %}
@@ -103,10 +100,9 @@
     {% endfor %}
     </ol>
     {% set folder = folder_path|last %}
-    {% set folder_id = 'folder_' ~ folder_path|length %}
     <h2 class="heading-medium folder-heading">
       <span class="folder-heading-folder">
-        {{ svgs.folder('Folder', classes="folder-heading-folder__icon", id=folder_id) }}
+        {{ svgs.folder(classes="folder-heading-folder__icon") }}
         {{ folder.name if folder.id else from_service.name }}
       </span>
     </h2>

--- a/app/templates/components/svgs.html
+++ b/app/templates/components/svgs.html
@@ -30,10 +30,9 @@
   </svg>
 {%- endmacro %}
 
-{% macro folder(alt, classes, id="folder", border_width=2.5) -%}
+{% macro folder(alt, classes, border_width=2.5) -%}
   <svg xmlns="http://www.w3.org/2000/svg" width="26" height="20" viewBox="0 0 26 20"
-    {%- if alt %} aria-labeledby="{{ id }}" role="img"
-    {%- else %} aria-hidden="true" focusable="false"{% endif %}
+    role="img" aria-hidden="true" focusable="false"
     class="svg-folder-icon{%- if classes %} {{ classes }}{% endif -%}"
   >
     <style><![CDATA[
@@ -47,7 +46,6 @@
         }
       }
     ]]></style>
-    {% if alt %}<title id="{{ id }}">{{ alt }}</title>{% endif %}
     {# We need to position the path in the centre of the required border to have a changable
        border (really stroke) width without altering the size of the shape.
        Because of this, we need to always move each of its coordinates inwards by half the
@@ -61,4 +59,5 @@
       V{{ 4 + border_inset }} H{{ 12 - diag_join_adjustment }}z"
       stroke="currentColor" stroke-width="{{ border_width }}" stroke-linecap="butt" fill="transparent"/>
   </svg>
+  <span class="govuk-visually-hidden">{% if alt %}{{ alt }}{% else %}Folder{% endif %} </span>
 {%- endmacro %}

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -18,16 +18,14 @@
       {% set item_num = loop.index %}
       {% set item_link_content %}
         {% for ancestor in item.ancestors %}
-          {% set folder_id = 'folder_' ~ item_num ~ '_ancestor_' ~ loop.index %}
           <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-            {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
+            {{ svgs.folder(classes="template-list-folder__icon") }}
             {{- format_template_name(ancestor.name) -}}
           </a> <span class="message-name-separator"></span>
         {% endfor %}
-        {% set folder_id = 'folder_' ~ item_num ~ '_ancestor_' ~ loop.index %}
         {% if item.is_folder %}
           <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-            {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
+            {{ svgs.folder(classes="template-list-folder__icon") }}
             <span class="live-search-relevant">{{- format_template_name(item.name) -}}</span>
           </a>
         {% else %}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -49,16 +49,14 @@
         {% set item_num = loop.index %}
         <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
           {% for ancestor in item.ancestors %}
-              {% set folder_id = 'folder_' ~ item_num ~ '_ancestor_' ~ loop.index %}
               <a href="{{ url_for('main.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-              {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
+              {{ svgs.folder(classes="template-list-folder__icon") }}
               {{ ancestor.name }}
             </a> <span class="message-name-separator"></span>
           {% endfor %}
-          {% set folder_id = 'folder_' ~ item_num %}
           {% if item.is_folder %}
             <a href="{{ url_for('main.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-              {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
+              {{ svgs.folder(classes="template-list-folder__icon") }}
               <span class="live-search-relevant">{{ format_template_name(item.name) }}</span>
             </a>
           {% else %}

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -31,25 +31,23 @@
           {% set item_num = loop.index %}
           <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
             {% for ancestor in item.ancestors %}
-              {% set folder_id = 'folder_' ~ item_num ~ '_ancestor_' ~ loop.index %}
               {% if ancestor.is_service %}
                 <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {% else %}
                 <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {% endif %}
-                {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
+                {{ svgs.folder(classes="template-list-folder__icon") }}
                 {{ ancestor.name }}
               </a> <span class="message-name-separator"></span>
             {% endfor %}
-            {% set folder_id = 'folder_' ~ item_num %}
             {% if item.is_service %}
               <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
+                {{ svgs.folder(classes="template-list-folder__icon") }}
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% elif item.is_folder %}
               <a href="{{ url_for('main.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id, to_folder_id=to_folder_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                {{ svgs.folder('Folder', classes="template-list-folder__icon", id=folder_id) }}
+                {{ svgs.folder(classes="template-list-folder__icon") }}
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% else %}

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -38,6 +38,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
 @pytest.mark.parametrize(
     (
         "expected_title_tag,"
+        "expected_page_breadcrumb,"
         "expected_page_title,"
         "expected_parent_link_args,"
         "extra_args,"
@@ -50,6 +51,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
     [
         (
             "Templates – service one – GOV.UK Notify",
+            [],
             "Templates",
             [],
             {},
@@ -110,6 +112,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "Templates – service one – GOV.UK Notify",
+            [],
             "Templates",
             [],
             {"template_type": "all"},
@@ -170,6 +173,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "Templates – service one – GOV.UK Notify",
+            [],
             "Templates",
             [],
             {"template_type": "sms"},
@@ -207,7 +211,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_one – Templates – service one – GOV.UK Notify",
-            "Templates Folder folder_one",
+            ["Templates"],
+            "Folder folder_one",
             [{"template_type": "all"}],
             {"template_folder_id": PARENT_FOLDER_ID},
             ["Email", "Text message", "Letter"],
@@ -237,7 +242,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_one – Templates – service one – GOV.UK Notify",
-            "Templates Folder folder_one",
+            ["Templates"],
+            "Folder folder_one",
             [{"template_type": "sms"}],
             {"template_type": "sms", "template_folder_id": PARENT_FOLDER_ID},
             ["All", "Email", "Letter"],
@@ -262,7 +268,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_one – Templates – service one – GOV.UK Notify",
-            "Templates Folder folder_one",
+            ["Templates"],
+            "Folder folder_one",
             [{"template_type": "email"}],
             {"template_type": "email", "template_folder_id": PARENT_FOLDER_ID},
             ["All", "Text message", "Letter"],
@@ -272,8 +279,9 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             "There are no email templates in this folder",
         ),
         (
-            "folder_one_one – folder_one – Templates – service one – GOV.UK Notify",
-            "Templates Folder folder_one Folder folder_one_one",
+            "folder_one_one – folder_one – service one – GOV.UK Notify",
+            ["Templates", "Folder folder_one"],
+            "Folder folder_one_one",
             [
                 {"template_type": "all"},
                 {"template_type": "all", "template_folder_id": PARENT_FOLDER_ID},
@@ -301,8 +309,9 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             None,
         ),
         (
-            "folder_one_one_one – folder_one_one – folder_one – Templates – service one – GOV.UK Notify",
-            "Templates Folder folder_one Folder folder_one_one Folder folder_one_one_one",
+            "folder_one_one_one – folder_one_one – service one – GOV.UK Notify",
+            ["Templates", "Folder folder_one", "Folder folder_one_one"],
+            "Folder folder_one_one_one",
             [
                 {"template_type": "all"},
                 {"template_type": "all", "template_folder_id": PARENT_FOLDER_ID},
@@ -322,8 +331,9 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             None,
         ),
         (
-            "folder_one_one_one – folder_one_one – folder_one – Templates – service one – GOV.UK Notify",
-            "Templates Folder folder_one Folder folder_one_one Folder folder_one_one_one",
+            "folder_one_one_one – folder_one_one – service one – GOV.UK Notify",
+            ["Templates", "Folder folder_one", "Folder folder_one_one"],
+            "Folder folder_one_one_one",
             [
                 {"template_type": "email"},
                 {"template_type": "email", "template_folder_id": PARENT_FOLDER_ID},
@@ -341,7 +351,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_two – Templates – service one – GOV.UK Notify",
-            "Templates Folder folder_two",
+            ["Templates"],
+            "Folder folder_two",
             [{"template_type": "all"}],
             {"template_folder_id": FOLDER_TWO_ID},
             ["Email", "Text message", "Letter"],
@@ -352,7 +363,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_two – Templates – service one – GOV.UK Notify",
-            "Templates Folder folder_two",
+            ["Templates"],
+            "Folder folder_two",
             [{"template_type": "sms"}],
             {"template_folder_id": FOLDER_TWO_ID, "template_type": "sms"},
             ["All", "Email", "Letter"],
@@ -363,7 +375,8 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
         ),
         (
             "folder_two – Templates – service one – GOV.UK Notify",
-            "Templates Folder folder_two",
+            ["Templates"],
+            "Folder folder_two",
             [{"template_type": "all"}],
             {"template_folder_id": FOLDER_TWO_ID, "template_type": "all"},
             ["Email", "Text message", "Letter"],
@@ -381,6 +394,7 @@ def test_should_show_templates_folder_page(
     service_one,
     mocker,
     expected_title_tag,
+    expected_page_breadcrumb,
     expected_page_title,
     expected_parent_link_args,
     extra_args,
@@ -416,11 +430,13 @@ def test_should_show_templates_folder_page(
     service_one["permissions"] += ["letter"]
 
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID, _test_page_title=False, **extra_args)
+    breadcrumb_links = page.select(".folder-heading-breadcrumb a")
 
     assert normalize_spaces(page.select_one("title").text) == expected_title_tag
+    assert [normalize_spaces(link.text) for link in breadcrumb_links] == expected_page_breadcrumb
     assert normalize_spaces(page.select_one("h1").text) == expected_page_title
 
-    assert len(page.select("h1 a")) == len(expected_parent_link_args)
+    assert len(breadcrumb_links) == len(expected_parent_link_args)
 
     for index, parent_link in enumerate(page.select("h1 a")):
         assert parent_link["href"] == url_for(
@@ -1545,23 +1561,20 @@ def test_show_custom_error_message(
             ],
             [
                 ["folder_A", "Folder", "folder_A", "1 template, 2 folders"],
-                ["folder_A folder_C", "Folder", "folder_A", "Folder", "folder_C", "1 template"],
+                ["folder_A folder_C", "Folder folder_A", "Folder", "folder_C", "1 template"],
                 [
                     "folder_A folder_C sms_template_C",
-                    "Folder",
-                    "folder_A",
-                    "Folder",
-                    "folder_C",
+                    "Folder folder_A",
+                    "Folder folder_C",
                     "sms_template_C",
                     "Text message template",
                 ],
-                ["folder_A folder_D", "Folder", "folder_A", "Folder", "folder_D", "Empty"],
-                ["folder_A sms_template_A", "Folder", "folder_A", "sms_template_A", "Text message template"],
+                ["folder_A folder_D", "Folder folder_A", "Folder", "folder_D", "Empty"],
+                ["folder_A sms_template_A", "Folder folder_A", "sms_template_A", "Text message template"],
                 ["folder_E folder_F folder_G", "Folder", "folder_E", "folder_F", "folder_G", "1 template"],
                 [
                     "folder_E folder_F folder_G email_template_G",
-                    "Folder",
-                    "folder_E",
+                    "Folder folder_E",
                     "folder_F",
                     "folder_G",
                     "email_template_G",
@@ -1581,8 +1594,7 @@ def test_show_custom_error_message(
                 ["folder_E folder_F folder_G", "Folder", "folder_E", "folder_F", "folder_G", "1 template"],
                 [
                     "folder_E folder_F folder_G email_template_G",
-                    "Folder",
-                    "folder_E",
+                    "Folder folder_E",
                     "folder_F",
                     "folder_G",
                     "email_template_G",
@@ -1599,17 +1611,15 @@ def test_show_custom_error_message(
             ],
             [
                 ["folder_A", "Folder", "folder_A", "1 template, 1 folder"],
-                ["folder_A folder_C", "Folder", "folder_A", "Folder", "folder_C", "1 template"],
+                ["folder_A folder_C", "Folder folder_A", "Folder", "folder_C", "1 template"],
                 [
                     "folder_A folder_C sms_template_C",
-                    "Folder",
-                    "folder_A",
-                    "Folder",
-                    "folder_C",
+                    "Folder folder_A",
+                    "Folder folder_C",
                     "sms_template_C",
                     "Text message template",
                 ],
-                ["folder_A sms_template_A", "Folder", "folder_A", "sms_template_A", "Text message template"],
+                ["folder_A sms_template_A", "Folder folder_A", "sms_template_A", "Text message template"],
             ],
             None,
         ),

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -821,7 +821,8 @@ def test_user_with_only_send_and_view_sees_letter_page(
         template_id=fake_uuid,
         _test_page_title=False,
     )
-    assert normalize_spaces(page.select_one("h1").text) == "Templates Two week reminder"
+    assert normalize_spaces(page.select_one(".folder-heading-breadcrumb").text) == "Templates"
+    assert normalize_spaces(page.select_one("h1").text) == "Two week reminder"
     assert normalize_spaces(page.select_one("title").text) == (
         "Two week reminder – Templates – service one – GOV.UK Notify"
     )
@@ -1731,7 +1732,8 @@ def test_should_be_able_to_view_a_template_with_links(
         _test_page_title=False,
     )
 
-    assert normalize_spaces(page.select_one("h1").text) == "Templates Two week reminder"
+    assert normalize_spaces(page.select_one(".folder-heading-breadcrumb").text) == "Templates"
+    assert normalize_spaces(page.select_one("h1").text) == "Two week reminder"
     assert normalize_spaces(page.select_one("title").text) == (
         "Two week reminder – Templates – service one – GOV.UK Notify"
     )
@@ -2454,8 +2456,8 @@ def test_choose_a_template_to_copy_from_folder_within_service(
         from_folder=PARENT_FOLDER_ID,
     )
 
-    assert normalize_spaces(page.select_one(".folder-heading").text) == "Folder service one Folder Parent folder"
-    breadcrumb_links = page.select(".folder-heading a")
+    assert normalize_spaces(page.select_one(".folder-heading").text) == "Folder Parent folder"
+    breadcrumb_links = page.select(".folder-heading-breadcrumb a")
     assert len(breadcrumb_links) == 1
     assert breadcrumb_links[0]["href"] == url_for(
         "main.choose_template_to_copy",


### PR DESCRIPTION
On pages where we currently put the name of the template or folder in with the path to it, this splits the name off from the path.

Intended to make it less confusing to screen reader users. Full details in the story:

https://trello.com/c/YGxJqotD/991-h1-for-template-or-folder-page-is-confusing-for-screen-readers

<img width="653" alt="image" src="https://github.com/user-attachments/assets/66278470-8b2c-4934-a6bc-908a62eefa11">

<img width="653" alt="image" src="https://github.com/user-attachments/assets/e3ecf5fc-5abb-46ea-b8dd-c76655e6085c">

<img width="650" alt="image" src="https://github.com/user-attachments/assets/0428b45a-d06f-49db-9890-913dede7ac91">

## Notes for reviewers

### Pages to check

This pattern appears on:
- the templates page at the root and in a folder
- manage folder page
- copy template page
- choose template (as part of the 'respond to inbound message' flow)

### Changes to the page title

Because the h1 was confusing when it contained the path, I also changed the page title because it also contained the path. 

Many other sites, including www.gov.uk, use the 'page - parent page - website' pattern because the parent page gives enough context to tell pages with the same name apart. I used a variation of this which also includes the service.

@karlchillmaid will need to sign off on these changes.