### PR TITLE
Fix a couple more uses of non-smart apostrophes

### DIFF
--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -42,7 +42,7 @@ def archive_user(user_id):
 
         return redirect(url_for(".user_information", user_id=user_id))
     else:
-        flash("There's no way to reverse this! Are you sure you want to archive this user?", "delete")
+        flash("There’s no way to reverse this! Are you sure you want to archive this user?", "delete")
         return user_information(user_id)
 
 

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -38,7 +38,7 @@ def verify_email(token):
             current_app.config["EMAIL_EXPIRY_SECONDS"],
         )
     except SignatureExpired:
-        flash("The link in the email we sent you has expired. We've sent you a new one.")
+        flash("The link in the email we sent you has expired. We’ve sent you a new one.")
         return redirect(url_for("main.resend_email_verification"))
 
     token = Token(token_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3163,7 +3163,7 @@ def client_request(request, _logged_in_client, mocker, service_one, fake_nonce):
 
         @staticmethod
         def test_for_non_smart_quotes(page):
-            for el in page.select("h1, h2, h3, h4, h5, h6, p, li"):
+            for el in page.select("h1, h2, h3, h4, h5, h6, p, li, .banner-dangerous"):
                 assert not ("'" in el.text or '"' in el.text), (
                     f"Non-smart quote or apostrophe found in <{el.name}>: {normalize_spaces(el.text)}"
                 )


### PR DESCRIPTION
These 2 were missed by the check we added in https://github.com/alphagov/notifications-admin/pull/5250 because:
- they weren’t in a paragraph, heading or list
- one of them was not covered by any test

This commit fixes the 2 occurrences, and makes the tests more robust.