### PR TITLE
Update inbound_sms_callback_details

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any
 
 from flask import abort, current_app
+from notifications_python_client.errors import HTTPError
 from notifications_utils.serialised_model import SerialisedModelCollection
 from werkzeug.utils import cached_property
 
@@ -652,7 +653,14 @@ class Service(JSONModel):
     @property
     def inbound_sms_callback_details(self):
         if self.inbound_api:
-            return service_api_client.get_service_callback_api(self.id, self.inbound_api[0], "inbound_sms")
+            try:
+                return service_api_client.get_service_callback_api(self.id, self.inbound_api[0], "inbound_sms")
+            except HTTPError:
+                pass
+        try:
+            return self._callback_service_callback_details("inbound_sms")
+        except HTTPError:
+            pass
 
     @property
     def delivery_status_callback_details(self):


### PR DESCRIPTION
 This is a short term fix in preparation for an API update to drop use of the service_inbound_api table
 in favour of using the service_callback_api table for inbound_sms callback. Once that is done,
 the self.inbound_api value would no longer be valid for retrieving callback details. This update ensures that once the API update is deployed that
 inbound_sms callback details would still be accessible.
 After the API update is deployed, inbound_sms_callback_details will be updated again to drop the reference to self.inbound_api.