### PR TITLE
Validate international text message limit when sending through the website

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.1.2
+# This file was automatically copied from notifications-utils@99.3.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -390,6 +390,9 @@ def recipient_count_label(count, template_type):
     if template_type == "sms":
         return "phone number" if singular else "phone numbers"
 
+    if template_type == "international_sms":
+        return "international phone number" if singular else "international phone numbers"
+
     if template_type == "email":
         return "email address" if singular else "email addresses"
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -617,8 +617,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, emergency_c
         ),
     )
 
-    notification_count = service_api_client.get_notification_count(service_id, notification_type=template.template_type)
-    remaining_messages = current_service.get_message_limit(template.template_type) - notification_count
+    remaining_messages = current_service.remaining_messages(template.template_type)
 
     if template.template_type == "email":
         template.reply_to = get_email_reply_to_address_from_session()

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -989,7 +989,10 @@ def get_template_error_dict(exception):
     if "service is in trial mode" in exception.message:
         error = "not-allowed-to-send-to"
     elif "Exceeded send limits" in exception.message:
-        error = "too-many-messages"
+        if "international_sms" in exception.message:
+            error = "too-many-international-sms-messages"
+        else:
+            error = "too-many-messages"
     # the error from the api is changing for message-too-long, but we need both until the api is deployed.
     elif "Content for template has a character count greater than the limit of" in exception.message:
         error = "message-too-long"

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -618,6 +618,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, emergency_c
     )
 
     remaining_messages = current_service.remaining_messages(template.template_type)
+    remaining_international_sms_messages = current_service.remaining_messages("international_sms")
 
     if template.template_type == "email":
         template.reply_to = get_email_reply_to_address_from_session()
@@ -637,6 +638,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, emergency_c
             else None
         ),
         remaining_messages=remaining_messages,
+        remaining_international_sms_messages=remaining_international_sms_messages,
         allow_international_sms=current_service.has_permission("international_sms"),
         allow_sms_to_uk_landline=current_service.has_permission("sms_to_uk_landlines"),
         allow_international_letters=current_service.has_permission("international_letters"),
@@ -669,6 +671,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, emergency_c
         "upload_id": upload_id,
         "form": CsvUploadForm(),
         "remaining_messages": remaining_messages,
+        "remaining_international_sms_messages": remaining_international_sms_messages,
         "_choose_time_form": choose_time_form,
         "back_link": back_link,
         "trying_to_send_letters_in_trial_mode": all(

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -618,7 +618,11 @@ class Service(JSONModel):
         return getattr(self, f"{notification_type}_message_limit")
 
     def remaining_messages(self, notification_type):
-        return self.get_message_limit(notification_type) - service_api_client.get_notification_count(self.id, notification_type=notification_type)
+        if notification_type == "international_sms" and not self.has_permission("international_sms"):
+            return 0
+        return self.get_message_limit(notification_type) - (
+            service_api_client.get_notification_count(self.id, notification_type=notification_type)
+        )
 
     @property
     def sign_in_method(self) -> str:

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -617,6 +617,9 @@ class Service(JSONModel):
     def get_message_limit(self, notification_type):
         return getattr(self, f"{notification_type}_message_limit")
 
+    def remaining_messages(self, notification_type):
+        return self.get_message_limit(notification_type) - service_api_client.get_notification_count(self.id, notification_type=notification_type)
+
     @property
     def sign_in_method(self) -> str:
         if self.has_permission("email_auth"):

--- a/app/templates/partials/check/too-many-international-sms-messages.html
+++ b/app/templates/partials/check/too-many-international-sms-messages.html
@@ -1,0 +1,19 @@
+<h1 class='banner-title'>
+  {% if original_file_name %}
+    Too many international phone numbers
+  {% else %}
+    Daily limit reached
+  {% endif %}
+</h1>
+<p class="govuk-body">
+  You can only send {{ current_service.get_message_limit("international_sms") | message_count("international_sms") }} per day.
+</p>
+{% if original_file_name %}
+  <p class="govuk-body">
+    {% if (current_service.get_message_limit("international_sms")) != remaining_international_sms_messages %}
+      You can still send {{ remaining_international_sms_messages|format_thousands }} {{ remaining_international_sms_messages|message_count_noun("international_sms") }} today, but
+    {% endif %}
+    ‘{{ original_file_name }}’ contains
+    {{ recipients.international_sms_count|recipient_count("international_sms") }}.
+  </p>
+{% endif %}

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -126,6 +126,10 @@
 
         {% include "partials/check/too-many-messages.html" %}
 
+      {% elif recipients.more_international_sms_than_can_send %}
+
+        {% include "partials/check/too-many-international-sms-messages.html" %}
+
       {% endif %}
 
     {% endcall %}

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -43,6 +43,12 @@
         {% include "partials/check/too-many-messages.html" %}
       {% endcall %}
     </div>
+  {% elif error == 'too-many-international-sms-messages' %}
+    <div class="bottom-gutter">
+      {% call banner_wrapper(type='dangerous') %}
+        {% include "partials/check/too-many-international-sms-messages.html" %}
+      {% endcall %}
+    </div>
   {% elif error == 'message-too-long' %}
     {# the only row_errors we can get when sending one off messages is that the message is too long #}
     <div class="bottom-gutter">

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.1.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.3.0
 
 govuk-frontend-jinja==3.5.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ff45d7df41c651261b8ca7ae78b9f0187cd89387
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@f3636bfdcdf43c0a18ab0e91b127e8eda5a63e50
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -164,7 +164,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ff45d7df41c651261b8ca7ae78b9f0187cd89387
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@f3636bfdcdf43c0a18ab0e91b127e8eda5a63e50
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.1.2
+# This file was automatically copied from notifications-utils@99.3.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.1.2
+# This file was automatically copied from notifications-utils@99.3.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -4148,6 +4148,7 @@ TRIAL_MODE_MSG = (
 )
 TOO_LONG_MSG = "Text messages cannot be longer than 918 characters. Your message is 954 characters."
 SERVICE_DAILY_LIMIT_MSG = "Exceeded send limits (sms: 1000) for today"
+SERVICE_DAILY_INTERNTIONAL_SMS_LIMIT_MSG = "Exceeded send limits (international_sms: 1234) for today"
 
 
 @pytest.mark.parametrize(
@@ -4167,6 +4168,11 @@ SERVICE_DAILY_LIMIT_MSG = "Exceeded send limits (sms: 1000) for today"
             SERVICE_DAILY_LIMIT_MSG,
             "Daily limit reached",
             "You can only send 1,000 text messages per day in trial mode.",
+        ),
+        (
+            SERVICE_DAILY_INTERNTIONAL_SMS_LIMIT_MSG,
+            "Daily limit reached",
+            "You can only send 500 international text messages per day.",
         ),
     ],
 )


### PR DESCRIPTION
One-off:

<img width="780" alt="image" src="https://github.com/user-attachments/assets/e3ce7f18-b479-457f-aa4a-a96936bf920f" />

***

Spreadsheet upload:

<img width="798" alt="image" src="https://github.com/user-attachments/assets/c959a492-c7dd-41fe-88c9-c226e58d9dcb" />

***

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/1221