### PR TITLE
Show economy stamp on letter preview

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@98.0.0
+# This file was automatically copied from notifications-utils@99.1.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -24,6 +24,7 @@ class BaseLetterImageTemplate(BaseLetterTemplate):
     allowed_postage_types = (
         Postage.FIRST,
         Postage.SECOND,
+        Postage.ECONOMY,
         Postage.EUROPE,
         Postage.REST_OF_WORLD,
     )
@@ -83,6 +84,7 @@ class BaseLetterImageTemplate(BaseLetterTemplate):
         return {
             Postage.FIRST: "first class",
             Postage.SECOND: "second class",
+            Postage.ECONOMY: "economy",
             Postage.EUROPE: "international",
             Postage.REST_OF_WORLD: "international",
         }.get(self.postage)
@@ -92,6 +94,7 @@ class BaseLetterImageTemplate(BaseLetterTemplate):
         return {
             Postage.FIRST: "letter-postage-first",
             Postage.SECOND: "letter-postage-second",
+            Postage.ECONOMY: "letter-postage-economy",
             Postage.EUROPE: "letter-postage-international",
             Postage.REST_OF_WORLD: "letter-postage-international",
         }.get(self.postage)

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@98.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.1.0
 
 govuk-frontend-jinja==3.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@794b88afc06bff187a3d58db0ed5f2871bad7ba6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84b675433fdd7c17c1eee6e546120aa3a4e5887b
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -164,7 +164,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@794b88afc06bff187a3d58db0ed5f2871bad7ba6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84b675433fdd7c17c1eee6e546120aa3a4e5887b
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@98.0.0
+# This file was automatically copied from notifications-utils@99.1.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,10 +1,8 @@
-# This file was automatically copied from notifications-utils@98.0.0
+# This file was automatically copied from notifications-utils@99.1.0
 
-exclude = [
+extend-exclude = [
     "migrations/versions/",
-    "venv*",
     "__pycache__",
-    "node_modules",
     "cache",
     "migrations",
     "build",

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -515,6 +515,12 @@ def test_notification_page_does_not_show_cancel_link_for_letter_which_cannot_be_
             "Estimated delivery date: Tuesday 5 January",
         ),
         (
+            "economy",
+            "Postage: economy",
+            "letter-postage-economy",
+            "Estimated delivery date: Thursday 7 January",
+        ),
+        (
             "europe",
             "Postage: international",
             "letter-postage-international",

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -231,7 +231,7 @@ def test_letter_image_renderer_requires_valid_postage():
             {"service": SERVICE_ONE_ID, "content": "", "subject": "", "template_type": "letter", "postage": "third"},
             image_url="foo",
         )
-    assert str(exception.value) == ("postage must be None, 'first', 'second', 'europe' or 'rest-of-world'")
+    assert str(exception.value) == ("postage must be None, 'first', 'second', 'economy', 'europe' or 'rest-of-world'")
 
 
 @pytest.mark.parametrize(
@@ -288,6 +288,11 @@ def test_letter_image_renderer_requires_image_url_to_render():
             "second",
             ["letter-postage", "letter-postage-second"],
             "Postage: second class",
+        ),
+        (
+            "economy",
+            ["letter-postage", "letter-postage-economy"],
+            "Postage: economy",
         ),
         (
             "europe",
@@ -367,6 +372,7 @@ def test_letter_image_renderer_passes_postage_to_html_attribute(
         pytest.param({"postage": None}, False, None, None),
         pytest.param({"postage": "first"}, True, "letter-postage-first", "first class"),
         pytest.param({"postage": "second"}, True, "letter-postage-second", "second class"),
+        pytest.param({"postage": "economy"}, True, "letter-postage-economy", "economy"),
         pytest.param({"postage": "europe"}, True, "letter-postage-international", "international"),
         pytest.param({"postage": "rest-of-world"}, True, "letter-postage-international", "international"),
         pytest.param(


### PR DESCRIPTION
If a letter template is economy or a letter has been sent as economy, we
now show the "economy mail" logo for it. The ability to change a
template to be economy is being done in a separate story.

https://trello.com/c/SK5WT7Sv/1248-show-economy-postage-on-letter-previews