### PR TITLE
Update billing details on the page seen when signed out of Notify

### DIFF
--- a/app/templates/views/guidance/pricing/billing-details-signed-out.html
+++ b/app/templates/views/guidance/pricing/billing-details-signed-out.html
@@ -24,7 +24,7 @@
     </ul>
 
     <p class="govuk-body">
-      You can use this information to add the Cabinet Office as a supplier. Your organisation may need to do this before you can raise a purchase order.
+      You can use this information to add the Department for Science, Innovation and Technology (DSIT) as a supplier. Your organisation may need to do this before you can raise a purchase order.
     </p>
 
 {% endblock %}


### PR DESCRIPTION
The billing and how to pay pages have [been updated with the new details](https://github.com/alphagov/notifications-admin/pull/5407), but the version of the billing page you see when signed out still showed the Cabinet Office as the supplier to add.

**Before**
<img width="500" alt="Screenshot 2025-03-14 at 10 51 58" src="https://github.com/user-attachments/assets/b7cc3271-3bd5-4cec-b24c-25fb8f15cc96" />

**After**
<img width="500" alt="Screenshot 2025-03-14 at 10 51 40" src="https://github.com/user-attachments/assets/9ac7eeb7-3814-4f35-a362-6d027da03aee" />
