### PR TITLE
Fix 'GOV.UK Notify' logo when focused

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -81,3 +81,12 @@ $link-colour-on-grey-background: #1852ab;
     top: 21px;
   }
 }
+
+
+// make 'GOV.UK Notify' logo sit on top of any content below it
+// mainly to stop the breadcrumb, which has a negative margin-top,
+// overlapping its focus style
+.govuk-header__link--homepage:focus {
+  position: relative;
+  z-index: 1;
+}


### PR DESCRIPTION
The bottom of the 'GOV.UK Notify' logo's focus style is getting overlapped on the product page.

Reviewers will need to turn on the rebrand by:
- [switching this variable to True in the main layout](https://github.com/alphagov/notifications-admin/blob/99cbbc122d00fe903b64aed8c95e537aa761a3a5/app/templates/admin_template.html#L5)
- [switching this variable to true in the static assets build](https://github.com/alphagov/notifications-admin/blob/99cbbc122d00fe903b64aed8c95e537aa761a3a5/rollup.config.mjs#L9)
- rebuilding the static assets by running `npm run build`