### PR TITLE
Replace HoganJS with template literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "cbor-js": "0.1.0",
         "govuk-frontend": "5.7.1",
-        "hogan": "1.0.2",
         "jquery": "3.5.0",
         "morphdom": "2.6.1",
         "query-command-supported": "1.0.0",
@@ -3095,11 +3094,6 @@
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "dev": true
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -5943,26 +5937,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hogan": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hogan/-/hogan-1.0.2.tgz",
-      "integrity": "sha512-2RV7G4f+Rt9YIYDu01r6pgZvP+XhrXi/JKlXd4b+vRybXk94ui4PQjbh/lFaH8gQtxCygy/WKkqmpm0IyZysJA==",
-      "dependencies": {
-        "hogan.js": "*"
-      }
-    },
-    "node_modules/hogan.js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
-      "integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
-      "dependencies": {
-        "mkdirp": "0.3.0",
-        "nopt": "1.0.10"
-      },
-      "bin": {
-        "hulk": "bin/hulk"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -8762,15 +8736,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/morphdom": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.6.1.tgz",
@@ -8909,20 +8874,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "cbor-js": "0.1.0",
     "govuk-frontend": "5.7.1",
-    "hogan": "1.0.2",
     "jquery": "3.5.0",
     "morphdom": "2.6.1",
     "query-command-supported": "1.0.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -76,7 +76,6 @@ export default [
   // ES5 JS compilation
   {
     input: [
-      paths.npm + 'hogan.js/dist/hogan-3.0.2.js',
       paths.npm + 'jquery/dist/jquery.min.js',
       paths.npm + 'query-command-supported/dist/queryCommandSupported.min.js',
       paths.npm + 'timeago/jquery.timeago.js',

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -124,10 +124,7 @@ export default [
         entryFileName: 'all.js'
       }),
       terser({
-        ecma: '5',
-        mangle: {
-          reserved: ["Hogan"]
-        }
+        ecma: '5'
       }),
     ]
   }

--- a/tests/javascripts/listEntry.test.js
+++ b/tests/javascripts/listEntry.test.js
@@ -1,6 +1,4 @@
 beforeAll(() => {
-  Hogan = require('hogan.js');
-
   require('../../app/assets/javascripts/listEntry.js');
 });
 


### PR DESCRIPTION
https://trello.com/c/mf90DD4c/1080-use-template-literals-instead-of-hoganjs-for-js-templating

Because:
- our supported browsers understand template literals
- HoganJS isn't needed now we have template literals
- HoganJS uses `eval()`, and [we'd like to ban it in our Content Security Policy](https://github.com/alphagov/notifications-admin/pull/5315#pullrequestreview-2481267816)
- we can delete some code

This also makes the JavaScript delivered to our users 8915 smaller before gzipping.

## Notes for reviewers

These changes make use of destructuring to unpack object properties into variables. We use the same feature detection to check if the code should run as design system, checking for `noModule`. Based on caniuse data, this should allow use of destructuring:
- [caniuse for destructuring](https://caniuse.com/?search=destructuring)
- [caniuse for noModule](https://caniuse.com/?search=nomodule)