### PR TITLE
Install uv from Docker registry

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,12 @@
 FROM --platform=linux/amd64 python:3.11-slim-bookworm AS base
 
+COPY --from=ghcr.io/astral-sh/uv:0.5.30 /uv /uvx /bin/
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
+ENV UV_CACHE_DIR='/tmp/uv-cache/'
 ENV UV_COMPILE_BYTECODE=1
+ENV VIRTUAL_ENV="/opt/venv"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -41,9 +45,6 @@ RUN echo "Install OS dependencies for python app requirements" &&  \
 
 COPY requirements.txt .
 
-RUN pip install uv
-
-ENV UV_CACHE_DIR='/tmp/uv-cache/'
 RUN echo "Installing python requirements" && \
     python3 -m venv /opt/venv && \
     uv pip sync --python /opt/venv/bin/python requirements.txt
@@ -106,9 +107,7 @@ COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 RUN mkdir -p app
 
 # Install dev/test requirements
-RUN pip install uv
 COPY --chown=notify:notify Makefile requirements_for_test.txt package-lock.json package.json rollup.config.mjs ./
-ENV UV_CACHE_DIR='/tmp/uv-cache/'
 RUN make bootstrap
 
 COPY --chown=notify:notify . .


### PR DESCRIPTION
Copies https://github.com/alphagov/notifications-api/pull/4376

Ensures we don’t get bitten by breaking changes to uv.

Also consolidates environment variables into a single block.