### PR TITLE
Fix letter template button overlap

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -18,6 +18,7 @@
   container-type: inline-size;
 
   position: relative;
+  z-index: 1;
 
   &--with-attach-pages-button {
     .page--last {


### PR DESCRIPTION
Letter template edit buttons used to overlap the sticky footer.

This fixes https://trello.com/c/lpI5ul8e/918-button-overlapping-on-letter-template-page

Before

<img width="789" alt="before" src="https://github.com/user-attachments/assets/1f643be0-36e7-407e-b474-1d956df16609" />


After

<img width="656" alt="Screenshot 2025-01-21 at 09 44 24" src="https://github.com/user-attachments/assets/d424c1cf-a355-45e3-b82c-c9773f402376" />

