### PR TITLE
Make success banners alert screen reader users

### DIFF
--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -5,9 +5,7 @@
 {% macro banner(body, type=None, with_tick=False, delete_button=None, subhead=None, context=None, action=None, id=None, thing=None) %}
   <div
     class='banner{% if type %}-{{ type }}{% endif %}{% if with_tick %}-with-tick{% endif %}'
-    {% if type == 'dangerous' %}
     role='alert'
-    {% endif %}
     {% if id %}
     id={{ id }}
     {% endif %}


### PR DESCRIPTION
https://trello.com/c/uHOOPsbV/1073-screen-reader-users-arent-notified-when-success-banners-appear

This story was created on the assumption that giving success banners a role of 'alert' would stop the page title being announced. I'm not sure how I got to that assumption but it was wrong.

Testing with NVDA and JAWS showed the banner gets announced when the page loads with the page title following. This means screen reader users will know their action was successful **but also** that the browser has navigated to a new page.