### PR TITLE
Update pricing pages

### DIFF
--- a/app/main/views/pricing.py
+++ b/app/main/views/pricing.py
@@ -30,7 +30,7 @@ def guidance_pricing_text_messages():
         ),
         _search_form=SearchByNameForm(),
         navigation_links=pricing_nav(),
-        last_updated=datetime(2025, 3, 21).astimezone(UTC),
+        last_updated=datetime(2025, 4, 1).astimezone(UTC),
     )
 
 

--- a/app/templates/views/guidance/pricing/letter-pricing.html
+++ b/app/templates/views/guidance/pricing/letter-pricing.html
@@ -20,23 +20,6 @@
       }
     ) }}
 
-  <div class="govuk-inset-text">
-    <p class="govuk-body">
-    Royal Mail is increasing its rates.
-    </p>
-    <p class="govuk-body">
-      On 1 April 2025:
-    </p> 
-
-    <ul class="govuk-list govuk-list--bullet">
-     <li>first class letters will go up by 52 pence</li>
-     <li>second class letters will go up by between 7 and 9 pence</li>
-    </ul>
-    <p class="govuk-body">
-      The exact difference for second class postage will depend on the number of pages in your letter. The changes listed do not include VAT. 
-    </p>  
-  </div>
-  
   <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
   <p class="govuk-body">Prices include:</p>

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -24,12 +24,15 @@ Text message pricing
       }
     ) }}
 
-  {% if sms_rate != 2.33 %}
-   <div class="govuk-inset-text">
-     <p class="govuk-body">On 1 April 2025 the cost of sending a text message will go up to 2.33 pence (plus VAT).</p>
-   </div>
-   {% endif %}  
-
+  <div class="govuk-inset-text">
+    <p class="govuk-body">
+    International text message rates have changed.
+    </p>
+    <p class="govuk-body">
+      Find out what it costs to <a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">send text messages to international numbers</a>.
+    </p>  
+  </div>
+  
 <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} (plus VAT) for each text message you send.</p>
 

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -18,8 +18,7 @@
     <div class="govuk-grid-column-five-sixths">
       {{ page_header('Send international text messages') }}
       <p class="govuk-body">
-        Messages to international mobile numbers are charged at 1, 2, or
-        3 times the cost of messages to UK mobile numbers.</p>
+        Messages to international mobile numbers are charged at between 1 and 12 times the cost of messages to UK mobile numbers.</p>
       <p class="govuk-body">
         See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages', _anchor='international-numbers') }}">pricing</a> for the list
         of rates.

--- a/tests/app/main/views/test_pricing.py
+++ b/tests/app/main/views/test_pricing.py
@@ -29,24 +29,16 @@ def test_guidance_pricing_letters(client_request, mock_get_letter_rates):
     "valid_from, expected_last_updated",
     (
         ("2040-04-01T12:00:00", "Last updated 1 April 2040"),
-        ("2023-04-01T12:00:00", "Last updated 21 March 2025"),
+        ("2025-04-01T12:00:00", "Last updated 1 April 2025"),
     ),
 )
 @pytest.mark.parametrize(
     "rate, expected_first_paragraph, expected_second_paragraph",
     (
         (
-            0.0227,
-            "On 1 April 2025 the cost of sending a text message will go up to 2.33 pence (plus VAT).",
-            "Each unique service you add has an annual allowance of free text messages.",
-        ),
-        (
             0.0233,
-            "Each unique service you add has an annual allowance of free text messages.",
-            (
-                "When a service has used its annual allowance, it costs 2.33 pence (plus VAT) "
-                "for each text message you send."
-            ),
+            "International text message rates have changed.",
+            "Find out what it costs to send text messages to international numbers.",
         ),
     ),
 )


### PR DESCRIPTION
This PR:

* removes the inset text announcing upcoming price changes for letters and text messages
* adds a new inset text area to the text message pricing page, announcing the changes to international SMS rates
* updates the international text messages settings page, to reflect the increase in rates