### PR TITLE
Add NHS pharmacies to the allowance table

### DIFF
--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -23,8 +23,9 @@
     <li>local authorities</li>
     <li>the armed forces</li>
     <li>the NHS</li>
-    <li>the emergency services</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#gp">GP surgeries</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#gp">pharmacies</a></li>
+    <li>the emergency services</li>
     <li>state-funded schools</li>
   </ul>
   <p class="govuk-body">
@@ -52,22 +53,14 @@
     Someone from the public sector organisation you’re working with needs to create an account and add the service first. Then they can invite you to join as a team member.
   </p>
 
-<h2 class="govuk-heading-m" id="pharmacies">Pharmacies</h2>
+<h2 class="govuk-heading-m" id="gp">GP surgeries and pharmacies</h2>
   <p class="govuk-body">
-    We are reviewing the decision to let pharmacies use GOV.UK Notify. We’ll update the guidance on this page by 1 April 2025.
-  </p>
-
-<h2 class="govuk-heading-m" id="gp">GP surgeries</h2>
-  <p class="govuk-body">
-    NHS-funded GP surgeries can use GOV.UK Notify, but they:
+    NHS-funded GP surgeries and pharmacies can use GOV.UK Notify, but they:
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>do not get an <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages') }}">annual allowance of free text messages</a></li>
     <li>cannot send any text messages in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a></li>
   </ul>
-
-  <p class="govuk-body">This is because GP surgeries will be able to use <a class="govuk-link govuk-link--no-visited-state" href="https://digital.nhs.uk/services/nhs-notify">NHS Notify to send messages</a>.</p>
-  <p class="govuk-body">NHS Notify should be available to GP surgeries in 2025.</p>
 
   <h2 class="govuk-heading-m" id="public">Members of the public</h2>
   <p class="govuk-body">

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -34,11 +34,7 @@ Text message pricing
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} (plus VAT) for each text message you send.</p>
 
   <div class="bottom-gutter-3-2">
-
-    {% set who_can_use_notify_link %}
-    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("main.guidance_who_can_use_notify") }}">GP surgeries</a>
-    {% endset %}
-
+    
     {% set central_government_organisations_text %}
     Central government departments and <br>national organisations
     {% endset %}
@@ -53,7 +49,7 @@ Text message pricing
         (central_government_organisations_text, '30,000 free text message'),
         ('Local authorities and regional organisations', '10,000 free text messages'),
         ('State-funded schools', '5,000 free text messages'),
-        (who_can_use_notify_link, 'No free allowance'),
+        ('GP surgeries and NHS pharmacies', 'No free allowance'),
         ('Other organisations', '5,000 free text messages'),
       ] %}
         {% call row() %}


### PR DESCRIPTION
We have reviewed the decision to let NHS pharmacies use GOV.UK Notify.

* pharmacies are allowed to keep using Notify
* MoD pharmacies still get an allowance
* all other pharmacies – no matter how they’re funded – do not get an allowance

This PR updates our guidance pages to make the new rules clear.

We’ve also updated our guidance for GP surgeries, which has been in place for a year now and no longer needs explanation.