### PR TITLE
Remove letter pricing announcement

### DIFF
--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -20,10 +20,6 @@
       }
     ) }}
 
-  <div class="govuk-inset-text">
-    International letter prices will go up on 2 January 2025. This is because Royal Mail is increasing its rates.
-  </div>
-
   <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
   <p class="govuk-body">Prices include:</p>


### PR DESCRIPTION
Turns out that we’re not affected by the Royal Mail price changes after all – so we need to remove the announcement from the Letter pricing page. This can happen before we send an email.