### PR TITLE
Hide economy postage rates

### DIFF
--- a/app/models/letter_rates.py
+++ b/app/models/letter_rates.py
@@ -35,7 +35,10 @@ class LetterRates(ModelList):
 
     @staticmethod
     def _get_items(*args, **kwargs):
-        return letter_rate_api_client.get_letter_rates(*args, **kwargs)
+        # Once the economy postage is live, we can remove this logic
+        resp = letter_rate_api_client.get_letter_rates(*args, **kwargs)
+        filtered_letter_rates = filter(lambda r: r["post_class"] in LetterRates.post_classes, resp)
+        return list(filtered_letter_rates)
 
     @property
     def rates(self):


### PR DESCRIPTION
We have added the new economy rates to the database in [this PR](https://github.com/alphagov/notifications-api/pull/4426). In some parts of the admin, the new rates were showing and could confuse users, so we added logic to filter out the economy postage options for now.
