### PR TITLE
Add Christmas dispatch dates

### DIFF
--- a/app/templates/views/guidance/using-notify/delivery-times.html
+++ b/app/templates/views/guidance/using-notify/delivery-times.html
@@ -33,7 +33,7 @@
   <p class="govuk-body">Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday).</p>
 
   <div class="govuk-inset-text">
-    Letters sent after 2pm on 24 December will be dispatched on Monday 30 December.
+    Letters sent after 5:30pm on Monday 23 December will be dispatched on Monday 30 December.
   </div>
 
   <p class="govuk-body">First class letters are delivered one day after they’re dispatched. Second class letters are delivered 2 days after they’re dispatched. Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>

--- a/app/templates/views/guidance/using-notify/delivery-times.html
+++ b/app/templates/views/guidance/using-notify/delivery-times.html
@@ -31,6 +31,11 @@
 
   <h2 id="letters" class="heading-medium">Letters</h2>
   <p class="govuk-body">Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday).</p>
+
+  <div class="govuk-inset-text">
+    Letters sent after 2pm on 24 December will be dispatched on Monday 30 December.
+  </div>
+
   <p class="govuk-body">First class letters are delivered one day after they’re dispatched. Second class letters are delivered 2 days after they’re dispatched. Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
   <p class="govuk-body">Letters to Europe are delivered 3 to 5 days after they’re dispatched. Letters sent anywhere else in the world take 5 to 7 days to arrive.</p>
 


### PR DESCRIPTION
For the first time in a few years, users have asked about Christmas delivery times.

We’ve only had a couple of enquiries so far – not enough to justify an email to all services that send letters.

Instead, we’ll continue to respond to enquiries through Zendesk.

To make this easier for the team and ensure that users get consistent information about postage times, we’re going to publish this information on the Delivery times page.

We’ll need to remove this content again after 30 December.