### PR TITLE
Make a model for API keys

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -16,7 +16,7 @@ from flask_wtf.file import FileField as FileField_wtf
 from markupsafe import Markup
 from notifications_utils.countries.data import Postage
 from notifications_utils.formatters import strip_all_whitespace
-from notifications_utils.insensitive_dict import InsensitiveDict
+from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
 from notifications_utils.recipient_validation.email_address import validate_email_address
 from notifications_utils.recipient_validation.errors import InvalidEmailError, InvalidPhoneError
 from notifications_utils.recipient_validation.phone_number import PhoneNumber as PhoneNumberUtils
@@ -1664,7 +1664,7 @@ class ChooseTimeForm(StripWhitespaceForm):
 
 class CreateKeyForm(StripWhitespaceForm):
     def __init__(self, existing_keys, *args, **kwargs):
-        self.existing_key_names = [key.name.lower() for key in existing_keys if not key.expiry_date]
+        self.existing_key_names = InsensitiveSet(key.name for key in existing_keys if not key.expiry_date)
         super().__init__(*args, **kwargs)
 
     key_name = GovukTextInputField(
@@ -1677,7 +1677,7 @@ class CreateKeyForm(StripWhitespaceForm):
     )
 
     def validate_key_name(self, key_name):
-        if key_name.data.lower() in self.existing_key_names:
+        if key_name.data in self.existing_key_names:
             raise ValidationError("A key with this name already exists")
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1664,7 +1664,7 @@ class ChooseTimeForm(StripWhitespaceForm):
 
 class CreateKeyForm(StripWhitespaceForm):
     def __init__(self, existing_keys, *args, **kwargs):
-        self.existing_key_names = [key["name"].lower() for key in existing_keys if not key["expiry_date"]]
+        self.existing_key_names = [key.name.lower() for key in existing_keys if not key.expiry_date]
         super().__init__(*args, **kwargs)
 
     key_name = GovukTextInputField(

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -12,11 +12,6 @@ from app.main import main
 from app.main.forms import CallbackForm, CreateKeyForm, GuestList
 from app.models.api_key import APIKey
 from app.models.notification import APINotifications
-from app.notify_client.api_key_api_client import (
-    KEY_TYPE_NORMAL,
-    KEY_TYPE_TEAM,
-    KEY_TYPE_TEST,
-)
 from app.utils.user import user_has_permissions
 
 dummy_bearer_token = "bearer_token_set"
@@ -75,9 +70,9 @@ def api_keys(service_id):
 def create_api_key(service_id):
     form = CreateKeyForm(current_service.api_keys)
     form.key_type.choices = [
-        (KEY_TYPE_NORMAL, "Live – sends to anyone"),
-        (KEY_TYPE_TEAM, "Team and guest list – limits who you can send to"),
-        (KEY_TYPE_TEST, "Test – pretends to send messages"),
+        (APIKey.TYPE_NORMAL, "Live – sends to anyone"),
+        (APIKey.TYPE_TEAM, "Team and guest list – limits who you can send to"),
+        (APIKey.TYPE_TEST, "Test – pretends to send messages"),
     ]
     # preserve order of items extended by starting with empty dicts
     form.key_type.param_extensions = {"items": [{}, {}]}
@@ -94,7 +89,7 @@ def create_api_key(service_id):
     if current_service.has_permission("letter"):
         form.key_type.param_extensions["items"][1]["hint"] = {"text": "Cannot be used to send letters"}
     if form.validate_on_submit():
-        if current_service.trial_mode and form.key_type.data == KEY_TYPE_NORMAL:
+        if current_service.trial_mode and form.key_type.data == APIKey.TYPE_NORMAL:
             abort(400)
         secret = APIKey.create(
             service_id=service_id,

--- a/app/models/api_key.py
+++ b/app/models/api_key.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from typing import Any
+
+from flask import abort
+
+from app.models import JSONModel, ModelList
+from app.notify_client.api_key_api_client import api_key_api_client
+
+
+class APIKey(JSONModel):
+    created_at: datetime
+    created_by: Any
+    expiry_date: datetime
+    id: Any
+    key_type: str
+    name: str
+
+    __sort_attribute__ = "name"
+
+    # must match key types in notifications-api/app/models.py
+    TYPE_NORMAL = "normal"
+    TYPE_TEAM = "team"
+    TYPE_TEST = "test"
+
+    @classmethod
+    def create(cls, service_id, name, key_type):
+        return api_key_api_client.create_api_key(service_id=service_id, key_name=name, key_type=key_type)
+
+    def revoke(self, *, service_id):
+        api_key_api_client.revoke_api_key(service_id=service_id, key_id=self.id)
+
+
+class APIKeys(ModelList):
+    model = APIKey
+
+    @staticmethod
+    def _get_items(*args, **kwargs):
+        return api_key_api_client.get_api_keys(*args, **kwargs)["apiKeys"]
+
+    def get(self, id):
+        for api_key in self:
+            if api_key.id == id:
+                return api_key
+        abort(404)

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -10,7 +10,7 @@ from notifications_utils.template import (
 from werkzeug.utils import cached_property
 
 from app.models import JSONModel, ModelList
-from app.notify_client.api_key_api_client import KEY_TYPE_TEST
+from app.models.api_key import APIKey
 from app.notify_client.notification_api_client import notification_api_client
 from app.notify_client.service_api_client import service_api_client
 from app.utils import DELIVERED_STATUSES, FAILURE_STATUSES
@@ -63,7 +63,7 @@ class Notification(JSONModel):
 
     @property
     def sent_with_test_key(self):
-        return self.key_type == KEY_TYPE_TEST
+        return self.key_type == APIKey.TYPE_TEST
 
     @property
     def sent_by(self):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -14,13 +14,13 @@ from app.constants import (
     SIGN_IN_METHOD_TEXT_OR_EMAIL,
 )
 from app.models import JSONModel
+from app.models.api_key import APIKeys
 from app.models.branding import EmailBranding, LetterBranding
 from app.models.contact_list import ContactLists
 from app.models.job import ImmediateJobs, PaginatedJobs, PaginatedUploads, ScheduledJobs
 from app.models.organisation import Organisation
 from app.models.unsubscribe_requests_report import UnsubscribeRequestsReports
 from app.models.user import InvitedUsers, User, Users
-from app.notify_client.api_key_api_client import api_key_api_client
 from app.notify_client.billing_api_client import billing_api_client
 from app.notify_client.inbound_number_client import inbound_number_client
 from app.notify_client.invite_api_client import invite_api_client
@@ -560,13 +560,7 @@ class Service(JSONModel):
 
     @cached_property
     def api_keys(self):
-        return sorted(
-            api_key_api_client.get_api_keys(self.id)["apiKeys"],
-            key=lambda key: key["name"].lower(),
-        )
-
-    def get_api_key(self, id):
-        return self._get_by_id(self.api_keys, id)
+        return APIKeys(self.id)
 
     @property
     def able_to_accept_agreement(self):

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -7,11 +7,6 @@ from werkzeug.local import LocalProxy
 from app import memo_resetters
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 
-# must match key types in notifications-api/app/models.py
-KEY_TYPE_NORMAL = "normal"
-KEY_TYPE_TEAM = "team"
-KEY_TYPE_TEST = "test"
-
 
 class ApiKeyApiClient(NotifyAdminAPIClient):
     def get_api_keys(self, service_id):

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -18,7 +18,7 @@
 
   <div class="body-copy-table">
     {% call(item, row_number) list_table(
-      current_service.api_keys,
+      current_service.api_keys|sort,
       empty_message="You have not created any API keys yet",
       caption="API keys",
       caption_visible=false,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -375,8 +375,8 @@ def template_version_json(service_id, id_, created_by, version=1, created_at=Non
     return template
 
 
-def api_key_json(id_, name, expiry_date=None):
-    return {"id": id_, "name": name, "expiry_date": expiry_date}
+def api_key_json(id_, name, expiry_date=None, key_type="normal"):
+    return {"id": id_, "name": name, "expiry_date": expiry_date, "key_type": key_type}
 
 
 def invite_json(

--- a/tests/app/main/forms/test_create_key_form.py
+++ b/tests/app/main/forms/test_create_key_form.py
@@ -2,6 +2,7 @@ import pytest
 from werkzeug.datastructures import MultiDict
 
 from app.main.forms import CreateKeyForm
+from app.models.api_key import APIKeys
 
 
 @pytest.mark.parametrize(
@@ -15,19 +16,25 @@ def test_return_validation_error_when_key_name_exists(
     client_request,
     expiry_date,
     expected_errors,
+    mocker,
 ):
-    _existing_keys = [
-        {
-            "name": "some key",
-            "expiry_date": expiry_date,
+    mocker.patch(
+        "app.models.api_key.api_key_api_client.get_api_keys",
+        return_value={
+            "apiKeys": [
+                {
+                    "name": "some key",
+                    "expiry_date": expiry_date,
+                },
+                {
+                    "name": "another key",
+                    "expiry_date": None,
+                },
+            ]
         },
-        {
-            "name": "another key",
-            "expiry_date": None,
-        },
-    ]
+    )
 
-    form = CreateKeyForm(_existing_keys, formdata=MultiDict([("key_name", "Some key")]))
+    form = CreateKeyForm(APIKeys("foo"), formdata=MultiDict([("key_name", "Some key")]))
 
     form.key_type.choices = [("a", "a"), ("b", "b")]
     form.validate()

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -399,7 +399,7 @@ def test_should_create_api_key_with_type_normal(
     fake_uuid,
     mocker,
 ):
-    post = mocker.patch("app.notify_client.api_key_api_client.ApiKeyApiClient.post", return_value={"data": fake_uuid})
+    post = mocker.patch("app.models.api_key.api_key_api_client.post", return_value={"data": fake_uuid})
 
     page = client_request.post(
         "main.create_api_key",
@@ -426,7 +426,7 @@ def test_cant_create_normal_api_key_in_trial_mode(
     mock_has_permissions,
     mocker,
 ):
-    mock_post = mocker.patch("app.notify_client.api_key_api_client.ApiKeyApiClient.post")
+    mock_post = mocker.patch("app.models.api_key.api_key_api_client.post")
 
     client_request.post(
         "main.create_api_key",

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -319,8 +319,9 @@ def test_should_show_api_keys_page(
     revoke_link = page.select_one("main tr a.govuk-link.govuk-link--destructive")
 
     assert rows[0] == "API keys Action"
-    assert rows[1] == "another key name Revoked 1 January at 1:00am"
-    assert rows[2] == "some key name Revoke some key name"
+    assert rows[1] == "another key name Test – pretends to send messages Revoked 1 January at 1:00am"
+    assert rows[2] == "some key name Live – sends to anyone Revoke some key name"
+    assert rows[3] == "third key Team and guest list – limits who you can send to Revoke third key"
 
     assert normalize_spaces(revoke_link.text) == "Revoke some key name"
     assert revoke_link["href"] == url_for(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1456,7 +1456,7 @@ def mock_revoke_api_key(notify_admin, mocker):
     def _revoke(service_id, key_id):
         return {}
 
-    return mocker.patch("app.api_key_api_client.revoke_api_key", side_effect=_revoke)
+    return mocker.patch("app.models.api_key.api_key_api_client.revoke_api_key", side_effect=_revoke)
 
 
 @pytest.fixture(scope="function")
@@ -1473,7 +1473,7 @@ def mock_get_api_keys(notify_admin, mocker, fake_uuid):
         }
         return keys
 
-    return mocker.patch("app.api_key_api_client.get_api_keys", side_effect=_get_keys)
+    return mocker.patch("app.models.api_key.api_key_api_client.get_api_keys", side_effect=_get_keys)
 
 
 @pytest.fixture(scope="function")
@@ -1482,7 +1482,7 @@ def mock_get_no_api_keys(notify_admin, mocker):
         keys = {"apiKeys": []}
         return keys
 
-    return mocker.patch("app.api_key_api_client.get_api_keys", side_effect=_get_keys)
+    return mocker.patch("app.models.api_key.api_key_api_client.get_api_keys", side_effect=_get_keys)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1464,11 +1464,18 @@ def mock_get_api_keys(notify_admin, mocker, fake_uuid):
     def _get_keys(service_id, key_id=None):
         keys = {
             "apiKeys": [
+                api_key_json(id_=fake_uuid, name="some key name", key_type="normal"),
                 api_key_json(
-                    id_=fake_uuid,
-                    name="some key name",
+                    id_="1234567",
+                    name="another key name",
+                    expiry_date=str(date.fromtimestamp(0)),
+                    key_type="test",
                 ),
-                api_key_json(id_="1234567", name="another key name", expiry_date=str(date.fromtimestamp(0))),
+                api_key_json(
+                    id_=str(uuid4()),
+                    name="third key",
+                    key_type="team",
+                ),
             ]
         }
         return keys


### PR DESCRIPTION
Follows the pattern we have for other entities in the admin app to avoid interacting directly with deserialised JSON