### PR TITLE
Announce notification status changes

### DIFF
--- a/app/templates/partials/notifications/status.html
+++ b/app/templates/partials/notifications/status.html
@@ -2,6 +2,7 @@
   {% set field_status = notification.status|format_notification_status_as_field_status(notification.notification_type) %}
   {% set status_url = notification.status|format_notification_status_as_url(notification.notification_type) %}
   <p class="notification-status {{ field_status }}">
+    <span class="govuk-visually-hidden">Status: </span>
     {% if status_url %}
       <a class="govuk-link govuk-link--destructive" href="{{ status_url }}">
     {% endif %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -102,11 +102,13 @@
         </div>
       </div>
     {% elif template.template_type == 'email' %}
-      <div class="js-stick-at-bottom-when-scrolling">
+      <div class="js-stick-at-bottom-when-scrolling" role="status">
         {{ ajax_block(partials, updates_url, 'status', finished=notification.finished) }}
       </div>
     {% elif template.template_type == 'sms' %}
+      <div role="status">
       {{ ajax_block(partials, updates_url, 'status', finished=notification.finished) }}
+      </div>
     {% endif %}
 
     {% if current_user.has_permissions('send_messages') and current_user.has_permissions('view_activity') and template.template_type == 'sms' and current_service.has_permission("inbound_sms") %}

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -80,7 +80,7 @@ def test_notification_status_page_shows_details(
     assert normalize_spaces(page.select(".sms-message-recipient")[0].text) == "To: 07123456789"
     assert normalize_spaces(page.select(".sms-message-wrapper")[0].text) == "service one: hello Jo"
 
-    assert normalize_spaces(page.select(".ajax-block-container p")[0].text) == expected_status
+    assert normalize_spaces(page.select(".ajax-block-container p")[0].text) == f"Status: {expected_status}"
 
     _mock_get_notification.assert_called_with(service_one["id"], fake_uuid)
 


### PR DESCRIPTION
To make updates to a single notification's status announce themselves to users using screen readers.

https://trello.com/c/W61SzMoA/1181-changes-to-status-of-notification-arent-announced-to-screen-readers

![image](https://github.com/user-attachments/assets/25ce6efc-0006-40f4-9f5f-1548859f0fa6)

Wrapping a notification's status in a `<div>` with `role=status` ensures it will get announced to screen readers. I've added a, visually hidden, prefix to give it the context users of the visual interface get.

The statuses it will work with are listed [here](https://github.com/alphagov/notifications-admin/blob/ba011fb93e920a590c452981f5f45ec2598ec112/app/formatters.py#L152).

We've already talked about this but mentioning @karlchillmaid here so he can see the code and consider the approach with that context.