### PR TITLE
feat: Crete form to remove inbound sms from service

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2272,6 +2272,20 @@ class AdminServiceInboundNumberForm(StripWhitespaceForm):
     )
 
 
+class AdminServiceInboundNumberArchive(StripWhitespaceForm):
+    removal_options = GovukRadiosField(
+        "What do you want to do with the number?",
+        choices=[("true", "Archive"), ("false", "Release")],
+        validators=[DataRequired(message="Select an option")],
+        param_extensions={
+            "items": [
+                {"hint": {"text": "No other services can use this phone number"}},
+                {"hint": {"text": "Another service can use this phone number"}},
+            ]
+        },
+    )
+
+
 class CallbackForm(StripWhitespaceForm):
     url = GovukTextInputField(
         "URL",

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -299,6 +299,7 @@ class MainNavigation(Navigation):
             "service_receive_text_messages",
             "service_receive_text_messages_start",
             "service_receive_text_messages_stop",
+            "service_receive_text_messages_stop_success",
             "service_set_auth_type",
             "service_set_channel",
             "send_files_by_email_contact_details",

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -338,6 +338,16 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.get(f"/service/{service_id}/inbound-sms/summary")
 
     @cache.delete("service-{service_id}")
+    @cache.delete_by_pattern("service-{service_id}-template-*")
+    def remove_service_inbound_sms(self, service_id, archive: bool):
+        return self.post(f"/service/{service_id}/inbound-sms/remove", data={"archive": archive})
+
+    def get_most_recent_inbound_number_usage_date(self, service_id):
+        return self.get(
+            f"/service/{service_id}/inbound-sms/most-recent-usage",
+        )
+
+    @cache.delete("service-{service_id}")
     def create_service_inbound_api(self, service_id, url, bearer_token, user_id):
         data = {"url": url, "bearer_token": bearer_token, "updated_by_id": user_id}
         return self.post(f"/service/{service_id}/inbound-api", data)

--- a/app/templates/views/service-settings/receive-text-messages-stop-success.html
+++ b/app/templates/views/service-settings/receive-text-messages-stop-success.html
@@ -1,0 +1,31 @@
+{% extends "withoutnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
+
+{% set heading = "You’ve stopped receiving text messages" %}
+
+{% block per_page_title %}
+    {{ heading }}
+{% endblock %}
+
+{% block maincolumn_content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            {{ page_header(heading) }}
+
+            <p class="govuk-body">
+                The Notify team has removed your unique phone number:
+            </p>
+
+            {{ govukInsetText({
+                "text": inbound_number,
+                "classes": "govuk-!-margin-top-0"
+            }) }}
+
+            <a class="govuk-link govuk-link--no-visited-state"
+               href="{{ url_for('main.service_settings', service_id=current_service.id) }}">
+                Back to service settings
+            </a>
+        </div>
+    </div>
+{% endblock %}

--- a/app/templates/views/service-settings/receive-text-messages-stop.html
+++ b/app/templates/views/service-settings/receive-text-messages-stop.html
@@ -2,6 +2,9 @@
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}
   When you stop receiving text messages
@@ -12,6 +15,8 @@
 {% endblock %}
 
 {% block maincolumn_content %}
+
+    {{ errorSummary(form) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
@@ -48,9 +53,25 @@
       </p>
 
       <h2 class="heading heading-medium">If you’re sure you want to delete your number</h2>
-      <p class="govuk-body">
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Contact the Notify team</a>.
-      </p>
+        {% if current_user.platform_admin %}
+            {% if not recent_use_date %}
+            <p class="hint">This number has never been used</p>
+            {% else %}
+            <p class="govuk-body">This number was last used
+                <time class="timeago" datetime="{{ recent_use_date}}">
+                    {{ recent_use_date|format_delta }}
+                </time>
+            </p>
+            {% endif %}
+            {% call form_wrapper() %}
+                {{ form.removal_options }}
+                {{ page_footer('Save') }}
+            {% endcall %}
+        {% else %}
+          <p class="govuk-body">
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Contact the Notify team</a>.
+          </p>
+        {% endif %}
     </div>
   </div>
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -295,6 +295,7 @@ EXCLUDED_ENDPOINTS = set(
             "service_preview_branding",
             "service_receive_text_messages_start",
             "service_receive_text_messages_stop",
+            "service_receive_text_messages_stop_success",
             "service_receive_text_messages",
             "service_set_auth_type_for_users",
             "service_set_auth_type",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2144,6 +2144,14 @@ def mock_get_inbound_sms_summary_with_no_messages(notify_admin, mocker):
 
 
 @pytest.fixture(scope="function")
+def mock_get_most_recent_inbound_usage_date(mocker):
+    return mocker.patch(
+        "app.service_api_client.get_most_recent_inbound_number_usage_date",
+        return_value={"most_recent_date": "2023-12-01T12:00:00Z"},
+    )
+
+
+@pytest.fixture(scope="function")
 def mock_get_inbound_number_for_service(notify_admin, mocker):
     return mocker.patch(
         "app.inbound_number_client.get_inbound_sms_number_for_service", return_value={"data": {"number": "0781239871"}}

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -246,6 +246,7 @@
     "/services/<uuid:service_id>/service-settings/receive-text-messages",
     "/services/<uuid:service_id>/service-settings/receive-text-messages/start",
     "/services/<uuid:service_id>/service-settings/receive-text-messages/stop",
+    "/services/<uuid:service_id>/service-settings/receive-text-messages/stop/success",
     "/services/<uuid:service_id>/service-settings/request-to-go-live",
     "/services/<uuid:service_id>/service-settings/request-to-go-live/estimate-usage",
     "/services/<uuid:service_id>/service-settings/send-files-by-email",


### PR DESCRIPTION
Added two endpoints: `remove_service_inbound_sms` and `get_most_recent_inbound_number_usage_date`
- `get_most_recent_inbound_number_usage_date` responsible for displaying the last date in which the inbound number has been used
- `remove_service_inbound_sms` responsible for updating inbound_sms permission for service, removing service_sms_sender row and releasing or arching inbound_number
- success case: when the platform admin chooses archive/release and the request is successful, we redirect to the `receive-text-messages-stop-success` template
- error case: when we get errors from the remove endpoint, we render `Failed to remove number from service` message
- added delete cache for `service` and `template-*` to update inbound_number for service through the platform

Demo:

https://github.com/user-attachments/assets/fde6622f-8ac1-489f-abbe-c5f5a48cd738



For platform admins
![Screenshot 2024-12-19 at 11 49 50](https://github.com/user-attachments/assets/7dbb198e-1e24-4517-ae11-cbbf46df3e69)

![Screenshot 2024-12-19 at 11 51 52](https://github.com/user-attachments/assets/232d0559-1f2c-4ced-936c-ad171896ec3f)

![Screenshot 2024-12-17 at 19 13 16](https://github.com/user-attachments/assets/63185ebb-cd95-4702-b848-bd23163b744e)

![Screenshot 2024-12-17 at 18 52 57](https://github.com/user-attachments/assets/3cfe11fe-6bf0-4048-abf4-e01cf1b1c047)

![Screenshot 2024-12-17 at 18 53 06](https://github.com/user-attachments/assets/4b0d45eb-0757-41c7-a872-770edfea48b1)

Unchanged for users
![Screenshot 2024-12-16 at 09 50 55](https://github.com/user-attachments/assets/a900f916-3925-41b4-8c09-fa204344f959)


### Ticket: 

https://trello.com/c/jC9B8l27/1056-build-platform-admin-endpoint-to-remove-inbound-sms-from-service