### PR TITLE
Add guidance on identifying returned letters via API

### DIFF
--- a/app/templates/views/guidance/using-notify/delivery-times.html
+++ b/app/templates/views/guidance/using-notify/delivery-times.html
@@ -51,7 +51,9 @@
            <li>the <code class="lang-py">reference</code> argument when making an API call if you use the <a class="govuk-link govuk-link--no-visited-state">Notify API</a> </li>
        </ul>
    </li>
-
  </ul>
+  <h3 id="automate-identifying-returned-letters" class="heading-small">Automate identifying the returned letters</h3>
+  <p class="govuk-body">Use the Notify API to get the returned letters report and identify the letters. Follow the instructions in our <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/using-notify/api-documentation">API documentation</a>.</p>
+  <p class="govuk-body">You’ll need a developer on your team to set this up for you.</p>
 
 {% endblock %}


### PR DESCRIPTION
This furthers the work done in https://github.com/alphagov/notifications-admin/pull/5308

This can only be shipped once we have:
- built callbacks for returned letters
- added these callbacks to our API documentation

Before | After
---|---
<img width="655" alt="image" src="https://github.com/user-attachments/assets/d631442f-ab1a-4c94-8988-b22c7b8a1ba7" /> | <img width="671" alt="image" src="https://github.com/user-attachments/assets/e4c65629-5f88-4b04-acc8-e0e19b5a82b5" />
