### PR TITLE
Add information about pharmacies

### DIFF
--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -71,8 +71,7 @@
 
   <h2 class="govuk-heading-m" id="public">Members of the public</h2>
   <p class="govuk-body">
-    The GOV.UK Notify service is only for people who work in the government
-    or other public sector organisations.
+    GOV.UK Notify is only for people who work in the government or other public sector organisations.
   </p>
   <p class="govuk-body">
     <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk">Find government services and information on GOV.UK</a>.

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -52,7 +52,12 @@
     Someone from the public sector organisation you’re working with needs to create an account and add the service first. Then they can invite you to join as a team member.
   </p>
 
-  <h2 class="govuk-heading-m" id="gp">GP surgeries</h2>
+<h2 class="govuk-heading-m" id="pharmacies">Pharmacies</h2>
+  <p class="govuk-body">
+    We are reviewing the decision to let pharmacies use GOV.UK Notify. We’ll update the guidance on this page by 1 April 2025.
+  </p>
+
+<h2 class="govuk-heading-m" id="gp">GP surgeries</h2>
   <p class="govuk-body">
     NHS-funded GP surgeries can use GOV.UK Notify, but they:
   </p>


### PR DESCRIPTION
We are reviewing the decision of whether or not to allow pharmacies to use GOV.UK Notify.

We need to add guidance for pharmacies to reduce the number of pharmacies adding new services. If we decide pharmacies are no longer allowed to use Notify, we do not want them to waste their time.