### PR TITLE
Update letter delivery time content

### DIFF
--- a/app/templates/views/guidance/using-notify/delivery-times.html
+++ b/app/templates/views/guidance/using-notify/delivery-times.html
@@ -32,8 +32,8 @@
   <h2 id="letters" class="heading-medium">Letters</h2>
   <p class="govuk-body">Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday).</p>
 
-  <p class="govuk-body">First class letters are delivered one day after they’re dispatched. Second class letters are delivered 2 days after they’re dispatched. Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
-  <p class="govuk-body">Letters to Europe are delivered 3 to 5 days after they’re dispatched. Letters sent anywhere else in the world take 5 to 7 days to arrive.</p>
+  <p class="govuk-body">First class letters should be delivered one day after they’re dispatched. Second class letters should be delivered 2 days after they’re dispatched. Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
+  <p class="govuk-body">Letters to Europe should be delivered 3 to 5 days after they’re dispatched. Letters sent anywhere else in the world should take 5 to 7 days to arrive.</p>
 
   <h2 id="returned-mail" class="heading-medium">Returned letters</h2>
   <p class="govuk-body">Every letter we send includes our print provider’s address on the back of the envelope. You cannot customise the return address.</p>


### PR DESCRIPTION
Our current description of how soon letters are delivered is very definitive. For example:

> Second class letters **are** delivered 2 days after they’re dispatched.

We cannot actually control this, and Royal Mail may take longer to deliver our letters.

Users have asked for clarity about the delivery times, so we need to update our language to more accurately reflect that this is a target rather than a guarantee.

The suggestion is to change `are` to `should be`.

All of this content will need to change again soon, when we introduce economy mail. But, for now, this is a small improvement.