### PR TITLE
Remove link with no `href`

### DIFF
--- a/app/templates/views/guidance/using-notify/delivery-times.html
+++ b/app/templates/views/guidance/using-notify/delivery-times.html
@@ -48,7 +48,7 @@
    <li>a reference for each letter if you include either:
        <ul class="govuk-list govuk-list--bullet">
            <li>a column called ‘reference’ in the list of addresses you upload</li>
-           <li>the <code class="lang-py">reference</code> argument when making an API call if you use the <a class="govuk-link govuk-link--no-visited-state">Notify API</a> </li>
+           <li>the <code class="lang-py">reference</code> argument when making an API call if you use the Notify API</li>
        </ul>
    </li>
 


### PR DESCRIPTION
This link doesn’t do anything when you click it.

We can link to the API documentation later once we add guidance for API users in https://github.com/alphagov/notifications-admin/pull/5352