### PR TITLE
BUGFIX: Adjust enhanced texbox height

### DIFF
--- a/app/assets/javascripts/esm/enhanced-textbox.mjs
+++ b/app/assets/javascripts/esm/enhanced-textbox.mjs
@@ -61,7 +61,12 @@ class EnhancedTextbox {
     this.$textbox.style.height =
       `${Math.max(
           this.initialHeight,
-          this.$backgroundHighlightElement.offsetHeight
+          // jquery .height and vanilla javascript offsetHeight or clientHeight 
+          // take padding values into account in different ways
+          // 15px adjustment would suffice to account for 15px padding
+          // set in CSS, but adjusting the height by 16px prevents the scrollbar
+          // from appearing entirely
+          this.$backgroundHighlightElement.offsetHeight + 16
       )}px`;
 
     if ('stickAtBottomWhenScrolling' in GOVUK) {


### PR DESCRIPTION
 jquery .height and vanilla javascript offsetHeight or clientHeight take padding values into account in different ways. A 15px adjustment would suffice to account for 15px padding set in CSS, but adjusting the height by 16px prevents the scrollbar from appearing entirely.

Before

https://github.com/user-attachments/assets/6417f935-8219-4328-b7db-c945e0c70236



After

https://github.com/user-attachments/assets/6a29bfe0-30a6-4204-b8fb-db2469bcbb6b

