### PR TITLE
feat: Add economy to letter upload

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1551,8 +1551,13 @@ class LetterTemplateLanguagesForm(StripWhitespaceForm):
 
 
 class LetterUploadPostageForm(StripWhitespaceForm):
-    def __init__(self, *args, postage_zone, **kwargs):
+    choices = [("first", "First class"), ("second", "Second class")]
+
+    def __init__(self, *args, postage_zone, show_economy_class, **kwargs):
         super().__init__(*args, **kwargs)
+
+        if show_economy_class:
+            self.postage.choices.append(("economy", "Economy mail"))
 
         if postage_zone != Postage.UK:
             self.postage.choices = [(postage_zone, "")]
@@ -1564,10 +1569,7 @@ class LetterUploadPostageForm(StripWhitespaceForm):
 
     postage = GovukRadiosField(
         "Choose the postage for this letter",
-        choices=[
-            ("first", "First class post"),
-            ("second", "Second class post"),
-        ],
+        choices=choices,
         default="second",
         validators=[DataRequired()],
     )

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -250,7 +250,9 @@ def uploaded_letter_preview(service_id, file_id):
 
     error_message = get_letter_validation_error(error_shortcode, invalid_pages, page_count)
 
-    form = LetterUploadPostageForm(postage_zone=postal_address.postage)
+    form = LetterUploadPostageForm(
+        postage_zone=postal_address.postage, show_economy_class=current_service.has_permission("economy_letter_sending")
+    )
 
     template = current_service.get_precompiled_letter_template(
         letter_preview_url=url_for(".view_letter_upload_as_preview", service_id=service_id, file_id=file_id),
@@ -317,7 +319,9 @@ def send_uploaded_letter(service_id, file_id):
 
     postal_address = PostalAddress(metadata.get("recipient"))
 
-    form = LetterUploadPostageForm(postage_zone=postal_address.postage)
+    form = LetterUploadPostageForm(
+        postage_zone=postal_address.postage, show_economy_class=current_service.has_permission("economy_letter_sending")
+    )
 
     if not form.validate_on_submit():
         return uploaded_letter_preview(service_id, file_id)

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -760,6 +760,135 @@ def test_uploaded_letter_preview_image_400s_for_bad_page_type(
     )
 
 
+def test_uploaded_letter_preview_displays_all_postage_for_service_with_permission(
+    active_user_with_permissions,
+    service_one,
+    client_request,
+    fake_uuid,
+    mocker,
+):
+    letter_template = {
+        "service": SERVICE_ONE_ID,
+        "template_type": "letter",
+        "reply_to_text": "",
+        "postage": "second",
+        "subject": "hi",
+        "content": "my letter",
+        "is_precompiled_letter": True,
+    }
+
+    service_one.update({"permissions": ["economy_letter_sending"]})
+
+    mocker.patch("uuid.uuid4", return_value=fake_uuid)
+    mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
+    mocker.patch(
+        "app.template_preview_client.sanitise_letter",
+        return_value=Mock(
+            content="The sanitised content",
+            json=lambda: {"file": "VGhlIHNhbml0aXNlZCBjb250ZW50", "recipient_address": "The Queen"},
+        ),
+    )
+    mocker.patch("app.main.views.uploads.upload_letter_to_s3")
+    mocker.patch("app.main.views.uploads.backup_original_letter_to_s3")
+    mocker.patch("app.main.views.uploads.pdf_page_count", return_value=3)
+    do_mock_get_page_counts_for_letter(mocker, count=3)
+    mocker.patch(
+        "app.main.views.uploads.get_letter_metadata",
+        return_value=LetterMetadata(
+            {
+                "filename": "tests/test_pdf_files/one_page_pdf.pdf",
+                "page_count": "3",
+                "status": "valid",
+                "recipient": "The Queen",
+            }
+        ),
+    )
+    mocker.patch("app.models.service.service_api_client.get_precompiled_template", return_value=letter_template)
+
+    service_one["restricted"] = False
+    client_request.login(active_user_with_permissions, service=service_one)
+
+    with open("tests/test_pdf_files/one_page_pdf.pdf", "rb") as file:
+        page = client_request.post(
+            "main.upload_letter",
+            service_id=SERVICE_ONE_ID,
+            _data={"file": file},
+            _follow_redirects=True,
+        )
+
+    radio_inputs = page.select("input[type=radio]")
+
+    assert len(radio_inputs) == 3
+    assert [(radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip()) for radio in radio_inputs] == [
+        ("first", "First class"),
+        ("second", "Second class"),
+        ("economy", "Economy mail"),
+    ]
+
+
+def test_uploaded_letter_preview_displays_only_first_and_second_class(
+    active_user_with_permissions,
+    service_one,
+    client_request,
+    fake_uuid,
+    mocker,
+):
+    letter_template = {
+        "service": SERVICE_ONE_ID,
+        "template_type": "letter",
+        "reply_to_text": "",
+        "postage": "second",
+        "subject": "hi",
+        "content": "my letter",
+        "is_precompiled_letter": True,
+    }
+
+    mocker.patch("uuid.uuid4", return_value=fake_uuid)
+    mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
+    mocker.patch(
+        "app.template_preview_client.sanitise_letter",
+        return_value=Mock(
+            content="The sanitised content",
+            json=lambda: {"file": "VGhlIHNhbml0aXNlZCBjb250ZW50", "recipient_address": "The Queen"},
+        ),
+    )
+    mocker.patch("app.main.views.uploads.upload_letter_to_s3")
+    mocker.patch("app.main.views.uploads.backup_original_letter_to_s3")
+    mocker.patch("app.main.views.uploads.pdf_page_count", return_value=3)
+    do_mock_get_page_counts_for_letter(mocker, count=3)
+    mocker.patch(
+        "app.main.views.uploads.get_letter_metadata",
+        return_value=LetterMetadata(
+            {
+                "filename": "tests/test_pdf_files/one_page_pdf.pdf",
+                "page_count": "3",
+                "status": "valid",
+                "recipient": "The Queen",
+            }
+        ),
+    )
+    mocker.patch("app.models.service.service_api_client.get_precompiled_template", return_value=letter_template)
+
+    service_one["restricted"] = False
+    client_request.login(active_user_with_permissions, service=service_one)
+
+    with open("tests/test_pdf_files/one_page_pdf.pdf", "rb") as file:
+        page = client_request.post(
+            "main.upload_letter",
+            service_id=SERVICE_ONE_ID,
+            _data={"file": file},
+            _follow_redirects=True,
+        )
+
+    radio_inputs = page.select("input[type=radio]")
+
+    assert len(radio_inputs) == 2
+    assert [(radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip()) for radio in radio_inputs] == [
+        ("first", "First class"),
+        ("second", "Second class"),
+    ]
+
+
 @pytest.mark.parametrize(
     "address, post_data, expected_postage",
     (
@@ -772,6 +901,11 @@ def test_uploaded_letter_preview_image_400s_for_bad_page_type(
             "address",
             {"filename": "my_file.pdf"},
             "second",
+        ),
+        (
+            "address",
+            {"filename": "my_file.pdf", "postage": "economy"},
+            "economy",
         ),
         (
             "123 Example Street\nLiechtenstein",
@@ -812,7 +946,7 @@ def test_send_uploaded_letter_sends_letter_and_redirects_to_notification_page(
     mock_send = mocker.patch("app.main.views.uploads.notification_api_client.send_precompiled_letter")
     mocker.patch("app.main.views.uploads.get_letter_metadata", return_value=metadata)
 
-    service_one["permissions"] = ["letter", "upload_letters"]
+    service_one["permissions"] = ["letter", "upload_letters", "economy_letter_sending"]
 
     client_request.post(
         "main.send_uploaded_letter",


### PR DESCRIPTION
## PR Summary
- Refactor existing letter class names from "post class" to "class" or "mail". Example: Previously we had "Second post class" not it's "Second class" . Design doc for these changes [here](https://docs.google.com/document/d/13tDcZVMYtmsRTkluzvPCrZ64JFgeW4ZyCTUiEhGvRNM/edit?tab=t.0)
- Refactor existing send_uploaded_letter to include economy
- Refactor uploaded_letter_preview to include economy and make sure the option is available for services with economy_letter_sending permission
- Extended form validation to only show economy when service has economy_letter_sending permission


**Upload letter page for sevice with permission**
![Screenshot 2025-05-02 at 16 08 15](https://github.com/user-attachments/assets/76b8b6f5-394d-44ff-8dee-5bf85abcccd7)

**Upload letter page**
![Screenshot 2025-05-02 at 16 13 35](https://github.com/user-attachments/assets/c39b8fb7-9825-4fd5-b897-d19a6fc5d38b)

### Ticket:
- [Allow users to select economy postage when sending a precompiled letter via the admin interface](https://trello.com/c/E3C2DUil/1271-allow-users-to-select-economy-postage-when-sending-a-precompiled-letter-via-the-admin-interface)