### PR TITLE
Remove instatiation of throwaway object

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.1
+# This file was automatically copied from notifications-utils@99.5.2
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,15 +1,20 @@
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from functools import total_ordering
 
 from flask import abort
 from notifications_utils.serialised_model import (
     SerialisedModel,
     SerialisedModelCollection,
+    SerialisedModelMeta,
 )
 
 
+class JSONModelMeta(SerialisedModelMeta, ABCMeta):
+    pass
+
+
 @total_ordering
-class JSONModel(SerialisedModel, ABC):
+class JSONModel(SerialisedModel, ABC, metaclass=JSONModelMeta):
     @property
     @abstractmethod
     def __sort_attribute__(self):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,7 +9,7 @@ from notifications_utils.serialised_model import (
 
 
 @total_ordering
-class SortingAndEqualityMixin(ABC):
+class JSONModel(SerialisedModel, ABC):
     @property
     @abstractmethod
     def __sort_attribute__(self):
@@ -38,8 +38,6 @@ class SortingAndEqualityMixin(ABC):
     def __hash__(self):
         return hash(self.id)
 
-
-class JSONModel(SerialisedModel, SortingAndEqualityMixin):
     def __init__(self, _dict):
         # in the case of a bad request _dict may be `None`
         self._dict = _dict or {}

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -28,7 +28,7 @@ class Branding(JSONModel):
 
     @classmethod
     def with_default_values(cls, **kwargs):
-        return cls(dict.fromkeys(cls({}).__annotations__) | kwargs)
+        return cls(dict.fromkeys(cls.__annotations__) | kwargs)
 
     def name_like(self, name):
         return make_string_safe(name, whitespace="") == make_string_safe(self.name, whitespace="")

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.2
 
 govuk-frontend-jinja==3.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@962c6e116ed7183b8b02e034a82a08628b1b2cc5
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -165,7 +165,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@962c6e116ed7183b8b02e034a82a08628b1b2cc5
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.1
+# This file was automatically copied from notifications-utils@99.5.2
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.1
+# This file was automatically copied from notifications-utils@99.5.2
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
We don’t need to do this because `Branding.__annotations__ == Branding().__annotations__`

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/1224