### PR TITLE
Stop passing the year to API when setting SMS fragment limit

### DIFF
--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -21,9 +21,11 @@ class BillingAPIClient(NotifyAdminAPIClient):
         )
         return result["free_sms_fragment_limit"]
 
-    def create_or_update_free_sms_fragment_limit(self, service_id, free_sms_fragment_limit, year=None):
-        # year = None will update current and future year in the API
-        data = {"financial_year_start": year, "free_sms_fragment_limit": free_sms_fragment_limit}
+    def create_or_update_free_sms_fragment_limit(self, service_id, free_sms_fragment_limit):
+        """
+        Updates the free sms fragment limit for the current financial year
+        """
+        data = {"free_sms_fragment_limit": free_sms_fragment_limit}
 
         return self.post(url=f"/service/{service_id}/billing/free-sms-fragment-limit", data=data)
 

--- a/tests/app/notify_client/test_billing_client.py
+++ b/tests/app/notify_client/test_billing_client.py
@@ -16,25 +16,17 @@ def test_get_free_sms_fragment_limit_for_year_correct_endpoint(mocker):
     mock_get.assert_called_once_with(expected_url, params={"financial_year_start": 1999})
 
 
-def test_post_free_sms_fragment_limit_for_current_year_endpoint(mocker):
+def test_post_create_or_update_free_sms_fragment_limit(mocker):
     service_id = uuid.uuid4()
-    sms_limit_data = {"free_sms_fragment_limit": 1111, "financial_year_start": None}
     mock_post = mocker.patch("app.notify_client.billing_api_client.BillingAPIClient.post")
     client = BillingAPIClient(mocker.MagicMock())
 
     client.create_or_update_free_sms_fragment_limit(service_id=service_id, free_sms_fragment_limit=1111)
 
-    mock_post.assert_called_once_with(url=f"/service/{service_id}/billing/free-sms-fragment-limit", data=sms_limit_data)
-
-
-def test_post_free_sms_fragment_limit_for_year_endpoint(mocker):
-    service_id = uuid.uuid4()
-    sms_limit_data = {"free_sms_fragment_limit": 1111, "financial_year_start": 2017}
-    mock_post = mocker.patch("app.notify_client.billing_api_client.BillingAPIClient.post")
-    client = BillingAPIClient(mocker.MagicMock())
-
-    client.create_or_update_free_sms_fragment_limit(service_id=service_id, free_sms_fragment_limit=1111, year=2017)
-    mock_post.assert_called_once_with(url=f"/service/{service_id}/billing/free-sms-fragment-limit", data=sms_limit_data)
+    mock_post.assert_called_once_with(
+        url=f"/service/{service_id}/billing/free-sms-fragment-limit",
+        data={"free_sms_fragment_limit": 1111},
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3227,7 +3227,7 @@ def mock_get_free_sms_fragment_limit(notify_admin, mocker):
 
 @pytest.fixture(scope="function")
 def mock_create_or_update_free_sms_fragment_limit(notify_admin, mocker):
-    sample_limit = 250000
+    sample_limit = {"free_sms_fragment_limit": 250000}
     return mocker.patch("app.billing_api_client.create_or_update_free_sms_fragment_limit", return_value=sample_limit)
 
 


### PR DESCRIPTION
The year argument was not being used by the api, and we don't let you specify which year you are setting the free SMS fragment limit for anyway - you can only set it for the current financial year.

This also updates a mock to make its return value match the real format.