### PR TITLE
refactor: Set estimated letter delivery to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.3.3
+# This file was automatically copied from notifications-utils@99.5.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -125,7 +125,7 @@ class Notification(JSONModel):
     @property
     def estimated_letter_delivery_date(self):
         if self.notification_type == "letter":
-            return get_letter_timings(self.created_at.replace(tzinfo=None), postage=self.postage).earliest_delivery
+            return get_letter_timings(self.created_at.replace(tzinfo=None), postage=self.postage).latest_delivery
 
     @property
     def letter_can_be_cancelled(self):

--- a/app/templates/partials/jobs/count-letters.html
+++ b/app/templates/partials/jobs/count-letters.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-one-half">
     <div class="keyline-block">
       {{ big_number(
-        job.letter_timings.earliest_delivery|string|format_date_short,
+        job.letter_timings.latest_delivery|string|format_date_short,
         'Estimated delivery date',
         smaller=True
       )}}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -78,7 +78,7 @@
             {{ notification.letter_print_day }}
           </p>
           <p class="govuk-body">
-            Estimated delivery date: {{ notification.estimated_letter_delivery_date|format_day_of_week }} {{ notification.estimated_letter_delivery_date|format_date_short }}
+            Estimated delivery by {{ notification.estimated_letter_delivery_date|format_day_of_week }} {{ notification.estimated_letter_delivery_date|format_date_short }}
           </p>
         {% endif %}
       {% endif %}

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.3.3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.0
 
 govuk-frontend-jinja==3.5.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7d7a531ec102078988e2cdc1493a56c2cc5d0368
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0b99dd5a5b0f55a77a537c7fdcf508d76e286a76
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -164,7 +164,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7d7a531ec102078988e2cdc1493a56c2cc5d0368
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0b99dd5a5b0f55a77a537c7fdcf508d76e286a76
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.3.3
+# This file was automatically copied from notifications-utils@99.5.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.3.3
+# This file was automatically copied from notifications-utils@99.5.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -321,7 +321,7 @@ def test_should_show_letter_job(
         "1 Example Street template subject 1 January at 11:09am"
     )
     assert normalize_spaces(page.select(".keyline-block")[0].text) == "1 Letter"
-    assert normalize_spaces(page.select(".keyline-block")[1].text) == "6 January Estimated delivery date"
+    assert normalize_spaces(page.select(".keyline-block")[1].text) == "7 January Estimated delivery date"
     assert page.select_one("a[id=download-job-report]")["href"] == url_for(
         "main.view_job_csv",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -263,7 +263,7 @@ def test_notification_page_shows_page_for_letter_notification(
     )
     assert normalize_spaces(page.select("main p:nth-of-type(2)")[0].text) == "Printing starts today at 5:30pm"
     assert normalize_spaces(page.select("main p:nth-of-type(3)")[0].text) == (
-        "Estimated delivery date: Wednesday 6 January"
+        "Estimated delivery by Thursday 7 January"
     )
     assert len(page.select(".letter-postage")) == 1
     assert normalize_spaces(page.select_one(".letter-postage").text) == "Postage: second class"
@@ -512,25 +512,25 @@ def test_notification_page_does_not_show_cancel_link_for_letter_which_cannot_be_
             "first",
             "Postage: first class",
             "letter-postage-first",
-            "Estimated delivery date: Tuesday 5 January",
+            "Estimated delivery by Tuesday 5 January",
         ),
         (
             "economy",
             "Postage: economy",
             "letter-postage-economy",
-            "Estimated delivery date: Thursday 7 January",
+            "Estimated delivery by Monday 11 January",
         ),
         (
             "europe",
             "Postage: international",
             "letter-postage-international",
-            "Estimated delivery date: Friday 8 January",
+            "Estimated delivery by Monday 11 January",
         ),
         (
             "rest-of-world",
             "Postage: international",
             "letter-postage-international",
-            "Estimated delivery date: Monday 11 January",
+            "Estimated delivery by Wednesday 13 January",
         ),
     ),
 )


### PR DESCRIPTION
## Summary
- We have changed the backend to provide the latest delivery date for letters, and this PR is changing the UI to align with the expectation of this date
- Before: Estimated delivery date: [date]
- Now: Estimated delivery by [date]
![Screenshot 2025-05-16 at 15 57 01](https://github.com/user-attachments/assets/9a0f7ee4-d43a-495e-aa95-6e9f2168be8b)


### Ticket:
- [Update delivery estimates code to accomodate economy postage](https://trello.com/c/JngKcHSO/1272-update-delivery-estimates-code-to-accomodate-economy-postage)