### PR TITLE
Show custom error message when test teardown fails

### DIFF
--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -15,9 +15,18 @@ def _attach_current_user(data):
 
 class NotifyAdminAPIClient(BaseAPIClient):
     def __init__(self, app):
+        try:
+            base_url = app.config["API_HOST_NAME"]
+        except RuntimeError as e:
+            raise RuntimeError(
+                "Could not teardown fixtures after test run. Try: \n"
+                "• moving `mocker` so it’s the final argument to your test function. \n"
+                "• running pytest with the `--setup-show` flag to see which fixture is the problem"
+            ) from e
+
         super().__init__(
             "x" * 100,
-            base_url=app.config["API_HOST_NAME"],
+            base_url=base_url,
         )
         # our credential lengths aren't what BaseAPIClient's __init__ will expect
         # given it's designed for destructuring end-user api keys


### PR DESCRIPTION
As of 21ceeb9eac16503b04c81112d96f2985ade9a8a6 test fixtures need to be declared in a certain order.

This is so when pytest tears down the fixtures it does so in a way that avoids instances of the internal API clients losing access to the app context.

If this happens you get a very oblique error message which requires knowledge of the above to resolve.

This commit adds a more helpful error message which tells you how to fix or diagnose what is happening.