### PR TITLE
Add correct styling to unsafe placeholders

### DIFF
--- a/app/assets/javascripts/esm/enhanced-textbox.mjs
+++ b/app/assets/javascripts/esm/enhanced-textbox.mjs
@@ -17,7 +17,7 @@ class EnhancedTextbox {
     }
 
     this.$module = $module;
-    this.tagPattern = /\(\(([^\)\((\?)]+)(\?\?)?([^\)\(]*)\)\)/g;
+    this.tagPattern = /\(\(([^\)\((\?)(\:)]+)((\?\?)|(::))?([^\)\(]*)\)\)/g;
     this.highlightPlaceholders = this.$module.dataset.highlightPlaceholders === 'true';
     this.autofocus = this.$module.dataset.autofocusTextbox === 'true';
     this.$textbox = this.$module;
@@ -42,10 +42,10 @@ class EnhancedTextbox {
     this.$visibleTextbox.style.visibility = 'hidden';
     this.$visibleTextbox.style.display = 'block';
     document.querySelector('body').append(this.$visibleTextbox);
-    
+
     this.initialHeight = this.$visibleTextbox.offsetHeight;
 
-    this.$backgroundHighlightElement.style.borderWidth = 
+    this.$backgroundHighlightElement.style.borderWidth =
       window.getComputedStyle(this.$textbox).getPropertyValue('border-width');
 
     this.$visibleTextbox.remove();
@@ -77,9 +77,11 @@ class EnhancedTextbox {
 
   contentReplaced () {
     return this.contentEscaped().replace(
-      this.tagPattern, (match, name, separator, value) => {
-        if (value && separator) {
-          return `<span class='placeholder-conditional'>((${name}??</span>${value}))`;
+      this.tagPattern, (match, name, separator, _, __, value) => {
+        if (value && separator == "??") {
+          return `<span class='placeholder-conditional'>((${name}${separator}</span>${value}))`;
+        } else if (value && separator == "::") {
+          return `<span class='placeholder-typed placeholder-unsafe'>((${name}</span>${separator}${value}))`;
         } else {
           return `<span class='placeholder'>((${name}${value}))</span>`;
         }

--- a/app/assets/stylesheets/components/placeholder.scss
+++ b/app/assets/stylesheets/components/placeholder.scss
@@ -14,6 +14,22 @@
 
 }
 
+.placeholder-unsafe {
+
+  @extend %placeholder;
+  border-radius: 0;
+  border-top-left-radius: 20px;
+  border-bottom-left-radius: 20px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+  box-shadow: inset 0.47em 0 0 0 #FFF, inset 0 -0.05em 0 0 #FFF, inset 0 0.26em 0 0 #FFF;
+
+  .sms-message-wrapper & {
+    box-shadow: inset 0.47em 0 0 0 govuk-shade(govuk-colour("light-grey"), 7%), inset -0.89em 0 0 0 govuk-shade(govuk-colour("light-grey"), 7%), inset 0 -0.18em 0 0 govuk-shade(govuk-colour("light-grey"), 7%), inset 0 0.18em 0 0 govuk-shade(govuk-colour("light-grey"), 7%);
+  }
+
+}
+
 .placeholder-no-brackets {
   @extend %placeholder;
   padding-left: 3px;

--- a/tests/javascripts/enhance-textbox.test.mjs
+++ b/tests/javascripts/enhance-textbox.test.mjs
@@ -162,7 +162,7 @@ describe('Enhanced textbox', () => {
           <label class="govuk-label" for="template_content">Message</label>
           <textarea class="govuk-textarea govuk-!-width-full govuk-textarea-highlight__textbox" id="template_content" name="template_content" rows="8" data-notify-module="enhanced-textbox" data-autofocus-textbox="true"></textarea>
         </div>`;
-       
+
         textarea = document.querySelector('textarea');
 
         new EnhancedTextbox(textarea);
@@ -358,7 +358,25 @@ describe('Enhanced textbox', () => {
 
     });
 
+    test("If an unsafe placeholder is added, it should be highlighted with placeholder-unsafe style", () => {
+
+      textarea.textContent = "Dear ((title::unsafe)) ((surname::unsafe))";
+
+      // start module
+      new EnhancedTextbox(textarea);
+
+      backgroundEl = textarea.nextElementSibling;
+      helpers.triggerEvent(textarea, 'input');
+
+      // add some more content with some optional content inside
+      const unsafeHighlightTags = backgroundEl.querySelectorAll('.placeholder-unsafe');
+
+      expect(unsafeHighlightTags.length).toEqual(2);
+
+    });
+
   });
+
 
   describe("When the content of the textbox is updated", () => {
 


### PR DESCRIPTION
Best reviewed commit by commit:

adds an extra css class `placeholder-unsafe` for highlighting the variable name of unsafe placeholders when editing and viewing templates, and updates the enhanced textbox javascript to dynamically style correctly when editing templates.