### PR TITLE
Announce 1 April letter price increases

### DIFF
--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -36,7 +36,8 @@
       The exact difference for second class postage will depend on the number of pages in your letter. The changes listed do not include VAT. 
     </p>  
   </div>
-<p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
+  
+  <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
   <p class="govuk-body">Prices include:</p>
   <ul class="govuk-list govuk-list--bullet">

--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -20,7 +20,23 @@
       }
     ) }}
 
-  <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
+  <div class="govuk-inset-text">
+    <p class="govuk-body">
+    Royal Mail is increasing its rates.
+    </p>
+    <p class="govuk-body">
+      On 1 April 2025:
+    </p> 
+
+    <ul class="govuk-list govuk-list--bullet">
+     <li>first class letters will go up by 52 pence</li>
+     <li>second class letters will go up by between 7 and 9 pence</li>
+    </ul>
+    <p class="govuk-body">
+      The exact difference for second class postage will depend on the number of pages in your letter. The changes listed do not include VAT. 
+    </p>  
+  </div>
+<p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
   <p class="govuk-body">Prices include:</p>
   <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Royal Mail are increasing their rates on 1 April.

We’ve emailed users about this, but we still need to add an announcement to the pricing page.