### PR TITLE
Add csp_nonce for inline script and gov_template

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -1,5 +1,7 @@
 {% extends "govuk_frontend_jinja/template.html"%}
 
+{% set cspNonce = request.csp_nonce %}
+
 {% block headIcons %}
   <link rel="icon" sizes="48x48" href="{{ asset_url('images/favicon.ico') }}">
   <link rel="icon" sizes="any" href="{{ asset_url('images/favicon.svg') }}" type="image/svg+xml">

--- a/app/templates/components/webauthn-api-check.html
+++ b/app/templates/components/webauthn-api-check.html
@@ -1,5 +1,5 @@
 {% macro webauthn_api_check() %}
-  <script>
+  <script nonce="{{ request.csp_nonce }}">
     if ('credentials' in window.navigator) {
       document.body.className = ((document.body.className) ? document.body.className + ' webauthn-api-enabled' : 'webauthn-api-enabled');
     }

--- a/app/templates/unbranded_template.html
+++ b/app/templates/unbranded_template.html
@@ -1,5 +1,7 @@
 {% extends "govuk_frontend_jinja/template.html"%}
 
+{% set cspNonce = request.csp_nonce %}
+
 {% block headIcons %}
 {% endblock %}
 

--- a/app/templates/views/email-link-interstitial.html
+++ b/app/templates/views/email-link-interstitial.html
@@ -18,7 +18,7 @@
 
 </div>
 
-<script type="text/javascript">
+<script nonce="{{ request.csp_nonce }}" type="text/javascript">
   document.getElementById("use-email-auth").submit();
 </script>
 

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -1,9 +1,13 @@
 def test_owasp_useful_headers_set(
     client_request,
+    mocker,
     mock_get_service_and_organisation_counts,
     mock_get_letter_rates,
     mock_get_sms_rate,
+    fake_nonce,
 ):
+    mocker.patch("secrets.token_urlsafe", return_value=fake_nonce)
+
     client_request.logout()
     response = client_request.get_response(".index")
 
@@ -11,7 +15,7 @@ def test_owasp_useful_headers_set(
     assert response.headers["X-XSS-Protection"] == "1; mode=block"
     assert response.headers["Content-Security-Policy"] == (
         "default-src 'self' static.example.com 'unsafe-inline';"
-        "script-src 'self' static.example.com 'unsafe-inline' 'unsafe-eval' data:;"
+        "script-src 'self' static.example.com 'nonce-TESTs5Vr8v3jgRYLoQuVwA';"
         "connect-src 'self';"
         "object-src 'self';"
         "font-src 'self' static.example.com data:;"
@@ -43,7 +47,10 @@ def test_headers_non_ascii_characters_are_replaced(
     mock_get_service_and_organisation_counts,
     mock_get_letter_rates,
     mock_get_sms_rate,
+    fake_nonce,
 ):
+    mocker.patch("secrets.token_urlsafe", return_value=fake_nonce)
+
     client_request.logout()
     mocker.patch.dict(
         "app.current_app.config",
@@ -54,7 +61,7 @@ def test_headers_non_ascii_characters_are_replaced(
 
     assert response.headers["Content-Security-Policy"] == (
         "default-src 'self' static.example.com 'unsafe-inline';"
-        "script-src 'self' static.example.com 'unsafe-inline' 'unsafe-eval' data:;"
+        "script-src 'self' static.example.com 'nonce-TESTs5Vr8v3jgRYLoQuVwA';"
         "connect-src 'self';"
         "object-src 'self';"
         "font-src 'self' static.example.com data:;"


### PR DESCRIPTION
Previously we added `unsafe-inline` and `unsafe-eval` directives for `script-src` header. We can remove these  directives as part of ITHC after removing `Hogan`. Additionally to fix CSP errors added `csp_nonce` for request to allow `govuk_frontend_jinja/template.html` and inline `script`. More details on [this card](https://trello.com/c/DTim1BKC/1083-spike-into-solutions-for-ithc-header-changes-which-affect-frontend).