### PR TITLE
Fix copy an existing template radio button bug

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -187,19 +187,12 @@
       return changed;
     };
 
-    this.$singleNotificationChannel = (document.querySelector('div[id=add_new_template_form]')).getAttribute("data-channel");
-    this.$singleChannelService = (document.querySelector('div[id=add_new_template_form]')).getAttribute("data-service");
-
     this.actionButtonClicked = function(event) {
       event.preventDefault();
       this.currentState = $(event.currentTarget).val();
 
-      if (event.currentTarget.value === 'add-new-template' && this.$singleNotificationChannel) {
-        window.location = "/services/" + this.$singleChannelService + "/templates/add-" + this.$singleNotificationChannel;
-      } else {
-        if (this.stateChanged()) {
+      if (this.stateChanged()) {
           this.render();
-        }
       }
     };
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -163,11 +163,6 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
         option_hints=option_hints,
     )
 
-    single_notification_channel = None
-    notification_channels = current_service.available_template_types
-    if len(notification_channels) == 1:
-        single_notification_channel = notification_channels[0]
-
     if request.method == "POST" and templates_and_folders_form.validate_on_submit():
         if not current_user.has_permissions("manage_templates"):
             abort(403)
@@ -205,7 +200,6 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
         form=templates_and_folders_form,
         move_to_children=templates_and_folders_form.move_to.children(),
         user_has_template_folder_permission=user_has_template_folder_permission,
-        single_notification_channel=single_notification_channel,
         option_hints=option_hints,
         error_summary_enabled=True,
         error_summary_extra_params={

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -33,7 +33,7 @@
       {{ page_footer('Add new folder', button_name='operation', button_value='add-new-folder') }}
     </div>
   </div>
-  <div id="add_new_template_form" class="sticky-template-form" role="region" aria-label="{{ add_a_template_heading_and_aria_label_text }}" {% if single_notification_channel %}data-channel="{{single_notification_channel}}" data-service="{{current_service.id}}"{% endif %}>
+  <div id="add_new_template_form" class="sticky-template-form" role="region" aria-label="{{ add_a_template_heading_and_aria_label_text }}">
     <h3 class="govuk-heading-s js-hidden">{{ add_a_template_heading_and_aria_label_text }}</h3>
     <div class="js-will-stick-at-bottom-when-scrolling">
      {{form.add_template_by_template_type}}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -351,42 +351,6 @@ def test_should_show_new_template_choices_if_service_has_folder_permission(
 
 
 @pytest.mark.parametrize(
-    "permissions,are_data_attrs_added",
-    [
-        (["sms"], True),
-        (["email"], True),
-        (["letter"], True),
-        (["sms", "email"], False),
-    ],
-)
-def test_should_add_data_attributes_for_services_that_only_allow_one_type_of_notifications(
-    client_request,
-    service_one,
-    mock_get_service_templates,
-    mock_get_template_folders,
-    mock_get_no_api_keys,
-    permissions,
-    are_data_attrs_added,
-):
-    service_one["permissions"] = permissions
-
-    page = client_request.get(
-        "main.choose_template",
-        service_id=SERVICE_ONE_ID,
-    )
-
-    if not page.select("#add_new_template_form"):
-        raise ElementNotFound
-
-    if are_data_attrs_added:
-        assert page.select_one("#add_new_template_form").attrs["data-channel"] == permissions[0]
-        assert page.select_one("#add_new_template_form").attrs["data-service"] == SERVICE_ONE_ID
-    else:
-        assert page.select_one("#add_new_template_form").attrs.get("data-channel") is None
-        assert page.select_one("#add_new_template_form").attrs.get("data-service") is None
-
-
-@pytest.mark.parametrize(
     "custom_email_sender_name, expected_email_from",
     (
         (None, "service one"),

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -328,37 +328,6 @@ describe('TemplateFolderForm', () => {
 
   });
 
-  describe("Click 'New template' for single channel service", () => {
-    test("should redirect to new template page", () => {
-      setFixtures(hierarchy, "data-channel='sms' data-service='123'")
-      templateFolderForm = document.querySelector('form[data-notify-module=template-folder-form]');
-
-      // start module
-      window.GOVUK.notifyModules.start();
-
-      formControls = templateFolderForm.querySelector('#sticky_template_forms');
-
-      // reset sticky JS mocks called when the module starts
-      resetStickyMocks();
-      // add listener for url change
-      const descriptor1 = Object.getOwnPropertyDescriptor(window, 'location');
-      delete window.location
-
-      const mockCallback = jest.fn(x => {});
-
-      Object.defineProperty(window, 'location', {
-        set: mockCallback
-      });
-      // click
-      helpers.triggerEvent(formControls.querySelector('[value=add-new-template]'), 'click');
-      // expect url to change
-      expect(mockCallback).toHaveBeenCalledWith("/services/123/templates/add-sms")
-
-      setFixtures(hierarchy)
-      resetStickyMocks()
-    });
-  })
-
   describe("Clicking 'New template'", () => {
 
     beforeEach(() => {


### PR DESCRIPTION
This PR fixes the bug, described [here](https://trello.com/c/yMwKveap/179-copy-an-existing-template-radio-button-only-appears-if-more-than-one-channel-is-turned-on), where the "copy an existing  template" radio buttonis not displayed when a service has only enabled a single notification channel.


![copy an existing template](https://github.com/user-attachments/assets/c51207ce-c0c3-4297-a1bf-818abe815694)
