### PR TITLE
Update wording on "Your services" page

### DIFF
--- a/app/templates/views/your-services.html
+++ b/app/templates/views/your-services.html
@@ -113,13 +113,13 @@
 
     {% if current_user.trial_mode_services %}
       {{ service_list(
-        heading='Trial services',
+        heading='Trial mode services',
         services=current_user.trial_mode_services
       ) }}
     {% else %}
       {{ no_service(
-        heading='Trial services',
-        no_live_service_text='No trial services'
+        heading='Trial mode services',
+        no_live_service_text='No trial mode services'
       ) }}
     {% endif %}
 

--- a/tests/app/main/views/accounts/test_your_services.py
+++ b/tests/app/main/views/accounts/test_your_services.py
@@ -122,7 +122,7 @@ def test_your_services_should_show_your_services_page(
     assert service_list_items[4].a.text == "service two (org 2)"
     assert service_list_items[4].a["href"] == url_for(".service_dashboard", service_id="67890")
 
-    assert normalize_spaces(headings[2].text) == "Trial services"
+    assert normalize_spaces(headings[2].text) == "Trial mode services"
 
     # trial services
     assert len(trial_services_list_items) == 3
@@ -152,9 +152,9 @@ def test_your_services_should_show_your_services_page_if_no_services(
     assert normalize_spaces(page.select_one("h1").text) == "Your services"
     assert normalize_spaces(add_service_link.text) == "Add a new service"
     assert add_service_link["href"] == url_for("main.add_service")
-    assert [normalize_spaces(h2.text) for h2 in page.select("main h2")] == ["Live services", "Trial services"]
+    assert [normalize_spaces(h2.text) for h2 in page.select("main h2")] == ["Live services", "Trial mode services"]
     assert normalize_spaces(no_live_service[0].text) == "No live services"
-    assert normalize_spaces(no_live_trial_mode[0].text) == "No trial services"
+    assert normalize_spaces(no_live_trial_mode[0].text) == "No trial mode services"
 
 
 def test_your_services_should_show_join_service_button(
@@ -190,7 +190,7 @@ def test_your_services_should_show_join_service_button(
             [
                 "Platform admin",
                 "Live services",
-                "Trial services",
+                "Trial mode services",
             ],
         ),
         (
@@ -199,7 +199,7 @@ def test_your_services_should_show_join_service_button(
                 "Platform admin",
                 "Organisations",
                 "Live services",
-                "Trial services",
+                "Trial mode services",
             ],
         ),
         (
@@ -217,7 +217,7 @@ def test_your_services_should_show_join_service_button(
             [
                 "Platform admin",
                 "Live services",
-                "Trial services",
+                "Trial mode services",
             ],
         ),
         (
@@ -235,7 +235,7 @@ def test_your_services_should_show_join_service_button(
             [
                 "Platform admin",
                 "Live services",
-                "Trial services",
+                "Trial mode services",
             ],
         ),
     ),
@@ -273,7 +273,7 @@ def test_your_services_should_show_organisations_link_for_platform_admin(
             {"organisations": [], "services": []},
             [
                 "Live services",
-                "Trial services",
+                "Trial mode services",
             ],
             "Your services",
         ),
@@ -282,7 +282,7 @@ def test_your_services_should_show_organisations_link_for_platform_admin(
             [
                 "Organisations",
                 "Live services",
-                "Trial services",
+                "Trial mode services",
             ],
             "Your organisations and services",
         ),
@@ -300,7 +300,7 @@ def test_your_services_should_show_organisations_link_for_platform_admin(
             [
                 "Organisations",
                 "Live services",
-                "Trial services",
+                "Trial mode services",
             ],
             "Your organisations and services",
         ),
@@ -318,7 +318,7 @@ def test_your_services_should_show_organisations_link_for_platform_admin(
             },
             [
                 "Live services",
-                "Trial services",
+                "Trial mode services",
             ],
             "Your services",
         ),
@@ -336,7 +336,7 @@ def test_your_services_should_show_organisations_link_for_platform_admin(
             },
             [
                 "Live services",
-                "Trial services",
+                "Trial mode services",
             ],
             "Your services",
         ),


### PR DESCRIPTION
To change "Trial services" to "Trial mode services".