### PR TITLE
Update docker compose to use amd64 unit-tests-image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm as base
+FROM --platform=linux/amd64 python:3.11-slim-bookworm AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
After recent change tp remove sh file, the new unit-tests-image does not work on mac because of the ghcr image only support amd64.