### PR TITLE
Sync newly-frozen requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,10 @@ fix-imports: ## Fix imports using ruff
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt
 	uv pip compile requirements.in -o requirements.txt
+	uv pip sync requirements.txt
 	python -c "from notifications_utils.version_tools import copy_config; copy_config()"
 	uv pip compile requirements_for_test.in -o requirements_for_test.txt
+	uv pip sync requirements_for_test.txt
 
 .PHONY: bump-utils
 bump-utils:  # Bump notifications-utils package to latest version


### PR DESCRIPTION
If we don’t do this then we’ll get old versions of the config files from utils, and we won’t get newer versions of any updates subdependencies installed.

Safe to assume that if someone is freezing requirements it’s because they want to use those new requirements.

Matches what we did in the API repo here: https://github.com/alphagov/notifications-api/commit/655bccda9688ebd30dca8c8c7e11494215cc5169

This was already changed in https://github.com/alphagov/notifications-admin/pull/5329 but then reverted (accidentally?) here https://github.com/alphagov/notifications-admin/pull/5285/commits/fe7395539c684bb843527e3d627d7a3ee41069c4#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L68-L73