### PR TITLE
Use nonce value in Content Security Policy style-src header

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -358,7 +358,7 @@ def useful_headers_after_request(response):
             "font-src 'self' {asset_domain} data:;"
             "img-src 'self' {asset_domain}"
             " *.notifications.service.gov.uk {logo_domain} data:;"
-            "style-src 'self' {asset_domain} 'unsafe-inline';"
+            "style-src 'self' {asset_domain} 'nonce-{csp_nonce}';"
             "frame-ancestors 'self';"
             "frame-src 'self';".format(
                 asset_domain=current_app.config["ASSET_DOMAIN"],

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -351,6 +351,10 @@ def useful_headers_after_request(response):
     response.headers.add(
         "Content-Security-Policy",
         (
+            # we need to keep 'unsafe-inline' on default-src
+            # as inline styles appear in branding iframe preview
+            # and on send email preview and changing that would
+            # require dev work
             "default-src 'self' {asset_domain} 'unsafe-inline';"
             "script-src 'self' {asset_domain} 'nonce-{csp_nonce}';"
             "connect-src 'self';"

--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -17,9 +17,6 @@
 
     <link rel="stylesheet" media="screen" href="/static/stylesheets/main.css?d077f86473501ab244de0b30600536ee" />
     <link rel="stylesheet" media="print" href="/static/stylesheets/print.css?28010888ca5719dc83d7c2c80f6ed2b2" />
-    <style>
-      .govuk-header__container { border-color: #1d70b8 }
-    </style>
 
     <meta property="og:image" content="/static/images/govuk-opengraph-image.png">
   </head>

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -18,7 +18,7 @@
   <link rel="stylesheet" media="print" href="{{ asset_url('stylesheets/print.css') }}" />
   {% block extra_stylesheets %}
   {% endblock %}
-  <style>
+  <style nonce="{{ cspNonce }}">
       .govuk-header__container { border-color: {{header_colour}} }
   </style>
   {% if g.hide_from_search_engines %}

--- a/app/templates/components/svgs.html
+++ b/app/templates/components/svgs.html
@@ -35,7 +35,7 @@
     role="img" aria-hidden="true" focusable="false"
     class="svg-folder-icon{%- if classes %} {{ classes }}{% endif -%}"
   >
-    <style><![CDATA[
+    <style nonce="{{ request.csp_nonce }}"><![CDATA[
       .svg-folder-icon > path {
         fill: #dee0e2;
       }

--- a/app/templates/unbranded_template.html
+++ b/app/templates/unbranded_template.html
@@ -8,7 +8,7 @@
 {% block head %}
   {% block extra_stylesheets %}
   {% endblock %}
-  <style>
+  <style nonce="{{ cspNonce }}">
     body {
       background: #f3f2f1;
       color: #0b0c0c;

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -22,7 +22,7 @@ def test_owasp_useful_headers_set(
         "img-src "
         "'self' static.example.com"
         " *.notifications.service.gov.uk static-logos.test.com data:;"
-        "style-src 'self' static.example.com 'unsafe-inline';"
+        "style-src 'self' static.example.com 'nonce-TESTs5Vr8v3jgRYLoQuVwA';"
         "frame-ancestors 'self';"
         "frame-src 'self';"
     )
@@ -68,7 +68,7 @@ def test_headers_non_ascii_characters_are_replaced(
         "img-src"
         " 'self' static.example.com"
         " *.notifications.service.gov.uk static-logos??.test.com data:;"
-        "style-src 'self' static.example.com 'unsafe-inline';"
+        "style-src 'self' static.example.com 'nonce-TESTs5Vr8v3jgRYLoQuVwA';"
         "frame-ancestors 'self';"
         "frame-src 'self';"
     )


### PR DESCRIPTION
## What
Continuation of work done in https://github.com/alphagov/notifications-admin/pull/5315 to serve an even more secure site by additionally restricting valid sources for styles.

Restricting execution of majority of our inline styles to only those that contain a `nonce` value, which was implemented in https://github.com/alphagov/notifications-admin/pull/5325

There are two notable exceptions documented in https://github.com/alphagov/notifications-admin/pull/5341/commits/4d149d79d11e5c771b8d7f3fff8fbb3c74852891

## How to test
run locally
- pages to test
  - homepage
  - templates
  - unbranded page (like request unsubscribe)
  - change email branding preview and send an email template preview