### PR TITLE
Split request to go live tasks into sections

### DIFF
--- a/app/templates/views/request-to-go-live.html
+++ b/app/templates/views/request-to-go-live.html
@@ -88,22 +88,38 @@
             }
           )%}
         {% endif %}
-        {% if current_service.able_to_accept_agreement %}
-          {% do task_list_items.append(
-            {
-              "title": {
-                "text": "Accept our data processing and financial agreement",
-                "classes": "govuk-link--no-visited-state",
-              },
-              "href": url_for('main.service_agreement', service_id=current_service.id),
-              "status": completed_status if current_service.organisation.agreement_signed else not_completed_status,
-            }
-          )%}
-        {% endif %}
+        <h2 class="govuk-heading-m">Your service</h2>
         {{ govukTaskList({
-          "idPrefix": "request-to-go-live",
+          "idPrefix": "request-to-go-live-service",
           "items": task_list_items
         }) }}
+        <h2 class="govuk-heading-m">Your organisation</h2>
+        {# show task-list if agreement not accepted or #}
+        {# the current user signed the org-level agreement #}
+        {# this is because for other services in that org that want to go live #}
+        {# we want to show a different text if org-level agreement already accepted #}
+        {% if current_service.able_to_accept_agreement and (current_service.organisation.agreement_signed_by_id == current_user.id or not current_service.organisation.agreement_signed_by_id) %}
+          {{ govukTaskList({
+            "idPrefix": "request-to-go-live-organisation",
+            "items": [
+              {
+                "title": {
+                  "text": "Accept our data processing and financial agreement",
+                  "classes": "govuk-link--no-visited-state",
+                },
+                "href": url_for('main.service_agreement', service_id=current_service.id),
+                "status": completed_status if current_service.organisation.agreement_signed else not_completed_status,
+              }
+            ]
+          }) }}
+        {% elif not current_service.organisation %}
+          <p class="govuk-body">When you send us a request to go live, we’ll ask you the name of the public sector body responsible for your service.</p>
+          <p class="govuk-body">We may also ask you to accept our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_agreement', service_id=current_service.id) }}">data processing and financial agreement</a>.</p>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        {% else %}
+          <p class="'govuk-body">{{current_service.organisation.name}} has already accepted our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_agreement', service_id=current_service.id) }}">data processing and financial agreement</a>.</p>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        {% endif %}
         {% if not current_user.is_gov_user %}
           <p class="govuk-body">
             Only team members with a government email address can request to go live.


### PR DESCRIPTION
Split current items into service specific and organisation specific (agreement) section.
[Ticket](https://trello.com/c/AZW2Avbt/1303-make-your-service-live-6-6-update-the-organisation-content-on-the-task-list-page)

There are 4 scenarios
- if a service can accept an agreement and one has not yet been accepted, we show the the task-list item
- if a service can accept an agreement and one has has been been accepted, we show the the task-list with 'Completed' to the user that accepted the agreement, and a text saying it's been accepted to all other service users
- if a service does not need to accept and agreement (already accepted) we show text say so and a link to the agreement
- if a service has does not belong to an organisation, we show text telling them about it once they send a request to go live

## Visual changes
**Agreement is or isn't accepted or accepted by the same user**
<img width="785" alt="Screenshot 2025-06-02 at 14 05 33" src="https://github.com/user-attachments/assets/455b9241-befe-4b21-a568-fa3463aa96e6" />


**Agreement already accepted at the organisation level**
<img width="830" alt="Screenshot 2025-06-02 at 14 07 03" src="https://github.com/user-attachments/assets/a69ede12-db8f-4bbc-a956-6290b4bab13f" />


**Service does not belong to an org**
<img width="755" alt="Screenshot 2025-06-02 at 14 10 37" src="https://github.com/user-attachments/assets/0e314f70-5d0d-4732-b7cc-7af11903bb6a" />

