### PR TITLE
Accept basic service callback info both in old and new format

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -164,7 +164,14 @@ def api_callbacks(service_id):
 
 def get_delivery_status_callback_details():
     if current_service.service_callback_api:
-        return service_api_client.get_service_callback_api(current_service.id, current_service.service_callback_api[0])
+        if isinstance(current_service.service_callback_api[0], str):
+            return service_api_client.get_service_callback_api(
+                current_service.id, current_service.service_callback_api[0]
+            )
+        else:
+            for row in current_service.service_callback_api:
+                if row["callback_type"] == "delivery_status":
+                    return service_api_client.get_service_callback_api(current_service.id, row["callback_id"])
 
 
 @main.route("/services/<uuid:service_id>/api/callbacks/delivery-status-callback", methods=["GET", "POST"])

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -601,6 +601,31 @@ def test_should_validate_guestlist_items(
 
 
 @pytest.mark.parametrize(
+    "callback_api_response",
+    [
+        ["8daaed46-bfa3-423b-9bd0-f66ceadd13d0"],
+        [{"callback_id": "8daaed46-bfa3-423b-9bd0-f66ceadd13d0", "callback_type": "delivery_status"}],
+    ],
+)
+def test_GET_delivery_status_callback_page_when_callback_set_up(
+    client_request,
+    service_one,
+    mock_get_valid_service_callback_api,
+    callback_api_response,
+):
+    service_one["service_callback_api"] = callback_api_response
+
+    page = client_request.get(
+        "main.delivery_status_callback",
+        service_id=SERVICE_ONE_ID,
+    )
+
+    textboxes = page.select("input.govuk-input")
+    assert textboxes[0].get("value") == "https://hello2.gov.uk"
+    assert textboxes[1].get("value") == "bearer_token_set"
+
+
+@pytest.mark.parametrize(
     "endpoint",
     [
         "main.delivery_status_callback",


### PR DESCRIPTION
So far we have been only getting callback id, but now we want to also be getting callback type, to fit in returned letter callbacks info.

So this commit helps admin accept the information in both formats, as a temporary measure.

Needs to be deployed before this one: https://github.com/alphagov/notifications-api/pull/4378