### PR TITLE
Remove economy mail feature flag and always show the option on the postage forms

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1523,18 +1523,13 @@ class LetterTemplatePostageForm(StripWhitespaceForm):
     choices = [
         ("first", "First class"),
         ("second", "Second class"),
+        ("economy", "Economy mail"),
     ]
-
-    def __init__(self, *args, show_economy_class, **kwargs):
-        super().__init__(*args, **kwargs)
-        if show_economy_class:
-            self.postage.choices.append(("economy", "Economy mail"))
-            self.postage.thing = "first class, second class or economy mail"
 
     postage = GovukRadiosField(
         "Choose the postage for this letter template",
         choices=choices,
-        thing="first class or second class",
+        thing="first class, second class or economy mail",
         validators=[DataRequired()],
     )
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1546,13 +1546,8 @@ class LetterTemplateLanguagesForm(StripWhitespaceForm):
 
 
 class LetterUploadPostageForm(StripWhitespaceForm):
-    choices = [("first", "First class"), ("second", "Second class")]
-
-    def __init__(self, *args, postage_zone, show_economy_class, **kwargs):
+    def __init__(self, *args, postage_zone, **kwargs):
         super().__init__(*args, **kwargs)
-
-        if show_economy_class:
-            self.postage.choices.append(("economy", "Economy mail"))
 
         if postage_zone != Postage.UK:
             self.postage.choices = [(postage_zone, "")]
@@ -1564,7 +1559,11 @@ class LetterUploadPostageForm(StripWhitespaceForm):
 
     postage = GovukRadiosField(
         "Choose the postage for this letter",
-        choices=choices,
+        choices=[
+            ("first", "First class"),
+            ("second", "Second class"),
+            ("economy", "Economy mail"),
+        ],
         default="second",
         validators=[DataRequired()],
     )

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -81,7 +81,6 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = {
     "inbound_sms": {"title": "Receive inbound SMS", "requires": "sms", "endpoint": ".service_set_inbound_number"},
     "email_auth": {"title": "Email authentication"},
     "sms_to_uk_landlines": {"title": "Sending SMS to UK landlines"},
-    "economy_letter_sending": {"title": "Sending economy letters", "requires": "letter"},
 }
 
 THANKS_FOR_BRANDING_REQUEST_MESSAGE = (

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1014,9 +1014,7 @@ def edit_template_postage(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
     if template.template_type != "letter":
         abort(404)
-    form = LetterTemplatePostageForm(
-        **template._template, show_economy_class=current_service.has_permission("economy_letter_sending")
-    )
+    form = LetterTemplatePostageForm(**template._template)
     if form.validate_on_submit():
         postage = form.postage.data
         service_api_client.update_service_template(service_id, template_id, postage=postage)

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -250,9 +250,7 @@ def uploaded_letter_preview(service_id, file_id):
 
     error_message = get_letter_validation_error(error_shortcode, invalid_pages, page_count)
 
-    form = LetterUploadPostageForm(
-        postage_zone=postal_address.postage, show_economy_class=current_service.has_permission("economy_letter_sending")
-    )
+    form = LetterUploadPostageForm(postage_zone=postal_address.postage)
 
     template = current_service.get_precompiled_letter_template(
         letter_preview_url=url_for(".view_letter_upload_as_preview", service_id=service_id, file_id=file_id),
@@ -319,9 +317,7 @@ def send_uploaded_letter(service_id, file_id):
 
     postal_address = PostalAddress(metadata.get("recipient"))
 
-    form = LetterUploadPostageForm(
-        postage_zone=postal_address.postage, show_economy_class=current_service.has_permission("economy_letter_sending")
-    )
+    form = LetterUploadPostageForm(postage_zone=postal_address.postage)
 
     if not form.validate_on_submit():
         return uploaded_letter_preview(service_id, file_id)

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -75,7 +75,6 @@ class Service(JSONModel):
         "international_letters",
         "international_sms",
         "sms_to_uk_landlines",
-        "economy_letter_sending",
     )
 
     @classmethod

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -79,18 +79,6 @@ def test_service_set_permission_requires_platform_admin(
             "False",
             [],
         ),
-        (
-            ["letter"],
-            "economy_letter_sending",
-            "True",
-            ["letter", "economy_letter_sending"],
-        ),
-        (
-            ["letter", "economy_letter_sending"],
-            "economy_letter_sending",
-            "False",
-            ["letter"],
-        ),
     ],
 )
 def test_service_set_permission(
@@ -134,12 +122,6 @@ def test_service_set_permission(
             ".service_set_inbound_number",
             {},
             "Receive inbound SMS Off Change your settings for Receive inbound SMS",
-        ),
-        (
-            {"permissions": ["letter"]},
-            ".service_set_permission",
-            {"permission": "economy_letter_sending"},
-            "Sending economy letters Off Change your settings for Sending economy letters",
         ),
     ],
 )

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -160,7 +160,6 @@ def mock_get_service_settings_page_common(
                 "Custom data retention Email – 7 days Change data retention",
                 "Email authentication Off Change your settings for Email authentication",
                 "Sending SMS to UK landlines Off Change your settings for Sending SMS to UK landlines",
-                "Sending economy letters Off Change your settings for Sending economy letters",
             ],
         ),
     ],

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1615,14 +1615,12 @@ def test_edit_letter_template_postage_page_displays_correctly(
     assert page.select("input[checked]")[0].attrs["value"] == "second"
 
 
-def test_edit_letter_template_displays_all_postage_for_service_with_permission(
+def test_edit_letter_template_displays_all_postage_options(
     client_request,
     service_one,
     fake_uuid,
     mock_get_service_letter_template,
 ):
-    service_one.update({"permissions": ["economy_letter_sending"]})
-
     page = client_request.get(
         "main.edit_template_postage",
         service_id=SERVICE_ONE_ID,
@@ -1638,29 +1636,6 @@ def test_edit_letter_template_displays_all_postage_for_service_with_permission(
         (radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip())
         for radio in page.select("input[type=radio]")
     ] == [("first", "First class"), ("second", "Second class"), ("economy", "Economy mail")]
-
-
-def test_edit_letter_template_displays_first_and_second_for_service_without_permission(
-    client_request,
-    service_one,
-    fake_uuid,
-    mock_get_service_letter_template,
-):
-    page = client_request.get(
-        "main.edit_template_postage",
-        service_id=SERVICE_ONE_ID,
-        template_id=fake_uuid,
-    )
-
-    assert page.select_one("h1").text.strip() == "Change postage"
-    assert page.select("input[checked]")[0].attrs["value"] == "second"
-
-    assert len(page.select("input[type=radio]")) == 2
-
-    assert [
-        (radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip())
-        for radio in page.select("input[type=radio]")
-    ] == [("first", "First class"), ("second", "Second class")]
 
 
 def test_edit_letter_template_postage_page_404s_if_template_is_not_a_letter(

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -777,8 +777,6 @@ def test_uploaded_letter_preview_displays_all_postage_for_service_with_permissio
         "is_precompiled_letter": True,
     }
 
-    service_one.update({"permissions": ["economy_letter_sending"]})
-
     mocker.patch("uuid.uuid4", return_value=fake_uuid)
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
     mocker.patch(
@@ -823,69 +821,6 @@ def test_uploaded_letter_preview_displays_all_postage_for_service_with_permissio
         ("first", "First class"),
         ("second", "Second class"),
         ("economy", "Economy mail"),
-    ]
-
-
-def test_uploaded_letter_preview_displays_only_first_and_second_class(
-    active_user_with_permissions,
-    service_one,
-    client_request,
-    fake_uuid,
-    mocker,
-):
-    letter_template = {
-        "service": SERVICE_ONE_ID,
-        "template_type": "letter",
-        "reply_to_text": "",
-        "postage": "second",
-        "subject": "hi",
-        "content": "my letter",
-        "is_precompiled_letter": True,
-    }
-
-    mocker.patch("uuid.uuid4", return_value=fake_uuid)
-    mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
-    mocker.patch(
-        "app.template_preview_client.sanitise_letter",
-        return_value=Mock(
-            content="The sanitised content",
-            json=lambda: {"file": "VGhlIHNhbml0aXNlZCBjb250ZW50", "recipient_address": "The Queen"},
-        ),
-    )
-    mocker.patch("app.main.views.uploads.upload_letter_to_s3")
-    mocker.patch("app.main.views.uploads.backup_original_letter_to_s3")
-    mocker.patch("app.main.views.uploads.pdf_page_count", return_value=3)
-    do_mock_get_page_counts_for_letter(mocker, count=3)
-    mocker.patch(
-        "app.main.views.uploads.get_letter_metadata",
-        return_value=LetterMetadata(
-            {
-                "filename": "tests/test_pdf_files/one_page_pdf.pdf",
-                "page_count": "3",
-                "status": "valid",
-                "recipient": "The Queen",
-            }
-        ),
-    )
-    mocker.patch("app.models.service.service_api_client.get_precompiled_template", return_value=letter_template)
-
-    service_one["restricted"] = False
-    client_request.login(active_user_with_permissions, service=service_one)
-
-    with open("tests/test_pdf_files/one_page_pdf.pdf", "rb") as file:
-        page = client_request.post(
-            "main.upload_letter",
-            service_id=SERVICE_ONE_ID,
-            _data={"file": file},
-            _follow_redirects=True,
-        )
-
-    radio_inputs = page.select("input[type=radio]")
-
-    assert len(radio_inputs) == 2
-    assert [(radio["value"], page.select_one(f"label[for={radio['id']}]").text.strip()) for radio in radio_inputs] == [
-        ("first", "First class"),
-        ("second", "Second class"),
     ]
 
 
@@ -946,7 +881,7 @@ def test_send_uploaded_letter_sends_letter_and_redirects_to_notification_page(
     mock_send = mocker.patch("app.main.views.uploads.notification_api_client.send_precompiled_letter")
     mocker.patch("app.main.views.uploads.get_letter_metadata", return_value=metadata)
 
-    service_one["permissions"] = ["letter", "economy_letter_sending"]
+    service_one["permissions"] = ["letter"]
 
     client_request.post(
         "main.send_uploaded_letter",


### PR DESCRIPTION
This undoes the changes added in 
- https://github.com/alphagov/notifications-admin/pull/5449
- https://github.com/alphagov/notifications-admin/pull/5455
- https://github.com/alphagov/notifications-admin/pull/5433

Making the feature available for all and always visible on the postage page