### PR TITLE
Bump utils to 99.3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.3.0
+# This file was automatically copied from notifications-utils@99.3.2
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.3.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.3.2
 
 govuk-frontend-jinja==3.5.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@f3636bfdcdf43c0a18ab0e91b127e8eda5a63e50
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73d5018cacd490863ca96544b059d63df07f2c3b
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx
@@ -142,7 +142,7 @@ pypdf==3.13.0
     # via notifications-utils
 python-dateutil==2.8.2
     # via botocore
-python-json-logger==2.0.7
+python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -164,7 +164,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@f3636bfdcdf43c0a18ab0e91b127e8eda5a63e50
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73d5018cacd490863ca96544b059d63df07f2c3b
     # via -r requirements.txt
 openpyxl==3.1.5
     # via
@@ -246,7 +246,7 @@ python-dateutil==2.8.2
     #   botocore
     #   freezegun
     #   moto
-python-json-logger==2.0.7
+python-json-logger==3.3.0
     # via
     #   -r requirements.txt
     #   notifications-utils

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.3.0
+# This file was automatically copied from notifications-utils@99.3.2
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.3.0
+# This file was automatically copied from notifications-utils@99.3.2
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 99.3.2

* Stops counting Crown Dependency phone numbers in CSV file as international

 ## 99.3.1

* Bump `python-json-logger` to version 3

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/99.3.0...99.3.2