### PR TITLE
Apply z-index to letter template edit text button

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -71,6 +71,9 @@
 
 .edit-template-link-letter-body {
   @extend %edit-template-link;
+  @include govuk-media-query($until: tablet) {
+    z-index: 2;
+  }
   @include govuk-media-query($from: tablet) {
     @include scalable-top(393);
     left: -20px;


### PR DESCRIPTION
Edit Welsh or English page text button can appear on any page other then first. In this case the Edit button is attached to the page number container.

As the image is position absolute, it is stacked over the the button, preventing the button to be clickable.

Applying a higher z-index to the button fixes the issue.
