### PR TITLE
Add logic to ignore some orgs from perf page

### DIFF
--- a/app/main/views/performance.py
+++ b/app/main/views/performance.py
@@ -9,6 +9,8 @@ from app import performance_dashboard_api_client, status_api_client
 from app.main import main
 from app.main.views.sub_navigation_dictionaries import features_nav
 
+ORGS_TO_IGNORE = ["1556fd80-a1b2-4b79-8453-f6fcb6f00d0c"]  # TODO: Move this into the database
+
 
 @main.route("/features/performance")
 @main.route("/features/performance.json", endpoint="performance_json")
@@ -16,6 +18,9 @@ def performance():
     stats = performance_dashboard_api_client.get_performance_dashboard_stats(
         start_date=(datetime.utcnow() - timedelta(days=7)).date(),
         end_date=datetime.utcnow().date(),
+    )
+    stats["services_using_notify"] = list(
+        filter(lambda d: d["organisation_id"] not in ORGS_TO_IGNORE, stats["services_using_notify"])
     )
     stats["organisations_using_notify"] = sorted(
         [


### PR DESCRIPTION
Quick fix for issue described in https://govuk.zendesk.com/agent/tickets/5996167

https://trello.com/c/efVuXBAo/1133-hide-organisation-from-performance-page

We will eventually put this in the database but, for now, this is a quick fix to ensure we can decide which orgs to display and which not.