### PR TITLE
Major utils bump to 98.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.5
+# This file was automatically copied from notifications-utils@98.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.5
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@98.0.0
 
 govuk-frontend-jinja==3.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d9258f3c7cd213845eb0d1fa5726413669d03f06
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@794b88afc06bff187a3d58db0ed5f2871bad7ba6
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -164,7 +164,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d9258f3c7cd213845eb0d1fa5726413669d03f06
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@794b88afc06bff187a3d58db0ed5f2871bad7ba6
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.5
+# This file was automatically copied from notifications-utils@98.0.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.5
+# This file was automatically copied from notifications-utils@98.0.0
 
 exclude = [
     "migrations/versions/",


### PR DESCRIPTION
This brings in the international text message rate multipliers for 1 April 2025 onwards.

Dominican Republic now appears 3 times on the pricing table since it now has three country prefixes, but we've agreed this is fine for now since this change needs to be made soon:
<img width="694" alt="Screenshot 2025-03-31 at 16 03 23" src="https://github.com/user-attachments/assets/418c3d3d-7aee-4347-8a87-adcf5c25c74e" />

