### PR TITLE
Refactor event handlers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,6 +47,7 @@ memo_resetters: list[Callable] = []
 from app import proxy_fix, webauthn_server
 from app.commands import setup_commands
 from app.config import Config, configs
+from app.event_handlers import Events
 from app.extensions import antivirus_client, redis_client, zendesk_client  # noqa
 from app.formatters import (
     convert_to_boolean,
@@ -549,10 +550,12 @@ def setup_blueprints(application):
     application.register_blueprint(status_blueprint)
 
 
+def on_user_logged_in(_sender, user):
+    Events.sucessful_login(user_id=user.id)
+
+
 def setup_event_handlers():
     from flask_login import user_logged_in
-
-    from app.event_handlers import on_user_logged_in
 
     user_logged_in.connect(on_user_logged_in)
 

--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -47,7 +47,7 @@ class Events(metaclass=EventsMeta):
     update_email_branding = {"email_branding_id", "updated_by_id", "old_email_branding"}
     update_letter_branding = {"letter_branding_id", "updated_by_id", "old_letter_branding"}
     set_inbound_sms_on = {"user_id", "service_id", "inbound_number_id"}
-    remove_platform_admin: {"user_id", "removed_by_id"}
+    remove_platform_admin = {"user_id", "removed_by_id"}
 
 
 def _construct_event_data(request):
@@ -63,16 +63,10 @@ def _get_remote_addr(request):
 
 
 def _get_browser_fingerprint(request):
-    browser = request.user_agent.browser
-    version = request.user_agent.version
-    platform = request.user_agent.platform
-    user_agent_string = request.user_agent.string
     # at some point this may be hashed?
-    finger_print = {
-        "browser": browser,
-        "platform": platform,
-        "version": version,
-        "user_agent_string": user_agent_string,
+    return {
+        "browser": request.user_agent.browser,
+        "platform": request.user_agent.platform,
+        "version": request.user_agent.version,
+        "user_agent_string": request.user_agent.string,
     }
-
-    return finger_print

--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -14,10 +14,11 @@ class Event:
         if self.schema != actual_keys:
             raise ValueError(f"Expected {self.schema}, but got {actual_keys}")
 
-        event_data = _construct_event_data()
-        event_data.update(kwargs)
+        events_api_client.create_event(self.name, self.event_data | kwargs)
 
-        events_api_client.create_event(self.name, event_data)
+    @property
+    def event_data(self):
+        return {"ip_address": _get_remote_addr(), "browser_fingerprint": _get_browser_fingerprint()}
 
 
 class EventsMeta(type):
@@ -48,10 +49,6 @@ class Events(metaclass=EventsMeta):
     update_letter_branding = {"letter_branding_id", "updated_by_id", "old_letter_branding"}
     set_inbound_sms_on = {"user_id", "service_id", "inbound_number_id"}
     remove_platform_admin = {"user_id", "removed_by_id"}
-
-
-def _construct_event_data():
-    return {"ip_address": _get_remote_addr(), "browser_fingerprint": _get_browser_fingerprint()}
 
 
 # This might not be totally correct depending on proxy setup

--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -14,7 +14,7 @@ class Event:
         if self.schema != actual_keys:
             raise ValueError(f"Expected {self.schema}, but got {actual_keys}")
 
-        event_data = _construct_event_data(request)
+        event_data = _construct_event_data()
         event_data.update(kwargs)
 
         events_api_client.create_event(self.name, event_data)
@@ -50,19 +50,19 @@ class Events(metaclass=EventsMeta):
     remove_platform_admin = {"user_id", "removed_by_id"}
 
 
-def _construct_event_data(request):
-    return {"ip_address": _get_remote_addr(request), "browser_fingerprint": _get_browser_fingerprint(request)}
+def _construct_event_data():
+    return {"ip_address": _get_remote_addr(), "browser_fingerprint": _get_browser_fingerprint()}
 
 
 # This might not be totally correct depending on proxy setup
-def _get_remote_addr(request):
+def _get_remote_addr():
     if request.headers.getlist("X-Forwarded-For"):
         return request.headers.getlist("X-Forwarded-For")[0]
     else:
         return request.remote_addr
 
 
-def _get_browser_fingerprint(request):
+def _get_browser_fingerprint():
     # at some point this may be hashed?
     return {
         "browser": request.user_agent.browser,

--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -58,8 +58,7 @@ def _construct_event_data():
 def _get_remote_addr():
     if request.headers.getlist("X-Forwarded-For"):
         return request.headers.getlist("X-Forwarded-For")[0]
-    else:
-        return request.remote_addr
+    return request.remote_addr
 
 
 def _get_browser_fingerprint():

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -6,7 +6,7 @@ from notifications_python_client.errors import HTTPError
 from werkzeug.datastructures import FileStorage
 
 from app import email_branding_client
-from app.event_handlers import create_update_email_branding_event
+from app.event_handlers import Events
 from app.main import main
 from app.main.forms import (
     AdminEditEmailBrandingForm,
@@ -96,7 +96,7 @@ def platform_admin_update_email_branding(branding_id):
                 brand_type=form.brand_type.data,
                 updated_by_id=current_user.id,
             )
-            create_update_email_branding_event(
+            Events.update_email_branding(
                 email_branding_id=branding_id,
                 updated_by_id=str(current_user.id),
                 old_email_branding=email_branding.serialize(),

--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
 from app import user_api_client
-from app.event_handlers import create_archive_user_event, create_remove_platform_admin_event
+from app.event_handlers import Events
 from app.main import main
 from app.main.forms import AuthTypeForm
 from app.models.user import User
@@ -24,7 +24,7 @@ def user_information(user_id):
 def remove_platform_admin(user_id):
     if request.method == "POST":
         User.from_id(user_id).remove_platform_admin()
-        create_remove_platform_admin_event(user_id=str(user_id), removed_by_id=current_user.id)
+        Events.remove_platform_admin(user_id=str(user_id), removed_by_id=current_user.id)
         return redirect(url_for(".user_information", user_id=user_id))
 
     flash("Are you sure you want to remove platform admin from this user?", "remove")
@@ -48,7 +48,7 @@ def archive_user(user_id):
                 )
                 return redirect(url_for("main.user_information", user_id=user_id))
 
-        create_archive_user_event(
+        Events.archive_user(
             user_id=str(user_id), user_email_address=original_email_address, archived_by_id=current_user.id
         )
 

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -4,7 +4,7 @@ from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
 from app import letter_branding_client, logo_client
-from app.event_handlers import create_update_letter_branding_event
+from app.event_handlers import Events
 from app.main import main
 from app.main.forms import (
     AdminEditLetterBrandingForm,
@@ -81,7 +81,7 @@ def update_letter_branding(branding_id):
                 name=letter_branding_details_form.name.data,
                 updated_by_id=current_user.id,
             )
-            create_update_letter_branding_event(
+            Events.update_letter_branding(
                 letter_branding_id=branding_id,
                 updated_by_id=current_user.id,
                 old_letter_branding=letter_branding.serialize(),

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -4,11 +4,7 @@ from notifications_python_client.errors import HTTPError
 
 from app import current_service, service_api_client
 from app.constants import SERVICE_JOIN_REQUEST_APPROVED, SERVICE_JOIN_REQUEST_REJECTED
-from app.event_handlers import (
-    create_email_change_event,
-    create_mobile_number_change_event,
-    create_remove_user_from_service_event,
-)
+from app.event_handlers import Events
 from app.formatters import redact_mobile_number
 from app.main import main
 from app.main.forms import (
@@ -280,7 +276,7 @@ def remove_user_from_service(service_id, user_id):
         else:
             abort(500, e)
     else:
-        create_remove_user_from_service_event(user_id=user_id, removed_by_id=current_user.id, service_id=service_id)
+        Events.remove_user_from_service(user_id=user_id, removed_by_id=current_user.id, service_id=service_id)
 
     return redirect(url_for(".manage_users", service_id=service_id))
 
@@ -329,7 +325,7 @@ def confirm_edit_user_email(service_id, user_id):
         except HTTPError as e:
             abort(500, e)
         else:
-            create_email_change_event(
+            Events.update_user_email(
                 user_id=user.id,
                 updated_by_id=current_user.id,
                 original_email_address=user.email_address,
@@ -380,7 +376,7 @@ def confirm_edit_user_mobile_number(service_id, user_id):
         except HTTPError as e:
             abort(500, e)
         else:
-            create_mobile_number_change_event(
+            Events.update_user_mobile_number(
                 user_id=user.id,
                 updated_by_id=current_user.id,
                 original_mobile_number=user.mobile_number,

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -25,10 +25,7 @@ from app import (
     service_api_client,
 )
 from app.constants import SIGN_IN_METHOD_TEXT_OR_EMAIL
-from app.event_handlers import (
-    create_archive_service_event,
-    create_set_inbound_sms_on_event,
-)
+from app.event_handlers import Events
 from app.extensions import zendesk_client
 from app.main import json_updates, main
 from app.main.forms import (
@@ -342,7 +339,7 @@ def archive_service(service_id):
         cached_service_user_ids = [user.id for user in current_service.active_users]
 
         service_api_client.archive_service(service_id, cached_service_user_ids)
-        create_archive_service_event(service_id=service_id, archived_by_id=current_user.id)
+        Events.archive_service(service_id=service_id, archived_by_id=current_user.id)
 
         flash(
             f"‘{current_service.name}’ was deleted",
@@ -686,7 +683,7 @@ def service_receive_text_messages_start(service_id):
     if request.method == "POST":
         sms_sender = inbound_number_client.add_inbound_number_to_service(current_service.id)
         current_service.force_permission("inbound_sms", on=True)
-        create_set_inbound_sms_on_event(
+        Events.set_inbound_sms_on(
             user_id=current_user.id,
             service_id=current_service.id,
             inbound_number_id=sms_sender["inbound_number_id"],

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -7,11 +7,7 @@ from notifications_python_client.errors import HTTPError
 from werkzeug.utils import cached_property
 
 from app.constants import PERMISSION_CAN_MAKE_SERVICES_LIVE
-from app.event_handlers import (
-    create_add_user_to_service_event,
-    create_set_organisation_user_permissions_event,
-    create_set_user_permissions_event,
-)
+from app.event_handlers import Events
 from app.models import JSONModel, ModelList
 from app.models.organisation import Organisation, Organisations
 from app.models.webauthn_credential import WebAuthnCredentials
@@ -154,7 +150,7 @@ class User(BaseUser, UserMixin):
             permissions=permissions,
             folder_permissions=folder_permissions,
         )
-        create_set_user_permissions_event(
+        Events.set_user_permissions(
             user_id=self.id,
             service_id=service_id,
             original_ui_permissions=self.permissions_for_service(service_id),
@@ -168,7 +164,7 @@ class User(BaseUser, UserMixin):
             organisation_id=organisation_id,
             permissions=[{"permission": p} for p in permissions],
         )
-        create_set_organisation_user_permissions_event(
+        Events.set_organisation_user_permissions(
             user_id=self.id,
             organisation_id=organisation_id,
             original_permissions=self.permissions_for_organisation(organisation_id),
@@ -429,7 +425,7 @@ class User(BaseUser, UserMixin):
                 permissions,
                 folder_permissions,
             )
-            create_add_user_to_service_event(
+            Events.add_user_to_service(
                 user_id=self.id,
                 invited_by_id=invited_by_id,
                 service_id=service_id,

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -514,7 +514,7 @@ class TestEditOrganisationUser:
         mock_set_org_permissions = mocker.patch(
             "app.notify_client.user_api_client.UserApiClient.set_organisation_permissions"
         )
-        mock_event = mocker.patch("app.models.user.create_set_organisation_user_permissions_event")
+        mock_event = mocker.patch("app.models.user.Events.set_organisation_user_permissions")
         client_request.login(platform_admin_user)
 
         # Override the `get_user` mock from `login` because we need to be able to get multiple users
@@ -560,7 +560,7 @@ class TestEditOrganisationUser:
     ):
         mocker.patch("app.models.user.OrganisationUsers._get_items", return_value=[_other_user])
         mocker.patch("app.notify_client.user_api_client.UserApiClient.set_organisation_permissions")
-        mocker.patch("app.models.user.create_set_organisation_user_permissions_event")
+        mocker.patch("app.models.user.Events.set_organisation_user_permissions")
         client_request.login(platform_admin_user)
 
         # Override the `get_user` mock from `login` because we need to be able to get multiple users

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4840,7 +4840,7 @@ def test_archive_service_after_confirm(
 ):
     service_one["restricted"] = is_trial_service
     mock_api = mocker.patch("app.service_api_client.post")
-    mock_event = mocker.patch("app.main.views.service_settings.index.create_archive_service_event")
+    mock_event = mocker.patch("app.main.views.service_settings.index.Events.archive_service")
     redis_delete_mock = mocker.patch("app.notify_client.service_api_client.redis_client.delete")
     mocker.patch("app.notify_client.service_api_client.redis_client.delete_by_pattern")
 
@@ -5675,7 +5675,7 @@ def test_post_service_receive_text_messages_start_turns_on_feature_and_redirects
         "app.inbound_number_client.add_inbound_number_to_service",
         return_value={"id": "abcd", "service_id": SERVICE_ONE_ID, "inbound_number_id": "1234"},
     )
-    mock_event = mocker.patch("app.main.views.service_settings.index.create_set_inbound_sms_on_event")
+    mock_event = mocker.patch("app.main.views.service_settings.index.Events.set_inbound_sms_on")
 
     page = client_request.post(
         ".service_receive_text_messages_start", service_id=SERVICE_ONE_ID, _follow_redirects=True

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -508,9 +508,7 @@ def test_update_existing_branding(
     }
 
     mocker.patch("app.main.views.email_branding.logo_client.save_permanent_logo", return_value="email/test.png")
-    mock_create_update_email_branding_event = mocker.patch(
-        "app.main.views.email_branding.create_update_email_branding_event"
-    )
+    mock_create_update_email_branding_event = mocker.patch("app.main.views.email_branding.Events.update_email_branding")
 
     client_request.login(platform_admin_user)
     client_request.post(
@@ -570,7 +568,7 @@ def test_update_existing_branding_does_not_reupload_logo_if_unchanged(
     }
 
     mock_save_permanent = mocker.patch("app.main.views.email_branding.logo_client.save_permanent_logo")
-    mocker.patch("app.main.views.email_branding.create_update_email_branding_event")
+    mocker.patch("app.main.views.email_branding.Events.update_email_branding")
 
     client_request.login(platform_admin_user)
     client_request.post(

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -272,7 +272,7 @@ def test_update_letter_branding_with_original_file_and_new_details(
     mock_save_temporary = mocker.patch("app.main.views.letter_branding.logo_client.save_temporary_logo")
     mock_save_permanent = mocker.patch("app.main.views.letter_branding.logo_client.save_permanent_logo")
     mock_create_update_letter_branding_event = mocker.patch(
-        "app.main.views.letter_branding.create_update_letter_branding_event"
+        "app.main.views.letter_branding.Events.update_letter_branding"
     )
 
     client_request.login(platform_admin_user)
@@ -368,7 +368,7 @@ def test_update_letter_branding_with_new_file_and_new_details(
     )
     mock_client_update = mocker.patch("app.main.views.letter_branding.letter_branding_client.update_letter_branding")
     mock_create_update_letter_branding_event = mocker.patch(
-        "app.main.views.letter_branding.create_update_letter_branding_event"
+        "app.main.views.letter_branding.Events.update_letter_branding"
     )
 
     branding_id = str(UUID(int=0))
@@ -407,7 +407,7 @@ def test_update_letter_branding_does_not_save_to_db_if_uploading_fails(
 ):
     mock_client_update = mocker.patch("app.main.views.letter_branding.letter_branding_client.update_letter_branding")
     mock_create_update_letter_branding_event = mocker.patch(
-        "app.main.views.letter_branding.create_update_letter_branding_event"
+        "app.main.views.letter_branding.Events.update_letter_branding"
     )
     mocker.patch(
         "app.main.views.letter_branding.logo_client.save_permanent_logo", side_effect=BotoClientError({}, "error")

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1381,7 +1381,7 @@ def test_manage_user_page_doesnt_show_folder_hint_if_service_cant_edit_folder_pe
 def test_remove_user_from_service(
     client_request, active_user_with_permissions, api_user_active, service_one, mock_remove_user_from_service, mocker
 ):
-    mock_event_handler = mocker.patch("app.main.views.manage_users.create_remove_user_from_service_event")
+    mock_event_handler = mocker.patch("app.main.views.manage_users.Events.remove_user_from_service")
 
     client_request.post(
         "main.remove_user_from_service",
@@ -1620,7 +1620,7 @@ def test_confirm_edit_user_email_changes_user_email(
     # get_user gets called twice - first to check if current user can see the page, then to see if the team member
     # whose email address we're changing belongs to the service
     mocker.patch("app.user_api_client.get_user", side_effect=[active_user_with_permissions, api_user_active])
-    mock_event_handler = mocker.patch("app.main.views.manage_users.create_email_change_event")
+    mock_event_handler = mocker.patch("app.main.views.manage_users.Events.update_user_email")
 
     new_email = "new_email@gov.uk"
     with client_request.session_transaction() as session:
@@ -1808,7 +1808,7 @@ def test_confirm_edit_user_mobile_number_changes_user_mobile_number(
     # get_user gets called twice - first to check if current user can see the page, then to see if the team member
     # whose mobile number we're changing belongs to the service
     mocker.patch("app.user_api_client.get_user", side_effect=[active_user_with_permissions, api_user_active])
-    mock_event_handler = mocker.patch("app.main.views.manage_users.create_mobile_number_change_event")
+    mock_event_handler = mocker.patch("app.main.views.manage_users.Events.update_user_mobile_number")
 
     new_number = "07554080636"
     with client_request.session_transaction() as session:

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -1,6 +1,7 @@
 import pytest
 from flask import url_for
 
+from tests.app.test_event_handlers import event_dict
 from tests.conftest import (
     SERVICE_ONE_ID,
     normalize_spaces,
@@ -79,6 +80,8 @@ def test_should_login_user_and_should_redirect_to_next_url(
             service_id=SERVICE_ONE_ID,
         ),
     )
+
+    mock_create_event.assert_called_once_with("sucessful_login", event_dict(user_id=api_user_active["id"]))
 
 
 def test_should_send_email_and_redirect_to_info_page_if_user_needs_to_revalidate_email(
@@ -288,7 +291,6 @@ def test_two_factor_sms_should_activate_pending_user(
     mocker,
     api_user_pending,
     mock_check_verify_code,
-    mock_create_event,
     mock_activate_user,
     mock_email_validated_recently,
 ):
@@ -345,7 +347,6 @@ def test_valid_two_factor_email_link_logs_in_user(
     mock_get_user,
     mock_get_services_with_one_service,
     mocker,
-    mock_create_event,
 ):
     mocker.patch("app.user_api_client.check_verify_code", return_value=(True, ""))
 

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -162,7 +162,7 @@ def test_invited_org_user_from_session_returns_none_if_nothing_present(client_re
 
 def test_set_permissions(client_request, mocker, active_user_view_permissions, fake_uuid):
     mock_api = mocker.patch("app.models.user.user_api_client.set_user_permissions")
-    mock_event = mocker.patch("app.models.user.create_set_user_permissions_event")
+    mock_event = mocker.patch("app.models.user.Events.set_user_permissions")
 
     User(active_user_view_permissions).set_permissions(
         service_id=SERVICE_ONE_ID,
@@ -183,7 +183,7 @@ def test_set_permissions(client_request, mocker, active_user_view_permissions, f
 
 def test_add_to_service(client_request, mocker, api_user_active, fake_uuid):
     mock_api = mocker.patch("app.models.user.user_api_client.add_user_to_service")
-    mock_event = mocker.patch("app.models.user.create_add_user_to_service_event")
+    mock_event = mocker.patch("app.models.user.Events.add_user_to_service")
 
     User(api_user_active).add_to_service(
         service_id=SERVICE_ONE_ID,

--- a/tests/app/test_event_handlers.py
+++ b/tests/app/test_event_handlers.py
@@ -1,30 +1,19 @@
 import uuid
 from unittest.mock import ANY
 
-from app.event_handlers import (
-    create_add_user_to_service_event,
-    create_archive_service_event,
-    create_archive_user_event,
-    create_email_change_event,
-    create_mobile_number_change_event,
-    create_remove_user_from_service_event,
-    create_set_user_permissions_event,
-    on_user_logged_in,
-)
-from app.models.user import User
+from app.event_handlers import Events
 
 
 def event_dict(**extra):
     return {
-        "browser_fingerprint": {"browser": ANY, "version": ANY, "platform": ANY, "user_agent_string": ""},
+        "browser_fingerprint": {"browser": ANY, "version": ANY, "platform": ANY, "user_agent_string": ANY},
         "ip_address": ANY,
         **extra,
     }
 
 
 def test_on_user_logged_in_calls_events_api(client_request, api_user_active, mock_events):
-    on_user_logged_in("_notify_admin", User(api_user_active))
-
+    Events.sucessful_login(user_id=api_user_active["id"])
     mock_events.assert_called_with("sucessful_login", event_dict(user_id=str(api_user_active["id"])))
 
 
@@ -36,7 +25,7 @@ def test_create_email_change_event_calls_events_api(client_request, mock_events)
         "new_email_address": "new@example.com",
     }
 
-    create_email_change_event(**kwargs)
+    Events.update_user_email(**kwargs)
     mock_events.assert_called_with("update_user_email", event_dict(**kwargs))
 
 
@@ -48,14 +37,14 @@ def test_create_add_user_to_service_event_calls_events_api(client_request, mock_
         "ui_permissions": {"manage_templates"},
     }
 
-    create_add_user_to_service_event(**kwargs)
+    Events.add_user_to_service(**kwargs)
     mock_events.assert_called_with("add_user_to_service", event_dict(**kwargs))
 
 
 def test_create_remove_user_from_service_event_calls_events_api(client_request, mock_events):
     kwargs = {"user_id": str(uuid.uuid4()), "removed_by_id": str(uuid.uuid4()), "service_id": str(uuid.uuid4())}
 
-    create_remove_user_from_service_event(**kwargs)
+    Events.remove_user_from_service(**kwargs)
     mock_events.assert_called_with("remove_user_from_service", event_dict(**kwargs))
 
 
@@ -67,21 +56,21 @@ def test_create_mobile_number_change_event_calls_events_api(client_request, mock
         "new_mobile_number": "07700900999",
     }
 
-    create_mobile_number_change_event(**kwargs)
+    Events.update_user_mobile_number(**kwargs)
     mock_events.assert_called_with("update_user_mobile_number", event_dict(**kwargs))
 
 
 def test_create_archive_user_event_calls_events_api(client_request, mock_events):
     kwargs = {"user_id": str(uuid.uuid4()), "user_email_address": "user@gov.uk", "archived_by_id": str(uuid.uuid4())}
 
-    create_archive_user_event(**kwargs)
+    Events.archive_user(**kwargs)
     mock_events.assert_called_with("archive_user", event_dict(**kwargs))
 
 
 def test_archive_service(client_request, mock_events):
     kwargs = {"service_id": str(uuid.uuid4()), "archived_by_id": str(uuid.uuid4())}
 
-    create_archive_service_event(**kwargs)
+    Events.archive_service(**kwargs)
     mock_events.assert_called_with("archive_service", event_dict(**kwargs))
 
 
@@ -94,5 +83,5 @@ def test_set_user_permissions(client_request, mock_events):
         "set_by_id": str(uuid.uuid4()),
     }
 
-    create_set_user_permissions_event(**kwargs)
+    Events.set_user_permissions(**kwargs)
     mock_events.assert_called_with("set_user_permissions", event_dict(**kwargs))


### PR DESCRIPTION
Prompted by https://github.com/alphagov/notifications-admin/pull/5427#discussion_r2049100998

***

Organising things like this means:
- things are only named once
- definitions are not split between schemas and (duplicative and very thin) functions
- the amount of code in this file is reduced by almost 50%
- no more horrible function names like `create_remove_user_from_service_event`

Makes use of [metaclasses](https://docs.python.org/3/reference/datamodel.html#metaclasses), which is fun.