### PR TITLE
Show different content if trying to join service without team members

### DIFF
--- a/app/templates/views/join-a-service/ask.html
+++ b/app/templates/views/join-a-service/ask.html
@@ -21,11 +21,22 @@
       <p class="govuk-body">
         You’re asking to join ‘{{ service.name }}’.
       </p>
-      {% call form_wrapper() %}
-        {{ form.users }}
-        {{ form.reason }}
-      {{ page_footer('Ask to join this service') }}
-      {% endcall %}
+
+      {% if service.active_users_with_permission("manage_service") %}
+        {% call form_wrapper() %}
+          {{ form.users }}
+          {{ form.reason }}
+        {{ page_footer('Ask to join this service') }}
+        {% endcall %}
+      {% else %}
+        <p class="govuk-body">
+          No one on that service has permission to approve your request.
+        </p>
+        <p class="govuk-body">
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Contact GOV.UK Notify support</a>
+        </p>
+        {% endif %}
+
     </div>
   </div>
 

--- a/tests/app/main/views/test_join_service.py
+++ b/tests/app/main/views/test_join_service.py
@@ -222,6 +222,46 @@ def test_page_lists_team_members_of_service(
     mock_get_users.assert_called_once_with(SERVICE_ONE_ID)
 
 
+def test_page_does_not_show_form_if_no_users_have_permission_to_approve_the_request(
+    client_request,
+    service_one,
+    mock_get_organisation_by_domain,
+    mock_get_invites_for_service,
+    mocker,
+):
+    service_one["organisation"] = ORGANISATION_ID
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_json(id_=ORGANISATION_ID, can_ask_to_join_a_service=True),
+    )
+
+    current_user = create_service_two_user_with_permissions()
+
+    # Users with permission for a different service
+    create_active_user_with_permissions()
+    create_active_user_with_permissions()
+    create_active_user_with_permissions()
+
+    client_request.login(current_user)
+
+    mocker.patch(
+        "app.models.user.Users._get_items",
+        return_value=[
+            # Three users, but none appear on the page
+            create_active_user_empty_permissions(),
+            create_active_user_manage_template_permissions(),
+            create_active_user_view_permissions(),
+        ],
+    )
+
+    page = client_request.get("main.join_service_ask", service_to_join_id=SERVICE_ONE_ID)
+
+    assert normalize_spaces(page.select_one("h1").text) == "Ask to join this service"
+    assert normalize_spaces(page.select_one("main p").text) == "You’re asking to join ‘service one’."
+    assert not page.select("form")
+    assert "No one on that service has permission to approve your request." in normalize_spaces(page.text)
+
+
 def test_page_redirects_on_post(
     client_request,
     mock_create_service_join_request,


### PR DESCRIPTION
If using the join a service feature and click on a service without team members, we want to show a message and a link to contact support. At the moment, we were showing a form that couldn't be submitted (since there were no checkboxes for team members).

<img width="500" alt="Screenshot 2025-04-29 at 10 54 53" src="https://github.com/user-attachments/assets/4ca46c62-5681-48b4-b5c0-963ff7ae83c8" />
