### PR TITLE
Add announcement of 2025 text message price increase

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -24,7 +24,13 @@ Text message pricing
       }
     ) }}
 
-  <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
+  {% if sms_rate != 2.33 %}
+   <div class="govuk-inset-text">
+     <p class="govuk-body">On 1 April 2025 the cost of sending a text message will go up to 2.33 pence (plus VAT).</p>
+   </div>
+   {% endif %}  
+
+<p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} (plus VAT) for each text message you send.</p>
 
   <div class="bottom-gutter-3-2">


### PR DESCRIPTION
This PR adds an announcement to the text message pricing page.

It recycles the pattern the @quis used last year – but will need a sense check to make sure I’ve done it correctly!