### PR TITLE
Update button label

### DIFF
--- a/app/templates/views/your-services.html
+++ b/app/templates/views/your-services.html
@@ -141,7 +141,7 @@
         {% if current_user.default_organisation.can_ask_to_join_a_service %}
           {{ govukButton({
             "element": "a",
-            "text": "Join a live service",
+            "text": "Join an existing service",
             "href": url_for('main.join_service_choose_service'),
             "classes": "govuk-button--secondary"
           }) }}

--- a/tests/app/main/views/accounts/test_your_services.py
+++ b/tests/app/main/views/accounts/test_your_services.py
@@ -176,7 +176,7 @@ def test_your_services_should_show_join_service_button(
             url_for("main.add_service"),
         ),
         (
-            "Join a live service",
+            "Join an existing service",
             url_for("main.join_service_choose_service"),
         ),
     ]


### PR DESCRIPTION
In onboarding usability testing we saw some confusion about new vs existing and trial vs live.

As a result we want to be more careful about keeping these concepts separate until users have had a chance to learn about them (in practice).

Therefore we want to rename the ‘join a service’ button to say ‘existing’ rather than ‘live’.