### PR TITLE
jobs: make aware of "finished all notifications created" job status

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -20,6 +20,7 @@ from app import (
 from app.formatters import get_time_left, message_count_noun
 from app.main import json_updates, main
 from app.models.job import Job
+from app.notify_client.job_api_client import JobApiClient
 from app.s3_client.s3_csv_client import s3download
 from app.utils import parse_filter_args, set_status_filters
 from app.utils.csv import generate_notifications_csv
@@ -134,7 +135,8 @@ def cancel_letter_job(service_id, job_id):
     if request.method == "POST":
         job = Job.from_id(job_id, service_id=service_id)
 
-        if job.status != "finished" or job.notifications_created < job.notification_count:
+        # reduce to just == FINISHED_ALL_NOTIFICATIONS_CREATED_JOB_STATUS once api support rolled out
+        if job.status not in JobApiClient.FINISHED_JOB_STATUSES or job.notifications_created < job.notification_count:
             flash("We are still processing these letters, please try again in a minute.", "try again")
             return view_job(service_id, job_id)
         try:

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -99,10 +99,12 @@ class Job(JSONModel):
 
     @property
     def still_processing(self):
-        return self.status != "finished" or self.percentage_complete < 100
+        # reduce to status != FINISHED_ALL_NOTIFICATIONS_CREATED_JOB_STATUS once api support rolled out
+        return self.status not in JobApiClient.FINISHED_JOB_STATUSES or self.percentage_complete < 100
 
     @cached_property
     def finished_processing(self):
+        # change to status == FINISHED_ALL_NOTIFICATIONS_CREATED_JOB_STATUS once api support rolled out
         return self.notification_count == self.notifications_sent
 
     @property

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -15,6 +15,7 @@ class JobApiClient(NotifyAdminAPIClient):
         "pending",
         "in progress",
         "finished",
+        "finished all notifications created",
         "cancelled",
         "sending limits exceeded",
         "ready to send",
@@ -22,8 +23,11 @@ class JobApiClient(NotifyAdminAPIClient):
     }
     SCHEDULED_JOB_STATUS = "scheduled"
     CANCELLED_JOB_STATUS = "cancelled"
+    FINISHED_JOB_STATUS = "finished"
+    FINISHED_ALL_NOTIFICATIONS_CREATED_JOB_STATUS = "finished all notifications created"
     NON_CANCELLED_JOB_STATUSES = JOB_STATUSES - {CANCELLED_JOB_STATUS}
     NON_SCHEDULED_JOB_STATUSES = JOB_STATUSES - {SCHEDULED_JOB_STATUS, CANCELLED_JOB_STATUS}
+    FINISHED_JOB_STATUSES = {FINISHED_JOB_STATUS, FINISHED_ALL_NOTIFICATIONS_CREATED_JOB_STATUS}
 
     def get_job(self, service_id, job_id):
         params = {}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -564,8 +564,9 @@ def test_should_not_show_cancelled_job(
     )
 
 
+@pytest.mark.parametrize("job_status", ["finished", "finished all notifications created"])
 def test_should_cancel_letter_job(
-    client_request, mocker, mock_get_service_letter_template, active_user_with_permissions
+    client_request, job_status, mock_get_service_letter_template, active_user_with_permissions, mocker
 ):
     job_id = str(uuid.uuid4())
     job = job_json(
@@ -573,7 +574,7 @@ def test_should_cancel_letter_job(
         active_user_with_permissions,
         job_id=job_id,
         created_at="2019-06-20T15:30:00.000001+00:00",
-        job_status="finished",
+        job_status=job_status,
         template_type="letter",
     )
     mocker.patch("app.job_api_client.get_job", side_effect=[{"data": job}])
@@ -626,14 +627,14 @@ def test_should_not_show_cancel_link_for_letter_job_if_too_late(
 
 
 @freeze_time("2019-06-20 15:32:00.000001")
-@pytest.mark.parametrize(" job_status", ["finished", "in progress"])
+@pytest.mark.parametrize("job_status", ["finished", "finished all notifications created", "in progress"])
 def test_should_show_cancel_link_for_letter_job(
     client_request,
-    mocker,
     mock_get_service_letter_template,
     mock_get_service_data_retention,
     active_user_with_permissions,
     job_status,
+    mocker,
 ):
     job_id = uuid.uuid4()
     job = job_json(
@@ -660,14 +661,14 @@ def test_should_show_cancel_link_for_letter_job(
 
 @freeze_time("2019-06-20 15:31:00.000001")
 @pytest.mark.parametrize("job_status,number_of_processed_notifications", [["in progress", 2], ["finished", 1]])
-def test_dont_cancel_letter_job_when_to_early_to_cancel(
+def test_dont_cancel_letter_job_when_too_early_to_cancel(
     client_request,
-    mocker,
     mock_get_service_letter_template,
     mock_get_service_data_retention,
     active_user_with_permissions,
     job_status,
     number_of_processed_notifications,
+    mocker,
 ):
     job_id = uuid.uuid4()
     job = job_json(

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -431,6 +431,7 @@ def test_view_contact_list(
         limit_days=7,
         statuses={
             "finished",
+            "finished all notifications created",
             "in progress",
             "pending",
             "ready to send",

--- a/tests/app/models/test_contact_list.py
+++ b/tests/app/models/test_contact_list.py
@@ -11,6 +11,7 @@ def test_get_jobs(mock_get_jobs):
         "b",
         contact_list_id="a",
         statuses={
+            "finished all notifications created",
             "finished",
             "sending limits exceeded",
             "ready to send",

--- a/tests/app/models/test_job.py
+++ b/tests/app/models/test_job.py
@@ -12,6 +12,8 @@ from tests.conftest import SERVICE_ONE_ID
         ("cancelled", 10, True),
         ("finished", 5, True),
         ("finished", 10, False),
+        ("finished all notifications created", 5, True),
+        ("finished all notifications created", 10, False),
     ],
 )
 def test_still_processing(notify_admin, job_status, num_notifications_created, expected_still_processing):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1685,7 +1685,7 @@ def mock_get_jobs(notify_admin, mocker, api_user_active, fake_uuid):
                 ("export 1/1/2016.xls", None, "finished", "Template A", 1),
                 ("all email addresses.xlsx", None, "pending", "Template B", 1),
                 ("applicants.ods", None, "finished", "Template C", 1),
-                ("thisisatest.csv", None, "finished", "Template D", 2),
+                ("thisisatest.csv", None, "finished all notifications created", "Template D", 2),
             )
         ]
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1665,7 +1665,7 @@ def mock_has_no_jobs(notify_admin, mocker):
 def mock_get_jobs(notify_admin, mocker, api_user_active, fake_uuid):
     def _get_jobs(service_id, limit_days=None, statuses=None, contact_list_id=None, page=1):
         if statuses is None:
-            statuses = ["", "scheduled", "pending", "cancelled", "finished"]
+            statuses = ["", "scheduled", "pending", "cancelled", "finished", "finished all notifications created"]
 
         jobs = [
             job_json(


### PR DESCRIPTION
This should make admin continue to work properly when https://github.com/alphagov/notifications-api/pull/4323 has been released.

There isn't a huge amount of stuff that's interested in the job status on admin, and most of that that is interested in whether a job is "finished" helpfully uses a model method to determine this.

I don't particularly like the convention for lowercase, space-separated job status values either but it's what we have.