### PR TITLE
Update guidance for users adding and approving a new service

### DIFF
--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -86,7 +86,7 @@ def org_member_make_service_live_service_name(service_id):
         truthy="Yes",
         falsey="No",
         name=f"Will recipients understand the name ‘{current_service.name}’?",
-        choices_for_error_message="‘yes’ if the service name is easy to understand",
+        choices_for_error_message="‘yes’ if recipients will understand the service name",
     )
 
     # Re-populate the form field data from URL query args, if present. This allows backlinks to take a user back to

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -85,7 +85,7 @@ def org_member_make_service_live_service_name(service_id):
     form = OnOffSettingForm(
         truthy="Yes",
         falsey="No",
-        name=f"Is the service name ‘{current_service.name}’ easy to understand?",
+        name=f"Will recipients understand the name ‘{current_service.name}’?",
         choices_for_error_message="‘yes’ if the service name is easy to understand",
     )
 

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -41,7 +41,7 @@
       <p class="govuk-body">Your service name should tell the recipient what your message is about, as well as who it’s from.</p>
     {% endif %}
 
-    <p class="govuk-body">Do not use an acronym or initialism unless your users are already familiar with it.</p>
+    <p class="govuk-body">Do not use an acronym, initialism or abbreviation unless your recipients are already familiar with it.</p>
 
     {% call form_wrapper() %}
       {{ form.name(param_extensions={"hint": {"text": "You can change this later"} }) }}

--- a/app/templates/views/organisations-admin/approve-service-check-unique.html
+++ b/app/templates/views/organisations-admin/approve-service-check-unique.html
@@ -22,12 +22,11 @@
     <div class="govuk-grid-column-five-sixths">
 
       <p class="govuk-body">
-        You are responsible for making sure that this service is the only one of its kind in your organisation.
+        ‘{{ current_service.name }}’ must be the only service of its kind in your organisation.
       </p>
 
     <p class="govuk-body">
-      Before you continue, you should check the list of
-      <a href="{{ url_for('.organisation_dashboard', org_id=current_service.organisation.id) }}" class="govuk-link govuk-link--no-visited-state">{{ current_service.organisation.name }} services</a>.
+      Before you continue, check the list of <a href="{{ url_for('.organisation_dashboard', org_id=current_service.organisation.id) }}" class="govuk-link govuk-link--no-visited-state">{{ current_service.organisation.name }} services</a>.
     </p>
 
     <p class="govuk-body">

--- a/app/templates/views/organisations-admin/approve-service-service-name.html
+++ b/app/templates/views/organisations-admin/approve-service-service-name.html
@@ -26,7 +26,7 @@
       </p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>acronyms, initialisms or abbreviations, unless they’re well known</li>
+        <li>acronyms, initialisms or abbreviations, unless your recipients will recognise them</li>
         <li>your own name or the name of someone on your team</li>
         <li>the name of a web application or back office system</li>
       </ul>

--- a/app/templates/views/organisations-admin/approve-service-start.html
+++ b/app/templates/views/organisations-admin/approve-service-start.html
@@ -38,7 +38,7 @@
       </p>
       <ul class="govuk-list govuk-list--bullet">
         <li>this service is unique</li>
-        <li>the service name is easy to understand</li>
+        <li>recipients will understand the service name</li>
       </ul>
       <p class="govuk-body govuk-!-margin-bottom-6">
         You should also make sure that the service meets your organisation’s requirements.

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -245,7 +245,7 @@ def test_post_org_member_make_service_live_service_name_error_summary(
 
     error_summary = page.select_one(".govuk-error-summary")
     assert "There is a problem" in error_summary.text
-    assert "Select ‘yes’ if the service name is easy to understand" in error_summary.text
+    assert "Select ‘yes’ if recipients will understand the service name" in error_summary.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What

This PR updates the content on the following pages:

* ‘Enter a service name’
* ‘Make this service live’
* ‘Confirm this service is unique’
* ‘Check the service name’

These changes affect:

* New users creating a new service, after creating a user account
* Existing users creating a new service
* Organisation-level team members with approval permissions, who need to validate a go-live request
* Members of the GOV.UK Notify team on non-tech support, who need to validate a go-live request

# Why

Content on the ‘Enter a service name’ page does not match our style guide.

We need to update the approver content ahead of any changes to the ‘Send a request to go live’ flow.