### PR TITLE
Updates to prepare for rebrand launch

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -68,3 +68,16 @@ $link-colour-on-grey-background: #1852ab;
     box-shadow: inset 0px -4px $govuk-focus-text-colour, inset 0px 15px $govuk-focus-colour, inset 15px 0px $govuk-focus-colour, inset 0px -11px $govuk-focus-colour;
   }
 }
+
+
+// adjust header navigation menu button positioning for rebrand
+// menu button sits height due to taller header
+// this centrally aligns is with GOV.UK and product name
+// applied only when rebrans is turned on
+// remove when we move to service navigation
+
+.govuk-template--rebranded .govuk-header__menu-button {
+  @include govuk-media-query($until: desktop) {
+    top: 21px;
+  }
+}

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -1,11 +1,13 @@
 {% extends "govuk_frontend_jinja/template.html"%}
 
 {% set cspNonce = request.csp_nonce %}
+{# toggle to enable new styles for rebrand #}
+{% set govukRebrand = False %}
 
 {% block headIcons %}
   <link rel="icon" sizes="48x48" href="{{ asset_url('images/favicon.ico') }}">
   <link rel="icon" sizes="any" href="{{ asset_url('images/favicon.svg') }}" type="image/svg+xml">
-  <link rel="mask-icon" href="{{ asset_url('images/govuk-icon-mask.svg') }}" color="#0b0c0c">
+  <link rel="mask-icon" href="{{ asset_url('images/govuk-icon-mask.svg') }}" color="{{'#1d70b8' if govukRebrand else '#0b0c0c'}}">
   <link rel="apple-touch-icon" href="{{ asset_url('images/govuk-icon-180.png') }}">
   <link rel="manifest" href="{{ asset_url('manifest.json') }}">
 {% endblock %}
@@ -18,9 +20,14 @@
   <link rel="stylesheet" media="print" href="{{ asset_url('stylesheets/print.css') }}" />
   {% block extra_stylesheets %}
   {% endblock %}
-  <style>
-      .govuk-header__container { border-color: {{header_colour}} }
-  </style>
+  {# rebranded header no longer uses bottom border #}
+  {# so not rendering until we have a different solution #}
+  {# for indicating different envs #}
+  {% if not govukRebrand %}
+    <style>
+        .govuk-header__container { border-color: {{header_colour}} }
+    </style>
+  {% endif %}
   {% if g.hide_from_search_engines %}
     <meta name="robots" content="noindex" />
   {% endif %}
@@ -48,7 +55,8 @@
     "productName": "Notify",
     "navigation": header_navigation.visible_header_nav(),
     "navigationClasses": "govuk-header__navigation--end",
-    "assetsPath": asset_path + "images"
+    "assetsPath": asset_path + "images",
+    "rebrand": govukRebrand
   }) }}
 {% endblock %}
 
@@ -76,6 +84,7 @@
 
   {{ govukFooter({
     "classes": "js-footer",
+    "rebrand": govukRebrand,
     "navigation": [
       {
         "title": "About Notify",

--- a/app/templates/unbranded_template.html
+++ b/app/templates/unbranded_template.html
@@ -1,6 +1,10 @@
 {% extends "govuk_frontend_jinja/template.html"%}
 
 {% set cspNonce = request.csp_nonce %}
+{# govukRebrand needs to be set due to a check #}
+{# upstream but as there no favicons or header or footer #}
+{# nothing changes #}
+{% set govukRebrand = False %}
 
 {% block headIcons %}
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cbor-js": "0.1.0",
-        "govuk-frontend": "5.9.0",
+        "govuk-frontend": "5.10.0",
         "jquery": "3.5.0",
         "morphdom": "2.6.1",
         "textarea-caret": "3.1.0",
@@ -6002,9 +6002,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
-      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.0.tgz",
+      "integrity": "sha512-9tjpB8PDwsDqutkQPJXfDalLvNOeKxzFhV7me21s/oyn7HcTg/ei/GC3Y4JvNsXauzjOkxv4eeCHntKeySkdMg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor-js": "0.1.0",
-    "govuk-frontend": "5.9.0",
+    "govuk-frontend": "5.10.0",
     "jquery": "3.5.0",
     "morphdom": "2.6.1",
     "textarea-caret": "3.1.0",

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ fido2==1.1.3
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.3.3
 
-govuk-frontend-jinja==3.5.0
+govuk-frontend-jinja==3.6.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 govuk-bank-holidays==0.15
     # via notifications-utils
-govuk-frontend-jinja==3.5.0
+govuk-frontend-jinja==3.6.0
     # via -r requirements.in
 greenlet==3.0.3
     # via eventlet

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -102,7 +102,7 @@ govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
-govuk-frontend-jinja==3.5.0
+govuk-frontend-jinja==3.6.0
     # via -r requirements.txt
 greenlet==3.0.3
     # via

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,11 +5,20 @@ import copy from 'rollup-plugin-copy';
 import styles from "rollup-plugin-styler";
 import postCSSReplace from 'postcss-replace';
 
+// toggle to enable rebrand styles
+const enableRebrand = false;
 const paths = {
   src: 'app/assets/',
   dist: 'app/static/',
   npm: 'node_modules/',
   govuk_frontend: 'node_modules/govuk-frontend/dist/'
+};
+
+// separate path config for govuk-frontend assets, so we can manage rebrand paths easily
+const govukFrontendAssetPaths = {
+  images: `${paths.govuk_frontend}govuk/assets/${enableRebrand ? 'rebrand/': ''}images/**/*`,
+  fonts: `${paths.govuk_frontend}govuk/assets/fonts/**/*`,
+  manifest: `${paths.govuk_frontend}govuk/assets/${enableRebrand ? 'rebrand/': ''}manifest.json`,
 };
 
 const isDevelopment = Boolean(process.env.NOTIFY_ENVIRONMENT === 'development')
@@ -31,9 +40,10 @@ export default [
       copy({
         targets: [
           { src: paths.src + 'error_pages/**/*', dest: paths.dist + 'error_pages/' },
-          { src: [ paths.src + 'images/**/*', paths.govuk_frontend + 'govuk/assets/images/**/*' ], dest: paths.dist + 'images/' },
-          { src: paths.govuk_frontend + 'govuk/assets/fonts/**/*', dest: paths.dist + 'fonts/' },
-          { src: paths.govuk_frontend + 'govuk/assets/manifest.json', dest: paths.dist }
+          { src: paths.src + 'images/**/*', dest: paths.dist + 'images/' },
+          { src: govukFrontendAssetPaths.images, dest: paths.dist + 'images/' },
+          { src: govukFrontendAssetPaths.fonts, dest: paths.dist + 'fonts/' },
+          { src: govukFrontendAssetPaths.manifest, dest: paths.dist }
         ]
       }),
     ]

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -4,7 +4,7 @@ from importlib import metadata
 from packaging.version import Version
 
 
-def test_govuk_frontend_jinja_overrides_on_design_system_v3():
+def test_govuk_frontend_jinja_overrides_on_design_system_v5():
     with open("package.json") as package_file:
         package_json = json.load(package_file)
         govuk_frontend_version = Version(package_json["dependencies"]["govuk-frontend"])
@@ -12,8 +12,8 @@ def test_govuk_frontend_jinja_overrides_on_design_system_v3():
     govuk_frontend_jinja_version = Version(metadata.version("govuk-frontend-jinja"))
 
     # Compatibility between these two libs is defined at https://github.com/LandRegistry/govuk-frontend-jinja/
-    correct_govuk_frontend_version = Version("5.9.0") == govuk_frontend_version
-    correct_govuk_frontend_jinja_version = Version("3.5.0") == govuk_frontend_jinja_version
+    correct_govuk_frontend_version = Version("5.10.0") == govuk_frontend_version
+    correct_govuk_frontend_jinja_version = Version("3.6.0") == govuk_frontend_jinja_version
 
     assert correct_govuk_frontend_version and correct_govuk_frontend_jinja_version, (
         "After upgrading either of the Design System packages, you must validate that "


### PR DESCRIPTION
## What
https://trello.com/c/G1F7uWpW/1311-update-header-and-footer-on-admin-app-to-bring-in-govuk-rebrand
This is the same approach as taken in https://github.com/alphagov/document-download-frontend/pull/294

To be able to switch on the rebrand easily updates have been made to support this, mainly:
- updated version of [govuk-frontend](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0) and [govuk_frontend_jinja](https://github.com/LandRegistry/govuk-frontend-jinja?tab=readme-ov-file#compatibility) that support the rebrand work
- changes to our frontend build configuration that copies static assets from the govuk-frontend package
- updates to our custom footer macro to bring in upstream changes
- updates to the page template with toggles to turn on rebrand

Notes: 
- govuk-frontend v 5.10.0 without the rebrand on, does bring in slightly updated footer top border and coat of arms colours - [see release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0#:~:text=The%20GOV.UK%20footer%20component%20top%20border%20is%20now%20consistent%20with%20GOV.UK)
- custom radios and checkboxes we have, have not been affected

## How to review
- set `{% set govukRebrand = True %}` in admin template and `const enableRebrand = true;` in rollup config
- compile with updated dependencies
 - best reviewed by commit


## Visual changes
(footer, header, favicons)

![notify localhost_6012_services_0db9a1b8-83cd-45cd-84c5-99759da1e8c1](https://github.com/user-attachments/assets/dc55654c-5d51-4bff-af49-857192ab674c)
