### PR TITLE
Bump utils to 92.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.0
+# This file was automatically copied from notifications-utils@92.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.0
+# This file was automatically copied from notifications-utils@92.0.1
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.1
 
 govuk-frontend-jinja==3.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ async-timeout==4.0.2
     # via redis
 awscrt==0.20.11
     # via botocore
-blinker==1.6.3
+blinker==1.9.0
     # via
     #   flask
     #   gds-metrics
@@ -17,7 +17,7 @@ botocore==1.34.129
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.3
+cachetools==5.5.0
     # via notifications-utils
 certifi==2024.7.4
     # via
@@ -43,7 +43,7 @@ eventlet==0.35.2
     # via gunicorn
 fido2==1.1.3
     # via -r requirements.in
-flask==3.0.0
+flask==3.1.0
     # via
     #   flask-login
     #   flask-redis
@@ -59,7 +59,7 @@ flask-wtf==1.2.1
     # via -r requirements.in
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
-govuk-bank-holidays==0.14
+govuk-bank-holidays==0.15
     # via notifications-utils
 govuk-frontend-jinja==3.4.0
     # via -r requirements.in
@@ -71,7 +71,7 @@ humanize==4.4.0
     # via -r requirements.in
 idna==3.7
     # via requests
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   flask
     #   flask-wtf
@@ -103,7 +103,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55cb9e55d4916334ff599201b881a39c412e15cb
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx
@@ -111,7 +111,7 @@ ordered-set==4.1.0
     # via notifications-utils
 packaging==23.1
     # via gunicorn
-phonenumbers==8.13.48
+phonenumbers==8.13.52
     # via notifications-utils
 pillow==10.3.0
     # via -r requirements.in
@@ -146,9 +146,9 @@ python-dateutil==2.8.2
     # via botocore
 python-json-logger==2.0.7
     # via notifications-utils
-pytz==2024.1
+pytz==2024.2
     # via notifications-utils
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via notifications-utils
 redis==4.5.4
     # via flask-redis
@@ -159,7 +159,7 @@ requests==2.32.3
     #   notifications-utils
 s3transfer==0.10.1
     # via boto3
-segno==1.5.2
+segno==1.6.1
     # via notifications-utils
 sentry-sdk==1.32.0
     # via -r requirements.in
@@ -176,7 +176,7 @@ urllib3==1.26.19
     #   botocore
     #   requests
     #   sentry-sdk
-werkzeug==3.0.6
+werkzeug==3.1.3
     # via
     #   flask
     #   flask-login

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -14,7 +14,7 @@ beautifulsoup4==4.12.3
     # via -r requirements_for_test_common.in
 black==24.10.0
     # via -r requirements_for_test_common.in
-blinker==1.6.3
+blinker==1.9.0
     # via
     #   -r requirements.txt
     #   flask
@@ -30,7 +30,7 @@ botocore==1.34.129
     #   boto3
     #   moto
     #   s3transfer
-cachetools==5.3.3
+cachetools==5.5.0
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -83,7 +83,7 @@ execnet==2.1.1
     # via pytest-xdist
 fido2==1.1.3
     # via -r requirements.txt
-flask==3.0.0
+flask==3.1.0
     # via
     #   -r requirements.txt
     #   flask-login
@@ -105,7 +105,7 @@ freezegun==1.5.1
     #   pytest-freezegun
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.txt
-govuk-bank-holidays==0.14
+govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -129,7 +129,7 @@ idna==3.7
     #   requests
 iniconfig==2.0.0
     # via pytest
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   -r requirements.txt
     #   flask
@@ -174,7 +174,7 @@ mypy-extensions==1.0.0
     # via black
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55cb9e55d4916334ff599201b881a39c412e15cb
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
     # via -r requirements.txt
 openpyxl==3.0.10
     # via
@@ -192,7 +192,7 @@ packaging==23.1
     #   pytest
 pathspec==0.12.1
     # via black
-phonenumbers==8.13.48
+phonenumbers==8.13.52
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -265,12 +265,12 @@ python-json-logger==2.0.7
     # via
     #   -r requirements.txt
     #   notifications-utils
-pytz==2024.1
+pytz==2024.2
     # via
     #   -r requirements.txt
     #   moto
     #   notifications-utils
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -298,7 +298,7 @@ s3transfer==0.10.1
     # via
     #   -r requirements.txt
     #   boto3
-segno==1.5.2
+segno==1.6.1
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -332,7 +332,7 @@ urllib3==1.26.19
     #   sentry-sdk
 webencodings==0.5.1
     # via html5lib
-werkzeug==3.0.6
+werkzeug==3.1.3
     # via
     #   -r requirements.txt
     #   flask

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.0
+# This file was automatically copied from notifications-utils@92.0.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4


### PR DESCRIPTION
 ## 92.0.1

* Bumps core dependencies to latest versions

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/92.0.0...92.0.1