### PR TITLE
User add returned letters callback

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -222,11 +222,6 @@ def delivery_status_callback(service_id):
     )
 
 
-def get_received_text_messages_callback():
-    if current_service.inbound_api:
-        return service_api_client.get_service_inbound_api(current_service.id, current_service.inbound_api[0])
-
-
 @main.route(
     "/services/<uuid:service_id>/api/callbacks/received-text-messages-callback",
     methods=["GET", "POST"],
@@ -236,7 +231,7 @@ def received_text_messages_callback(service_id):
     if not current_service.has_permission("inbound_sms"):
         return redirect(url_for(".api_integration", service_id=service_id))
 
-    received_text_messages_callback = get_received_text_messages_callback()
+    received_text_messages_callback = current_service.inbound_sms_callback_details
     form = CallbackForm(
         url=(received_text_messages_callback.get("url") if received_text_messages_callback else ""),
         bearer_token=dummy_bearer_token if received_text_messages_callback else "",

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -221,7 +221,7 @@ def delivery_status_callback(service_id):
                 delivery_status_callback["id"],
             )
         elif form.url.data:
-            service_api_client.create_service_callback_api(
+            service_api_client.create_delivery_status_callback_api(
                 service_id,
                 url=form.url.data,
                 bearer_token=form.bearer_token.data,

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -332,12 +332,12 @@ def returned_letters_callback(service_id):
                     callback_api_id=returned_letter_callback.get("id"),
                 )
         elif returned_letter_callback and not form.url.data:
-            service_api_client.delete_service_callback_api(
+            service_api_client.delete_returned_letter_callback_api(
                 service_id,
                 returned_letter_callback["id"],
             )
         elif form.url.data:
-            service_api_client.create_service_callback_api(
+            service_api_client.create_returned_letter_callback_api(
                 service_id,
                 url=form.url.data,
                 bearer_token=form.bearer_token.data,

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -183,10 +183,12 @@ def api_callbacks(service_id):
 
 
 def get_delivery_status_callback_details():
-    if current_service.service_callback_api:
-        return service_api_client.get_service_callback_api(
-            current_service.id, current_service.service_callback_api[0], "delivery_status"
-        )
+    if callback_api := current_service.service_callback_api:
+        for row in callback_api:
+            if row["callback_type"] == "delivery_status":
+                return service_api_client.get_service_callback_api(
+                    current_service.id, row["callback_id"], row["callback_type"]
+                )
 
 
 @main.route(
@@ -292,13 +294,22 @@ def received_text_messages_callback(service_id):
     )
 
 
+def get_returned_letter_callback_details():
+    if callback_api := current_service.service_callback_api:
+        for row in callback_api:
+            if row["callback_type"] == "returned_letter":
+                return service_api_client.get_service_callback_api(
+                    current_service.id, row["callback_id"], row["callback_type"]
+                )
+
+
 @main.route(
     "/services/<uuid:service_id>/api/callbacks/returned-letters-callback",
     methods=["GET", "POST"],
 )
 @user_has_permissions("manage_api_keys")
 def returned_letters_callback(service_id):
-    delivery_status_callback = get_delivery_status_callback_details()
+    returned_letter_callback = get_returned_letter_callback_details()
     back_link = (
         ".api_callbacks"
         if current_service.has_permission("inbound_sms") or current_service.has_permission("letter")
@@ -306,24 +317,24 @@ def returned_letters_callback(service_id):
     )
 
     form = CallbackForm(
-        url=delivery_status_callback.get("url") if delivery_status_callback else "",
-        bearer_token=dummy_bearer_token if delivery_status_callback else "",
+        url=returned_letter_callback.get("url") if returned_letter_callback else "",
+        bearer_token=dummy_bearer_token if returned_letter_callback else "",
     )
 
     if form.validate_on_submit():
-        if delivery_status_callback and form.url.data:
-            if delivery_status_callback.get("url") != form.url.data or form.bearer_token.data != dummy_bearer_token:
-                service_api_client.update_service_callback_api(
+        if returned_letter_callback and form.url.data:
+            if returned_letter_callback.get("url") != form.url.data or form.bearer_token.data != dummy_bearer_token:
+                service_api_client.update_returned_letter_callback_api(
                     service_id,
                     url=form.url.data,
                     bearer_token=check_token_against_dummy_bearer(form.bearer_token.data),
                     user_id=current_user.id,
-                    callback_api_id=delivery_status_callback.get("id"),
+                    callback_api_id=returned_letter_callback.get("id"),
                 )
-        elif delivery_status_callback and not form.url.data:
+        elif returned_letter_callback and not form.url.data:
             service_api_client.delete_service_callback_api(
                 service_id,
-                delivery_status_callback["id"],
+                returned_letter_callback["id"],
             )
         elif form.url.data:
             service_api_client.create_service_callback_api(

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -185,9 +185,7 @@ def api_callbacks(service_id):
 def get_delivery_status_callback_details():
     if current_service.service_callback_api:
         return service_api_client.get_service_callback_api(
-            current_service.id,
-            current_service.service_callback_api[0],
-            "delivery_status"
+            current_service.id, current_service.service_callback_api[0], "delivery_status"
         )
 
 

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -273,7 +273,7 @@ def received_text_messages_callback(service_id):
 @user_has_permissions("manage_api_keys")
 def returned_letters_callback(service_id):
     returned_letters_callback_details = current_service.returned_letters_callback_details
-    back_link = ".api_callbacks" if current_service.can_have_multiple_callbacks else ".api_integration"
+    back_link = ".api_callbacks"
 
     form = CallbackForm(
         url=returned_letters_callback_details.get("url") if returned_letters_callback_details else "",

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -136,22 +136,25 @@ def revoke_api_key(service_id, key_id):
 
 
 def get_apis():
-    callback_api = None
+    delivery_status_callback_api = None
+    returned_letter_callback_api = None
     inbound_api = None
-    if current_service.service_callback_api:
-        if isinstance(current_service.service_callback_api[0], str):
-            callback_api = service_api_client.get_service_callback_api(
-                current_service.id, current_service.service_callback_api[0]
-            )
-        else:
-            for row in current_service.service_callback_api:
-                if row["callback_type"] == "delivery_status":
-                    callback_api = service_api_client.get_service_callback_api(current_service.id, row["callback_id"])
+
+    if callback_apis := current_service.service_callback_api:
+        for row in callback_apis:
+            if row["callback_type"] == "delivery_status":
+                delivery_status_callback_api = service_api_client.get_service_callback_api(
+                    current_service.id, row["callback_id"], row["callback_type"]
+                )
+            elif row["callback_type"] == "returned_letter":
+                returned_letter_callback_api = service_api_client.get_service_callback_api(
+                    current_service.id, row["callback_id"], row["callback_type"]
+                )
 
     if current_service.inbound_api:
         inbound_api = service_api_client.get_service_inbound_api(current_service.id, current_service.inbound_api[0])
 
-    return (callback_api, inbound_api)
+    return delivery_status_callback_api, inbound_api, returned_letter_callback_api
 
 
 def check_token_against_dummy_bearer(token):

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -182,43 +182,37 @@ def api_callbacks(service_id):
     )
 
 
-def get_delivery_status_callback_details():
-    if callback_api := current_service.service_callback_api:
-        for row in callback_api:
-            if row["callback_type"] == "delivery_status":
-                return service_api_client.get_service_callback_api(
-                    current_service.id, row["callback_id"], row["callback_type"]
-                )
-
-
 @main.route(
     "/services/<uuid:service_id>/api/callbacks/delivery-status-callback",
     methods=["GET", "POST"],
 )
 @user_has_permissions("manage_api_keys")
 def delivery_status_callback(service_id):
-    delivery_status_callback = get_delivery_status_callback_details()
+    delivery_status_callback_details = current_service.delivery_status_callback_details
     back_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".api_integration"
 
     form = CallbackForm(
-        url=delivery_status_callback.get("url") if delivery_status_callback else "",
+        url=delivery_status_callback_details.get("url") if delivery_status_callback_details else "",
         bearer_token=dummy_bearer_token if delivery_status_callback else "",
     )
 
     if form.validate_on_submit():
-        if delivery_status_callback and form.url.data:
-            if delivery_status_callback.get("url") != form.url.data or form.bearer_token.data != dummy_bearer_token:
+        if delivery_status_callback_details and form.url.data:
+            if (
+                delivery_status_callback_details.get("url") != form.url.data
+                or form.bearer_token.data != dummy_bearer_token
+            ):
                 service_api_client.update_delivery_status_callback_api(
                     service_id,
                     url=form.url.data,
                     bearer_token=check_token_against_dummy_bearer(form.bearer_token.data),
                     user_id=current_user.id,
-                    callback_api_id=delivery_status_callback.get("id"),
+                    callback_api_id=delivery_status_callback_details.get("id"),
                 )
-        elif delivery_status_callback and not form.url.data:
+        elif delivery_status_callback_details and not form.url.data:
             service_api_client.delete_service_callback_api(
                 service_id,
-                delivery_status_callback["id"],
+                delivery_status_callback_details["id"],
             )
         elif form.url.data:
             service_api_client.create_delivery_status_callback_api(
@@ -294,22 +288,13 @@ def received_text_messages_callback(service_id):
     )
 
 
-def get_returned_letter_callback_details():
-    if callback_api := current_service.service_callback_api:
-        for row in callback_api:
-            if row["callback_type"] == "returned_letter":
-                return service_api_client.get_service_callback_api(
-                    current_service.id, row["callback_id"], row["callback_type"]
-                )
-
-
 @main.route(
     "/services/<uuid:service_id>/api/callbacks/returned-letters-callback",
     methods=["GET", "POST"],
 )
 @user_has_permissions("manage_api_keys")
 def returned_letters_callback(service_id):
-    returned_letter_callback = get_returned_letter_callback_details()
+    returned_letter_callback_details = current_service.returned_letter_callback_details
     back_link = (
         ".api_callbacks"
         if current_service.has_permission("inbound_sms") or current_service.has_permission("letter")
@@ -317,24 +302,27 @@ def returned_letters_callback(service_id):
     )
 
     form = CallbackForm(
-        url=returned_letter_callback.get("url") if returned_letter_callback else "",
-        bearer_token=dummy_bearer_token if returned_letter_callback else "",
+        url=returned_letter_callback_details.get("url") if returned_letter_callback_details else "",
+        bearer_token=dummy_bearer_token if returned_letter_callback_details else "",
     )
 
     if form.validate_on_submit():
-        if returned_letter_callback and form.url.data:
-            if returned_letter_callback.get("url") != form.url.data or form.bearer_token.data != dummy_bearer_token:
+        if returned_letter_callback_details and form.url.data:
+            if (
+                returned_letter_callback_details.get("url") != form.url.data
+                or form.bearer_token.data != dummy_bearer_token
+            ):
                 service_api_client.update_returned_letter_callback_api(
                     service_id,
                     url=form.url.data,
                     bearer_token=check_token_against_dummy_bearer(form.bearer_token.data),
                     user_id=current_user.id,
-                    callback_api_id=returned_letter_callback.get("id"),
+                    callback_api_id=returned_letter_callback_details.get("id"),
                 )
-        elif returned_letter_callback and not form.url.data:
+        elif returned_letter_callback_details and not form.url.data:
             service_api_client.delete_returned_letter_callback_api(
                 service_id,
-                returned_letter_callback["id"],
+                returned_letter_callback_details["id"],
             )
         elif form.url.data:
             service_api_client.create_returned_letter_callback_api(

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -169,29 +169,26 @@ def check_token_against_dummy_bearer(token):
 def api_callbacks(service_id):
     if not current_service.has_permission("inbound_sms") and not current_service.has_permission("letter"):
         return redirect(url_for(".delivery_status_callback", service_id=service_id))
-    delivery_status_callback, received_text_messages_callback = get_apis()
-    returned_letters_callback = None
-    returned_letters_callback = {"url": "https://test.test.com"}
+
+    delivery_status_callback, received_text_messages_callback, returned_letter_callback = get_apis()
+
     return render_template(
         "views/api/callbacks.html",
         received_text_messages_callback=(
             received_text_messages_callback["url"] if received_text_messages_callback else None
         ),
         delivery_status_callback=(delivery_status_callback["url"] if delivery_status_callback else None),
-        returned_letters_callback=(returned_letters_callback["url"] if returned_letters_callback else None),
+        returned_letter_callback=(returned_letter_callback["url"] if returned_letter_callback else None),
     )
 
 
 def get_delivery_status_callback_details():
     if current_service.service_callback_api:
-        if isinstance(current_service.service_callback_api[0], str):
-            return service_api_client.get_service_callback_api(
-                current_service.id, current_service.service_callback_api[0]
-            )
-        else:
-            for row in current_service.service_callback_api:
-                if row["callback_type"] == "delivery_status":
-                    return service_api_client.get_service_callback_api(current_service.id, row["callback_id"])
+        return service_api_client.get_service_callback_api(
+            current_service.id,
+            current_service.service_callback_api[0],
+            "delivery_status"
+        )
 
 
 @main.route(

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -208,7 +208,7 @@ def delivery_status_callback(service_id):
     if form.validate_on_submit():
         if delivery_status_callback and form.url.data:
             if delivery_status_callback.get("url") != form.url.data or form.bearer_token.data != dummy_bearer_token:
-                service_api_client.update_service_callback_api(
+                service_api_client.update_delivery_status_callback_api(
                     service_id,
                     url=form.url.data,
                     bearer_token=check_token_against_dummy_bearer(form.bearer_token.data),

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -145,24 +145,7 @@ def api_callbacks(service_id):
     if not current_service.can_have_multiple_callbacks:
         return redirect(url_for(".delivery_status_callback", service_id=service_id))
 
-    return render_template(
-        "views/api/callbacks.html",
-        received_text_messages_callback=(
-            current_service.inbound_sms_callback_details["url"]
-            if current_service.inbound_sms_callback_details
-            else None
-        ),
-        delivery_status_callback=(
-            current_service.delivery_status_callback_details["url"]
-            if current_service.delivery_status_callback_details
-            else None
-        ),
-        returned_letters_callback=(
-            current_service.returned_letters_callback_details["url"]
-            if current_service.returned_letters_callback_details
-            else None
-        ),
-    )
+    return render_template("views/api/callbacks.html")
 
 
 @main.route(

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -686,12 +686,14 @@ def get_url_for_notify_record(uuid_):
             "api_key": _EndpointSpec(".api_keys", with_service_id=True),
             "template_folder": _EndpointSpec(".choose_template", "template_folder_id", with_service_id=True),
             "service_inbound_api": _EndpointSpec(".received_text_messages_callback", with_service_id=True),
-            "service_callback_api": _EndpointSpec(".delivery_status_callback", with_service_id=True),
+            "delivery_status_callback_api": _EndpointSpec(".delivery_status_callback", with_service_id=True),
+            "returned_letters_callback_api": _EndpointSpec(".returned_letters_callback", with_service_id=True),
             "complaint": _EndpointSpec(".platform_admin_list_complaints"),
             "inbound_sms": _EndpointSpec(
                 ".conversation", "notification_id", with_service_id=True, extra={"_anchor": f"n{uuid_}"}
             ),
         }
+
         if not (spec := url_for_data.get(result["type"])):
             raise KeyError(f"Don't know how to redirect to {result['type']}")
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -647,7 +647,7 @@ class Service(JSONModel):
         return self._callback_service_callback_details("delivery_status")
 
     @property
-    def returned_letter_callback_details(self):
+    def returned_letters_callback_details(self):
         return self._callback_service_callback_details("returned_letter")
 
     def _callback_service_callback_details(self, callback_type):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -642,6 +642,24 @@ class Service(JSONModel):
     def datetime_of_latest_unsubscribe_request(self) -> str | None:
         return self.unsubscribe_requests_statistics["datetime_of_latest_unsubscribe_request"]
 
+    @property
+    def delivery_status_callback_details(self):
+        return self._callback_service_callback_details("delivery_status")
+
+    @property
+    def returned_letter_callback_details(self):
+        return self._callback_service_callback_details("returned_letter")
+
+    def _callback_service_callback_details(self, callback_type):
+        if callback_api := self.service_callback_api:
+            for row in callback_api:
+                if row["callback_type"] == callback_type:
+                    return service_api_client.get_service_callback_api(
+                        self.id, row["callback_id"], row["callback_type"]
+                    )
+        else:
+            return None
+
 
 class Services(SerialisedModelCollection):
     model = Service

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -643,6 +643,12 @@ class Service(JSONModel):
         return self.unsubscribe_requests_statistics["datetime_of_latest_unsubscribe_request"]
 
     @property
+    def can_have_multiple_callbacks(self):
+        if self.has_permission("inbound_sms") or self.has_permission("letter"):
+            return True
+        return False
+
+    @property
     def inbound_sms_callback_details(self):
         if self.inbound_api:
             return service_api_client.get_service_inbound_api(self.id, self.inbound_api[0])

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -643,6 +643,11 @@ class Service(JSONModel):
         return self.unsubscribe_requests_statistics["datetime_of_latest_unsubscribe_request"]
 
     @property
+    def inbound_sms_callback_details(self):
+        if self.inbound_api:
+            return service_api_client.get_service_inbound_api(self.id, self.inbound_api[0])
+
+    @property
     def delivery_status_callback_details(self):
         return self._callback_service_callback_details("delivery_status")
 
@@ -657,8 +662,6 @@ class Service(JSONModel):
                     return service_api_client.get_service_callback_api(
                         self.id, row["callback_id"], row["callback_type"]
                     )
-        else:
-            return None
 
 
 class Services(SerialisedModelCollection):

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -326,6 +326,7 @@ class MainNavigation(Navigation):
             "create_api_key",
             "delivery_status_callback",
             "received_text_messages_callback",
+            "returned_letters_callback",
             "revoke_api_key",
             "guest_list",
             "old_guest_list",

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -472,19 +472,19 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(f"/service/{service_id}/delivery-receipt-api", data)
 
     @cache.delete("service-{service_id}")
-    def create_returned_letter_callback_api(self, service_id, url, bearer_token, user_id):
+    def create_returned_letters_callback_api(self, service_id, url, bearer_token, user_id):
         data = {"url": url, "bearer_token": bearer_token, "updated_by_id": user_id}
         return self.post(f"/service/{service_id}/returned-letter-api", data)
 
     @cache.delete("service-{service_id}")
-    def update_returned_letter_callback_api(self, service_id, url, bearer_token, user_id, callback_api_id):
+    def update_returned_letters_callback_api(self, service_id, url, bearer_token, user_id, callback_api_id):
         data = {"url": url, "updated_by_id": user_id}
         if bearer_token:
             data["bearer_token"] = bearer_token
         return self.post(f"/service/{service_id}/returned-letter-api/{callback_api_id}", data)
 
     @cache.delete("service-{service_id}")
-    def delete_returned_letter_callback_api(self, service_id, callback_api_id):
+    def delete_returned_letters_callback_api(self, service_id, callback_api_id):
         return self.delete(f"/service/{service_id}/returned-letter-api/{callback_api_id}")
 
     @cache.delete("service-{service_id}-data-retention")

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -467,7 +467,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.delete(f"/service/{service_id}/delivery-receipt-api/{callback_api_id}")
 
     @cache.delete("service-{service_id}")
-    def create_service_callback_api(self, service_id, url, bearer_token, user_id):
+    def create_delivery_status_callback_api(self, service_id, url, bearer_token, user_id):
         data = {"url": url, "bearer_token": bearer_token, "updated_by_id": user_id}
         return self.post(f"/service/{service_id}/delivery-receipt-api", data)
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -471,6 +471,13 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         data = {"url": url, "bearer_token": bearer_token, "updated_by_id": user_id}
         return self.post(f"/service/{service_id}/delivery-receipt-api", data)
 
+    @cache.delete("service-{service_id}")
+    def update_returned_letter_callback_api(self, service_id, url, bearer_token, user_id, callback_api_id):
+        data = {"url": url, "updated_by_id": user_id}
+        if bearer_token:
+            data["bearer_token"] = bearer_token
+        return self.post(f"/service/{service_id}/returned-letter-api/{callback_api_id}", data)
+
     @cache.delete("service-{service_id}-data-retention")
     def create_service_data_retention(self, service_id, notification_type, days_of_retention):
         data = {"notification_type": notification_type, "days_of_retention": days_of_retention}

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -456,7 +456,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             return self.get(f"/service/{service_id}/returned-letter-api/{callback_api_id}")["data"]
 
     @cache.delete("service-{service_id}")
-    def update_service_callback_api(self, service_id, url, bearer_token, user_id, callback_api_id):
+    def update_delivery_status_callback_api(self, service_id, url, bearer_token, user_id, callback_api_id):
         data = {"url": url, "updated_by_id": user_id}
         if bearer_token:
             data["bearer_token"] = bearer_token

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -450,9 +450,9 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(f"/service/{service_id}/sms-sender/{sms_sender_id}/archive", data=None)
 
     def get_service_callback_api(self, service_id, callback_api_id, callback_type):
-        if callback_type == 'delivery_status':
+        if callback_type == "delivery_status":
             return self.get(f"/service/{service_id}/delivery-receipt-api/{callback_api_id}")["data"]
-        elif callback_type == 'returned_letter':
+        elif callback_type == "returned_letter":
             return self.get(f"/service/{service_id}/returned-letter-api/{callback_api_id}")["data"]
 
     @cache.delete("service-{service_id}")

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -449,8 +449,11 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def delete_sms_sender(self, service_id, sms_sender_id):
         return self.post(f"/service/{service_id}/sms-sender/{sms_sender_id}/archive", data=None)
 
-    def get_service_callback_api(self, service_id, callback_api_id):
-        return self.get(f"/service/{service_id}/delivery-receipt-api/{callback_api_id}")["data"]
+    def get_service_callback_api(self, service_id, callback_api_id, callback_type):
+        if callback_type == 'delivery_status':
+            return self.get(f"/service/{service_id}/delivery-receipt-api/{callback_api_id}")["data"]
+        elif callback_type == 'returned_letter':
+            return self.get(f"/service/{service_id}/returned-letter-api/{callback_api_id}")["data"]
 
     @cache.delete("service-{service_id}")
     def update_service_callback_api(self, service_id, url, bearer_token, user_id, callback_api_id):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -472,11 +472,20 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(f"/service/{service_id}/delivery-receipt-api", data)
 
     @cache.delete("service-{service_id}")
+    def create_returned_letter_callback_api(self, service_id, url, bearer_token, user_id):
+        data = {"url": url, "bearer_token": bearer_token, "updated_by_id": user_id}
+        return self.post(f"/service/{service_id}/returned-letter-api", data)
+
+    @cache.delete("service-{service_id}")
     def update_returned_letter_callback_api(self, service_id, url, bearer_token, user_id, callback_api_id):
         data = {"url": url, "updated_by_id": user_id}
         if bearer_token:
             data["bearer_token"] = bearer_token
         return self.post(f"/service/{service_id}/returned-letter-api/{callback_api_id}", data)
+
+    @cache.delete("service-{service_id}")
+    def delete_returned_letter_callback_api(self, service_id, callback_api_id):
+        return self.delete(f"/service/{service_id}/returned-letter-api/{callback_api_id}")
 
     @cache.delete("service-{service_id}-data-retention")
     def create_service_data_retention(self, service_id, notification_type, days_of_retention):

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('main.api_callbacks', service_id=current_service.id) }) }}
+  {{ govukBackLink({ "href": url_for('main.api_integration', service_id=current_service.id) }) }}
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -34,7 +34,7 @@
 
 		{% call row() %}
 			{{ text_field('Returned letters') }}
-			{{ optional_text_field(returned_letters_callback, truncate=true) }}
+			{{ optional_text_field(returned_letter_callback, truncate=true) }}
 			{{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
 		{% endcall %}
 	  {% endcall %}

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -22,14 +22,14 @@
     ) %}
       {% call row() %}
         {{ text_field('Delivery receipts') }}
-        {{ optional_text_field(delivery_status_callback, truncate=true) }}
+        {{ optional_text_field(current_service.delivery_status_callback_details.url, truncate=true) }}
         {{ edit_field('Change', url_for('main.delivery_status_callback', service_id=current_service.id)) }}
       {% endcall %}
 
       {% if current_service.has_permission("inbound_sms") %}
         {% call row() %}
           {{ text_field('Received text messages') }}
-          {{ optional_text_field(received_text_messages_callback, truncate=true) }}
+          {{ optional_text_field(current_service.inbound_sms_callback_details.url, truncate=true) }}
           {{ edit_field('Change', url_for('main.received_text_messages_callback', service_id=current_service.id)) }}
         {% endcall %}
       {% endif %}
@@ -37,7 +37,7 @@
       {% if current_service.has_permission("letter") %}
         {% call row() %}
           {{ text_field('Returned letters') }}
-          {{ optional_text_field(returned_letters_callback, truncate=true) }}
+          {{ optional_text_field(current_service.returned_letters_callback_details.url, truncate=true) }}
           {{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
         {% endcall %}
       {% endif %}

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -34,7 +34,7 @@
 
 		{% call row() %}
 			{{ text_field('Returned letters') }}
-			{{ optional_text_field(returned_letter_callback, truncate=true) }}
+			{{ optional_text_field(returned_letters_callback, truncate=true) }}
 			{{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
 		{% endcall %}
 	  {% endcall %}

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -32,11 +32,13 @@
 	   	  {{ edit_field('Change', url_for('main.received_text_messages_callback', service_id=current_service.id)) }}
 	    {% endcall %}
 
-		{% call row() %}
-			{{ text_field('Returned letters') }}
-			{{ optional_text_field(returned_letters_callback, truncate=true) }}
-			{{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
-		{% endcall %}
+         {% if current_user.platform_admin %}
+            {% call row() %}
+                {{ text_field('Returned letters') }}
+                {{ optional_text_field(returned_letters_callback, truncate=true) }}
+                {{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
+            {% endcall %}
+         {% endif %}
 	  {% endcall %}
 	</div>
 {% endblock %}

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -14,30 +14,34 @@
 {% block maincolumn_content %}
   {{ page_header('Callbacks') }}
   <div class="bottom-gutter-3-2 dashboard-table body-copy-table">
-		{% call mapping_table(
-	    caption='General',
-	    field_headings=['Label', 'Value', 'Action'],
-	    field_headings_visible=False,
-	    caption_visible=False
-	  ) %}
-	    {% call row() %}
-	      {{ text_field('Delivery receipts') }}
-	      {{ optional_text_field(delivery_status_callback, truncate=true) }}
-	      {{ edit_field('Change', url_for('main.delivery_status_callback', service_id=current_service.id)) }}
-	    {% endcall %}
+    {% call mapping_table(
+      caption='General',
+      field_headings=['Label', 'Value', 'Action'],
+      field_headings_visible=False,
+      caption_visible=False
+    ) %}
+      {% call row() %}
+        {{ text_field('Delivery receipts') }}
+        {{ optional_text_field(delivery_status_callback, truncate=true) }}
+        {{ edit_field('Change', url_for('main.delivery_status_callback', service_id=current_service.id)) }}
+      {% endcall %}
 
-	    {% call row() %}
-	      {{ text_field('Received text messages') }}
+      {% if current_service.has_permission("inbound_sms") %}
+        {% call row() %}
+          {{ text_field('Received text messages') }}
           {{ optional_text_field(received_text_messages_callback, truncate=true) }}
-	   	  {{ edit_field('Change', url_for('main.received_text_messages_callback', service_id=current_service.id)) }}
-	    {% endcall %}
+          {{ edit_field('Change', url_for('main.received_text_messages_callback', service_id=current_service.id)) }}
+        {% endcall %}
+      {% endif %}
 
-		{% call row() %}
-			{{ text_field('Returned letters') }}
-			{{ optional_text_field(returned_letters_callback, truncate=true) }}
-			{{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
-		{% endcall %}
+      {% if current_service.has_permission("letter") %}
+        {% call row() %}
+          {{ text_field('Returned letters') }}
+          {{ optional_text_field(returned_letters_callback, truncate=true) }}
+          {{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
+        {% endcall %}
+      {% endif %}
 
-	  {% endcall %}
-	</div>
+    {% endcall %}
+  </div>
 {% endblock %}

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('main.api_integration', service_id=current_service.id) }) }}
+  {{ govukBackLink({ "href": url_for('main.api_callbacks', service_id=current_service.id) }) }}
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -31,6 +31,12 @@
           {{ optional_text_field(received_text_messages_callback, truncate=true) }}
 	   	  {{ edit_field('Change', url_for('main.received_text_messages_callback', service_id=current_service.id)) }}
 	    {% endcall %}
+
+		{% call row() %}
+			{{ text_field('Returned letters') }}
+			{{ optional_text_field(returned_letters_callback, truncate=true) }}
+			{{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
+		{% endcall %}
 	  {% endcall %}
 	</div>
 {% endblock %}

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -32,13 +32,12 @@
 	   	  {{ edit_field('Change', url_for('main.received_text_messages_callback', service_id=current_service.id)) }}
 	    {% endcall %}
 
-         {% if current_user.platform_admin %}
-            {% call row() %}
-                {{ text_field('Returned letters') }}
-                {{ optional_text_field(returned_letters_callback, truncate=true) }}
-                {{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
-            {% endcall %}
-         {% endif %}
+		{% call row() %}
+			{{ text_field('Returned letters') }}
+			{{ optional_text_field(returned_letters_callback, truncate=true) }}
+			{{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
+		{% endcall %}
+
 	  {% endcall %}
 	</div>
 {% endblock %}

--- a/app/templates/views/api/callbacks/returned-letters-callback.html
+++ b/app/templates/views/api/callbacks/returned-letters-callback.html
@@ -20,9 +20,10 @@
       {{ page_header('Callbacks for returned letters') }}
 
       <p class="govuk-body">
-        When you receive a returned letter in Notify, We can forward it to your system.
+        When a letter you sent is returned, Notify will send details of the returned letter to your callback url.
+      </p>
+      <p class="govuk-body">
         Read the callbacks section of our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a> for more information
-
       </p>
 
       {% call form_wrapper() %}

--- a/app/templates/views/api/callbacks/returned-letters-callback.html
+++ b/app/templates/views/api/callbacks/returned-letters-callback.html
@@ -1,0 +1,45 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% block service_page_title %}
+  Callbacks for delivery receipts
+{% endblock %}
+
+
+{% block backLink %}
+  {{ govukBackLink({ "href": url_for(back_link, service_id=current_service.id) }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-five-sixths">
+
+      {{ page_header('Callbacks for returned letters') }}
+
+      <p class="govuk-body">
+        When you receive a returned letter in Notify, We can forward it to your system.
+        Read the callbacks section of our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a> for more information
+
+      </p>
+
+      {% call form_wrapper() %}
+        {{ form.url(param_extensions={
+          "classes": "govuk-!-width-full",
+          "hint": {"text": "Must start with https://"}
+        }) }}
+
+        {{ form.bearer_token(param_extensions={
+          "classes": "govuk-!-width-full",
+          "hint": {"text": "At least 10 characters"},
+          "autocomplete": "new-password"
+        }) }}
+
+        {{ page_footer('Save') }}
+      {% endcall %}
+    </div>
+  </div>
+
+{% endblock %}

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -855,8 +855,8 @@ def test_create_delivery_status_and_receive_text_message_callbacks(
         )
 
 
-def test_create_returned_letter_callbacks(
-    client_request, service_one, mock_get_notifications, mock_create_returned_letter_callback_api, fake_uuid
+def test_create_returned_letters_callbacks(
+    client_request, service_one, mock_get_notifications, mock_create_returned_letters_callback_api, fake_uuid
 ):
     data = {"url": "https://test.url.com/", "bearer_token": "1234567890", "user_id": fake_uuid}
 
@@ -866,7 +866,7 @@ def test_create_returned_letter_callbacks(
         _data=data,
     )
 
-    mock_create_returned_letter_callback_api.assert_called_once_with(
+    mock_create_returned_letters_callback_api.assert_called_once_with(
         service_one["id"],
         url="https://test.url.com/",
         bearer_token="1234567890",
@@ -900,10 +900,10 @@ def test_update_delivery_status_callback_details(
     )
 
 
-def test_update_returned_letter_callback_details(
+def test_update_returned_letters_callback_details(
     client_request,
     service_one,
-    mock_update_returned_letter_callback_api,
+    mock_update_returned_letters_callback_api,
     mock_get_valid_service_callback_api,
     fake_uuid,
 ):
@@ -917,7 +917,7 @@ def test_update_returned_letter_callback_details(
         _data=data,
     )
 
-    mock_update_returned_letter_callback_api.assert_called_once_with(
+    mock_update_returned_letters_callback_api.assert_called_once_with(
         service_one["id"],
         url="https://test.url.com/",
         bearer_token="1234567890",
@@ -972,10 +972,10 @@ def test_update_delivery_status_callback_without_changes_does_not_update(
     assert mock_update_delivery_status_callback_api.called is False
 
 
-def test_update_returned_letter_callback_without_changes_does_not_update(
+def test_update_returned_letters_callback_without_changes_does_not_update(
     client_request,
     service_one,
-    mock_update_returned_letter_callback_api,
+    mock_update_returned_letters_callback_api,
     fake_uuid,
     mock_get_valid_service_callback_api,
 ):
@@ -988,7 +988,7 @@ def test_update_returned_letter_callback_without_changes_does_not_update(
         _data=data,
     )
 
-    assert mock_update_returned_letter_callback_api.called is False
+    assert mock_update_returned_letters_callback_api.called is False
 
 
 def test_update_receive_text_message_callback_without_changes_does_not_update(

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -735,22 +735,30 @@ def test_callback_forms_can_be_cleared_when_callback_and_inbound_apis_are_empty(
 
 
 @pytest.mark.parametrize(
-    "has_inbound_sms, expected_link",
+    "has_inbound_sms, has_letter, expected_link",
     [
-        (True, "main.api_callbacks"),
-        (False, "main.delivery_status_callback"),
+        (True, True, "main.api_callbacks"),
+        (True, False, "main.api_callbacks"),
+        (False, True, "main.api_callbacks"),
+        (False, False, "main.delivery_status_callback"),
     ],
 )
-def test_callbacks_button_links_straight_to_delivery_status_if_service_has_no_inbound_sms(
+def test_callbacks_button_links_straight_to_delivery_status_if_service_has_no_inbound_sms_and_no_letter(
     client_request,
     service_one,
     mock_get_notifications,
     mock_get_service_data_retention,
     has_inbound_sms,
+    has_letter,
     expected_link,
 ):
+    service_one["permissions"] = []
     if has_inbound_sms:
         service_one["permissions"] = ["inbound_sms"]
+    if has_letter:
+        service_one["permissions"] = ["letter"]
+    if has_inbound_sms and has_letter:
+        service_one["permissions"] = ["inbound_sms", "letter"]
 
     page = client_request.get(
         "main.api_integration",
@@ -967,6 +975,6 @@ def test_callbacks_page_works_when_no_apis_set(
         expected_2nd_table_row,
     ]
     rows = page.select("tbody tr")
-    assert len(rows) == 2
+    assert len(rows) == 3
     for index, row in enumerate(expected_rows):
         assert row == normalize_spaces(rows[index].text)

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -1030,7 +1030,7 @@ def test_update_receive_text_message_callback_without_changes_does_not_update(
             ],
             {"url": "https://delivery.receipts"},
             "Delivery receipts https://delivery.receipts Change",
-            "DReturned letters Not set Change",
+            "Returned letters Not set Change",
         ),
         (
             [

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -1060,6 +1060,7 @@ def test_callbacks_page_works_when_no_apis_set(
     inbound_url,
     expected_2nd_table_row,
     expected_3rd_table_row,
+    platform_admin_user,
 ):
     service_one["permissions"] = ["inbound_sms"]
     service_one["inbound_api"] = inbound_api
@@ -1068,6 +1069,7 @@ def test_callbacks_page_works_when_no_apis_set(
     mocker.patch("app.service_api_client.get_service_callback_api", return_value=delivery_url)
     mocker.patch("app.service_api_client.get_service_inbound_api", return_value=inbound_url)
 
+    client_request.login(platform_admin_user)
     page = client_request.get("main.api_callbacks", service_id=service_one["id"], _follow_redirects=True)
     expected_rows = [
         expected_1st_table_row,

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -600,20 +600,17 @@ def test_should_validate_guestlist_items(
     assert mock_update_guest_list.called is False
 
 
-@pytest.mark.parametrize(
-    "callback_api_response",
-    [
-        ["8daaed46-bfa3-423b-9bd0-f66ceadd13d0"],
-        [{"callback_id": "8daaed46-bfa3-423b-9bd0-f66ceadd13d0", "callback_type": "delivery_status"}],
-    ],
-)
 def test_GET_delivery_status_callback_page_when_callback_set_up(
     client_request,
     service_one,
     mock_get_valid_service_callback_api,
-    callback_api_response,
 ):
-    service_one["service_callback_api"] = callback_api_response
+    service_one["service_callback_api"] = [
+        {
+            "callback_id": "8daaed46-bfa3-423b-9bd0-f66ceadd13d0",
+            "callback_type": "delivery_status",
+        }
+    ]
 
     page = client_request.get(
         "main.delivery_status_callback",
@@ -621,7 +618,7 @@ def test_GET_delivery_status_callback_page_when_callback_set_up(
     )
 
     textboxes = page.select("input.govuk-input")
-    assert textboxes[0].get("value") == "https://hello2.gov.uk"
+    assert textboxes[0].get("value") == "https://hello2.gov.uk/delivery_status"
     assert textboxes[1].get("value") == "bearer_token_set"
 
 

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -877,7 +877,7 @@ def test_create_returned_letter_callbacks(
 def test_update_delivery_status_callback_details(
     client_request,
     service_one,
-    mock_update_service_callback_api,
+    mock_update_delivery_status_callback_api,
     mock_get_valid_service_callback_api,
     fake_uuid,
 ):
@@ -891,7 +891,7 @@ def test_update_delivery_status_callback_details(
         _data=data,
     )
 
-    mock_update_service_callback_api.assert_called_once_with(
+    mock_update_delivery_status_callback_api.assert_called_once_with(
         service_one["id"],
         url="https://test.url.com/",
         bearer_token="1234567890",
@@ -956,7 +956,7 @@ def test_update_receive_text_message_callback_details(
 def test_update_delivery_status_callback_without_changes_does_not_update(
     client_request,
     service_one,
-    mock_update_service_callback_api,
+    mock_update_delivery_status_callback_api,
     fake_uuid,
     mock_get_valid_service_callback_api,
 ):
@@ -969,7 +969,7 @@ def test_update_delivery_status_callback_without_changes_does_not_update(
         _data=data,
     )
 
-    assert mock_update_service_callback_api.called is False
+    assert mock_update_delivery_status_callback_api.called is False
 
 
 def test_update_returned_letter_callback_without_changes_does_not_update(

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -600,7 +600,7 @@ def test_should_validate_guestlist_items(
     assert mock_update_guest_list.called is False
 
 
-def test_GET_delivery_status_callback_page_when_callback_set_up(
+def test_GET_delivery_status_callback_page_when_callback_is_set_up(
     client_request,
     service_one,
     mock_get_valid_service_callback_api,
@@ -775,7 +775,7 @@ def test_callbacks_button_links_straight_to_delivery_status_if_service_has_no_in
     assert page.select(".pill-separate-item")[2]["href"] == url_for(expected_link, service_id=service_one["id"])
 
 
-def test_callbacks_page_redirects_to_delivery_status_if_service_has_no_inbound_sms(
+def test_callbacks_page_redirects_to_delivery_status_if_service_has_no_inbound_sms_or_letter_permissions(
     client_request, service_one, mock_get_valid_service_callback_api
 ):
     page = client_request.get(
@@ -788,17 +788,18 @@ def test_callbacks_page_redirects_to_delivery_status_if_service_has_no_inbound_s
 
 
 @pytest.mark.parametrize(
-    "has_inbound_sms, expected_link",
+    "service_permissions, expected_link",
     [
-        (True, "main.api_callbacks"),
-        (False, "main.api_integration"),
+        (["inbound_sms"], "main.api_callbacks"),
+        (["inbound_sms", "letter"], "main.api_callbacks"),
+        (["letter"], "main.api_callbacks"),
+        ([], "main.api_integration"),
     ],
 )
-def test_back_link_directs_to_api_integration_from_delivery_callback_if_no_inbound_sms(
-    client_request, service_one, has_inbound_sms, expected_link
+def test_back_link_directs_to_api_integration_from_delivery_callback_if_no_inbound_sms_or_letter(
+    client_request, service_one, service_permissions, expected_link
 ):
-    if has_inbound_sms:
-        service_one["permissions"] = ["inbound_sms"]
+    service_one["permissions"] = service_permissions
 
     page = client_request.get(
         "main.delivery_status_callback",

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -1008,8 +1008,12 @@ class TestPlatformAdminSearch:
                 "/services/abc/api/callbacks/received-text-messages-callback",
             ),
             (
-                {"type": "service_callback_api", "context": {"service_id": "abc"}},
+                {"type": "delivery_status_callback_api", "context": {"service_id": "abc"}},
                 "/services/abc/api/callbacks/delivery-status-callback",
+            ),
+            (
+                    {"type": "returned_letters_callback_api", "context": {"service_id": "abc"}},
+                    "/services/abc/api/callbacks/returned-letters-callback",
             ),
             ({"type": "complaint"}, "/platform-admin/complaints"),
             (

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -1012,8 +1012,8 @@ class TestPlatformAdminSearch:
                 "/services/abc/api/callbacks/delivery-status-callback",
             ),
             (
-                    {"type": "returned_letters_callback_api", "context": {"service_id": "abc"}},
-                    "/services/abc/api/callbacks/returned-letters-callback",
+                {"type": "returned_letters_callback_api", "context": {"service_id": "abc"}},
+                "/services/abc/api/callbacks/returned-letters-callback",
             ),
             ({"type": "complaint"}, "/platform-admin/complaints"),
             (

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -386,7 +386,7 @@ _clients_by_name = {
         ("service", "update_sms_sender", [SERVICE_ONE_ID] + [""] * 2, {}),
         ("service", "delete_sms_sender", [SERVICE_ONE_ID, ""], {}),
         ("service", "update_service_callback_api", [SERVICE_ONE_ID] + [""] * 4, {}),
-        ("service", "create_service_callback_api", [SERVICE_ONE_ID] + [""] * 3, {}),
+        ("service", "create_delivery_status_callback_api", [SERVICE_ONE_ID] + [""] * 3, {}),
         ("user", "add_user_to_service", [SERVICE_ONE_ID, uuid4(), [], []], {}),
         ("invite", "accept_invite", [SERVICE_ONE_ID, uuid4()], {}),
     ],

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -385,7 +385,7 @@ _clients_by_name = {
         ("service", "add_sms_sender", [SERVICE_ONE_ID, ""], {}),
         ("service", "update_sms_sender", [SERVICE_ONE_ID] + [""] * 2, {}),
         ("service", "delete_sms_sender", [SERVICE_ONE_ID, ""], {}),
-        ("service", "update_service_callback_api", [SERVICE_ONE_ID] + [""] * 4, {}),
+        ("service", "update_delivery_status_callback_api", [SERVICE_ONE_ID] + [""] * 4, {}),
         ("service", "create_delivery_status_callback_api", [SERVICE_ONE_ID] + [""] * 3, {}),
         ("user", "add_user_to_service", [SERVICE_ONE_ID, uuid4(), [], []], {}),
         ("invite", "accept_invite", [SERVICE_ONE_ID, uuid4()], {}),

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -255,6 +255,7 @@ EXCLUDED_ENDPOINTS = set(
             "returned_letter_summary",
             "returned_letters_report",
             "returned_letters",
+            "returned_letters_callback",
             "revalidate_email_sent",
             "revoke_api_key",
             "save_contact_list",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3376,6 +3376,16 @@ def mock_create_service_callback_api(notify_admin, mocker):
 
 
 @pytest.fixture(scope="function")
+def mock_create_returned_letter_callback_api(notify_admin, mocker):
+    def _create_returned_letter_callback_api(service_id, url, bearer_token, user_id):
+        return
+
+    return mocker.patch(
+        "app.service_api_client.create_returned_letter_callback_api", side_effect=_create_returned_letter_callback_api
+    )
+
+
+@pytest.fixture(scope="function")
 def mock_update_service_callback_api(notify_admin, mocker):
     def _update_service_callback_api(service_id, url, bearer_token, user_id, callback_api_id):
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3388,11 +3388,13 @@ def mock_create_returned_letter_callback_api(notify_admin, mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_service_callback_api(notify_admin, mocker):
-    def _update_service_callback_api(service_id, url, bearer_token, user_id, callback_api_id):
+def mock_update_delivery_status_callback_api(notify_admin, mocker):
+    def _update_delivery_status_callback_api(service_id, url, bearer_token, user_id, callback_api_id):
         return
 
-    return mocker.patch("app.service_api_client.update_service_callback_api", side_effect=_update_service_callback_api)
+    return mocker.patch(
+        "app.service_api_client.update_delivery_status_callback_api", side_effect=_update_delivery_status_callback_api
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3322,12 +3322,12 @@ def mock_get_valid_service_inbound_api(notify_admin, mocker):
 
 @pytest.fixture(scope="function")
 def mock_get_valid_service_callback_api(notify_admin, mocker):
-    def _get(service_id, callback_api_id):
+    def _get(service_id, callback_api_id, callback_type):
         return {
             "created_at": "2017-12-04T10:52:55.289026Z",
             "updated_by_id": fake_uuid,
             "id": callback_api_id,
-            "url": "https://hello2.gov.uk",
+            "url": f"https://hello2.gov.uk/{callback_type}",
             "service_id": service_id,
             "updated_at": "2017-12-04T11:28:42.575153Z",
         }
@@ -3347,7 +3347,7 @@ def mock_get_empty_service_inbound_api(notify_admin, mocker):
 def mock_get_empty_service_callback_api(notify_admin, mocker):
     return mocker.patch(
         "app.service_api_client.get_service_callback_api",
-        side_effect=lambda service_id, callback_api_id: None,
+        side_effect=lambda service_id, callback_api_id, callback_type: None,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3369,10 +3369,12 @@ def mock_update_service_inbound_api(notify_admin, mocker):
 
 @pytest.fixture(scope="function")
 def mock_create_service_callback_api(notify_admin, mocker):
-    def _create_service_callback_api(service_id, url, bearer_token, user_id):
+    def _create_delivery_status_callback_api(service_id, url, bearer_token, user_id):
         return
 
-    return mocker.patch("app.service_api_client.create_service_callback_api", side_effect=_create_service_callback_api)
+    return mocker.patch(
+        "app.service_api_client.create_delivery_status_callback_api", side_effect=_create_delivery_status_callback_api
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3378,12 +3378,12 @@ def mock_create_service_callback_api(notify_admin, mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_create_returned_letter_callback_api(notify_admin, mocker):
-    def _create_returned_letter_callback_api(service_id, url, bearer_token, user_id):
+def mock_create_returned_letters_callback_api(notify_admin, mocker):
+    def _create_returned_letters_callback_api(service_id, url, bearer_token, user_id):
         return
 
     return mocker.patch(
-        "app.service_api_client.create_returned_letter_callback_api", side_effect=_create_returned_letter_callback_api
+        "app.service_api_client.create_returned_letters_callback_api", side_effect=_create_returned_letters_callback_api
     )
 
 
@@ -3398,12 +3398,12 @@ def mock_update_delivery_status_callback_api(notify_admin, mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_update_returned_letter_callback_api(notify_admin, mocker):
-    def _update_returned_letter_callback_api(service_id, url, bearer_token, user_id, callback_api_id):
+def mock_update_returned_letters_callback_api(notify_admin, mocker):
+    def _update_returned_letters_callback_api(service_id, url, bearer_token, user_id, callback_api_id):
         return
 
     return mocker.patch(
-        "app.service_api_client.update_returned_letter_callback_api", side_effect=_update_returned_letter_callback_api
+        "app.service_api_client.update_returned_letters_callback_api", side_effect=_update_returned_letters_callback_api
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3384,6 +3384,16 @@ def mock_update_service_callback_api(notify_admin, mocker):
 
 
 @pytest.fixture(scope="function")
+def mock_update_returned_letter_callback_api(notify_admin, mocker):
+    def _update_returned_letter_callback_api(service_id, url, bearer_token, user_id, callback_api_id):
+        return
+
+    return mocker.patch(
+        "app.service_api_client.update_returned_letter_callback_api", side_effect=_update_returned_letter_callback_api
+    )
+
+
+@pytest.fixture(scope="function")
 def organisation_one(api_user_active):
     return organisation_json(ORGANISATION_ID, "organisation one", [api_user_active["id"]])
 

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -140,6 +140,7 @@
     "/services/<uuid:service_id>/api/callbacks",
     "/services/<uuid:service_id>/api/callbacks/delivery-status-callback",
     "/services/<uuid:service_id>/api/callbacks/received-text-messages-callback",
+    "/services/<uuid:service_id>/api/callbacks/returned-letters-callback",
     "/services/<uuid:service_id>/api/documentation",
     "/services/<uuid:service_id>/api/guest-list",
     "/services/<uuid:service_id>/api/keys",


### PR DESCRIPTION
This PR adds the returned letter callback feature as described in this [card](https://trello.com/c/SYbHsAz5/212-let-users-add-a-callback-for-returned-letters).
This PR is dependent on https://github.com/alphagov/notifications-api/pull/4378.

A user now has the option to add a returned letters callback if letter notifications are enabled for the service
<img width="811" alt="returned-letters 1" src="https://github.com/user-attachments/assets/14a3259c-0539-4c44-8a5a-dc4440e2c775" />
<img width="808" alt="returned-letters 2" src="https://github.com/user-attachments/assets/f2f35a2c-7938-4b2e-aa6a-39a4490edd9a" />
<img width="780" alt="returned-letters 3" src="https://github.com/user-attachments/assets/9b00a1ec-a47e-47e4-b321-c58b1ca27755" />
