### PR TITLE
Always show headings on the "Your Services" page

### DIFF
--- a/app/main/views/your_services.py
+++ b/app/main/views/your_services.py
@@ -27,22 +27,11 @@ def your_services():
             len(AllOrganisations()),
             status_api_client.get_count_of_live_services_and_organisations()["services"],
         )
-    # show headings if: user is platform admin, or there are more than two visible sections
-    show_headings = (
-        current_user.platform_admin
-        or [
-            bool(current_user.organisations),
-            bool(current_user.live_services),
-            bool(current_user.trial_mode_services),
-        ].count(True)
-        >= 2
-    )
     return render_template(
         "views/your-services.html",
         can_add_service=current_user.is_gov_user,
         org_count=org_count,
         live_service_count=live_service_count,
-        show_headings=show_headings,
     )
 
 

--- a/app/templates/views/your-services.html
+++ b/app/templates/views/your-services.html
@@ -3,22 +3,17 @@
 
 {% macro service_list(
   heading,
-  show_heading,
   organisations=[],
   services=[]
 ) %}
-  {% if show_heading %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <h2>
-          {{ heading }}
-        </h2>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <ul>
-  {% else %}
-    <ul>
-  {% endif %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter">
+      <h2>
+        {{ heading }}
+      </h2>
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      <ul>
   {% for org in organisations|sort %}
     <li class="browse-list-item">
       <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="govuk-link govuk-link--no-visited-state">{{ org.name }}</a>
@@ -33,13 +28,9 @@
       <a href="{{ url_for('main.service_dashboard', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state">{{ service.name }}</a>
     </li>
   {% endfor %}
-  {% if show_heading %}
-        </ul>
-      </div>
+      </ul>
     </div>
-  {% else %}
-    </ul>
-  {% endif %}
+  </div>
   <div class="keyline-block"></div>
 {% endmacro %}
 
@@ -82,7 +73,6 @@
   </h1>
 
   <nav class="browse-list">
-
     {% if current_user.platform_admin %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter">
@@ -105,7 +95,6 @@
     {% if current_user.organisations %}
       {{ service_list(
         heading='Organisations',
-        show_heading=show_headings,
         organisations=current_user.organisations,
       ) }}
     {% endif %}
@@ -113,27 +102,21 @@
     {% if current_user.live_services %}
       {{ service_list(
         heading='Live services',
-        show_heading=show_headings,
         services=current_user.live_services
+      ) }}
+    {% else %}
+      {{ no_service(
+        heading='Live services',
+        no_live_service_text='No live services'
       ) }}
     {% endif %}
 
     {% if current_user.trial_mode_services %}
       {{ service_list(
         heading='Trial services',
-        show_heading=show_headings,
         services=current_user.trial_mode_services
       ) }}
-    {% endif %}
-
-    {% if not current_user.live_services and not current_user.trial_mode_services %}
-      {% if not current_user.organisations %}
-        <div class="keyline-block"></div>
-      {% endif %}
-      {{ no_service(
-        heading='Live services',
-        no_live_service_text='No live services'
-      ) }}
+    {% else %}
       {{ no_service(
         heading='Trial services',
         no_live_service_text='No trial services'
@@ -144,13 +127,11 @@
 
   {% if can_add_service %}
     <div class="js-stick-at-bottom-when-scrolling">
-      {% if (not current_user.live_services and not current_user.trial_mode_services) or show_headings %}
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-quarter">
-            &nbsp;
-          </div>
-          <div class="govuk-grid-column-three-quarters">
-      {% endif %}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-quarter">
+          &nbsp;
+        </div>
+        <div class="govuk-grid-column-three-quarters">
         {{ govukButton({
           "element": "a",
           "text": "Add a new service",
@@ -165,10 +146,8 @@
             "classes": "govuk-button--secondary"
           }) }}
         {% endif %}
-      {% if (not current_user.live_services and not current_user.trial_mode_services) or show_headings %}
         </div>
-          </div>
-      {% endif %}
+      </div>
     </div>
   {% endif %}
 

--- a/tests/app/main/views/accounts/test_your_services.py
+++ b/tests/app/main/views/accounts/test_your_services.py
@@ -73,7 +73,7 @@ def mock_get_orgs_and_services(notify_admin, mocker):
     return mocker.patch("app.user_api_client.get_organisations_and_services_for_user", return_value=SAMPLE_DATA)
 
 
-def test_your_services_should_show_your_servicess_page(
+def test_your_services_should_show_your_services_page(
     client_request,
     mock_get_non_empty_organisations_and_services_for_user,
     mock_get_organisation,
@@ -134,7 +134,7 @@ def test_your_services_should_show_your_servicess_page(
     assert mock_get_organisation.call_args_list == []
 
 
-def test_your_services_should_show_your_servicess_page_if_no_services(
+def test_your_services_should_show_your_services_page_if_no_services(
     client_request,
     mock_get_orgs_and_services,
     mock_get_organisation,
@@ -217,6 +217,7 @@ def test_your_services_should_show_join_service_button(
             [
                 "Platform admin",
                 "Live services",
+                "Trial services",
             ],
         ),
         (
@@ -233,6 +234,7 @@ def test_your_services_should_show_join_service_button(
             },
             [
                 "Platform admin",
+                "Live services",
                 "Trial services",
             ],
         ),
@@ -284,7 +286,6 @@ def test_your_services_should_show_organisations_link_for_platform_admin(
             ],
             "Your organisations and services",
         ),
-        # no headings as only one thing to show
         (
             {
                 "organisations": [
@@ -297,12 +298,12 @@ def test_your_services_should_show_organisations_link_for_platform_admin(
                 "services": [],
             },
             [
+                "Organisations",
                 "Live services",
                 "Trial services",
             ],
             "Your organisations and services",
         ),
-        # no headings as only one thing to show
         (
             {
                 "organisations": [],
@@ -315,10 +316,12 @@ def test_your_services_should_show_organisations_link_for_platform_admin(
                     }
                 ],
             },
-            [],
+            [
+                "Live services",
+                "Trial services",
+            ],
             "Your services",
         ),
-        # no headings as only one thing to show
         (
             {
                 "organisations": [],
@@ -331,7 +334,10 @@ def test_your_services_should_show_organisations_link_for_platform_admin(
                     }
                 ],
             },
-            [],
+            [
+                "Live services",
+                "Trial services",
+            ],
             "Your services",
         ),
     ),


### PR DESCRIPTION
There are four potential sections on the "Your services" page:
- Platform admin
- Organisations
- Live services
- Trial services

We were showing the section headings if you were a platform admin user,
or if there were more than two visible sections. We now want the live
and trial sections to always show (with set text if they are empty).
This means we can get rid of the logic which decides whether or not to
show the section headings since we will always be showing at least two.

## Screenshots
### No services or organisations

<img width="600" alt="Screenshot 2025-01-06 at 11 15 34" src="https://github.com/user-attachments/assets/6dd32122-56ea-4f56-95e9-e67be6cdf89c" />

### Organisations and only one type of service
<img width="600" alt="Screenshot 2025-01-06 at 11 18 24" src="https://github.com/user-attachments/assets/91329ab4-efb9-42e9-ae08-3d187ae3d017" />

### Only one type of service
<img width="600" alt="Screenshot 2025-01-06 at 11 17 00" src="https://github.com/user-attachments/assets/4917e42a-50d1-488f-9690-202c162d991b" />
