### PR TITLE
Move the status update into the main content

### DIFF
--- a/app/assets/javascripts/esm/focus-banner.mjs
+++ b/app/assets/javascripts/esm/focus-banner.mjs
@@ -23,7 +23,7 @@ class FocusBanner {
 
     // focus success and error banners when they appear in any content updates
     $(document).on("updateContent.onafterupdate", function(evt, el) {
-      this.focusBanner($(".banner-dangerous, .banner-default-with-tick", el));
+      this.focusBanner($(".banner-dangerous", el));
     }.bind(this));
   }
 

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -5,7 +5,7 @@
 {% macro banner(body, type=None, with_tick=False, delete_button=None, subhead=None, context=None, action=None, id=None, thing=None) %}
   <div
     class='banner{% if type %}-{{ type }}{% endif %}{% if with_tick %}-with-tick{% endif %}'
-    role='alert'
+    {% if type == 'dangerous' %}role="alert"{% else %}role="status"{% endif %}
     {% if id %}
     id={{ id }}
     {% endif %}

--- a/app/templates/views/service-settings/email-reply-to/_verify-updates.html
+++ b/app/templates/views/service-settings/email-reply-to/_verify-updates.html
@@ -1,4 +1,4 @@
-{% from "components/banner.html" import banner, banner_wrapper %}
+{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
@@ -6,21 +6,33 @@
 
 <div class="ajax-block-container">
   {% if verification_status == "pending" %}
-    {{ page_header('Checking email reply-to address') }}
-    <p class="govuk-body">
-      We’re checking that ‘{{ reply_to_email_address }}’ is a real email address.
-    </p>
-    <p class="govuk-body">
-      <span class='loading-indicator'>This can take a minute</span>
-    </p>
+    <div role="status"></div>
+    {{ page_header('Reply-to email address check') }}
+    <div role="status">
+      <p class="govuk-body">
+        We need to check that ‘{{ reply_to_email_address }}’ is a real email address.
+      </p>
+      <p class="govuk-body">
+        This can take up to a minute.
+      </p>
+      <p class="govuk-body">
+        <span class='loading-indicator'>Please wait</span>
+      </p>
+    </div>
 
     <p class="js-hidden govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_verify_reply_to_address', service_id=service_id, notification_id=notification_id, is_default=is_default, replace=replace) }}">Refresh</a>
     </p>
   {% elif verification_status == "success" %}
-    {{ banner("‘{}’ is ready to use".format(reply_to_email_address), type='default', with_tick=True) }}
-
-    {{ page_header('Checking email reply-to address') }}
+    {{ page_header('Reply-to email address check') }}
+    <div role="status">
+      <p class="govuk-body">
+        The check is complete.
+      </p>
+      <p class="govuk-body">
+        We’ve added ‘{{ reply_to_email_address }}’ to your reply-to email addresses.
+      </p>
+    </div>
     <div class="js-stick-at-bottom-when-scrolling">
       {{ govukButton({
         "element": "a",
@@ -42,7 +54,7 @@
         </p>
       {% endcall %}
     </div>
-    {{ page_header('Checking email reply-to address') }}
+    {{ page_header('Reply-to email address check') }}
     {% if replace %}
       {% set form_url = url_for('main.service_edit_email_reply_to', service_id=service_id, reply_to_email_id=replace) %}
     {% else %}

--- a/app/templates/views/service-settings/email-reply-to/verify.html
+++ b/app/templates/views/service-settings/email-reply-to/verify.html
@@ -3,7 +3,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
-  Checking email reply-to address
+  Reply-to email address check
 {% endblock %}
 
 {% block backLink %}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2871,9 +2871,9 @@ def test_service_add_reply_to_email_address_without_verification_for_platform_ad
 @pytest.mark.parametrize(
     "status,expected_failure,expected_success",
     [
-        ("delivered", 0, 1),
-        ("sending", 0, 0),
-        ("permanent-failure", 1, 0),
+        ("delivered", False, True),
+        ("sending", False, False),
+        ("permanent-failure", True, False),
     ],
 )
 @freeze_time("2018-06-01 11:11:00.061258")
@@ -2907,7 +2907,7 @@ def test_service_verify_reply_to_address(
         notification_id=notification["id"],
         _optional_args=f"?is_default={is_default}{replace}",
     )
-    assert page.select_one("h1").text == "Checking email reply-to address"
+    assert page.select_one("h1").text == "Reply-to email address check"
     back_link = page.select_one(".govuk-back-link")
     assert back_link.text.strip() == "Back"
     if replace:
@@ -2915,8 +2915,10 @@ def test_service_verify_reply_to_address(
     else:
         assert "/email-reply-to/add" in back_link["href"]
 
-    assert len(page.select("div.banner-dangerous")) == expected_failure
-    assert len(page.select("div.banner-default-with-tick")) == expected_success
+    assert (page.select_one("div.banner-dangerous") is not None) == expected_failure
+    assert (
+        page.select_one("main p.govuk-body:nth-of-type(1)").text.strip() == "The check is complete."
+    ) == expected_success
 
     if status == "delivered":
         if replace:

--- a/tests/javascripts/focus-banner.test.mjs
+++ b/tests/javascripts/focus-banner.test.mjs
@@ -56,35 +56,6 @@ describe('Focus banner', () => {
 
     });
 
-    test('If there is a div.banner-default-with-tick in the updated content, it should be focused', () => {
-
-      document.body.innerHTML = `
-        <div class="ajax-block-container">
-        </div>`;
-
-      const ajaxBlockContainer = document.querySelector('.ajax-block-container');
-
-      (new FocusBanner());
-
-      ajaxBlockContainer.innerHTML = `
-        <div class="banner-default-with-tick">
-          <h2>This is a problem with your upload</h2>
-          <p>The file uploaded needs to be a PNG</p>
-        </div>`;
-
-      // simulate a content update event
-      $(document).trigger('updateContent.onafterupdate', ajaxBlockContainer);
-
-      const bannerEl = document.querySelector('.banner-default-with-tick');
-
-      expect(document.activeElement).toBe(bannerEl);
-
-      $(bannerEl).trigger('blur');
-
-      expect(bannerEl.hasAttribute('tabindex')).toBe(false);
-
-    });
-
   });
 
 });


### PR DESCRIPTION
https://trello.com/c/wckYWWfa/1194-reply-to-success-banner-isnt-announced-to-screen-readers

Fix for successful adding of reply-to addresses not being announced to screen readers. This ended up being a lot more complicated than expected and resulted in me and @karlchillmaid deciding to move the update into the content of the page, removing the success banner in the process.

## Before

|Checking state|Complete state|Failed state|
|---|---|---|
|<img width="986" alt="checking_page_current" src="https://github.com/user-attachments/assets/6e1acdd3-78c4-4c05-ab72-3a8cd77a4a1f" />|<img width="987" alt="success_page_current" src="https://github.com/user-attachments/assets/5c79bfd4-9523-448c-b735-c55dd7f7d47d" />|<img width="986" alt="failure_page_current" src="https://github.com/user-attachments/assets/f4b4a0ec-282a-4412-b241-72ef47c2d954" />|

## After

|Checking state|Complete state|Failed state|
|---|---|---|
|<img width="991" alt="check-reply-to-address-checking-new" src="https://github.com/user-attachments/assets/f61f2c4a-39fe-4c5c-b19a-9020f75fe5f1" />|<img width="991" alt="reply-to-email-address-check-complete-new" src="https://github.com/user-attachments/assets/c8451b13-0266-49a6-8e35-0e49466ca0fd" />|<img width="991" alt="check-reply-to-address-failure-new" src="https://github.com/user-attachments/assets/10b6f56e-2617-4ff0-b664-8d9b9097ea29" />|




## Notes for reviewers

This is very screen reader-centric but I've tested this in [all the supported screen readers](https://github.com/alphagov/notifications-manuals/wiki/Support-for-browsers,-email-clients-and-assistive-technologies#support-for-assistive-technologies) so reviewers can judge it on whether the logic of these changes make sense and the code is ok, if not comfortable testing with a screen reader.

Local testing can't receive a successful callback from the email we send to check addresses. Because of this, I suggest using this update in your local DB to simulate that change, setting the interval to whatever's best for you:

```sql
UPDATE notifications SET
 notification_status = 'delivered',
 sent_at = NOW(),
 updated_at = NOW()
 WHERE created_at > NOW() - interval '1 minute';
```