### PR TITLE
Update billing details

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -85,7 +85,7 @@ class Config:
 
     NOTIFY_SERVICE_ID = "d6aa2c68-a2d9-4437-ab19-3ae8eb202553"
 
-    NOTIFY_BILLING_DETAILS = json.loads(os.environ.get("NOTIFY_BILLING_DETAILS") or "null") or {
+    BILLING_DETAILS = json.loads(os.environ.get("BILLING_DETAILS") or "null") or {
         "account_number": "98765432",
         "sort_code": "01-23-45",
         "IBAN": "GB33BUKB20201555555555",

--- a/app/main/views/pricing.py
+++ b/app/main/views/pricing.py
@@ -47,7 +47,7 @@ def guidance_pricing_letters():
 def guidance_how_to_pay():
     return render_template(
         "views/guidance/pricing/how-to-pay.html",
-        billing_details=current_app.config["NOTIFY_BILLING_DETAILS"],
+        billing_details=current_app.config["BILLING_DETAILS"],
         navigation_links=pricing_nav(),
     )
 
@@ -57,7 +57,7 @@ def guidance_billing_details():
     if current_user.is_authenticated:
         return render_template(
             "views/guidance/pricing/billing-details.html",
-            billing_details=current_app.config["NOTIFY_BILLING_DETAILS"],
+            billing_details=current_app.config["BILLING_DETAILS"],
             navigation_links=pricing_nav(),
         )
     return render_template(

--- a/app/templates/views/guidance/pricing/billing-details.html
+++ b/app/templates/views/guidance/pricing/billing-details.html
@@ -15,7 +15,7 @@
     {{ page_header('Billing details') }}
 
     <p class="govuk-body">
-      You can use the information on this page to add the Cabinet Office as a supplier. Your organisation may need to do this before you can raise a purchase order (PO).
+      You can use the information on this page to add the Department for Science, Innovation and Technology (DSIT) as a supplier. Your organisation may need to do this before you can raise a purchase order (PO).
     </p>
 
     <p class="govuk-body">
@@ -27,14 +27,13 @@
     </h2>
 
     <p class="govuk-body">
-      Cabinet Office
+      Department for Science, Innovation and Technology
     </p>
 
     <p class="govuk-body">
-      The White Chapel Building <br>
-      10 Whitechapel High Street <br>
+      100 Parliament Street <br>
       London <br>
-      E1 8QS
+      SW1A 2BQ
     </p>
 
     <h3 class="heading-small" id="email-addresses">
@@ -51,7 +50,7 @@
 
     <div class="govuk-!-margin-bottom-4">
     {{ copy_to_clipboard(
-        'GB 88 88 010 80',
+        'GB 888 8255 50',
         thing='<abbr title="Value Added Tax">VAT</abbr> number',
     ) }}
     </div>
@@ -61,12 +60,12 @@
     </h2>
 
     <p class="govuk-body">
-      National Westminster Bank PLC (part of RBS group) <br>
-      Government Banking Services Branch <br>
-      2nd Floor <br>
-      280 Bishopsgate <br>
-      London <br>
-      EC2M 4RB
+      National Westminster Bank PLC <br>
+      NatWest Customer Service Centre <br>
+      Brampton Road <br>
+      Newcastle-under-Lyme <br>
+      Staffordshire <br>
+      ST5 0QX
     </p>
 
     <h3 class="heading-small" id="account-name">
@@ -74,7 +73,7 @@
     </h3>
 
     <p class="govuk-body">
-      Cabinet Office
+      Department for Science, Innovation and Technology
     </p>
 
     <h3 class="heading-small" id="account-number">
@@ -121,17 +120,26 @@
       ) }}
     </div>
 
+    <h3 class="heading-small" id="duns-number">
+      D-U-N-S number
+    </h3>
+
+    <div class="govuk-!-margin-bottom-4">
+    {{ copy_to_clipboard(
+        '227331642',
+        thing='<abbr title="Data Universal Numbering System">D-U-N-S</abbr> number',
+    ) }}
+    </div>
+
     <h2 class="heading-medium govuk-!-margin-top-7" id="invoice-address">
       Invoice address
     </h2>
 
     <p class="govuk-body">
-      SSCL – Accounts Receivable <br>
-      PO Box 221 <br>
-      Thornton-Cleveleys <br>
-      Blackpool <br>
-      Lancashire <br>
-      FY1 9JN
+      Department for Science, Innovation and Technology <br>
+      100 Parliament Street <br>
+      London <br>
+      SW1A 2BQ
     </p>
 
 {% endblock %}

--- a/app/templates/views/guidance/pricing/how-to-pay.html
+++ b/app/templates/views/guidance/pricing/how-to-pay.html
@@ -34,15 +34,19 @@
     </h3>
 
     <p class="govuk-body">
-      GOV.UK Notify is run by the Government Digital Service (GDS), which is part of the Cabinet Office.
+      GOV.UK Notify is run by the Government Digital Service (GDS).
     </p>
 
     <p class="govuk-body">
-      Before you can send us a <abbr title="purchase order">PO</abbr> your organisation may need to add the Cabinet Office as a supplier.
+      GDS is moving from the Cabinet Office to the Department for Science, Innovation and Technology (DSIT).
     </p>
 
     <p class="govuk-body">
-      To do this, they’ll need the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">Cabinet Office billing details</a>.
+      Before you can send us a <abbr title="purchase order">PO</abbr> your organisation may need to add DSIT as a supplier.
+    </p>
+
+    <p class="govuk-body">
+      To do this, they’ll need the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_billing_details') }}">DSIT billing details</a>.
     </p>
 
     <h3 class="heading-small" id="where-to-send-your-po">
@@ -61,7 +65,7 @@
 
     {% if current_user.is_authenticated %}
     <p class="govuk-body">
-      The email address is {{ billing_details['notify_billing_email_address'] }}
+      Their email address is {{ billing_details['notify_billing_email_address'] }}
     </p>
     {% else %}
     <p class="govuk-body">
@@ -78,7 +82,7 @@
     </h2>
 
     <p class="govuk-body">
-      The Cabinet Office will send your organisation an invoice each quarter if you:
+      We will send your organisation an invoice each quarter if you:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
The billing details need to change from the Cabinet Office to DSIT. The new DSIT details have already been added to a new environment variable called `BILLING_DETAILS` to replace `NOTIFY_BILLING_DETAILS` - this means we can ensure that the page content and billing details are updated at exactly the same time.

Full details in the [Trello card](https://trello.com/c/QQrBVLGv/1178-mog-update-billing-details-page)