### PR TITLE
Bump utils to 97.0.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.4
+# This file was automatically copied from notifications-utils@97.0.5
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.4
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.5
 
 govuk-frontend-jinja==3.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@689fdfb98b4e50be14d1a912c4c3afe80b512ac2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d9258f3c7cd213845eb0d1fa5726413669d03f06
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -164,7 +164,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@689fdfb98b4e50be14d1a912c4c3afe80b512ac2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d9258f3c7cd213845eb0d1fa5726413669d03f06
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.4
+# This file was automatically copied from notifications-utils@97.0.5
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.4
+# This file was automatically copied from notifications-utils@97.0.5
 
 exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 97.0.5

* Fix mailto: URLs in Markdown links

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/97.0.4...97.0.5