### PR TITLE
Let platform admins remove each other’s permission

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -24,6 +24,7 @@ $govuk-assets-path: "/static/";
 @import "govuk/components/tabs/index";
 @import "govuk/components/textarea/index";
 @import "govuk/components/summary-list/index";
+@import "govuk/components/tag/index";
 
 @import "govuk/utilities";
 @import "govuk/overrides";

--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -21,6 +21,7 @@ EVENT_SCHEMAS = {
     "update_email_branding": {"email_branding_id", "updated_by_id", "old_email_branding"},
     "update_letter_branding": {"letter_branding_id", "updated_by_id", "old_letter_branding"},
     "set_inbound_sms_on": {"user_id", "service_id", "inbound_number_id"},
+    "remove_platform_admin": {"user_id", "removed_by_id"},
 }
 
 
@@ -70,6 +71,10 @@ def create_update_letter_branding_event(**kwargs):
 
 def create_set_inbound_sms_on_event(**kwargs):
     _send_event("set_inbound_sms_on", **kwargs)
+
+
+def create_remove_platform_admin_event(**kwargs):
+    _send_event("remove_platform_admin", **kwargs)
 
 
 def _send_event(event_type, **kwargs):

--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -19,6 +19,17 @@ def user_information(user_id):
     )
 
 
+@main.route("/users/<uuid:user_id>/remove-platform-admin", methods=["GET", "POST"])
+@user_is_platform_admin
+def remove_platform_admin(user_id):
+    if request.method == "POST":
+        User.from_id(user_id).update(platform_admin=False)
+        return redirect(url_for(".user_information", user_id=user_id))
+
+    flash("Are you sure you want to remove platform admin from this user?", "remove")
+    return user_information(user_id)
+
+
 @main.route("/users/<uuid:user_id>/archive", methods=["GET", "POST"])
 @user_is_platform_admin
 def archive_user(user_id):

--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -23,7 +23,7 @@ def user_information(user_id):
 @user_is_platform_admin
 def remove_platform_admin(user_id):
     if request.method == "POST":
-        User.from_id(user_id).update(platform_admin=False)
+        User.from_id(user_id).remove_platform_admin()
         return redirect(url_for(".user_information", user_id=user_id))
 
     flash("Are you sure you want to remove platform admin from this user?", "remove")

--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
 from app import user_api_client
-from app.event_handlers import create_archive_user_event
+from app.event_handlers import create_archive_user_event, create_remove_platform_admin_event
 from app.main import main
 from app.main.forms import AuthTypeForm
 from app.models.user import User
@@ -24,6 +24,7 @@ def user_information(user_id):
 def remove_platform_admin(user_id):
     if request.method == "POST":
         User.from_id(user_id).remove_platform_admin()
+        create_remove_platform_admin_event(user_id=str(user_id), removed_by_id=current_user.id)
         return redirect(url_for(".user_information", user_id=user_id))
 
     flash("Are you sure you want to remove platform admin from this user?", "remove")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -469,6 +469,14 @@ class User(BaseUser, UserMixin):
             and self.has_permission_for_organisation(service.organisation_id, PERMISSION_CAN_MAKE_SERVICES_LIVE)
         )
 
+    def remove_platform_admin(self):
+        if not self.platform_admin:
+            return
+        self.update(
+            platform_admin=False,
+            auth_type="sms_auth" if self.mobile_number else "email_auth",
+        )
+
 
 class InvitedUser(BaseUser):
     service: Any

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -19,6 +19,7 @@ ALLOWED_ATTRIBUTES = {
     "email_access_validated_at",
     "take_part_in_research",
     "receives_new_features_email",
+    "platform_admin",
 }
 
 
@@ -64,6 +65,9 @@ class UserApiClient(NotifyAdminAPIClient):
         disallowed_attributes = set(data.keys()) - ALLOWED_ATTRIBUTES
         if disallowed_attributes:
             raise TypeError(f"Not allowed to update user attributes: {', '.join(disallowed_attributes)}")
+
+        if "platform_admin" in data and data["platform_admin"] is not False:
+            raise TypeError(f"Not allowed to update user attribute platform_admin to {data['platform_admin']}")
 
         url = f"/user/{user_id}"
         user_data = self.post(url, data=data)

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -10,6 +10,13 @@
       <h1 class="heading-large">
         {{ user.name }}
       </h1>
+      {% if user.platform_admin %}
+        <p class="govuk-body">
+          <strong class="govuk-tag govuk-tag--red">Platform admin</strong>
+          &ensp;
+          <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.remove_platform_admin', user_id=user.id) }}">Remove</a>
+        </p>
+      {% endif %}
       <p class="govuk-body">{{ user.email_address }}</p>
       <p class="{{ '' if user.mobile_number else 'hint' }}">{{ user.mobile_number or 'No mobile number'}}</p>
 

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -211,7 +211,7 @@ def test_remove_platform_admin_prompts_for_confirmation(
         (None, "email_auth"),
     ),
 )
-def test_remove_platform_removes(
+def test_remove_platform_admin_removes_user_admin_privilege_and_changes_user_auth(
     client_request,
     platform_admin_user,
     fake_uuid,

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -5,7 +5,7 @@ from flask import url_for
 from notifications_python_client.errors import HTTPError
 
 from tests import user_json
-from tests.conftest import normalize_spaces
+from tests.conftest import create_user, normalize_spaces
 
 
 def test_user_information_page_shows_information_about_user(
@@ -64,6 +64,8 @@ def test_user_information_page_shows_information_about_user(
         "Nature Therapy",
         "Fresh Orchard Juice",
     ]
+
+    assert "platform admin" not in page.select_one("main").text.lower()
 
 
 def test_user_information_page_shows_change_auth_type_link(
@@ -163,6 +165,58 @@ def test_user_information_page_displays_if_there_are_failed_login_attempts(
     page = client_request.get("main.user_information", user_id=fake_uuid)
 
     assert normalize_spaces(page.select("main p")[-1].text) == "2 failed login attempts"
+
+
+def test_user_information_page_shows_if_user_is_platform_admin(
+    client_request,
+    platform_admin_user,
+    api_user_active,
+    mock_get_organisations_and_services_for_user,
+    mocker,
+):
+    client_request.login(platform_admin_user)
+    other_platform_admin_user = create_user(platform_admin=True, id=uuid.uuid4())
+    mocker.patch("app.user_api_client.get_user", return_value=other_platform_admin_user)
+
+    page = client_request.get("main.user_information", user_id=other_platform_admin_user["id"])
+
+    assert normalize_spaces(page.select_one(".govuk-tag").text) == "Platform admin"
+    assert normalize_spaces(page.select_one("main p a").text) == "Remove"
+    assert page.select_one("main p a")["href"] == url_for(
+        "main.remove_platform_admin",
+        user_id=other_platform_admin_user["id"],
+    )
+
+
+def test_remove_platform_admin_prompts_for_confirmation(
+    client_request,
+    platform_admin_user,
+    api_user_active,
+    mock_get_organisations_and_services_for_user,
+):
+    client_request.login(platform_admin_user)
+    page = client_request.get("main.remove_platform_admin", user_id=api_user_active["id"])
+
+    assert normalize_spaces(page.select_one("div.banner-dangerous").text) == (
+        "Are you sure you want to remove platform admin from this user? Yes, remove"
+    )
+    assert page.select_one("div.banner-dangerous form[method=post] button[type=submit]")
+
+
+def test_remove_platform_removes(
+    client_request,
+    platform_admin_user,
+    api_user_active,
+    mock_get_organisations_and_services_for_user,
+    mock_update_user_attribute,
+):
+    client_request.login(platform_admin_user)
+    client_request.post("main.remove_platform_admin", user_id=api_user_active["id"])
+
+    mock_update_user_attribute.assert_called_once_with(
+        api_user_active["id"],
+        platform_admin=False,
+    )
 
 
 def test_user_information_page_shows_archive_link_for_active_users(

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import ANY, call
 
 import pytest
 from flask import url_for
@@ -218,6 +219,7 @@ def test_remove_platform_removes(
     mock_update_user_attribute,
     mobile_number,
     expected_auth_type,
+    mock_events,
 ):
     platform_admin_user["mobile_number"] = mobile_number
     client_request.login(platform_admin_user)
@@ -228,6 +230,7 @@ def test_remove_platform_removes(
         platform_admin=False,
         auth_type=expected_auth_type,
     )
+    assert mock_events.call_args_list == [call("remove_platform_admin", ANY)]
 
 
 def test_user_information_page_shows_archive_link_for_active_users(

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -203,19 +203,30 @@ def test_remove_platform_admin_prompts_for_confirmation(
     assert page.select_one("div.banner-dangerous form[method=post] button[type=submit]")
 
 
+@pytest.mark.parametrize(
+    "mobile_number, expected_auth_type",
+    (
+        ("12345", "sms_auth"),
+        (None, "email_auth"),
+    ),
+)
 def test_remove_platform_removes(
     client_request,
     platform_admin_user,
-    api_user_active,
+    fake_uuid,
     mock_get_organisations_and_services_for_user,
     mock_update_user_attribute,
+    mobile_number,
+    expected_auth_type,
 ):
+    platform_admin_user["mobile_number"] = mobile_number
     client_request.login(platform_admin_user)
-    client_request.post("main.remove_platform_admin", user_id=api_user_active["id"])
+    client_request.post("main.remove_platform_admin", user_id=fake_uuid)
 
     mock_update_user_attribute.assert_called_once_with(
-        api_user_active["id"],
+        platform_admin_user["id"],
         platform_admin=False,
+        auth_type=expected_auth_type,
     )
 
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -247,6 +247,7 @@ EXCLUDED_ENDPOINTS = set(
             "register_from_org_invite",
             "register",
             "registration_continue",
+            "remove_platform_admin",
             "remove_user_from_organisation",
             "remove_user_from_service",
             "rename_template",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -385,6 +385,7 @@
     "/users/<uuid:user_id>",
     "/users/<uuid:user_id>/archive",
     "/users/<uuid:user_id>/change_auth",
+    "/users/<uuid:user_id>/remove-platform-admin",
     "/using-notify",
     "/using-notify/api-documentation",
     "/using-notify/attach-pages",


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/4418

***

Sometimes we need to do this if someone has lost their Yubikey and needs to log back in to add a new one. Other times we need to do it because people have left the team.

It might also be useful if we ever needed to revoke someone’s platform admin access in a hurry (although we’d probably archive their whole account in that case).

Keeping some safeguards in here so that it isn’t possible to write code which _grants_ platform admin access through the UI (that should still be done through the DB).


<img width="805" alt="image" src="https://github.com/user-attachments/assets/e612985a-bc77-42e7-b1d5-445c05c02cfc" />

<img width="795" alt="image" src="https://github.com/user-attachments/assets/1a1882bf-8622-4c74-9dcb-326d3d36e16b" />
