### PR TITLE
feat: Include economy class of template preview

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1523,12 +1523,20 @@ class WelshLetterTemplateForm(BaseTemplateForm, TemplateNameMixin):
 
 
 class LetterTemplatePostageForm(StripWhitespaceForm):
+    choices = [
+        ("first", "First class"),
+        ("second", "Second class"),
+    ]
+
+    def __init__(self, *args, show_economy_class, **kwargs):
+        super().__init__(*args, **kwargs)
+        if show_economy_class:
+            self.postage.choices.append(("economy", "Economy mail"))
+            self.postage.thing = "first class, second class or economy mail"
+
     postage = GovukRadiosField(
         "Choose the postage for this letter template",
-        choices=[
-            ("first", "First class"),
-            ("second", "Second class"),
-        ],
+        choices=choices,
         thing="first class or second class",
         validators=[DataRequired()],
     )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1014,7 +1014,9 @@ def edit_template_postage(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
     if template.template_type != "letter":
         abort(404)
-    form = LetterTemplatePostageForm(**template._template)
+    form = LetterTemplatePostageForm(
+        **template._template, show_economy_class=current_service.has_permission("economy_letter_sending")
+    )
     if form.validate_on_submit():
         postage = form.postage.data
         service_api_client.update_service_template(service_id, template_id, postage=postage)

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1617,6 +1617,54 @@ def test_edit_letter_template_postage_page_displays_correctly(
     assert page.select("input[checked]")[0].attrs["value"] == "second"
 
 
+def test_edit_letter_template_displays_all_postage_for_service_with_permission(
+    client_request,
+    service_one,
+    fake_uuid,
+    mock_get_service_letter_template,
+):
+    service_one.update({"permissions": ["economy_letter_sending"]})
+
+    page = client_request.get(
+        "main.edit_template_postage",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+    )
+
+    assert page.select_one("h1").text.strip() == "Change postage"
+    assert page.select("input[checked]")[0].attrs["value"] == "second"
+
+    assert len(page.select("input[type=radio]")) == 3
+
+    assert [
+        (radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip())
+        for radio in page.select("input[type=radio]")
+    ] == [("first", "First class"), ("second", "Second class"), ("economy", "Economy mail")]
+
+
+def test_edit_letter_template_displays_first_and_second_for_service_without_permission(
+    client_request,
+    service_one,
+    fake_uuid,
+    mock_get_service_letter_template,
+):
+    page = client_request.get(
+        "main.edit_template_postage",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+    )
+
+    assert page.select_one("h1").text.strip() == "Change postage"
+    assert page.select("input[checked]")[0].attrs["value"] == "second"
+
+    assert len(page.select("input[type=radio]")) == 2
+
+    assert [
+        (radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip())
+        for radio in page.select("input[type=radio]")
+    ] == [("first", "First class"), ("second", "Second class")]
+
+
 def test_edit_letter_template_postage_page_404s_if_template_is_not_a_letter(
     client_request,
     service_one,


### PR DESCRIPTION
## PR Summary
- Include economy mail for Letter template preview. Currently only available for services that have the `economy_letter_sending` permissions active. When ready for release, precondition should be removed.

**Services without the permissions set see this:**
![Screenshot 2025-04-30 at 16 52 10](https://github.com/user-attachments/assets/b34b0f81-1f02-4713-92be-80b8dfb60e13)


**Services with the permissions set see this:**
![Screenshot 2025-05-01 at 10 43 23](https://github.com/user-attachments/assets/f18753a2-a1a2-4b9e-af06-51e05282d5da)


### Ticket:
- [Allow users to select postage on template preview](https://trello.com/c/KobshQto/1253-allow-users-to-select-economy-postage-on-template-set-postage-page)