### PR TITLE
Bump utils to 93.2.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@93.2.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,13 +24,14 @@ from flask_wtf.csrf import CSRFError
 from gds_metrics import GDSMetrics
 from itsdangerous import BadSignature
 from notifications_python_client.errors import HTTPError
-from notifications_utils import logging, request_helper
+from notifications_utils import request_helper
 from notifications_utils.asset_fingerprinter import asset_fingerprinter
 from notifications_utils.eventlet import EventletTimeout
 from notifications_utils.formatters import (
     formatted_list,
     get_lines_with_normalised_whitespace,
 )
+from notifications_utils.logging import flask as utils_logging
 from notifications_utils.recipient_validation.phone_number import format_phone_number_human_readable
 from notifications_utils.safe_string import make_string_safe_for_email_local_part, make_string_safe_for_id
 from notifications_utils.sanitise_text import SanitiseASCII
@@ -194,7 +195,7 @@ def create_app(application):
     ):
         client.init_app(application)
 
-    logging.init_app(application)
+    utils_logging.init_app(application)
     webauthn_server.init_app(application)
 
     login_manager.login_view = "main.sign_in"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@93.2.1
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@93.2.1
 
 govuk-frontend-jinja==3.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -103,7 +103,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b9ef1b45b655324d6341995afffc3ebc25a3ed72
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@27797ff3485a9b8c564b6ae0cebb7aa8cd4fea4f
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -174,7 +174,7 @@ mypy-extensions==1.0.0
     # via black
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b9ef1b45b655324d6341995afffc3ebc25a3ed72
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@27797ff3485a9b8c564b6ae0cebb7aa8cd4fea4f
     # via -r requirements.txt
 openpyxl==3.0.10
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@93.2.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -33,6 +33,7 @@
     "/features/letters",
     "/features/messages-status",
     "/features/performance",
+    "/features/performance.json",
     "/features/roadmap",
     "/features/security",
     "/features/sms",


### PR DESCRIPTION
 ## 93.2.1

* Replaces symlink at `./pyproject.toml` with a duplicate file

 ## 93.2.0

* logging: add verbose eventlet context to app.request logs if request_time is over a threshold

 ## 93.1.0

* Introduce `NOTIFY_LOG_LEVEL_HANDLERS` config variable for separate control of handler log level

 ## 93.0.0

* BREAKING CHANGE: logging: all contents of `logging/__init__.py` have been moved to `logging/flask.py` because they all assume a flask(-like) environment and this way we don't implicitly import all of flask etc. every time anything under `logging` is imported.
* Adds `request_cpu_time` to `app.request` logs when available.
* Adds ability to track eventlet's switching of greenlets and annotate `app.request` logs with useful metrics when the flask config parameter `NOTIFY_EVENTLET_STATS` is set and the newly provided function `account_greenlet_times` is installed as a greenlet trace hook.

 ## 92.1.1

* Bump minimum version of `jinja2` to 3.1.5

 ## 92.1.0

* RequestCache: add CacheResultWrapper to allow dynamic cache decisions

 ## 92.0.2

* Downgrade minimum version of `requests` to 2.32.3

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/92.0.1...93.2.1