### PR TITLE
Show error if user tries to make archived service live

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -269,6 +269,9 @@ def submit_request_to_go_live(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/switch-live", methods=["GET", "POST"])
 @user_is_platform_admin
 def service_switch_live(service_id):
+    if not current_service.active:
+        abort(403)
+
     if current_service.trial_mode and (
         not current_service.organisation or current_service.organisation.agreement_signed is False
     ):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -455,6 +455,8 @@ class User(BaseUser, UserMixin):
         return False
 
     def can_make_service_live(self, service):
+        if not service.active:
+            return False
         if not service.has_active_go_live_request:
             return False
         if not service.organisation_id:

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -687,6 +687,41 @@ def test_switch_service_to_live_with_no_organisation(
     )
 
 
+@pytest.mark.parametrize(
+    "active",
+    (
+        pytest.param(False),
+        pytest.param(True, marks=pytest.mark.xfail(reason="403 caused by something else")),
+    ),
+)
+def test_switch_archived_service_to_live(
+    client_request,
+    service_one,
+    platform_admin_user,
+    fake_uuid,
+    active,
+    mocker,
+):
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_json(agreement_signed=True),
+    )
+    service_one["organisation"] = fake_uuid
+    service_one["active"] = active
+
+    client_request.login(platform_admin_user)
+    client_request.get(
+        "main.service_switch_live",
+        service_id=SERVICE_ONE_ID,
+        _expected_status=403,
+    )
+    client_request.post(
+        "main.service_switch_live",
+        service_id=SERVICE_ONE_ID,
+        _expected_status=403,
+    )
+
+
 def test_show_live_service(
     client_request,
     mock_get_live_service,

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -14,7 +14,13 @@ from tests.conftest import (
 )
 
 test_user_auth_combinations = (
-    "user, organisation_can_approve_own_go_live_requests, service_has_active_go_live_request, expected_status",
+    """
+        user,
+        organisation_can_approve_own_go_live_requests,
+        service_has_active_go_live_request,
+        service_is_active,
+        expected_status,
+    """,
     (
         (
             # A user who is a member of the organisation
@@ -25,6 +31,7 @@ test_user_auth_combinations = (
             ),
             True,
             True,
+            True,
             200,
         ),
         (
@@ -32,11 +39,13 @@ test_user_auth_combinations = (
             create_user(id=sample_uuid(), platform_admin=True),
             True,
             True,
+            True,
             200,
         ),
         (
             # User who is a not an organisation team member can’t approve go live requests
             create_user(id=sample_uuid()),
+            True,
             True,
             True,
             403,
@@ -50,6 +59,7 @@ test_user_auth_combinations = (
             ),
             False,
             True,
+            True,
             403,
         ),
         (
@@ -61,11 +71,21 @@ test_user_auth_combinations = (
             ),
             True,
             False,
+            True,
             403,
         ),
         (
             # If the user doesn't have the "can make services live" permission then the user is blocked
             create_user(id=sample_uuid(), organisations=[ORGANISATION_ID], organisation_permissions={}),
+            True,
+            False,
+            True,
+            403,
+        ),
+        (
+            # If the service is not active then the user is blocked
+            create_user(id=sample_uuid(), platform_admin=True),
+            True,
             True,
             False,
             403,
@@ -82,6 +102,7 @@ def test_get_org_member_make_service_live_start(
     user,
     organisation_can_approve_own_go_live_requests,
     service_has_active_go_live_request,
+    service_is_active,
     expected_status,
     mocker,
 ):
@@ -92,6 +113,7 @@ def test_get_org_member_make_service_live_start(
     service_one["has_active_go_live_request"] = service_has_active_go_live_request
     service_one["organisation"] = ORGANISATION_ID
     service_one["volume_letter"] = None
+    service_one["active"] = service_is_active
 
     client_request.login(user)
 
@@ -162,6 +184,7 @@ def test_get_org_member_make_service_live_service_name(
     user,
     organisation_can_approve_own_go_live_requests,
     service_has_active_go_live_request,
+    service_is_active,
     expected_status,
     mocker,
 ):
@@ -172,6 +195,7 @@ def test_get_org_member_make_service_live_service_name(
     service_one["has_active_go_live_request"] = service_has_active_go_live_request
     service_one["organisation"] = ORGANISATION_ID
     service_one["volume_letter"] = None
+    service_one["active"] = service_is_active
 
     client_request.login(user)
 
@@ -334,6 +358,7 @@ def test_get_org_member_make_service_live_unique_service(
     user,
     organisation_can_approve_own_go_live_requests,
     service_has_active_go_live_request,
+    service_is_active,
     expected_status,
     mocker,
 ):
@@ -344,6 +369,7 @@ def test_get_org_member_make_service_live_unique_service(
     service_one["has_active_go_live_request"] = service_has_active_go_live_request
     service_one["organisation"] = ORGANISATION_ID
     service_one["volume_letter"] = None
+    service_one["active"] = service_is_active
 
     client_request.login(user)
 
@@ -465,6 +491,7 @@ def test_get_org_member_make_service_live_contact_user(
     user,
     organisation_can_approve_own_go_live_requests,
     service_has_active_go_live_request,
+    service_is_active,
     expected_status,
     data,
     expected_redirect,
@@ -477,6 +504,7 @@ def test_get_org_member_make_service_live_contact_user(
     service_one["has_active_go_live_request"] = service_has_active_go_live_request
     service_one["organisation"] = ORGANISATION_ID
     service_one["volume_letter"] = None
+    service_one["active"] = service_is_active
 
     client_request.login(user)
 
@@ -502,6 +530,7 @@ def test_get_org_member_make_service_live_decision(
     user,
     organisation_can_approve_own_go_live_requests,
     service_has_active_go_live_request,
+    service_is_active,
     expected_status,
     mocker,
 ):
@@ -512,6 +541,7 @@ def test_get_org_member_make_service_live_decision(
     service_one["has_active_go_live_request"] = service_has_active_go_live_request
     service_one["organisation"] = ORGANISATION_ID
     service_one["volume_letter"] = None
+    service_one["active"] = service_is_active
 
     client_request.login(user)
 


### PR DESCRIPTION
A platform admin user can try and make an archived service live - we would not do this intentionally, but it could happen if someone clicks the button to make the service live just after the service was archived. If this happens the user will see the “something went wrong” error page due to API giving a validation error of
```python
{'normalised_service_name': ['Unacceptable characters: `normalised_service_name` may only contain letters, numbers and full stops.']}
```

It shouldn’t be giving this error, it should be clear what has happened instead.

I think a generic ‘permission denied’ error is clear enough for this edge case – if the user goes back and tries again they will see that the service is now archived.

***

https://trello.com/c/ruquwn6U/103-attempting-to-make-an-archived-service-live-gives-an-unexpected-error