### PR TITLE
Fix for template search visibility

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -181,6 +181,11 @@ a {
       padding-left: 0;
       width: auto;
     }
+    // some template-list items are not radios or checkboxes (copy template page)
+    // so we need these override styles
+    &[hidden] {
+      display: none;
+    }
   }
 
   &-folder,


### PR DESCRIPTION
In https://github.com/alphagov/notifications-admin/pull/5370 we redid they way we toggle search result visibility, now using the hidden attribute.

We additionally placed a CSS override for radios and checkboxes when they contain the `hidden` attribute - https://github.com/alphagov/notifications-admin/blob/3d45002d0a4793e9e4682440cc0234f98563f5d0/app/assets/stylesheets/govuk-frontend/extensions.scss#L240

It turn out there are template-list-items that aren't checkboxes, so `hidden` attribute by it self currently doesn't hide them as they have `display:block' set in CSS.

This fixes the omission.

## How to test

- go to `<serviceID>/templates/copy` and search for templates. Only matched should be visible now

**Before**
![before](https://github.com/user-attachments/assets/f08c7560-9c4e-4d64-b6ee-dbc7487d5a36)

**After**

![after](https://github.com/user-attachments/assets/4dcdec2c-1b0e-4b7f-a8f6-0eb0911b9b8a)
