### PR TITLE
Remove the announcement about a February letter price increase

### DIFF
--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -20,10 +20,6 @@
       }
     ) }}
 
-  <div class="govuk-inset-text">
-    International letter prices will go up on 6 February 2025. This is because Royal Mail has increased its rates.
-  </div>
-
   <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
   <p class="govuk-body">Prices include:</p>


### PR DESCRIPTION
New prices come into effect on 6 February, so we can remove the announcement about an upcoming increase.

Do not deploy until Thursday 6 February.