### PR TITLE
Remove SHA reference to Flask-Login dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 ago==0.0.95
 humanize==4.4.0
 Flask-WTF==1.2.1
-Flask-Login @ git+https://github.com/maxcountryman/flask-login.git@2204b4eee7b215977ba5a1bf85e2061f7fa65e20#egg=flask-login
+Flask-Login==0.6.3
 
 Pillow==10.3.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ flask==3.1.0
     #   gds-metrics
     #   notifications-utils
     #   sentry-sdk
-flask-login @ git+https://github.com/maxcountryman/flask-login.git@2204b4eee7b215977ba5a1bf85e2061f7fa65e20#egg=flask-login
+flask-login==0.6.3
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -88,7 +88,7 @@ flask==3.1.0
     #   flask-wtf
     #   gds-metrics
     #   notifications-utils
-flask-login @ git+https://github.com/maxcountryman/flask-login.git@2204b4eee7b215977ba5a1bf85e2061f7fa65e20#egg=flask-login
+flask-login==0.6.3
     # via -r requirements.txt
 flask-redis==0.4.0
     # via


### PR DESCRIPTION
I think we added this because the version of Flask-Login we required for Flask 3 compatibility hadn’t been released at the time of 58fce7a712463a9867b36fb87b64b32ad8d358ae (27 October 2023).

It was [released](https://github.com/maxcountryman/flask-login/releases/tag/0.6.3) on 30 October 2023.

Making it a version number makes it legible to Dependabot. Currently Dependabot gives this error when trying to open a PR: 
<img width="926" alt="image" src="https://github.com/user-attachments/assets/2267c1c2-2d62-4793-a5ce-d7c112dff317" />

***

Changes: https://github.com/maxcountryman/flask-login/compare/2204b4eee7b215977ba5a1bf85e2061f7fa65e20...0.6.3