### PR TITLE
Move `email_needs_revalidating` onto the user model

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -16,7 +16,6 @@ from app.main.forms import TwoFactorForm
 from app.models.token import Token
 from app.models.user import User
 from app.utils.login import (
-    email_needs_revalidating,
     log_in_user,
     redirect_if_logged_in,
     redirect_to_sign_in,
@@ -73,7 +72,7 @@ def two_factor_sms():
     redirect_url = request.args.get("next")
 
     if form.validate_on_submit():
-        if email_needs_revalidating(user):
+        if user.email_needs_revalidating:
             user_api_client.send_verify_code(user.id, "email", None, redirect_url)
             return redirect(url_for(".revalidate_email_sent", next=redirect_url))
         else:

--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -7,7 +7,7 @@ from app.main import main
 from app.models.user import User
 from app.models.webauthn_credential import RegistrationError, WebAuthnCredential
 from app.notify_client.user_api_client import user_api_client
-from app.utils.login import email_needs_revalidating, log_in_user, redirect_to_sign_in
+from app.utils.login import log_in_user, redirect_to_sign_in
 from app.utils.user import user_is_logged_in
 
 
@@ -159,7 +159,7 @@ def _complete_webauthn_login_attempt(user, webauthn_credential_id_used_for_login
         # user account is locked as too many failed logins
         abort(403)
 
-    if email_needs_revalidating(user):
+    if user.email_needs_revalidating:
         user_api_client.send_verify_code(user.id, "email", None, redirect_url)
         return redirect(url_for(".revalidate_email_sent", next=redirect_url))
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -15,6 +15,7 @@ from app.notify_client import InviteTokenError
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.org_invite_api_client import org_invite_api_client
 from app.notify_client.user_api_client import user_api_client
+from app.utils.time import is_less_than_days_ago
 from app.utils.user import is_gov_user
 from app.utils.user_permissions import (
     all_ui_permissions,
@@ -126,6 +127,10 @@ class User(BaseUser, UserMixin):
         self._organisation_permissions = {
             organisation: set(permissions) for organisation, permissions in permissions_by_organisation.items()
         }
+
+    @property
+    def email_needs_revalidating(self):
+        return not is_less_than_days_ago(self.email_access_validated_at, 90)
 
     def update(self, **kwargs):
         response = user_api_client.update_user_attribute(self.id, **kwargs)

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -3,7 +3,6 @@ from functools import wraps
 from flask import redirect, request, session, url_for
 
 from app.models.user import User
-from app.utils.time import is_less_than_days_ago
 
 
 def redirect_to_sign_in(f):
@@ -54,10 +53,6 @@ def redirect_if_logged_in(f):
             return f(*args, **kwargs)
 
     return wrapped
-
-
-def email_needs_revalidating(user):
-    return not is_less_than_days_ago(user.email_access_validated_at, 90)
 
 
 # see https://stackoverflow.com/questions/60532973/how-do-i-get-a-is-safe-url-function-to-use-with-flask-and-how-does-it-work  # noqa

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -1,3 +1,5 @@
+from unittest.mock import PropertyMock
+
 import pytest
 from flask import url_for
 
@@ -12,7 +14,7 @@ from tests.conftest import (
 
 @pytest.fixture
 def mock_email_validated_recently(mocker):
-    return mocker.patch("app.main.views.two_factor.email_needs_revalidating", return_value=False)
+    return mocker.patch("app.models.user.User.email_needs_revalidating", new_callable=PropertyMock, return_value=False)
 
 
 @pytest.mark.parametrize("request_url", ["two_factor_email_sent", "revalidate_email_sent"])
@@ -93,7 +95,7 @@ def test_should_send_email_and_redirect_to_info_page_if_user_needs_to_revalidate
     client_request.logout()
 
     mocker.patch("app.user_api_client.get_user", return_value=api_user_active)
-    mocker.patch("app.main.views.two_factor.email_needs_revalidating", return_value=True)
+    mocker.patch("app.models.user.User.email_needs_revalidating", new_callable=PropertyMock, return_value=True)
     with client_request.session_transaction() as session:
         session["user_details"] = {"id": api_user_active["id"], "email": api_user_active["email_address"]}
     client_request.post(

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -1,5 +1,5 @@
 import base64
-from unittest.mock import ANY, Mock
+from unittest.mock import ANY, Mock, PropertyMock
 
 import pytest
 from fido2 import cbor
@@ -371,7 +371,7 @@ def test_verify_webauthn_login_signs_user_in(
     client_request.login(platform_admin_user)
     mocker.patch("app.main.views.webauthn_credentials._verify_webauthn_authentication")
     mocker.patch("app.user_api_client.complete_webauthn_login_attempt", return_value=(True, None))
-    mocker.patch("app.main.views.webauthn_credentials.email_needs_revalidating", return_value=False)
+    mocker.patch("app.models.user.User.email_needs_revalidating", new_callable=PropertyMock, return_value=False)
 
     resp = client_request.post_response("main.webauthn_complete_authentication", _expected_status=200, **url_kwargs)
 
@@ -414,7 +414,7 @@ def test_verify_webauthn_login_signs_user_in_sends_revalidation_email_if_needed(
     mocker.patch("app.user_api_client.get_user", return_value=platform_admin_user)
     mocker.patch("app.main.views.webauthn_credentials._verify_webauthn_authentication")
     mocker.patch("app.user_api_client.complete_webauthn_login_attempt", return_value=(True, None))
-    mocker.patch("app.main.views.webauthn_credentials.email_needs_revalidating", return_value=True)
+    mocker.patch("app.models.user.User.email_needs_revalidating", new_callable=PropertyMock, return_value=True)
 
     resp = client_request.post_response(
         "main.webauthn_complete_authentication",
@@ -444,7 +444,7 @@ def test_verify_webauthn_login_passes_webauthn_credential_id_to_api(
         "app.main.views.webauthn_credentials._verify_webauthn_authentication",
         return_value=Mock(id="12345"),
     )
-    mocker.patch("app.main.views.webauthn_credentials.email_needs_revalidating", return_value=False)
+    mocker.patch("app.models.user.User.email_needs_revalidating", new_callable=PropertyMock, return_value=False)
     mock_succesful_login_api_call = mocker.patch(
         "app.user_api_client.complete_webauthn_login_attempt", return_value=(True, None)
     )

--- a/tests/app/utils/test_login.py
+++ b/tests/app/utils/test_login.py
@@ -2,7 +2,6 @@ import pytest
 from freezegun import freeze_time
 
 from app.models.user import User
-from app.utils.login import email_needs_revalidating
 
 
 @freeze_time("2020-11-27T12:00:00")
@@ -19,4 +18,4 @@ def test_email_needs_revalidating(
     expected_result,
 ):
     api_user_active["email_access_validated_at"] = email_access_validated_at
-    assert email_needs_revalidating(User(api_user_active)) == expected_result
+    assert User(api_user_active).email_needs_revalidating == expected_result


### PR DESCRIPTION
A function which takes an instance as its only argument should probably be a method on that class.

Hopefully means it’s easier to find, and one less thing to import.