### PR TITLE
Remove fixed issues from acessibility statement

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -12,7 +12,7 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "28 November 2024",
+      "Last updated": "20 December 2024",
       "Next review due": "29 January 2025"
     }
     ) }}
@@ -46,8 +46,6 @@
     We know some parts of this website are not fully accessible:
   </p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>you have to scroll to see all of the content on the inbox page</li>
-    <li>errors from starting a new template are not focused when they appear</li>
     <li>pages for template folders may be announced in a confusing way by screen readers</li>
     <li>the Notify status page has several accessibility issues</li>
   </ul>
@@ -91,7 +89,7 @@
   </p>
 
   <p class="govuk-body">
-    This website is partially compliant with the Web Content Accessibility Guidelines version 2.2 AA standard, due to the non-compliances listed below.
+    This website is partially compliant with the Web Content Accessibility Guidelines version 2.2 AA standard, due to a non-compliance listed below.
   </p>
 
   <h2 class="heading-medium" id="non-accessible-content">Non-accessible content</h2>
@@ -102,15 +100,11 @@
     The following content on the Notify website is not compliant with the WCAG version 2.2 AA standard:
   </p>
 
-  <p class="govuk-body">
-      Content on the inbox page needs horizontal scrolling on smaller screens. This makes it harder to access on mobile devices or at 400% zoom on a 1280 pixel screen and breaks <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html">success criterion 1.4.10: Reflow</a>.
-  </p>
-
   <h3 class="heading-small" id="problems-with-using-the-interface">Problems with using the interface</h3>
 
   <ol class="govuk-list govuk-list--number">
     <li>
-      Page headings on pages for folders can be confusing when using a screen reader. We are investigating this issue.
+      Page headings on pages for folders can be confusing when using a screen reader. We have redesigned them and will be testing this new design for the same problems soon.
     </li>
   </ol>
 


### PR DESCRIPTION
One of these was a left over from the last time. Whoops. This statement was updated so it was actually fixed a while ago.

Also includes a change to our listing of the issue with some h1s. The fix we made is due to be tested in the next few months so while the redesign will definitely help with some aspects of the issue reported, we can't confirm it solves the confusion reported until we test again with accessibility auditors.