### PR TITLE
Bump govuk frontend to v5.9.0

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,9 +1,15 @@
 // Path to assets for use with file-url()
 $path: '/static/images/';
 
+// TODO: remove this when moving to a version of GOVUK Frontend above 6
+// The organisation colours will be set to the new ones by default from that version
+// See: https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0
+//      > Deprecated features > Migrate to the new organisation colour palette
+$govuk-new-organisation-colours: true;
+
 // By default GOV.UK Frontend adds .js-enabled for all browsers that have
 // javascript enabled which isn't useful as their and our enhancements
-// only run in browsers that support type='module' and add 
+// only run in browsers that support type='module' and add
 // .govuk-frontend-supported to the body element
 // We use the this CSS class from GOV.UK Frontend to hide/show Javascript enhanced
 // elements in browser that we do/don't support

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,6 +1,12 @@
 /* stylelint-disable declaration-no-important */
 // set asset URL root to match that of application
 $govuk-assets-path: "/static/";
+//
+// TODO: remove this when moving to a version of GOVUK Frontend above 6
+// The organisation colours will be set to the new ones by default from that version
+// See: https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0
+//      > Deprecated features > Migrate to the new organisation colour palette
+$govuk-new-organisation-colours: true;
 
 @import "govuk/settings";
 @import "govuk/tools";

--- a/app/templates/govuk_frontend_jinja_overrides/templates/components/checkboxes/macro.html
+++ b/app/templates/govuk_frontend_jinja_overrides/templates/components/checkboxes/macro.html
@@ -1,4 +1,4 @@
-{#- Copied from https://github.com/LandRegistry/govuk-frontend-jinja/blob/3.1.0/govuk_frontend_jinja/templates/components/checkboxes/macro.html
+{#- Copied from https://github.com/LandRegistry/govuk-frontend-jinja/blob/3.5.0/govuk_frontend_jinja/templates/components/checkboxes/macro.html
     Changes we have made
     - `classes` option added to `item` allow custom classes on the `.govuk-checkboxes__item` element
     - `asList` option added the root `params` object to allow setting of the `.govuk-checkboxes` and `.govuk-checkboxes__item` element types

--- a/app/templates/govuk_frontend_jinja_overrides/templates/components/nested-radios/macro.html
+++ b/app/templates/govuk_frontend_jinja_overrides/templates/components/nested-radios/macro.html
@@ -1,6 +1,6 @@
 {#
-  A copy of the radios component from v3.1.0 of govuk_frontend_jinja
-  Blob permalink: https://raw.githubusercontent.com/LandRegistry/govuk-frontend-jinja/3.1.0/govuk_frontend_jinja/templates/components/radios/macro.html
+  A copy of the radios component from v3.5.0 of govuk_frontend_jinja
+  Blob permalink: https://github.com/LandRegistry/govuk-frontend-jinja/blob/3.5.0/govuk_frontend_jinja/templates/components/radios/macro.html
 
   Changes we have made:
   1) Rename macro to `govukNestedRadios`

--- a/app/templates/govuk_frontend_jinja_overrides/templates/components/radios-with-images/macro.html
+++ b/app/templates/govuk_frontend_jinja_overrides/templates/components/radios-with-images/macro.html
@@ -1,6 +1,6 @@
 {#
-  A copy of the radios component from v3.1.0 of govuk_frontend_jinja
-  Blob permalink: https://raw.githubusercontent.com/LandRegistry/govuk-frontend-jinja/3.1.0/govuk_frontend_jinja/templates/components/radios/macro.html
+  A copy of the radios component from v3.5.0 of govuk_frontend_jinja
+  Blob permalink: https://github.com/LandRegistry/govuk-frontend-jinja/blob/3.5.0/govuk_frontend_jinja/templates/components/radios/macro.html
 
   Changes:
   1) Rename macro to `govukRadiosWithImages`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cbor-js": "0.1.0",
-        "govuk-frontend": "5.7.1",
+        "govuk-frontend": "5.9.0",
         "jquery": "3.5.0",
         "morphdom": "2.6.1",
         "textarea-caret": "3.1.0",
@@ -6002,10 +6002,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
-      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
-      "license": "MIT",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor-js": "0.1.0",
-    "govuk-frontend": "5.7.1",
+    "govuk-frontend": "5.9.0",
     "jquery": "3.5.0",
     "morphdom": "2.6.1",
     "textarea-caret": "3.1.0",

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ fido2==1.1.3
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@98.0.0
 
-govuk-frontend-jinja==3.4.0
+govuk-frontend-jinja==3.5.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 govuk-bank-holidays==0.15
     # via notifications-utils
-govuk-frontend-jinja==3.4.0
+govuk-frontend-jinja==3.5.0
     # via -r requirements.in
 greenlet==3.0.3
     # via eventlet

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -102,7 +102,7 @@ govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
-govuk-frontend-jinja==3.4.0
+govuk-frontend-jinja==3.5.0
     # via -r requirements.txt
 greenlet==3.0.3
     # via

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -12,8 +12,8 @@ def test_govuk_frontend_jinja_overrides_on_design_system_v3():
     govuk_frontend_jinja_version = Version(metadata.version("govuk-frontend-jinja"))
 
     # Compatibility between these two libs is defined at https://github.com/LandRegistry/govuk-frontend-jinja/
-    correct_govuk_frontend_version = Version("5.7.1") == govuk_frontend_version
-    correct_govuk_frontend_jinja_version = Version("3.4.0") == govuk_frontend_jinja_version
+    correct_govuk_frontend_version = Version("5.9.0") == govuk_frontend_version
+    correct_govuk_frontend_jinja_version = Version("3.5.0") == govuk_frontend_jinja_version
 
     assert correct_govuk_frontend_version and correct_govuk_frontend_jinja_version, (
         "After upgrading either of the Design System packages, you must validate that "


### PR DESCRIPTION
One of the tasks in https://trello.com/c/eztuoh8p/1223-bump-design-system-to-version-before-govuk-rebrand-on-all-websites.

Brings in the following:
- https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0
- https://github.com/alphagov/govuk-frontend/releases/tag/v5.8.0
- https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.1

A quick overview of the features added/changed, and the effect on this repo, is:
- a new file upload component was added but we can't use this due to our upload flow not being one it can work in
- some form controls now default their id attribute to match the name but this is already done for us by WTForms
- a new base JS component was added, which we might use in future but not yet
- changes to how you import all the Sass in one go, which we don't do
- the existing file upload component can no longer have a value set but we don't use it

Also: this app doesn't actually use the departmental colours. We set the `$govuk-new-organisation-colours` flag here just to silence the deprecation warnings you see when compiling your Sass.