### PR TITLE
Fix overflowing email addresses in template preview

### DIFF
--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -45,7 +45,8 @@ $email-message-gutter-mobile: govuk-spacing(3);
       }
 
       // deal with long email addresses
-      & > .email-message-meta__reply-to {
+      & > .email-message-meta__reply-to,
+      & > .email-message-meta__send-to {
         word-break: break-word;
       }
 

--- a/app/templates/partials/templates/email_preview_template.jinja2
+++ b/app/templates/partials/templates/email_preview_template.jinja2
@@ -32,6 +32,7 @@
       "html": "To"
     },
     "value": {
+      "classes": "email-message-meta__send-to",
       "html": recipient
     }
 }) %}


### PR DESCRIPTION
When previewing the email template befoire sending, any long email adresses in "Reply to" or "To" fields will overflow the container on mobile or high zoom level.

We already had a fix for the "reply-to" fields.
This adds the same fix to the "To" filed by adding a HTML class to the list item and includes it in the CSS style rule.

Fixes https://trello.com/c/lOf1ttlw/1193-long-email-addresses-for-notifications-dont-reflow

**Before**
<img width="665" alt="Screenshot 2025-02-25 at 14 31 33" src="https://github.com/user-attachments/assets/8f9a1c85-95a3-47ac-8ace-7b5644ccbcf9" />


**After**
<img width="654" alt="Screenshot 2025-02-25 at 14 32 35" src="https://github.com/user-attachments/assets/31f81f76-a116-4506-bc6a-b1deffaed6d6" />

## How to test

Try to send an email and go through the steps to preview the message just before sending. Switch to mobile view or increase text magnification.