### PR TITLE
Return performance data as JSON

### DIFF
--- a/app/main/views/performance.py
+++ b/app/main/views/performance.py
@@ -30,6 +30,7 @@ def performance():
         ],
         key=itemgetter("organisation_name"),
     )
+    stats.pop("services_using_notify")
     stats["average_percentage_under_10_seconds"] = mean(
         [row["percentage_under_10_seconds"] for row in stats["processing_time"]] or [0]
     )

--- a/app/main/views/performance.py
+++ b/app/main/views/performance.py
@@ -3,7 +3,7 @@ from itertools import groupby
 from operator import itemgetter
 from statistics import mean
 
-from flask import render_template
+from flask import jsonify, render_template, request
 
 from app import performance_dashboard_api_client, status_api_client
 from app.main import main
@@ -11,6 +11,7 @@ from app.main.views.sub_navigation_dictionaries import features_nav
 
 
 @main.route("/features/performance")
+@main.route("/features/performance.json", endpoint="performance_json")
 def performance():
     stats = performance_dashboard_api_client.get_performance_dashboard_stats(
         start_date=(datetime.utcnow() - timedelta(days=7)).date(),
@@ -33,6 +34,10 @@ def performance():
         [row["percentage_under_10_seconds"] for row in stats["processing_time"]] or [0]
     )
     stats["count_of_live_services_and_organisations"] = status_api_client.get_count_of_live_services_and_organisations()
+
+    if request.endpoint == "main.performance_json":
+        return jsonify(stats)
+
     return render_template(
         "views/guidance/features/performance.html",
         **stats,

--- a/tests/app/main/views/test_performance.py
+++ b/tests/app/main/views/test_performance.py
@@ -178,7 +178,6 @@ def test_should_return_performance_data_as_json(
         "notifications_by_type",
         "organisations_using_notify",
         "processing_time",
-        "services_using_notify",
         "sms_notifications",
         "total_notifications",
     }

--- a/tests/app/main/views/test_performance.py
+++ b/tests/app/main/views/test_performance.py
@@ -156,3 +156,33 @@ def test_should_render_performance_page(
         "Department of One Service 1 "
         "No organisation 1"
     )
+
+
+@freeze_time("2021-01-01")
+def test_should_return_performance_data_as_json(
+    client_request,
+    mock_get_service_and_organisation_counts,
+    mocker,
+):
+    mock_get_performance_data = mocker.patch(
+        "app.performance_dashboard_api_client.get_performance_dashboard_stats",
+        return_value=_get_example_performance_data(),
+    )
+    response = client_request.get_response("main.performance_json")
+    assert response.json.keys() == {
+        "average_percentage_under_10_seconds",
+        "count_of_live_services_and_organisations",
+        "email_notifications",
+        "letter_notifications",
+        "live_service_count",
+        "notifications_by_type",
+        "organisations_using_notify",
+        "processing_time",
+        "services_using_notify",
+        "sms_notifications",
+        "total_notifications",
+    }
+    mock_get_performance_data.assert_called_once_with(
+        start_date=date(2020, 12, 25),
+        end_date=date(2021, 1, 1),
+    )

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -225,6 +225,7 @@ EXCLUDED_ENDPOINTS = set(
             "org_member_make_service_live_contact_user",
             "org_member_make_service_live_decision",
             "performance",
+            "performance_json",
             "platform_admin_archive_email_branding",
             "platform_admin_confirm_archive_email_branding",
             "platform_admin_create_email_branding",


### PR DESCRIPTION
Looks like this when running locally:
```json
{
  "average_percentage_under_10_seconds": 0,
  "count_of_live_services_and_organisations": {
    "organisations": 1,
    "services": 48
  },
  "email_notifications": 15,
  "letter_notifications": 0,
  "live_service_count": 48,
  "notifications_by_type": [],
  "organisations_using_notify": [
    {
      "count_of_live_services": 47,
      "organisation_name": "Department for Social Affairs and Citizenship"
    },
    {
      "count_of_live_services": 1,
      "organisation_name": "No organisation"
    }
  ],
  "processing_time": [],
  "sms_notifications": 47,
  "total_notifications": 62
}
```