### PR TITLE
BUGFIX: Adjust enhanced texbox background element computed height

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -184,9 +184,8 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
     white-space: pre-wrap;
     overflow-wrap: break-word;
     word-wrap: break-word;
-    padding: 4px;
+    padding: 4px 4px govuk-spacing(6) 4px;
     border: 2px solid transparent;
-    padding-bottom: govuk-spacing(3);
     z-index: 10;
     // match govuk-textarea line height
     line-height: 1.25;


### PR DESCRIPTION

jquery .height and vanilla javascript offsetHeight  or clientHeight take padding values into account 
in different ways. A 10px padding adjustment would  suffice but adjusting the padding by 15px prevents the scrollbar from appearing entirely.


Before

https://github.com/user-attachments/assets/6417f935-8219-4328-b7db-c945e0c70236



After

https://github.com/user-attachments/assets/6a29bfe0-30a6-4204-b8fb-db2469bcbb6b