### PR TITLE
Add economy letter feature flag

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -86,6 +86,7 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = {
     "extra_email_formatting": {"title": "Extra email formatting options", "requires": "email"},
     "extra_letter_formatting": {"title": "Extra letter formatting options", "requires": "letter"},
     "sms_to_uk_landlines": {"title": "Sending SMS to UK landlines"},
+    "economy_letter_sending": {"title": "Sending economy letters", "requires": "letter"},
 }
 
 THANKS_FOR_BRANDING_REQUEST_MESSAGE = (

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -76,6 +76,7 @@ class Service(JSONModel):
         "international_sms",
         "upload_document",
         "sms_to_uk_landlines",
+        "economy_letter_sending",
     )
 
     @classmethod

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -103,6 +103,18 @@ def test_service_set_permission_requires_platform_admin(
             "False",
             [],
         ),
+        (
+            ["letter"],
+            "economy_letter_sending",
+            "True",
+            ["letter", "economy_letter_sending"],
+        ),
+        (
+            ["letter", "economy_letter_sending"],
+            "economy_letter_sending",
+            "False",
+            ["letter"],
+        ),
     ],
 )
 def test_service_set_permission(
@@ -158,6 +170,12 @@ def test_service_set_permission(
             ".service_set_permission",
             {"permission": "extra_letter_formatting"},
             "Extra letter formatting options Off Change your settings for Extra letter formatting options",
+        ),
+        (
+            {"permissions": ["letter"]},
+            ".service_set_permission",
+            {"permission": "economy_letter_sending"},
+            "Sending economy letters Off Change your settings for Sending economy letters",
         ),
     ],
 )

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -162,6 +162,7 @@ def mock_get_service_settings_page_common(
                 "Email authentication Off Change your settings for Email authentication",
                 "Extra letter formatting options Off Change your settings for Extra letter formatting options",
                 "Sending SMS to UK landlines Off Change your settings for Sending SMS to UK landlines",
+                "Sending economy letters Off Change your settings for Sending economy letters",
             ],
         ),
     ],


### PR DESCRIPTION
We have added a service-level permission economy letter feature flag to make sure other teams do not accidentally use the economy rates or options while we are still developing the feature. [Card](https://trello.com/c/k2L5QcH2/1249-service-level-permission-for-economy-rates) for this PR.