### PR TITLE
Help users to avoid reporting non-emergencies outside office hours

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1701,7 +1701,7 @@ class FeedbackOrProblem(StripWhitespaceForm):
 
 class Triage(StripWhitespaceForm):
     severe = GovukRadiosField(
-        "Is it an emergency?",
+        "Did you get one of the following errors?",
         choices=[
             ("yes", "Yes"),
             ("no", "No"),

--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -3,7 +3,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
-  Report an emergency out of hours
+  How to report a problem outside office hours
 {% endblock %}
 
 {% block backLink %}
@@ -12,7 +12,7 @@
 
 {% block maincolumn_content %}
 
-    {{ page_header('Report an emergency out of hours')}}
+    {{ page_header('How to report a problem outside office hours')}}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">
@@ -26,22 +26,31 @@
           If your problem is not listed on the status page, contact us using our emergency email address.
         </p>
         <p class="govuk-body">
-          This is the email address we sent to your service manager in an email called ‘Your service is live’.
+          This is the email address we sent to your service manager when we made your service live.
         </p>
         <p class="govuk-body">
-          We do not offer out of hours support if your service is in
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a>.
+          When you contact our emergency email address we’ll reply within 30 minutes.
         </p>
 
-        <h2 class="heading-medium">When you report an emergency</h2>
-        <p class="govuk-body">
-          We’ll reply within 30 minutes.
-        </p>
+        <h2 class="heading-medium">Do not use our emergency email address if</h2>
 
-        <h2 class="heading-medium">If it’s not an emergency</h2>
+        <ul class="govuk-list govuk-list--bullet">
+        <li>
+          you did not get a ‘technical difficulties’ error when uploading a file
+        </li>
+        <li>
+          you did not get a 500 response code when using the API
+        </li>
+        <li>
+          your service is still in trial mode
+        </li>
+      </ul>
+
         <p class="bottom-gutter-2">
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.feedback', ticket_type='report-problem', severe='no') }}">Fill in this form</a>
-          and we’ll reply by the end of the next working day.
+          Instead you need to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.feedback', ticket_type='report-problem', severe='no') }}">fill in our support form</a>.
+        </p>
+        <p class="govuk-body">
+          We’ll reply by the end of the next working day.
         </p>
       </div>
     </div>

--- a/app/templates/views/support/form.html
+++ b/app/templates/views/support/form.html
@@ -20,9 +20,9 @@
       <div class="govuk-grid-column-two-thirds">
         {% if show_status_page_banner %}
           {% set insetHtml %}
-          Check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">
-            system status</a>
-          page to see if there are any known issues with GOV.UK Notify.
+          <p class="govuk-body">First, check the <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">
+            GOV.UK Notify status page</a>.</p>
+          <p class="govuk-body">You do not need to contact us if your problem is already listed on that page.</p>
           {% endset %}
           {{ govukInsetText({"html": insetHtml, classes: "govuk-!-margin-top-0 govuk-!-margin-bottom-3"}) }}
         {% endif %}

--- a/app/templates/views/support/triage.html
+++ b/app/templates/views/support/triage.html
@@ -19,41 +19,6 @@
         {{ form.severe(param_extensions={'fieldset': {'legend': {'classes': 'govuk-fieldset__legend--l', 'isPageHeading': True} } }) }}
         {{ page_footer('Continue') }}
       {% endcall %}
-      <h2 class="heading-small">
-        It’s only an emergency if:
-      </h2>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>
-          no one in your team can log in
-        </li>
-        <li>
-          you get a ‘technical difficulties’ error message when you try
-          to upload a file
-        </li>
-        <li>
-          you get a 500 response code when you try to send messages
-          using the API
-        </li>
-      </ul>
-      <h2 class="heading-small">
-        It’s not an emergency if:
-      </h2>
-      <ul class="govuk-list govuk-list--bullet bottom-gutter">
-        <li>
-          all your messages stay in ‘sending’ for a few hours
-        </li>
-        <li>
-          you send the wrong message by accident
-        </li>
-        <li>
-          a team member uses GOV.UK Notify to send an
-          inappropriate message
-        </li>
-        <li>
-          your system is telling the GOV.UK Notify API to send the wrong
-          message
-        </li>
-      </ul>
     </div>
   </div>
 

--- a/app/templates/views/support/triage.html
+++ b/app/templates/views/support/triage.html
@@ -16,8 +16,20 @@
   <div class="govuk-grid-row govuk-!-margin-top-5">
     <div class="govuk-grid-column-two-thirds">
       {% call form_wrapper() %}
-        {{ form.severe(param_extensions={'fieldset': {'legend': {'classes': 'govuk-fieldset__legend--l', 'isPageHeading': True} } }) }}
-        {{ page_footer('Continue') }}
+      {{ form.severe(param_extensions={
+        'fieldset': {'legend': {'classes': 'govuk-fieldset__legend--l', 'isPageHeading': True} },
+        'formGroup': {
+          'beforeInputs': {
+            'html': (
+              '<ul class="govuk-list govuk-list--bullet">'
+                '<li>a ‘technical difficulties’ error when uploading a file</li>'
+                '<li>a 500 response code when using the API</li>'
+              '</ul>'
+            )
+          }
+        }
+      }) }}  
+      {{ page_footer('Continue') }}
       {% endcall %}
     </div>
   </div>

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -510,7 +510,7 @@ def test_options_on_triage_page(
     ticket_type,
 ):
     page = client_request.get("main.triage", ticket_type=ticket_type)
-    assert normalize_spaces(page.select_one("h1").text) == "Is it an emergency?"
+    assert normalize_spaces(page.select_one("h1").text) == "Did you get one of the following errors?"
     assert page.select("form input[type=radio]")[0]["value"] == "yes"
     assert page.select("form input[type=radio]")[1]["value"] == "no"
 


### PR DESCRIPTION
# What
We need to reduce the number of ‘false’ emergencies reported out of hours.

To do this we’re going to:

* update some of our guidance
* stop asking users to self-identify whether their problem is an emergency

# Why

We’re seeing more emergency (P1) incidents out-of-hours that turn out not to be emergencies.

The out-of-hours on-call team is only responsible for dealing with ‘emergencies’.

Our definition of an emergency is very narrow.

Because ‘emergency’ is an ambiguous term, users sometimes report problems as emergencies outside office hours.

Treating problems as emergencies has cost implications for GOV.UK Notify.

# Additional context

This change is a short-term fix intended to buy us a bit of time to design a better solution.

