### PR TITLE
notify api clients: use a common thread-local `requests.Session`

### DIFF
--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, api_client_request_session
 
 # must match key types in notifications-api/app/models.py
 KEY_TYPE_NORMAL = "normal"
@@ -31,7 +31,7 @@ class ApiKeyApiClient(NotifyAdminAPIClient):
 _api_key_api_client_context_var: ContextVar[ApiKeyApiClient] = ContextVar("api_key_api_client")
 get_api_key_api_client: LazyLocalGetter[ApiKeyApiClient] = LazyLocalGetter(
     _api_key_api_client_context_var,
-    lambda: ApiKeyApiClient(current_app),
+    lambda: ApiKeyApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_api_key_api_client.clear())
 api_key_api_client = LocalProxy(get_api_key_api_client)

--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session
 
 
 class BillingAPIClient(NotifyAdminAPIClient):
@@ -78,7 +78,7 @@ class BillingAPIClient(NotifyAdminAPIClient):
 _billing_api_client_context_var: ContextVar[BillingAPIClient] = ContextVar("billing_api_client")
 get_billing_api_client: LazyLocalGetter[BillingAPIClient] = LazyLocalGetter(
     _billing_api_client_context_var,
-    lambda: BillingAPIClient(current_app),
+    lambda: BillingAPIClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_billing_api_client.clear())
 billing_api_client = LocalProxy(get_billing_api_client)

--- a/app/notify_client/complaint_api_client.py
+++ b/app/notify_client/complaint_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session
 
 
 class ComplaintApiClient(NotifyAdminAPIClient):
@@ -20,7 +20,7 @@ class ComplaintApiClient(NotifyAdminAPIClient):
 _complaint_api_client_context_var: ContextVar[ComplaintApiClient] = ContextVar("complaint_api_client")
 get_complaint_api_client: LazyLocalGetter[ComplaintApiClient] = LazyLocalGetter(
     _complaint_api_client_context_var,
-    lambda: ComplaintApiClient(current_app),
+    lambda: ComplaintApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_complaint_api_client.clear())
 complaint_api_client = LocalProxy(get_complaint_api_client)

--- a/app/notify_client/contact_list_api_client.py
+++ b/app/notify_client/contact_list_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, api_client_request_session
 
 
 class ContactListApiClient(NotifyAdminAPIClient):
@@ -43,7 +43,7 @@ class ContactListApiClient(NotifyAdminAPIClient):
 _contact_list_api_client_context_var: ContextVar[ContactListApiClient] = ContextVar("contact_list_api_client")
 get_contact_list_api_client: LazyLocalGetter[ContactListApiClient] = LazyLocalGetter(
     _contact_list_api_client_context_var,
-    lambda: ContactListApiClient(current_app),
+    lambda: ContactListApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_contact_list_api_client.clear())
 contact_list_api_client = LocalProxy(get_contact_list_api_client)

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class EmailBrandingClient(NotifyAdminAPIClient):
@@ -64,7 +64,7 @@ class EmailBrandingClient(NotifyAdminAPIClient):
 _email_branding_client_context_var: ContextVar[EmailBrandingClient] = ContextVar("email_branding_client")
 get_email_branding_client: LazyLocalGetter[EmailBrandingClient] = LazyLocalGetter(
     _email_branding_client_context_var,
-    lambda: EmailBrandingClient(current_app),
+    lambda: EmailBrandingClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_email_branding_client.clear())
 email_branding_client = LocalProxy(get_email_branding_client)

--- a/app/notify_client/events_api_client.py
+++ b/app/notify_client/events_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session
 
 
 class EventsApiClient(NotifyAdminAPIClient):
@@ -18,7 +18,7 @@ class EventsApiClient(NotifyAdminAPIClient):
 _events_api_client_context_var: ContextVar[EventsApiClient] = ContextVar("events_api_client")
 get_events_api_client: LazyLocalGetter[EventsApiClient] = LazyLocalGetter(
     _events_api_client_context_var,
-    lambda: EventsApiClient(current_app),
+    lambda: EventsApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_events_api_client.clear())
 events_api_client = LocalProxy(get_events_api_client)

--- a/app/notify_client/inbound_number_client.py
+++ b/app/notify_client/inbound_number_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class InboundNumberClient(NotifyAdminAPIClient):
@@ -32,7 +32,7 @@ class InboundNumberClient(NotifyAdminAPIClient):
 _inbound_number_client_context_var: ContextVar[InboundNumberClient] = ContextVar("inbound_number_client")
 get_inbound_number_client: LazyLocalGetter[InboundNumberClient] = LazyLocalGetter(
     _inbound_number_client_context_var,
-    lambda: InboundNumberClient(current_app),
+    lambda: InboundNumberClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_inbound_number_client.clear())
 inbound_number_client = LocalProxy(get_inbound_number_client)

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, api_client_request_session, cache
 from app.utils.user_permissions import (
     all_ui_permissions,
     translate_permissions_from_ui_to_db,
@@ -13,8 +13,8 @@ from app.utils.user_permissions import (
 
 
 class InviteApiClient(NotifyAdminAPIClient):
-    def __init__(self, app):
-        super().__init__(app)
+    def __init__(self, app, *args, **kwargs):
+        super().__init__(app, *args, **kwargs)
 
         self.admin_url = app.config["ADMIN_BASE_URL"]
 
@@ -85,7 +85,7 @@ class InviteApiClient(NotifyAdminAPIClient):
 _invite_api_client_context_var: ContextVar[InviteApiClient] = ContextVar("invite_api_client")
 get_invite_api_client: LazyLocalGetter[InviteApiClient] = LazyLocalGetter(
     _invite_api_client_context_var,
-    lambda: InviteApiClient(current_app),
+    lambda: InviteApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_invite_api_client.clear())
 invite_api_client = LocalProxy(get_invite_api_client)

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -6,7 +6,7 @@ from werkzeug.local import LocalProxy
 
 from app import memo_resetters
 from app.extensions import redis_client
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, api_client_request_session, cache
 
 
 class JobApiClient(NotifyAdminAPIClient):
@@ -125,7 +125,7 @@ class JobApiClient(NotifyAdminAPIClient):
 _job_api_client_context_var: ContextVar[JobApiClient] = ContextVar("job_api_client")
 get_job_api_client: LazyLocalGetter[JobApiClient] = LazyLocalGetter(
     _job_api_client_context_var,
-    lambda: JobApiClient(current_app),
+    lambda: JobApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_job_api_client.clear())
 job_api_client = LocalProxy(get_job_api_client)

--- a/app/notify_client/letter_attachment_client.py
+++ b/app/notify_client/letter_attachment_client.py
@@ -6,7 +6,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class LetterAttachmentClient(NotifyAdminAPIClient):
@@ -37,7 +37,7 @@ class LetterAttachmentClient(NotifyAdminAPIClient):
 _letter_attachment_client_context_var: ContextVar[LetterAttachmentClient] = ContextVar("letter_attachment_client")
 get_letter_attachment_client: LazyLocalGetter[LetterAttachmentClient] = LazyLocalGetter(
     _letter_attachment_client_context_var,
-    lambda: LetterAttachmentClient(current_app),
+    lambda: LetterAttachmentClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_letter_attachment_client.clear())
 letter_attachment_client = LocalProxy(get_letter_attachment_client)

--- a/app/notify_client/letter_branding_client.py
+++ b/app/notify_client/letter_branding_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class LetterBrandingClient(NotifyAdminAPIClient):
@@ -47,7 +47,7 @@ class LetterBrandingClient(NotifyAdminAPIClient):
 _letter_branding_client_context_var: ContextVar[LetterBrandingClient] = ContextVar("letter_branding_client")
 get_letter_branding_client: LazyLocalGetter[LetterBrandingClient] = LazyLocalGetter(
     _letter_branding_client_context_var,
-    lambda: LetterBrandingClient(current_app),
+    lambda: LetterBrandingClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_letter_branding_client.clear())
 letter_branding_client = LocalProxy(get_letter_branding_client)

--- a/app/notify_client/letter_jobs_client.py
+++ b/app/notify_client/letter_jobs_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class LetterJobsClient(NotifyAdminAPIClient):
@@ -18,7 +18,7 @@ class LetterJobsClient(NotifyAdminAPIClient):
 _letter_jobs_client_context_var: ContextVar[LetterJobsClient] = ContextVar("letter_jobs_client")
 get_letter_jobs_client: LazyLocalGetter[LetterJobsClient] = LazyLocalGetter(
     _letter_jobs_client_context_var,
-    lambda: LetterJobsClient(current_app),
+    lambda: LetterJobsClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_letter_jobs_client.clear())
 letter_jobs_client = LocalProxy(get_letter_jobs_client)

--- a/app/notify_client/letter_rate_api_client.py
+++ b/app/notify_client/letter_rate_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class LetterRateApiClient(NotifyAdminAPIClient):
@@ -17,7 +17,7 @@ class LetterRateApiClient(NotifyAdminAPIClient):
 _letter_rate_api_client_context_var: ContextVar[LetterRateApiClient] = ContextVar("letter_rate_api_client")
 get_letter_rate_api_client: LazyLocalGetter[LetterRateApiClient] = LazyLocalGetter(
     _letter_rate_api_client_context_var,
-    lambda: LetterRateApiClient(current_app),
+    lambda: LetterRateApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_letter_rate_api_client.clear())
 letter_rate_api_client = LocalProxy(get_letter_rate_api_client)

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, api_client_request_session
 
 
 class NotificationApiClient(NotifyAdminAPIClient):
@@ -135,7 +135,7 @@ class NotificationApiClient(NotifyAdminAPIClient):
 _notification_api_client_context_var: ContextVar[NotificationApiClient] = ContextVar("notification_api_client")
 get_notification_api_client: LazyLocalGetter[NotificationApiClient] = LazyLocalGetter(
     _notification_api_client_context_var,
-    lambda: NotificationApiClient(current_app),
+    lambda: NotificationApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_notification_api_client.clear())
 notification_api_client = LocalProxy(get_notification_api_client)

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -5,12 +5,12 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, api_client_request_session
 
 
 class OrgInviteApiClient(NotifyAdminAPIClient):
-    def __init__(self, app):
-        super().__init__(app)
+    def __init__(self, app, *args, **kwargs):
+        super().__init__(app, *args, **kwargs)
 
         self.admin_url = app.config["ADMIN_BASE_URL"]
 
@@ -53,7 +53,7 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
 _org_invite_api_client_context_var: ContextVar[OrgInviteApiClient] = ContextVar("org_invite_api_client")
 get_org_invite_api_client: LazyLocalGetter[OrgInviteApiClient] = LazyLocalGetter(
     _org_invite_api_client_context_var,
-    lambda: OrgInviteApiClient(current_app),
+    lambda: OrgInviteApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_org_invite_api_client.clear())
 org_invite_api_client = LocalProxy(get_org_invite_api_client)

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -8,7 +8,7 @@ from werkzeug.local import LocalProxy
 
 from app import memo_resetters
 from app.extensions import redis_client
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class OrganisationsClient(NotifyAdminAPIClient):
@@ -166,7 +166,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
 _organisations_client_context_var: ContextVar[OrganisationsClient] = ContextVar("organisations_client")
 get_organisations_client: LazyLocalGetter[OrganisationsClient] = LazyLocalGetter(
     _organisations_client_context_var,
-    lambda: OrganisationsClient(current_app),
+    lambda: OrganisationsClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_organisations_client.clear())
 organisations_client = LocalProxy(get_organisations_client)

--- a/app/notify_client/performance_dashboard_api_client.py
+++ b/app/notify_client/performance_dashboard_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class PerformanceDashboardAPIClient(NotifyAdminAPIClient):
@@ -30,7 +30,7 @@ _performance_dashboard_api_client_context_var: ContextVar[PerformanceDashboardAP
 )
 get_performance_dashboard_api_client: LazyLocalGetter[PerformanceDashboardAPIClient] = LazyLocalGetter(
     _performance_dashboard_api_client_context_var,
-    lambda: PerformanceDashboardAPIClient(current_app),
+    lambda: PerformanceDashboardAPIClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_performance_dashboard_api_client.clear())
 performance_dashboard_api_client = LocalProxy(get_performance_dashboard_api_client)

--- a/app/notify_client/platform_admin_api_client.py
+++ b/app/notify_client/platform_admin_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session
 
 
 class AdminApiClient(NotifyAdminAPIClient):
@@ -37,7 +37,7 @@ class AdminApiClient(NotifyAdminAPIClient):
 _admin_api_client_context_var: ContextVar[AdminApiClient] = ContextVar("admin_api_client")
 get_admin_api_client: LazyLocalGetter[AdminApiClient] = LazyLocalGetter(
     _admin_api_client_context_var,
-    lambda: AdminApiClient(current_app),
+    lambda: AdminApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_admin_api_client.clear())
 admin_api_client = LocalProxy(get_admin_api_client)

--- a/app/notify_client/protected_sender_id_api_client.py
+++ b/app/notify_client/protected_sender_id_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session
 
 
 class ProtectedSenderIDApiClient(NotifyAdminAPIClient):
@@ -18,7 +18,7 @@ _protected_sender_id_api_client_context_var: ContextVar[ProtectedSenderIDApiClie
 )
 get_protected_sender_id_api_client: LazyLocalGetter[ProtectedSenderIDApiClient] = LazyLocalGetter(
     _protected_sender_id_api_client_context_var,
-    lambda: ProtectedSenderIDApiClient(current_app),
+    lambda: ProtectedSenderIDApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_protected_sender_id_api_client.clear())
 protected_sender_id_api_client = LocalProxy(get_protected_sender_id_api_client)

--- a/app/notify_client/provider_client.py
+++ b/app/notify_client/provider_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, api_client_request_session
 
 
 class ProviderClient(NotifyAdminAPIClient):
@@ -27,7 +27,7 @@ class ProviderClient(NotifyAdminAPIClient):
 _provider_client_context_var: ContextVar[ProviderClient] = ContextVar("provider_client")
 get_provider_client: LazyLocalGetter[ProviderClient] = LazyLocalGetter(
     _provider_client_context_var,
-    lambda: ProviderClient(current_app),
+    lambda: ProviderClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_provider_client.clear())
 provider_client = LocalProxy(get_provider_client)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -9,7 +9,7 @@ from werkzeug.local import LocalProxy
 from app import memo_resetters
 from app.constants import LetterLanguageOptions
 from app.extensions import redis_client
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, api_client_request_session, cache
 
 ALLOWED_TEMPLATE_ATTRIBUTES = {
     "content",
@@ -587,7 +587,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 _service_api_client_context_var: ContextVar[ServiceAPIClient] = ContextVar("service_api_client")
 get_service_api_client: LazyLocalGetter[ServiceAPIClient] = LazyLocalGetter(
     _service_api_client_context_var,
-    lambda: ServiceAPIClient(current_app),
+    lambda: ServiceAPIClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_service_api_client.clear())
 service_api_client = LocalProxy(get_service_api_client)

--- a/app/notify_client/sms_rate_client.py
+++ b/app/notify_client/sms_rate_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class SMSRateApiClient(NotifyAdminAPIClient):
@@ -17,7 +17,7 @@ class SMSRateApiClient(NotifyAdminAPIClient):
 _sms_rate_api_client_context_var: ContextVar[SMSRateApiClient] = ContextVar("sms_rate_api_client")
 get_sms_rate_api_client: LazyLocalGetter[SMSRateApiClient] = LazyLocalGetter(
     _sms_rate_api_client_context_var,
-    lambda: SMSRateApiClient(current_app),
+    lambda: SMSRateApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_sms_rate_api_client.clear())
 sms_rate_api_client = LocalProxy(get_sms_rate_api_client)

--- a/app/notify_client/status_api_client.py
+++ b/app/notify_client/status_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class StatusApiClient(NotifyAdminAPIClient):
@@ -20,7 +20,7 @@ class StatusApiClient(NotifyAdminAPIClient):
 _status_api_client_context_var: ContextVar[StatusApiClient] = ContextVar("status_api_client")
 get_status_api_client: LazyLocalGetter[StatusApiClient] = LazyLocalGetter(
     _status_api_client_context_var,
-    lambda: StatusApiClient(current_app),
+    lambda: StatusApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_status_api_client.clear())
 status_api_client = LocalProxy(get_status_api_client)

--- a/app/notify_client/template_folder_api_client.py
+++ b/app/notify_client/template_folder_api_client.py
@@ -6,7 +6,7 @@ from werkzeug.local import LocalProxy
 
 from app import memo_resetters
 from app.extensions import redis_client
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 
 
 class TemplateFolderAPIClient(NotifyAdminAPIClient):
@@ -63,7 +63,7 @@ class TemplateFolderAPIClient(NotifyAdminAPIClient):
 _template_folder_api_client_context_var: ContextVar[TemplateFolderAPIClient] = ContextVar("template_folder_api_client")
 get_template_folder_api_client: LazyLocalGetter[TemplateFolderAPIClient] = LazyLocalGetter(
     _template_folder_api_client_context_var,
-    lambda: TemplateFolderAPIClient(current_app),
+    lambda: TemplateFolderAPIClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_template_folder_api_client.clear())
 template_folder_api_client = LocalProxy(get_template_folder_api_client)

--- a/app/notify_client/template_statistics_api_client.py
+++ b/app/notify_client/template_statistics_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session
 
 
 class TemplateStatisticsApiClient(NotifyAdminAPIClient):
@@ -28,7 +28,7 @@ _template_statistics_client_context_var: ContextVar[TemplateStatisticsApiClient]
 )
 get_template_statistics_client: LazyLocalGetter[TemplateStatisticsApiClient] = LazyLocalGetter(
     _template_statistics_client_context_var,
-    lambda: TemplateStatisticsApiClient(current_app),
+    lambda: TemplateStatisticsApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_template_statistics_client.clear())
 template_statistics_client = LocalProxy(get_template_statistics_client)

--- a/app/notify_client/unsubscribe_api_client.py
+++ b/app/notify_client/unsubscribe_api_client.py
@@ -6,7 +6,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session
 
 
 class UnsubscribeApiClient(NotifyAdminAPIClient):
@@ -23,7 +23,7 @@ class UnsubscribeApiClient(NotifyAdminAPIClient):
 _unsubscribe_api_client_context_var: ContextVar[UnsubscribeApiClient] = ContextVar("unsubscribe_api_client")
 get_unsubscribe_api_client: LazyLocalGetter[UnsubscribeApiClient] = LazyLocalGetter(
     _unsubscribe_api_client_context_var,
-    lambda: UnsubscribeApiClient(current_app),
+    lambda: UnsubscribeApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_unsubscribe_api_client.clear())
 unsubscribe_api_client = LocalProxy(get_unsubscribe_api_client)

--- a/app/notify_client/upload_api_client.py
+++ b/app/notify_client/upload_api_client.py
@@ -5,7 +5,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session
 
 
 class UploadApiClient(NotifyAdminAPIClient):
@@ -22,7 +22,7 @@ class UploadApiClient(NotifyAdminAPIClient):
 _upload_api_client_context_var: ContextVar[UploadApiClient] = ContextVar("upload_api_client")
 get_upload_api_client: LazyLocalGetter[UploadApiClient] = LazyLocalGetter(
     _upload_api_client_context_var,
-    lambda: UploadApiClient(current_app),
+    lambda: UploadApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_upload_api_client.clear())
 upload_api_client = LocalProxy(get_upload_api_client)

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -6,7 +6,7 @@ from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
 from app import memo_resetters
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient, api_client_request_session, cache
 from app.utils.user_permissions import translate_permissions_from_ui_to_db
 
 ALLOWED_ATTRIBUTES = {
@@ -23,8 +23,8 @@ ALLOWED_ATTRIBUTES = {
 
 
 class UserApiClient(NotifyAdminAPIClient):
-    def __init__(self, app):
-        super().__init__(app)
+    def __init__(self, app, *args, **kwargs):
+        super().__init__(app, *args, **kwargs)
 
         self.admin_url = app.config["ADMIN_BASE_URL"]
 
@@ -242,7 +242,7 @@ class UserApiClient(NotifyAdminAPIClient):
 _user_api_client_context_var: ContextVar[UserApiClient] = ContextVar("user_api_client")
 get_user_api_client: LazyLocalGetter[UserApiClient] = LazyLocalGetter(
     _user_api_client_context_var,
-    lambda: UserApiClient(current_app),
+    lambda: UserApiClient(current_app, request_session=api_client_request_session),
 )
 memo_resetters.append(lambda: get_user_api_client.clear())
 user_api_client = LocalProxy(get_user_api_client)

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ pyexcel-io==0.6.6
 pyexcel-xls==0.7.0
 pyexcel-xlsx==0.6.0
 pyexcel-ods3==0.6.1
-notifications-python-client==10.0.0
+notifications-python-client @ git+https://github.com/alphagov/notifications-python-client.git@5eafd129144f5006e2d7bf501a9c38450979d4b6
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ markupsafe==2.1.1
     #   wtforms
 mistune==0.8.4
     # via notifications-utils
-notifications-python-client==10.0.0
+notifications-python-client @ git+https://github.com/alphagov/notifications-python-client.git@5eafd129144f5006e2d7bf501a9c38450979d4b6
     # via -r requirements.in
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d6311c3ab83b8225265277f781157c48f9318ae9
     # via -r requirements.in

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -167,7 +167,7 @@ mistune==0.8.4
     #   notifications-utils
 moto==4.0.9
     # via -r requirements_for_test.in
-notifications-python-client==10.0.0
+notifications-python-client @ git+https://github.com/alphagov/notifications-python-client.git@5eafd129144f5006e2d7bf501a9c38450979d4b6
     # via -r requirements.txt
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d6311c3ab83b8225265277f781157c48f9318ae9
     # via -r requirements.txt


### PR DESCRIPTION
Depends on https://github.com/alphagov/notifications-python-client/pull/255

We're currently dividing the effectiveness of any connection-pooling we're doing to api-web by >20x by having a separate connection pool per sub-api-client. This contributes to the excessive number of GreenThreads api-web needs to keep active when it has keepalive enabled.

Instead keep a single (lazily-constructed) `requests.Session` per-thread which gets injected into each sub-api-client at lazy-construction-time.