### PR TITLE
Give content pages' sub nav padding-bottom

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -4,7 +4,7 @@ $notify-secondary-button-colour: govuk-shade(govuk-colour("light-grey"), 7%);
 $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 18%);
 
 // adjusted link colour on grey to satisfy WCAG criterion
-// on govuk-shade(govuk-colour("light-grey"), 7%) this 
+// on govuk-shade(govuk-colour("light-grey"), 7%) this
 // now has a contrast ratio of 5.67
 // this HEX is lighter than $govuk-link-hover-colour
 $link-colour-on-grey-background: #1852ab;
@@ -12,10 +12,10 @@ $link-colour-on-grey-background: #1852ab;
 // Additional padding-bottom override, following the GOV.UK Frontend spacing scale:
 // https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale
 .govuk-\!-padding-bottom-12 {
-  padding-bottom: 70px;
+  padding-bottom: 70px !important; /* stylelint-disable-line declaration-no-important */
 
   @include govuk-media-query($from: tablet) {
-    padding-bottom: 90px;
+    padding-bottom: 90px !important; /* stylelint-disable-line declaration-no-important */
   }
 }
 

--- a/app/templates/components/sub-navigation.html
+++ b/app/templates/components/sub-navigation.html
@@ -25,7 +25,7 @@
   item_set,
   nav_label_prefix
 ) %}
-  <nav class="navigation govuk-!-margin-top-7" aria-label="{{ nav_label_prefix }}">
+  <nav class="navigation govuk-!-margin-top-7 govuk-!-padding-bottom-12" aria-label="{{ nav_label_prefix }}">
     <ol itemscope itemtype="http://schema.org/ItemList">
       {% for item in item_set %}
         {% if item.sub_navigation_items %}


### PR DESCRIPTION
This makes sure it has the same distance from the page footer as the main content column.

## Before

<img width="982" alt="side_nav_before" src="https://github.com/user-attachments/assets/0b46a79c-d089-452d-ab05-7955e1b08e55" />

## After

<img width="1005" alt="side_nav_after" src="https://github.com/user-attachments/assets/7c0b0186-a0ae-4690-914e-61897df63731" />
