### PR TITLE
Update guidance for self-approving organisations

### DIFF
--- a/app/templates/views/organisations-admin/approve-service-check-unique.html
+++ b/app/templates/views/organisations-admin/approve-service-check-unique.html
@@ -22,11 +22,11 @@
     <div class="govuk-grid-column-five-sixths">
 
       <p class="govuk-body">
-        Your organisation cannot have more than one live service for the same thing.
+        You are responsible for making sure that this service is the only one of its kind in your organisation.
       </p>
 
     <p class="govuk-body">
-      Before you continue, you may want to check the list of
+      Before you continue, you should check the list of
       <a href="{{ url_for('.organisation_dashboard', org_id=current_service.organisation.id) }}" class="govuk-link govuk-link--no-visited-state">{{ current_service.organisation.name }} services</a>.
     </p>
 

--- a/app/templates/views/organisations-admin/approve-service-service-name.html
+++ b/app/templates/views/organisations-admin/approve-service-service-name.html
@@ -22,9 +22,18 @@
     <div class="govuk-grid-column-five-sixths">
 
       <p class="govuk-body">
-        A service name should tell the recipient what your message is about, as well as who it’s from. For example:
+        The service name must not include:
       </p>
 
+      <ul class="govuk-list govuk-list--bullet">
+        <li>acronyms, initialisms or abbreviations, unless they’re well known</li>
+        <li>your own name or the name of someone on your team</li>
+        <li>the name of a web application or back office system</li>
+
+      <p class="govuk-body">
+        A service name should tell the recipient what the message is about, as well as who it’s from. For example:
+      </p>
+      
       <ul class="govuk-list govuk-list--bullet">
         {% if organisation.organisation_type == 'local' %}
           <li>School admissions - {{ organisation.name }}</li>
@@ -36,10 +45,6 @@
           <li>Check your state pension</li>
         {% endif %}
       </ul>
-
-      <p class="govuk-body">
-        Avoid acronyms and initialisms unless they’re well known.
-      </p>
 
     {% call form_wrapper() %}
       {{ form.enabled }}

--- a/app/templates/views/organisations-admin/approve-service-service-name.html
+++ b/app/templates/views/organisations-admin/approve-service-service-name.html
@@ -29,6 +29,7 @@
         <li>acronyms, initialisms or abbreviations, unless they’re well known</li>
         <li>your own name or the name of someone on your team</li>
         <li>the name of a web application or back office system</li>
+      </ul>
 
       <p class="govuk-body">
         A service name should tell the recipient what the message is about, as well as who it’s from. For example:


### PR DESCRIPTION
Organisations that can approve their own services sometimes approve services that do not meet our guidelines and terms of use.

This PR updates the guidance for approvers to clarify our rules (and their responsibilities).

This is a short term fix while we:

* plan when and how to roll this feature out to more organisations
* design and test changes to the onboarding journey which could help with this problem