### PR TITLE
Remove unused service permissions

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -80,7 +80,6 @@ from app.utils.user import (
 PLATFORM_ADMIN_SERVICE_PERMISSIONS = {
     "inbound_sms": {"title": "Receive inbound SMS", "requires": "sms", "endpoint": ".service_set_inbound_number"},
     "email_auth": {"title": "Email authentication"},
-    "extra_email_formatting": {"title": "Extra email formatting options", "requires": "email"},
     "sms_to_uk_landlines": {"title": "Sending SMS to UK landlines"},
     "economy_letter_sending": {"title": "Sending economy letters", "requires": "letter"},
 }

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -81,7 +81,6 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = {
     "inbound_sms": {"title": "Receive inbound SMS", "requires": "sms", "endpoint": ".service_set_inbound_number"},
     "email_auth": {"title": "Email authentication"},
     "extra_email_formatting": {"title": "Extra email formatting options", "requires": "email"},
-    "extra_letter_formatting": {"title": "Extra letter formatting options", "requires": "letter"},
     "sms_to_uk_landlines": {"title": "Sending SMS to UK landlines"},
     "economy_letter_sending": {"title": "Sending economy letters", "requires": "letter"},
 }

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -72,7 +72,6 @@ class Service(JSONModel):
         "edit_folder_permissions",
         "email_auth",
         "extra_email_formatting",
-        "extra_letter_formatting",
         "inbound_sms",
         "international_letters",
         "international_sms",

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -71,7 +71,6 @@ class Service(JSONModel):
     ALL_PERMISSIONS = TEMPLATE_TYPES + (
         "edit_folder_permissions",
         "email_auth",
-        "extra_email_formatting",
         "inbound_sms",
         "international_letters",
         "international_sms",

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -76,7 +76,6 @@ class Service(JSONModel):
         "inbound_sms",
         "international_letters",
         "international_sms",
-        "upload_document",
         "sms_to_uk_landlines",
         "economy_letter_sending",
     )

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -80,18 +80,6 @@ def test_service_set_permission_requires_platform_admin(
             ["email"],
         ),
         (
-            ["letter"],
-            "extra_letter_formatting",
-            "True",
-            ["letter", "extra_letter_formatting"],
-        ),
-        (
-            ["letter", "extra_letter_formatting"],
-            "extra_letter_formatting",
-            "False",
-            ["letter"],
-        ),
-        (
             [],
             "sms_to_uk_landlines",
             "True",
@@ -164,12 +152,6 @@ def test_service_set_permission(
             ".service_set_permission",
             {"permission": "extra_email_formatting"},
             "Extra email formatting options Off Change your settings for Extra email formatting options",
-        ),
-        (
-            {"permissions": ["letter"]},
-            ".service_set_permission",
-            {"permission": "extra_letter_formatting"},
-            "Extra letter formatting options Off Change your settings for Extra letter formatting options",
         ),
         (
             {"permissions": ["letter"]},

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -68,18 +68,6 @@ def test_service_set_permission_requires_platform_admin(
             [],
         ),
         (
-            ["email"],
-            "extra_email_formatting",
-            "True",
-            ["email", "extra_email_formatting"],
-        ),
-        (
-            ["email", "extra_email_formatting"],
-            "extra_email_formatting",
-            "False",
-            ["email"],
-        ),
-        (
             [],
             "sms_to_uk_landlines",
             "True",
@@ -146,12 +134,6 @@ def test_service_set_permission(
             ".service_set_inbound_number",
             {},
             "Receive inbound SMS Off Change your settings for Receive inbound SMS",
-        ),
-        (
-            {"permissions": ["email"]},
-            ".service_set_permission",
-            {"permission": "extra_email_formatting"},
-            "Extra email formatting options Off Change your settings for Extra email formatting options",
         ),
         (
             {"permissions": ["letter"]},

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -160,7 +160,6 @@ def mock_get_service_settings_page_common(
                 "Letter branding Not set Change letter branding (admin view)",
                 "Custom data retention Email – 7 days Change data retention",
                 "Email authentication Off Change your settings for Email authentication",
-                "Extra letter formatting options Off Change your settings for Extra letter formatting options",
                 "Sending SMS to UK landlines Off Change your settings for Sending SMS to UK landlines",
                 "Sending economy letters Off Change your settings for Sending economy letters",
             ],

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -129,7 +129,6 @@ def mock_get_service_settings_page_common(
                 "Custom data retention Email – 7 days Change data retention",
                 "Receive inbound SMS Off Change your settings for Receive inbound SMS",
                 "Email authentication Off Change your settings for Email authentication",
-                "Extra email formatting options Off Change your settings for Extra email formatting options",
                 "Sending SMS to UK landlines Off Change your settings for Sending SMS to UK landlines",
             ],
         ),

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -5081,7 +5081,6 @@ def test_send_files_by_email_contact_details_does_not_update_invalid_contact_det
     mocker,
 ):
     service_one["contact_link"] = "http://example.com/"
-    service_one["permissions"].append("upload_document")
 
     page = client_request.post(
         "main.send_files_by_email_contact_details",

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1339,7 +1339,7 @@ def test_menu_send_messages(
     mock_get_free_sms_fragment_limit,
     mock_get_returned_letter_statistics_with_no_returned_letters,
 ):
-    service_one["permissions"] = ["email", "sms", "letter", "upload_letters"]
+    service_one["permissions"] = ["email", "sms", "letter"]
 
     page = _test_dashboard_menu(
         client_request,
@@ -1362,33 +1362,6 @@ def test_menu_send_messages(
     assert url_for("main.service_settings", service_id=service_one["id"]) not in page
     assert url_for("main.api_keys", service_id=service_one["id"]) not in page
     assert url_for("main.view_providers") not in page
-
-
-def test_menu_send_messages_when_service_does_not_have_upload_letters_permission(
-    client_request,
-    mocker,
-    api_user_active,
-    service_one,
-    mock_get_service_templates,
-    mock_has_no_jobs,
-    mock_get_template_statistics,
-    mock_get_service_statistics,
-    mock_get_unsubscribe_requests_statistics,
-    mock_get_annual_usage_for_service,
-    mock_get_inbound_sms_summary,
-    mock_get_free_sms_fragment_limit,
-    mock_get_returned_letter_statistics_with_no_returned_letters,
-):
-    page = _test_dashboard_menu(
-        client_request,
-        mocker,
-        api_user_active,
-        service_one,
-        ["view_activity", "send_texts", "send_emails", "send_letters"],
-    )
-
-    assert page.select_one(".navigation")
-    assert url_for("main.uploads", service_id=service_one["id"]) not in page.select_one(".navigation")
 
 
 def test_menu_manage_service(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1057,7 +1057,6 @@ def test_POST_letter_template_change_to_welsh_and_english_resets_english_subject
         },
     )
 
-    service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
 
     mock_template_change_language = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
@@ -1194,7 +1193,6 @@ def test_POST_letter_template_confirm_remove_welsh_resets_english_subject_and_co
 
     mocker.patch("app.service_api_client.get_service_template", side_effect=_get)
 
-    service_one["permissions"].append("extra_letter_formatting")
     client_request.login(active_user_with_permissions)
 
     mock_template_change_language = mocker.patch("app.main.views.templates.service_api_client.update_service_template")
@@ -1903,7 +1901,6 @@ def test_should_be_able_to_view_a_letter_template_with_bilingual_content(
     fake_uuid,
     mocker,
 ):
-    service_one["permissions"].append("extra_letter_formatting")
     do_mock_get_page_counts_for_letter(mocker, count=5, welsh_page_count=3)
     page = client_request.get(
         "main.view_template",
@@ -3646,7 +3643,6 @@ def test_update_template_for_english_content_in_welsh_letter(
 ):
     do_mock_get_page_counts_for_letter(mocker, count=1, welsh_page_count=1)
     service_one["permissions"].append("letter")
-    service_one["permissions"].append("extra_letter_formatting")
     name = "new template name"
     content = "English letter content"
     subject = "English letter subject"

--- a/tests/app/main/views/uploads/test_upload_hub.py
+++ b/tests/app/main/views/uploads/test_upload_hub.py
@@ -18,12 +18,7 @@ from tests.conftest import (
             [],
             marks=pytest.mark.xfail(raises=AssertionError),
         ),
-        pytest.param(
-            ["upload_letters"],
-            marks=pytest.mark.xfail(raises=AssertionError),
-        ),
         ["letter"],
-        ["letter", "upload_letters"],
     ),
 )
 def test_upload_letters_button_only_with_letters_permission(
@@ -102,7 +97,7 @@ def test_get_upload_hub_page(
     mocker,
 ):
     mocker.patch("app.job_api_client.get_jobs", return_value={"data": []})
-    service_one["permissions"] += ["letter", "upload_letters"]
+    service_one["permissions"] += ["letter"]
     page = client_request.get("main.uploads", service_id=SERVICE_ONE_ID)
     assert page.select_one("h1").text == "Uploads"
 

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -946,7 +946,7 @@ def test_send_uploaded_letter_sends_letter_and_redirects_to_notification_page(
     mock_send = mocker.patch("app.main.views.uploads.notification_api_client.send_precompiled_letter")
     mocker.patch("app.main.views.uploads.get_letter_metadata", return_value=metadata)
 
-    service_one["permissions"] = ["letter", "upload_letters", "economy_letter_sending"]
+    service_one["permissions"] = ["letter", "economy_letter_sending"]
 
     client_request.post(
         "main.send_uploaded_letter",
@@ -976,7 +976,7 @@ def test_send_uploaded_letter_redirects_if_file_not_in_s3(
 ):
     mocker.patch("app.main.views.uploads.get_letter_metadata", side_effect=LetterNotFoundError)
 
-    service_one["permissions"] = ["letter", "upload_letters"]
+    service_one["permissions"] = ["letter"]
 
     client_request.post(
         "main.send_uploaded_letter",
@@ -1040,7 +1040,7 @@ def test_send_uploaded_letter_when_metadata_states_pdf_is_invalid(
         ),
     )
 
-    service_one["permissions"] = ["letter", "upload_letters"]
+    service_one["permissions"] = ["letter"]
 
     client_request.post(
         "main.send_uploaded_letter",


### PR DESCRIPTION
This removes 4 service permissions which were designed to test new features but are not being used:
* `upload_document `
* `extra_email_formatting `
* `extra_letter_formatting `
* `upload_letter`

These will also need to be removed from the api and the database.