### PR TITLE
Bump utils to 99.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.0
+# This file was automatically copied from notifications-utils@99.5.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.1
 
 govuk-frontend-jinja==3.5.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ eventlet==0.39.1
     # via gunicorn
 fido2==1.1.3
     # via -r requirements.in
-flask==3.1.0
+flask==3.1.1
     # via
     #   flask-login
     #   flask-redis
@@ -93,6 +93,7 @@ lxml==5.3.1
     #   pyexcel-ods3
 markupsafe==2.1.1
     # via
+    #   flask
     #   jinja2
     #   sentry-sdk
     #   werkzeug
@@ -101,7 +102,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0b99dd5a5b0f55a77a537c7fdcf508d76e286a76
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -76,7 +76,7 @@ execnet==2.1.1
     # via pytest-xdist
 fido2==1.1.3
     # via -r requirements.txt
-flask==3.1.0
+flask==3.1.1
     # via
     #   -r requirements.txt
     #   flask-login
@@ -153,6 +153,7 @@ lxml==5.3.1
 markupsafe==2.1.1
     # via
     #   -r requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -164,7 +165,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0b99dd5a5b0f55a77a537c7fdcf508d76e286a76
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.0
+# This file was automatically copied from notifications-utils@99.5.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.0
+# This file was automatically copied from notifications-utils@99.5.1
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 99.5.1

* Bump minimum Flask version to 3.1.1

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/99.5.0...99.5.1

***

Closes #5467