### PR TITLE
gunicorn: reduce keepalive timeout to 35s

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -7,5 +7,5 @@ set_gunicorn_defaults(globals())
 
 workers = 5
 worker_class = "eventlet"
-keepalive = 90
+keepalive = 35
 timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class


### PR DESCRIPTION
This was originally set to a generous value >60s, because we had our ALB idle timeout set to 60s and ALBs are known to have problems if the keepalive connection isn't held open for more than the idle timeout. Now that we've reduced the ALB idle timeout to 30s, we should be able to reduce the keepalive timeout too.

Excessively long keepalive timeouts cause a `GreenThread` (and all its associated thread-local resources) to be unnecessarily reserved for that period of time following a request, no matter how short the original request.