### PR TITLE
Hide new economy postage option on admin

### DIFF
--- a/app/models/letter_rates.py
+++ b/app/models/letter_rates.py
@@ -37,8 +37,7 @@ class LetterRates(ModelList):
     def _get_items(*args, **kwargs):
         # Once the economy postage is live, we can remove this logic
         resp = letter_rate_api_client.get_letter_rates(*args, **kwargs)
-        filtered_letter_rates = filter(lambda r: r["post_class"] in LetterRates.post_classes, resp)
-        return list(filtered_letter_rates)
+        return [rate for rate in resp if rate["post_class"] in LetterRates.post_classes]
 
     @property
     def rates(self):


### PR DESCRIPTION
We have added the new economy rates to the database. In some parts of the admin, the new rates were showing and could confuse users, so we added logic to filter out the economy postage options for now.
Minor refactor of previous [PR](https://github.com/alphagov/notifications-admin/pull/5430).