### PR TITLE
Drop inbound api

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -28,3 +28,11 @@ QR_CODE_TOO_LONG = "qr-code-too-long"
 class LetterLanguageOptions(str, enum.Enum):
     english = "english"
     welsh_then_english = "welsh_then_english"
+
+
+# Service callbacks
+class ServiceCallbackTypes(enum.StrEnum):
+    delivery_status = "delivery_status"
+    complaint = "complaint"
+    returned_letter = "returned_letter"
+    inbound_sms = "inbound_sms"

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -305,3 +305,35 @@ def returned_letters_callback(service_id):
         back_link=back_link,
         form=form,
     )
+
+
+def create_or_update_or_remove_callback(callback_details, callback_type, form, service_id):
+    if callback_details and form.url.data:
+        if callback_details.get("url") != form.url.data or form.bearer_token.data != dummy_bearer_token:
+            service_api_client.update_service_callback_api(
+                service_id,
+                url=form.url.data,
+                bearer_token=check_token_against_dummy_bearer(form.bearer_token.data),
+                user_id=current_user.id,
+                callback_api_id=callback_details.get("id"),
+                callback_type=callback_type,
+            )
+    elif callback_details and not form.url.data:
+        service_api_client.delete_service_callback_api(
+            service_id=service_id,
+            callback_api_id=callback_details["id"],
+            callback_type=callback_type,
+        )
+    elif form.url.data:
+        service_api_client.create_service_callback_api(
+            service_id,
+            url=form.url.data,
+            bearer_token=form.bearer_token.data,
+            user_id=current_user.id,
+            callback_type=callback_type,
+        )
+    else:
+        # If no callback is set up and the user chooses to continue
+        # having no callback (ie both fields empty) then there’s
+        # nothing for us to do here
+        pass

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -161,6 +161,7 @@ def delivery_status_callback(service_id):
         url=delivery_status_callback_details.get("url") if delivery_status_callback_details else "",
         bearer_token=dummy_bearer_token if delivery_status_callback else "",
     )
+
     if form.validate_on_submit():
         if delivery_status_callback_details and form.url.data:
             if (

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Any
 
 from flask import abort, current_app
-from notifications_python_client.errors import HTTPError
 from notifications_utils.serialised_model import SerialisedModelCollection
 from werkzeug.utils import cached_property
 
@@ -657,15 +656,7 @@ class Service(JSONModel):
 
     @property
     def inbound_sms_callback_details(self):
-        if self.inbound_api:
-            try:
-                return service_api_client.get_service_callback_api(self.id, self.inbound_api[0], "inbound_sms")
-            except HTTPError:
-                pass
-        try:
-            return self.get_service_callback_details("inbound_sms")
-        except HTTPError:
-            pass
+        return self.get_service_callback_details("inbound_sms")
 
     @property
     def delivery_status_callback_details(self):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -663,19 +663,19 @@ class Service(JSONModel):
             except HTTPError:
                 pass
         try:
-            return self._callback_service_callback_details("inbound_sms")
+            return self.get_service_callback_details("inbound_sms")
         except HTTPError:
             pass
 
     @property
     def delivery_status_callback_details(self):
-        return self._callback_service_callback_details("delivery_status")
+        return self.get_service_callback_details("delivery_status")
 
     @property
     def returned_letters_callback_details(self):
-        return self._callback_service_callback_details("returned_letter")
+        return self.get_service_callback_details("returned_letter")
 
-    def _callback_service_callback_details(self, callback_type):
+    def get_service_callback_details(self, callback_type):
         if callback_api := self.service_callback_api:
             for row in callback_api:
                 if row["callback_type"] == callback_type:

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -44,7 +44,6 @@ class Service(JSONModel):
     go_live_at: datetime
     has_active_go_live_request: bool
     id: Any
-    inbound_api: Any
     email_message_limit: int
     international_sms_message_limit: int
     sms_message_limit: int

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -176,7 +176,6 @@ def service_json(
     branding="govuk",
     created_at=None,
     letter_contact_block=None,
-    inbound_api=None,
     service_callback_api=None,
     permissions=None,
     organisation_type="central",
@@ -198,8 +197,6 @@ def service_json(
         permissions = ["email", "sms"]
     if service_callback_api is None:
         service_callback_api = []
-    if inbound_api is None:
-        inbound_api = []
     return {
         "id": id_,
         "name": name,
@@ -222,7 +219,6 @@ def service_json(
         "letter_branding": None,
         "letter_contact_block": letter_contact_block,
         "permissions": permissions,
-        "inbound_api": inbound_api,
         "service_callback_api": service_callback_api,
         "prefix_sms": prefix_sms,
         "contact_link": contact_link,

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -4,7 +4,7 @@ from unittest.mock import call
 import pytest
 from flask import url_for
 
-from tests import generate_uuid, sample_uuid, validate_route_permission
+from tests import generate_uuid, validate_route_permission
 from tests.conftest import SERVICE_ONE_ID, create_notifications, normalize_spaces
 
 
@@ -683,8 +683,8 @@ def test_callback_forms_can_be_cleared(
     service_one["service_callback_api"] = [
         {"callback_id": fake_uuid, "callback_type": "delivery_status"},
         {"callback_id": fake_uuid, "callback_type": "returned_letter"},
+        {"callback_id": fake_uuid, "callback_type": "inbound_sms"},
     ]
-    service_one["inbound_api"] = [fake_uuid]
     service_one["permissions"] = ["inbound_sms"]
     mocked_delete = mocker.patch("app.service_api_client.delete")
 
@@ -897,19 +897,21 @@ def test_create_service_callbacks(
 
 
 @pytest.mark.parametrize(
-    "endpoint, service_callback_api, inbound_callback_api, callback_type",
+    "endpoint, service_callback_api, callback_type",
     [
         (
             "main.delivery_status_callback",
             [{"callback_id": uuid.uuid4(), "callback_type": "delivery_status"}],
-            [],
             "delivery_status",
         ),
-        ("main.received_text_messages_callback", None, [uuid.uuid4()], "inbound_sms"),
+        (
+            "main.received_text_messages_callback",
+            [{"callback_id": uuid.uuid4(), "callback_type": "inbound_sms"}],
+            "inbound_sms",
+        ),
         (
             "main.returned_letters_callback",
             [{"callback_id": uuid.uuid4(), "callback_type": "returned_letter"}],
-            [],
             "returned_letter",
         ),
     ],
@@ -922,10 +924,8 @@ def test_update_service_callback_details(
     endpoint,
     callback_type,
     service_callback_api,
-    inbound_callback_api,
     fake_uuid,
 ):
-    service_one["inbound_api"] = inbound_callback_api
     service_one["permissions"] = ["inbound_sms"]
     service_one["service_callback_api"] = service_callback_api
 
@@ -941,9 +941,7 @@ def test_update_service_callback_details(
         service_id=service_one["id"],
         _data=data,
     )
-    callback_api_id = (
-        inbound_callback_api[0] if callback_type == "inbound_sms" else service_callback_api[0]["callback_id"]
-    )
+    callback_api_id = service_callback_api[0]["callback_id"]
     mock_update_service_callback_api.assert_called_once_with(
         service_one["id"],
         url=f"https://test.url.com/{callback_type}",
@@ -984,10 +982,9 @@ def test_update_service_callback_without_changes_does_not_update(
 
 
 @pytest.mark.parametrize(
-    "service_callback_api, inbound_api, delivery_url, expected_1st_row, expected_2nd_row, expected_3rd_row",
+    "service_callback_api, delivery_url, expected_1st_row, expected_2nd_row, expected_3rd_row",
     [
         (
-            None,
             None,
             {},
             "Delivery receipts Not set Change",
@@ -998,18 +995,17 @@ def test_update_service_callback_without_changes_does_not_update(
             [
                 {"callback_id": uuid.uuid4(), "callback_type": "delivery_status"},
                 {"callback_id": uuid.uuid4(), "callback_type": "returned_letter"},
+                {"callback_id": uuid.uuid4(), "callback_type": "inbound_sms"},
             ],
-            None,
             {"url": "https://generic.urls"},
             "Delivery receipts https://generic.urls Change",
-            "Received text messages Not set Change",
+            "Received text messages https://generic.urls Change",
             "Returned letters https://generic.urls Change",
         ),
         (
             [
                 {"callback_id": uuid.uuid4(), "callback_type": "delivery_status"},
             ],
-            None,
             {"url": "https://delivery.receipts"},
             "Delivery receipts https://delivery.receipts Change",
             "Received text messages Not set Change",
@@ -1019,15 +1015,15 @@ def test_update_service_callback_without_changes_does_not_update(
             [
                 {"callback_id": uuid.uuid4(), "callback_type": "returned_letter"},
             ],
-            None,
             {"url": "https://returned.letter"},
             "Delivery receipts Not set Change",
             "Received text messages Not set Change",
             "Returned letters https://returned.letter Change",
         ),
         (
-            None,
-            sample_uuid(),
+            [
+                {"callback_id": uuid.uuid4(), "callback_type": "inbound_sms"},
+            ],
             {"url": "https://inbound.sms"},
             "Delivery receipts Not set Change",
             "Received text messages https://inbound.sms Change",
@@ -1042,13 +1038,11 @@ def test_callbacks_page_works_when_no_apis_set(
     service_callback_api,
     delivery_url,
     expected_1st_row,
-    inbound_api,
     expected_2nd_row,
     expected_3rd_row,
     platform_admin_user,
 ):
     service_one["permissions"] = ["inbound_sms", "letter"]
-    service_one["inbound_api"] = inbound_api
     service_one["service_callback_api"] = service_callback_api
 
     mocker.patch("app.service_api_client.get_service_callback_api", return_value=delivery_url)


### PR DESCRIPTION
This PR removes all references to `service_inbound_api` from the admin app.
It also includes refactoring of the callback endpoints to reduce duplication.
This PR is linked to https://github.com/alphagov/notifications-api/pull/4467