### PR TITLE
feat: Platform Admin Users List

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -25,6 +25,7 @@ from app.main.forms import (
     AdminReturnedLettersForm,
     BillingReportDateFilterForm,
     PlatformAdminSearchForm,
+    PlatformAdminUsersListForm,
     RequiredDateFilterForm,
 )
 from app.notify_client.platform_admin_api_client import admin_api_client
@@ -39,6 +40,7 @@ from app.utils.pagination import (
     get_page_from_request,
 )
 from app.utils.user import user_is_platform_admin
+from app.utils.user_permissions import all_ui_permissions, translate_permissions_from_db_to_ui
 
 COMPLAINT_THRESHOLD = 0.02
 FAILURE_THRESHOLD = 3
@@ -752,3 +754,95 @@ def format_stats_by_service(services):
             "created_at": service["created_at"],
             "active": service["active"],
         }
+
+
+@main.route("/platform-admin/reports/users-list", methods=["GET", "POST"])
+@user_is_platform_admin
+def platform_admin_users_list():
+    form = PlatformAdminUsersListForm()
+
+    if not form.validate_on_submit():
+        return render_template("views/platform-admin/users-list.html", form=form, error_summary_enabled=True)
+
+    take_part_in_research = {"yes": True, "no": False}.get(form.take_part_in_research.data)
+
+    selected_permissions = form.permissions_field.data
+
+    def extract_date(field):
+        return str(field.data) if field.data else None
+
+    results = admin_api_client.fetch_users_list(
+        created_from_date=extract_date(form.created_from_date),
+        created_to_date=extract_date(form.created_to_date),
+        logged_from_date=extract_date(form.logged_from_date),
+        logged_to_date=extract_date(form.logged_to_date),
+        take_part_in_research=take_part_in_research,
+    ).get("data", [])
+
+    if not results:
+        flash("No results for filters selected")
+        return render_template("views/platform-admin/users-list.html", form=form, error_summary_enabled=True)
+
+    column_names = {
+        "name": "Name",
+        "email_address": "Email",
+        "created_at": "Created At",
+        "take_part_in_research": "Research Opt In",
+        "is_team_member_of_organisation": "Is Org Team Member",
+        "num_live_services": "Number of Live Services",
+        "live_service_permissions": "Live Service Permissions",
+    }
+
+    live_services_data = [list(column_names.values())]
+
+    def format_user_row(user):
+        created_at = datetime.strptime(user["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%d-%m-%Y")
+        is_team_member_of_org = "Yes" if user.get("organisations", []) else "No"
+        live_service_permissions = build_live_service_permissions_for_users_list(
+            user["services"], user["permissions"], selected_permissions
+        )
+
+        return {
+            "name": user["name"],
+            "email_address": user["email_address"],
+            "created_at": created_at,
+            "take_part_in_research": "Yes" if user["take_part_in_research"] else "No",
+            "is_team_member_of_organisation": is_team_member_of_org,
+            "num_live_services": len(user["services"]),
+            "live_service_permissions": live_service_permissions,
+        }
+
+    live_services_data.extend([list(format_user_row(user).values()) for user in results])
+
+    return (
+        Spreadsheet.from_rows(live_services_data).as_csv_data,
+        200,
+        {
+            "Content-Type": "text/csv; charset=utf-8",
+            "Content-Disposition": f'inline; filename="{format_date_numeric(datetime.now())}_users_list.csv"',
+        },
+    )
+
+
+def build_live_service_permissions_for_users_list(services, permissions, selected_permissions) -> str:
+    """ "
+    Returns a string of service_name: permissions selected on the form
+    eg, "Service Name 1: manage_service, manage_users; Service Name 2: view_activity"
+    """
+    service_permissions = []
+
+    if not selected_permissions:
+        selected_permissions = all_ui_permissions
+
+    service_name_lookup = {str(service["id"]): service["name"] for service in services}
+
+    for service_id, service_perms in permissions.items():
+        translated_perms = translate_permissions_from_db_to_ui(service_perms)
+
+        filtered_permissions = translated_perms.intersection(set(selected_permissions))
+
+        if filtered_permissions:
+            service_name = service_name_lookup.get(service_id, f"Service {service_id}")
+            service_permissions.append(f"{service_name}: {', '.join(filtered_permissions)}")
+
+    return "; ".join(service_permissions)

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -109,6 +109,7 @@ class HeaderNavigation(Navigation):
             "live_services_csv",
             "notifications_sent_by_service",
             "get_billing_report",
+            "platform_admin_users_list",
             "get_daily_volumes",
             "get_dvla_billing_report",
             "get_daily_sms_provider_volumes",
@@ -426,6 +427,7 @@ class PlatformAdminNavigation(Navigation):
             "get_volumes_by_service",
             "get_daily_volumes",
             "get_daily_sms_provider_volumes",
+            "platform_admin_users_list",
         },
         "email-branding": {
             "email_branding",

--- a/app/notify_client/platform_admin_api_client.py
+++ b/app/notify_client/platform_admin_api_client.py
@@ -14,6 +14,25 @@ class AdminApiClient(NotifyAdminAPIClient):
     def find_by_uuid(self, uuid_):
         return self.post(url="/platform-admin/find-by-uuid", data={"uuid": uuid_})
 
+    def fetch_users_list(
+        self,
+        created_from_date: str | None = None,
+        created_to_date: str | None = None,
+        logged_from_date: str | None = None,
+        logged_to_date: str | None = None,
+        take_part_in_research: bool | None = None,
+    ):
+        return self.post(
+            url="/platform-admin/users-list",
+            data={
+                "created_start": created_from_date,
+                "created_end": created_to_date,
+                "logged_in_start": logged_from_date,
+                "logged_in_end": logged_to_date,
+                "take_part_in_research": take_part_in_research,
+            },
+        )
+
 
 _admin_api_client_context_var: ContextVar[AdminApiClient] = ContextVar("admin_api_client")
 get_admin_api_client: LazyLocalGetter[AdminApiClient] = LazyLocalGetter(

--- a/app/templates/views/platform-admin/reports.html
+++ b/app/templates/views/platform-admin/reports.html
@@ -31,4 +31,7 @@
 <p class="govuk-body">
   <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.get_daily_sms_provider_volumes') }}">Daily SMS provider volumes Report</a>
 </p>
+<p class="govuk-body">
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.platform_admin_users_list') }}">Users List</a>
+</p>
 {% endblock %}

--- a/app/templates/views/platform-admin/users-list.html
+++ b/app/templates/views/platform-admin/users-list.html
@@ -1,0 +1,106 @@
+{% extends "views/platform-admin/_base_template.html" %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/table.html" import mapping_table, row, text_field %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
+
+{% block per_page_title %}
+    Users List
+{% endblock %}
+
+{% block platform_admin_content %}
+
+<h1 class="govuk-heading-l">
+    Export Users List
+</h1>
+
+<p class="govuk-body">
+    Filter and download the list of users.
+</p>
+
+{% call form_wrapper() %}
+<fieldset class="govuk-fieldset">
+
+    {% set creation_date_content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+            {{ form.created_from_date(param_extensions={"hint": {"text": "YYYY-MM-DD"}}) }}
+        </div>
+        <div class="govuk-grid-column-one-half">
+            {{ form.created_to_date(param_extensions={"hint": {"text": "YYYY-MM-DD"}}) }}
+        </div>
+    </div>
+    {% endset %}
+    {{ govukDetails({
+                "summaryText": "Filter by creation date",
+                "html": creation_date_content,
+                "open": (form.created_from_date.value or form.created_to_date.value) or ('created_from_date' in form.errors) or ('created_to_date' in form.errors)
+            }) }}
+
+    {% set login_date_content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+            {{ form.logged_from_date(param_extensions={"hint": {"text": "YYYY-MM-DD"}}) }}
+        </div>
+        <div class="govuk-grid-column-one-half">
+            {{ form.logged_to_date(param_extensions={"hint": {"text": "YYYY-MM-DD"}}) }}
+        </div>
+    </div>
+    {% endset %}
+    {{ govukDetails({
+                "summaryText": "Filter by last login date",
+                "html": login_date_content,
+                "open": (form.logged_from_date.value or form.logged_to_date.value) or ('logged_from_date' in form.errors) or ('logged_to_date' in form.errors)
+            }) }}
+
+    {% set permissions_content %}
+    <fieldset class="govuk-fieldset">
+        <div class="govuk-checkboxes">
+            {{ form.permissions_field }}
+        </div>
+    </fieldset>
+    {% endset %}
+    {{ govukDetails({
+                "summaryText": "Filter by permissions",
+                "html": permissions_content,
+                "open": (form.permissions_field.value) or ('permissions_field' in form.errors)
+            }) }}
+
+    {% set research_content %}
+    {{ form.take_part_in_research }}
+    {% endset %}
+    {{ govukDetails({
+                "summaryText": "Filter by research opt-in",
+                "html": research_content,
+                "open": (form.take_part_in_research.value) or ('take_part_in_research' in form.errors)
+            }) }}
+
+    {{ page_footer('Download report (CSV)') }}
+</fieldset>
+{% endcall %}
+
+<div class="bottom-gutter-3-2">
+    {% call mapping_table(
+          caption="Data included in the report",
+          field_headings=['Field', 'Description'],
+          field_headings_visible=True,
+          caption_visible=True
+        ) %}
+        {% for column_heading, description in [
+            ('Name', 'The full name of the user'),
+            ('Email', 'The email address associated with the user'),
+            ('Created At', 'The date the user account was created'),
+            ('Research Opt In', 'Whether the user has opted in to research'),
+            ('Is Org Team Member', 'Indicates if the user is a member of an organisation'),
+            ('Number of Live Services', 'The number of live services the user has access to'),
+            ('Live Service Permissions', 'The services and associated permissions assigned to the user'),
+          ] %}
+            {% call row() %}
+                {{ text_field(column_heading) }}
+                {{ text_field(description) }}
+            {% endcall %}
+        {% endfor %}
+    {% endcall %}
+</div>
+
+{% endblock %}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -124,6 +124,7 @@ EXCLUDED_ENDPOINTS = set(
             "get_daily_sms_provider_volumes",
             "get_daily_volumes",
             "get_dvla_billing_report",
+            "platform_admin_users_list",
             "get_example_csv",
             "get_volumes_by_service",
             "go_to_dashboard_after_tour",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -100,6 +100,7 @@
     "/platform-admin/reports/live-services.csv",
     "/platform-admin/reports/notifications-sent-by-service",
     "/platform-admin/reports/usage-for-all-services",
+    "/platform-admin/reports/users-list",
     "/platform-admin/reports/volumes-by-service",
     "/platform-admin/returned-letters",
     "/pricing",


### PR DESCRIPTION
## Summary:
This PR Introduces a new platform admin reports page to filter and export a list of users based on multiple criteria, including creation date, last login date, permissions, and research opt-in status. The filtered results can be downloaded as a CSV report.

- Users can be filtered by: Creation date (created_from_date, created_to_date), Last login date (logged_from_date, logged_to_date), Permissions (selectable from a predefined list), Research opt-in status (Yes/No)
- Form validation ensures at least one filter is selected before submitting the request and enforces date validation to ensure the "From" date is not later than the "To" date.

- The final report includes: Name, Email, Created At, Research opt-in status, If User is an Organisation Team Member, Number of Live services associated to the user,  Live service permissions for each service name

Walk through:
List of Filters available 
![Screenshot 2025-02-17 at 23 31 53](https://github.com/user-attachments/assets/1aab2005-76bf-4b66-9546-ef3a605798da)

1) Creation Date and Last Login date Filters
![Screenshot 2025-02-17 at 23 33 09](https://github.com/user-attachments/assets/53c2c747-4238-48bb-82fd-be33988ac2e8)

2) Permission filters
![Screenshot 2025-02-17 at 23 33 35](https://github.com/user-attachments/assets/36c4a600-d9ea-4348-945a-66d162c341a8)

3) Research opt in
![Screenshot 2025-02-17 at 23 33 57](https://github.com/user-attachments/assets/3613b6cf-20fe-4b4c-8bf7-b2c8be4d0412)

### Related Ticket:
[Add getting list  users and emails for yearly survey to platform admin](https://trello.com/c/qeSQJ5XB/1138-add-getting-list-users-and-emails-for-yearly-survey-to-platform-admin)
