### PR TITLE
Approved join service redirect and message

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2892,7 +2892,7 @@ class JoinServiceForm(StripWhitespaceForm):
 
     users = GovukCheckboxesField(
         "Select at least one team member who can approve your request",
-        validators=[NotifyDataRequired(thing="at least 1 person to ask")],
+        validators=[DataRequired(message="Select at least 1 person to ask")],
         param_extensions={
             "fieldset": {
                 "legend": {

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -204,6 +204,8 @@ def service_join_request_choose_permissions(service_id, request_id):
             folder_permissions=form.folder_permissions.data,
             auth_type=form.login_authentication.data,
         )
+
+        flash(f"{requested_by_user.name} has joined this service", "default_with_tick")
         return redirect(url_for(".manage_users", service_id=service_id))
 
     return render_template(

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -204,7 +204,7 @@ def service_join_request_choose_permissions(service_id, request_id):
             folder_permissions=form.folder_permissions.data,
             auth_type=form.login_authentication.data,
         )
-        return redirect(url_for("main.your_services"))
+        return redirect(url_for(".manage_users", service_id=service_id))
 
     return render_template(
         "views/join-service-request-choose-permissions.html",

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -2429,7 +2429,7 @@ def test_service_join_request_choose_permissions_on_save(
         request_id=request_id,
         _data={"permissions_field": selected_permissions, "folder_permissions": ["folder-id-1", "folder-id-2"]},
         _expected_status=302,
-        _expected_redirect=url_for("main.your_services"),
+        _expected_redirect=url_for("main.manage_users", service_id=SERVICE_ONE_ID),
     )
 
     mock_update_service_join_requests.assert_called_once_with(
@@ -2488,7 +2488,7 @@ def test_service_join_request_choose_auth_type_on_save(
         request_id=request_id,
         _data={"permissions_field": selected_permissions, "folder_permissions": [], "login_authentication": auth_type},
         _expected_status=302,
-        _expected_redirect=url_for("main.your_services"),
+        _expected_redirect=url_for("main.manage_users", service_id=SERVICE_ONE_ID),
     )
 
     mock_update_service_join_requests.assert_called_once_with(


### PR DESCRIPTION
Join a service - Change redirect from 'Your Services' page to 'Team members' page for approvers. The approver is currently re-directed to the ‘Your services’ page, which doesn’t feel like the best place to go after just adding a user to a specific service.

https://github.com/user-attachments/assets/e124e81e-fbf0-4d29-89b2-aefbe9454fdb



Add green confirmation banner on Team Members page when request is approved (for approver). To reduce the number of duplicate services created, and make the go-live process more efficient (for users and the team) we want to let users ask to join other services in their organisation.

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/c204a854-1de2-42fe-ab9f-7695a14e8e97" />


Ask to join a service (R3) update the validation error from Enter to Select when the approver is not selected.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/84901ed7-c63e-4709-a818-6476d8b650a5" />

