### PR TITLE
Go live request submission page updates

### DIFF
--- a/app/main/views/make_your_service_live.py
+++ b/app/main/views/make_your_service_live.py
@@ -58,4 +58,9 @@ def submit_request_to_go_live(service_id):
     current_service.notify_organisation_users_of_request_to_go_live()
 
     flash("Thanks for your request to go live. We’ll get back to you within one working day.", "default")
-    return redirect(url_for(".service_settings", service_id=service_id))
+    # current_service.update won’t modify itself, it only makes a request to the API and returns the JSON response
+    # https://github.com/alphagov/notifications-admin/blob/main/app/models/service.py#L103-L104
+    # so what you have in memory will be whatever the state of the service was before calling update
+    # we do this because usually post-redirect-get is a better way to do things
+    # after the redirect, GET request gets a fresh copy of the JSON from the API
+    return redirect(url_for(".request_to_go_live", service_id=service_id))

--- a/app/templates/views/request-to-go-live.html
+++ b/app/templates/views/request-to-go-live.html
@@ -21,99 +21,101 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {{ page_header('Make your service live') }}
-      <p class="govuk-body">To remove the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a> restrictions and make your service live:</p>
-      <ol class="govuk-list govuk-list--number">
-        <li>Complete the tasks on this page.</li>
-        <li>Select ‘Send a request to go live’</li>
-      </ol>
-      <p class="govuk-body">It can take up to one working day to make a service live. This is because we need to check that it meets our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.terms_of_use') }}">terms of use</a>.</p>
-      {# core set of task for to do #}
-      {% set task_list_items =
-        [{
-          "title": {
-            "text": "Tell us how many messages you expect to send",
-            "classes": "govuk-link--no-visited-state",
-          },
-          "href": url_for('main.estimate_usage', service_id=current_service.id),
-          "status": completed_status if current_service.has_estimated_usage else not_completed_status,
-        },
-        {
-          "title": {
-            "text": "Give another team member the ‘manage settings’ permission",
-            "classes": "govuk-link--no-visited-state",
-          },
-          "href": url_for('main.manage_users', service_id=current_service.id),
-          "status": completed_status if current_service.has_team_members_with_manage_service_permission else not_completed_status,
-        },
-        {
-          "title": {
-            "text": "Add templates with examples of your content",
-            "classes": "govuk-link--no-visited-state",
-          },
-          "href": url_for('main.choose_template', service_id=current_service.id),
-          "status": completed_status if current_service.has_templates else not_completed_status,
-        }]
-      %}
-
-      {# all the conditional task #}
-      {% if current_service.intending_to_send_email %}
-        {% do task_list_items.append(
-          {
-            "title": {
-              "text": "Add a reply-to email address",
-              "classes": "govuk-link--no-visited-state",
-            },
-            "href":  url_for('main.service_email_reply_to', service_id=current_service.id),
-            "status": completed_status if current_service.has_email_reply_to_address else not_completed_status,
-          }
-        )%}
-      {% endif %}
-      {% if (current_service.intending_to_send_sms and current_service.shouldnt_use_govuk_as_sms_sender) %}
-        {% do task_list_items.append(
-          {
-            "title": {
-              "text": "Change your Text message sender ID",
-              "classes": "govuk-link--no-visited-state",
-            },
-            "href": url_for('main.service_sms_senders', service_id=current_service.id),
-            "status": completed_status if not current_service.sms_sender_is_govuk else not_completed_status,
-          }
-        )%}
-      {% endif %}
-      {% if current_service.able_to_accept_agreement %}
-        {% do task_list_items.append(
-          {
-            "title": {
-              "text": "Accept our data processing and financial agreement",
-              "classes": "govuk-link--no-visited-state",
-            },
-            "href": url_for('main.service_agreement', service_id=current_service.id),
-            "status": completed_status if current_service.organisation.agreement_signed else not_completed_status,
-          }
-        )%}
-      {% endif %}
-      {{ govukTaskList({
-        "idPrefix": "request-to-go-live",
-        "items": task_list_items
-      }) }}
-      {% if not current_user.is_gov_user %}
-        <p class="govuk-body">
-          Only team members with a government email address can request to go live.
-        </p>
-      {% elif current_service.has_active_go_live_request %}
-        <p class="govuk-body">
-          Your team has already sent a request to go live for this service.
-        </p>
+      {% if current_service.has_active_go_live_request %}
+        {% set requester = 'You' if current_user.id == current_service.go_live_user.id else current_service.go_live_user.name %}
+        <p class="govuk-body">{{ requester }} sent a request to go live for this service.</p>
+        <p class="govuk-body">It can take up to one working day to make a service live. This is because we need to check that it meets our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.terms_of_use') }}">terms of use</a>.</p>
       {% else %}
-        {% set go_live_disabled = True if (not current_service.go_live_checklist_completed) or (current_service.able_to_accept_agreement and not current_service.organisation.agreement_signed) else False %}
-        {% if go_live_disabled %}
-          <p class="govuk-body">
-            You must complete all the tasks before you can send a request to go live.
-          </p>
+        <p class="govuk-body">To remove the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a> restrictions and make your service live:</p>
+        <ol class="govuk-list govuk-list--number">
+          <li>Complete the tasks on this page.</li>
+          <li>Select ‘Send a request to go live’</li>
+        </ol>
+        <p class="govuk-body">It can take up to one working day to make a service live. This is because we need to check that it meets our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.terms_of_use') }}">terms of use</a>.</p>
+        {# core set of task for to do #}
+        {% set task_list_items =
+          [{
+            "title": {
+              "text": "Tell us how many messages you expect to send",
+              "classes": "govuk-link--no-visited-state",
+            },
+            "href": url_for('main.estimate_usage', service_id=current_service.id),
+            "status": completed_status if current_service.has_estimated_usage else not_completed_status,
+          },
+          {
+            "title": {
+              "text": "Give another team member the ‘manage settings’ permission",
+              "classes": "govuk-link--no-visited-state",
+            },
+            "href": url_for('main.manage_users', service_id=current_service.id),
+            "status": completed_status if current_service.has_team_members_with_manage_service_permission else not_completed_status,
+          },
+          {
+            "title": {
+              "text": "Add templates with examples of your content",
+              "classes": "govuk-link--no-visited-state",
+            },
+            "href": url_for('main.choose_template', service_id=current_service.id),
+            "status": completed_status if current_service.has_templates else not_completed_status,
+          }]
+        %}
+
+        {# all the conditional task #}
+        {% if current_service.intending_to_send_email %}
+          {% do task_list_items.append(
+            {
+              "title": {
+                "text": "Add a reply-to email address",
+                "classes": "govuk-link--no-visited-state",
+              },
+              "href":  url_for('main.service_email_reply_to', service_id=current_service.id),
+              "status": completed_status if current_service.has_email_reply_to_address else not_completed_status,
+            }
+          )%}
         {% endif %}
-        {% call form_wrapper() %}
-          {{ page_footer('Send a request to go live', disabled=go_live_disabled) }}
-        {% endcall %}
+        {% if (current_service.intending_to_send_sms and current_service.shouldnt_use_govuk_as_sms_sender) %}
+          {% do task_list_items.append(
+            {
+              "title": {
+                "text": "Change your Text message sender ID",
+                "classes": "govuk-link--no-visited-state",
+              },
+              "href": url_for('main.service_sms_senders', service_id=current_service.id),
+              "status": completed_status if not current_service.sms_sender_is_govuk else not_completed_status,
+            }
+          )%}
+        {% endif %}
+        {% if current_service.able_to_accept_agreement %}
+          {% do task_list_items.append(
+            {
+              "title": {
+                "text": "Accept our data processing and financial agreement",
+                "classes": "govuk-link--no-visited-state",
+              },
+              "href": url_for('main.service_agreement', service_id=current_service.id),
+              "status": completed_status if current_service.organisation.agreement_signed else not_completed_status,
+            }
+          )%}
+        {% endif %}
+        {{ govukTaskList({
+          "idPrefix": "request-to-go-live",
+          "items": task_list_items
+        }) }}
+        {% if not current_user.is_gov_user %}
+          <p class="govuk-body">
+            Only team members with a government email address can request to go live.
+          </p>
+        {% else %}
+          {% set go_live_disabled = True if (not current_service.go_live_checklist_completed) or (current_service.able_to_accept_agreement and not current_service.organisation.agreement_signed) else False %}
+          {% if go_live_disabled %}
+            <p class="govuk-body">
+              You must complete all the tasks before you can send a request to go live.
+            </p>
+          {% endif %}
+          {% call form_wrapper() %}
+            {{ page_footer('Send a request to go live', disabled=go_live_disabled) }}
+          {% endcall %}
+        {% endif %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## What

Ticket: https://trello.com/c/tetaeq9J/1299-make-your-service-live-2-6-change-what-happens-when-a-user-submits-the-task-list-form

Upon a request to go live submission take the user back to the same page and show new content instead of the task list.
We show the same content (minus the flash banner) if there's already an active request to go live.

## How to review
- best reviewed by commit and with [hidden whitespace changes](https://github.com/alphagov/notifications-admin/pull/5478/files?diff=split&w=1)

## Visual changes
Upon submission
<img width="754" alt="Screenshot 2025-05-23 at 11 24 14" src="https://github.com/user-attachments/assets/0d2c6f51-8f0e-44b2-a4f7-1c637e939852" />

Go live request already created by the same person or another team member
<img width="724" alt="Screenshot 2025-05-23 at 10 00 11" src="https://github.com/user-attachments/assets/96d6d110-86ce-449a-9e18-42173ec87add" />
<img width="727" alt="Screenshot 2025-05-23 at 10 08 45" src="https://github.com/user-attachments/assets/6323cd80-1296-4d87-878a-43a83d98dd82" />
