### PR TITLE
Update the link guidance to make it clearer

### DIFF
--- a/app/templates/views/guidance/using-notify/links-and-URLs.html
+++ b/app/templates/views/guidance/using-notify/links-and-URLs.html
@@ -13,25 +13,29 @@
 
   <h1 class="heading-large">Links and URLs</h1>
 
-  <p class="govuk-body">When composing a message, write URLs in full. For example:</p>
+  <p class="govuk-body">To add a link to a message, write the URL in full. For example:</p>
 
   <pre class="formatting-example"><code class="lang-md">Apply now at https://www.gov.uk/example</code></pre>
+
+  <p class="govuk-body">GOV.UK Notify will convert the URL into a link for you.</p>
 
   <p class="govuk-body">URLs should be easy to read.</p>
 
   <p class="govuk-body">If you have a long, complex web address, you may want to set up a short URL.</p>
 
-  <p class="govuk-body">We do not recommend using a third-party link shortening service because:</p>
+  <p class="govuk-body">If your webpage is published on GOV.UK, you can contact <abbr title="Government Digital Service">GDS</abbr> to <a class="govuk-link govuk-link--no-visited-state"
+    href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">request a short URL</a>.
+  </p>
+
+  <p class="govuk-body">If your webpage is not published on GOV.UK, ask your IT department to set up a short URL for you.</p>
+
+  <p class="govuk-body">Do not use a third-party link shortening service because:</p>
 
   <ul class="govuk-list govuk-list--bullet">
     <li>your users cannot see where the link will take them</li>
     <li>your link might stop working if there’s a service outage</li>
     <li>you can no longer control where the redirect goes</li>
   </ul>
-
-  <p class="govuk-body">If your webpage is published on GOV.UK, you can contact <abbr title="Government Digital Service">GDS</abbr> to <a class="govuk-link govuk-link--no-visited-state"
-    href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">request a short URL</a>.
-  </p>
 
   <h2 class="heading-medium" id="link-text-in-emails">Link text in emails</h2>
 


### PR DESCRIPTION
When we rewrote the links guidance a couple of years ago we omitted the line about how Notify automatically converts URLs into links.

This has come up on support a couple of times, so we’ve decided to add it back in.

We’re also restructuring the first section of the page to take the emphasis off third-party link-shorteners. The current content gives too much emphasis to something we do not want users to do, and not enough to the actual solution they need.