### PR TITLE
Remove uses of `datetime.utcnow`

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -60,7 +60,7 @@ def format_time_24h(date):
 def get_human_day(time, date_prefix=""):
     #  Add 1 minute to transform 00:00 into ‘midnight today’ instead of ‘midnight tomorrow’
     date = (utc_string_to_aware_gmt_datetime(time) - timedelta(minutes=1)).date()
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     if date == (now + timedelta(days=1)).date():
         return "tomorrow"

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,7 +1,7 @@
 import weakref
 from contextlib import suppress
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from functools import partial
 from itertools import chain
 from numbers import Number
@@ -127,20 +127,20 @@ def get_human_day(time):
 
     #  Add 1 hour to get ‘midnight today’ instead of ‘midnight tomorrow’
     time = (time - timedelta(hours=1)).strftime(date_format)
-    if time == datetime.utcnow().strftime(date_format):
+    if time == datetime.now(UTC).strftime(date_format):
         return "Today"
-    if time == (datetime.utcnow() + timedelta(days=1)).strftime(date_format):
+    if time == (datetime.now(UTC) + timedelta(days=1)).strftime(date_format):
         return "Tomorrow"
 
     return time
 
 
 def get_furthest_possible_scheduled_time():
-    return (datetime.utcnow() + timedelta(days=7)).replace(hour=0)
+    return (datetime.now(UTC) + timedelta(days=7)).replace(hour=0)
 
 
 def get_next_hours_until(until):
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     hours = int((until - now).total_seconds() / (60 * 60))
     return [
         (now + timedelta(hours=i)).replace(minute=0, second=0, microsecond=0).replace(tzinfo=pytz.utc)
@@ -149,7 +149,7 @@ def get_next_hours_until(until):
 
 
 def get_next_days_until(until):
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     days = int((until - now).total_seconds() / (60 * 60 * 24))
 
     return [get_human_day((now + timedelta(days=i)).replace(tzinfo=pytz.utc)) for i in range(days + 1)]

--- a/app/main/views/agreement.py
+++ b/app/main/views/agreement.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import abort, redirect, render_template, request, send_file, url_for
 from flask_login import current_user
@@ -9,6 +9,7 @@ from app.main.forms import AcceptAgreementForm
 from app.models.organisation import Organisation
 from app.s3_client.s3_mou_client import get_mou
 from app.utils import hide_from_search_engines
+from app.utils.time import str_no_tz
 from app.utils.user import user_has_permissions
 
 
@@ -61,7 +62,7 @@ def service_confirm_agreement(service_id):
     if request.method == "POST":
         current_service.organisation.update(
             agreement_signed=True,
-            agreement_signed_at=str(datetime.utcnow()),
+            agreement_signed_at=str_no_tz(datetime.now(UTC)),
             agreement_signed_by_id=current_user.id,
         )
         return redirect(url_for("main.request_to_go_live", service_id=current_service.id))

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -1,5 +1,5 @@
 import calendar
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import partial
 from itertools import groupby
 
@@ -446,7 +446,7 @@ def inbox_download(service_id):
         mimetype="text/csv",
         headers={
             "Content-Disposition": (
-                f'inline; filename="Received text messages {format_date_numeric(datetime.utcnow().isoformat())}.csv"'
+                f'inline; filename="Received text messages {format_date_numeric(datetime.now(UTC))}.csv"'
             )
         },
     )
@@ -593,7 +593,7 @@ def format_monthly_stats_to_list(historical_stats):
         (
             dict(
                 date=key,
-                future=yyyy_mm_to_datetime(key) > datetime.utcnow(),
+                future=yyyy_mm_to_datetime(key) > datetime.now(UTC),
                 name=yyyy_mm_to_datetime(key).strftime("%B"),
                 **aggregate_status_types(value),
             )
@@ -604,7 +604,7 @@ def format_monthly_stats_to_list(historical_stats):
 
 
 def yyyy_mm_to_datetime(string):
-    return datetime(int(string[0:4]), int(string[5:7]), 1)
+    return datetime(int(string[0:4]), int(string[5:7]), 1, tzinfo=UTC)
 
 
 def aggregate_status_types(counts_dict):

--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytz
 from flask import current_app, redirect, render_template, request, session, url_for
@@ -193,7 +193,7 @@ def thanks():
 
 
 def in_business_hours():
-    now = datetime.utcnow().replace(tzinfo=pytz.utc)
+    now = datetime.now(UTC)
 
     if is_weekend(now) or is_bank_holiday(now):
         return False

--- a/app/main/views/performance.py
+++ b/app/main/views/performance.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from itertools import groupby
 from operator import itemgetter
 from statistics import mean
@@ -16,8 +16,8 @@ ORGS_TO_IGNORE = ["1556fd80-a1b2-4b79-8453-f6fcb6f00d0c"]  # TODO: Move this int
 @main.route("/features/performance.json", endpoint="performance_json")
 def performance():
     stats = performance_dashboard_api_client.get_performance_dashboard_stats(
-        start_date=(datetime.utcnow() - timedelta(days=7)).date(),
-        end_date=datetime.utcnow().date(),
+        start_date=(datetime.now(UTC) - timedelta(days=7)).date(),
+        end_date=datetime.now(UTC).date(),
     )
     stats["services_using_notify"] = list(
         filter(lambda d: d["organisation_id"] not in ORGS_TO_IGNORE, stats["services_using_notify"])

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from flask import abort, redirect, render_template, session, url_for
 
@@ -88,7 +88,7 @@ def _do_registration(form, send_sms=True, send_email=True, organisation_id=None)
     if user:
         if send_email:
             user.send_already_registered_email()
-        session["expiry_date"] = str(datetime.utcnow() + timedelta(hours=1))
+        session["expiry_date"] = str(datetime.now(UTC) + timedelta(hours=1))
         session["user_details"] = {"email": user.email_address, "id": user.id}
     else:
         user = User.register(
@@ -104,7 +104,7 @@ def _do_registration(form, send_sms=True, send_email=True, organisation_id=None)
 
         if send_sms:
             user.send_verify_code()
-        session["expiry_date"] = str(datetime.utcnow() + timedelta(hours=1))
+        session["expiry_date"] = str(datetime.now(UTC) + timedelta(hours=1))
         session["user_details"] = {"email": user.email_address, "id": user.id}
     if organisation_id:
         session["organisation_id"] = organisation_id

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import (
     abort,
@@ -437,7 +437,7 @@ def get_service_verify_reply_to_address_partials(service_id, notification_id):
                     current_service.id, email_address=notification["to"], is_default=is_default
                 )
     seconds_since_sending = (
-        utc_string_to_aware_gmt_datetime(datetime.utcnow().isoformat())
+        utc_string_to_aware_gmt_datetime(datetime.now(UTC))
         - utc_string_to_aware_gmt_datetime(notification["created_at"])
     ).seconds
     if notification["status"] in FAILURE_STATUSES or (

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -2,7 +2,6 @@ import base64
 import itertools
 import json
 import uuid
-from datetime import datetime
 from functools import partial
 from io import BytesIO
 from zipfile import BadZipFile
@@ -83,7 +82,6 @@ def uploads(service_id):
         jobs=listed_uploads,
         prev_page=prev_page,
         next_page=next_page,
-        now=datetime.utcnow().isoformat(),
     )
 
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -15,7 +15,7 @@ from app.notify_client import InviteTokenError
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.org_invite_api_client import org_invite_api_client
 from app.notify_client.user_api_client import user_api_client
-from app.utils.time import is_less_than_days_ago
+from app.utils.time import is_less_than_days_ago, isoformat_no_tz
 from app.utils.user import is_gov_user
 from app.utils.user_permissions import (
     all_ui_permissions,
@@ -141,7 +141,7 @@ class User(BaseUser, UserMixin):
         self.__init__(response)
 
     def update_email_access_validated_at(self):
-        self.update(email_access_validated_at=datetime.utcnow().isoformat())
+        self.update(email_access_validated_at=isoformat_no_tz(datetime.now(UTC)))
 
     def password_changed_more_recently_than(self, aware_datetime):
         if not self.password_changed_at:

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,5 +1,5 @@
 from contextvars import ContextVar
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import current_app
 from notifications_utils.clients.redis import daily_limit_cache_key
@@ -10,6 +10,7 @@ from app import memo_resetters
 from app.constants import LetterLanguageOptions
 from app.extensions import redis_client
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
+from app.utils.time import str_no_tz
 
 ALLOWED_TEMPLATE_ATTRIBUTES = {
     "content",
@@ -151,7 +152,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             sms_message_limit=get_daily_limit(live, "sms"),
             letter_message_limit=get_daily_limit(live, "letter"),
             restricted=(not live),
-            go_live_at=str(datetime.utcnow()) if live else None,
+            go_live_at=str_no_tz(datetime.now(UTC)) if live else None,
             has_active_go_live_request=False,
         )
 

--- a/app/utils/letters.py
+++ b/app/utils/letters.py
@@ -8,16 +8,13 @@ from notifications_utils.letter_timings import letter_can_be_cancelled
 from notifications_utils.recipient_validation.postal_address import PostalAddress
 from notifications_utils.template import BaseLetterTemplate
 from notifications_utils.timezones import (
-    convert_bst_to_utc,
-    convert_utc_to_bst,
+    local_timezone,
     utc_string_to_aware_gmt_datetime,
 )
 
 
 def printing_today_or_tomorrow(created_at):
-    print_cutoff = convert_bst_to_utc(convert_utc_to_bst(datetime.utcnow()).replace(hour=17, minute=30)).replace(
-        tzinfo=pytz.utc
-    )
+    print_cutoff = datetime.now(local_timezone).replace(hour=17, minute=30)
     created_at = utc_string_to_aware_gmt_datetime(created_at)
 
     if created_at < print_cutoff:

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -5,7 +5,7 @@ from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 
 
 def get_current_financial_year():
-    now = utc_string_to_aware_gmt_datetime(datetime.utcnow())
+    now = utc_string_to_aware_gmt_datetime(datetime.now(UTC))
     current_month = int(now.strftime("%-m"))
     current_year = int(now.strftime("%Y"))
     return current_year if current_month > 3 else current_year - 1
@@ -14,7 +14,7 @@ def get_current_financial_year():
 def percentage_through_current_financial_year():
     """Returns a float representing how far through the current financial year as a percentage (0.001-100)"""
     financial_year_start_date = utc_string_to_aware_gmt_datetime(datetime(get_current_financial_year(), 4, 1))
-    now = utc_string_to_aware_gmt_datetime(datetime.utcnow())
+    now = utc_string_to_aware_gmt_datetime(datetime.now(UTC))
     financial_year_end_date = utc_string_to_aware_gmt_datetime(datetime(get_current_financial_year() + 1, 3, 31))
     seconds_in_financial_year = (financial_year_end_date - financial_year_start_date).total_seconds()
     seconds_since_start_of_financial_year = (now - financial_year_start_date).total_seconds()
@@ -29,3 +29,13 @@ def is_less_than_days_ago(date_from_db, number_of_days):
 def to_utc_string(aware_datetime):
     # Format matches app.utils.DATETIME_FORMAT in the API codebase
     return aware_datetime.astimezone(pytz.utc).replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def str_no_tz(aware_datetime):
+    # Matches calling str() on a naive datetime, for backwards compatibility
+    return str(aware_datetime.astimezone(pytz.utc).replace(tzinfo=None))
+
+
+def isoformat_no_tz(aware_datetime):
+    # Matches calling .isoformat() on a naive datetime, for backwards compatibility
+    return aware_datetime.astimezone(pytz.utc).replace(tzinfo=None).isoformat()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -120,7 +120,7 @@ def user_json(
         "permissions": permissions,
         "auth_type": auth_type,
         "failed_login_count": failed_login_count,
-        "logged_in_at": logged_in_at or datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f"),
+        "logged_in_at": logged_in_at or datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f"),
         "state": state,
         "platform_admin": platform_admin,
         "current_session_id": current_session_id,
@@ -145,7 +145,7 @@ def invited_user(
         "from_user": from_user,
         "email_address": email_address,
         "status": status,
-        "created_at": created_at or datetime.utcnow(),
+        "created_at": created_at or datetime.now(UTC),
         "auth_type": auth_type,
     }
     if service:
@@ -215,7 +215,7 @@ def service_json(
         "organisation_type": organisation_type,
         "email_branding": email_branding,
         "branding": branding,
-        "created_at": created_at or str(datetime.utcnow()),
+        "created_at": created_at or str(datetime.now(UTC)),
         "letter_branding": None,
         "letter_contact_block": letter_contact_block,
         "permissions": permissions,
@@ -278,7 +278,7 @@ def organisation_json(
         "name": "Test Organisation" if name is False else name,
         "active": active,
         "users": users,
-        "created_at": created_at or str(datetime.utcnow()),
+        "created_at": created_at or str(datetime.now(UTC)),
         "email_branding_id": email_branding_id,
         "letter_branding_id": letter_branding_id,
         "organisation_type": organisation_type,
@@ -334,7 +334,7 @@ def template_json(
         "content": content,
         "service": service_id,
         "version": version,
-        "updated_at": updated_at or datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f"),
+        "updated_at": updated_at or datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f"),
         "archived": archived,
         "service_letter_contact": service_letter_contact,
         "reply_to": reply_to,
@@ -367,7 +367,7 @@ def template_version_json(service_id, id_, created_by, version=1, created_at=Non
         created_by["email_address"],
     )
     if created_at is None:
-        created_at = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")
+        created_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")
     template["created_at"] = created_at
     template["version"] = version
     return template
@@ -413,7 +413,7 @@ def inbound_sms_json():
                 "user_number": phone_number,
                 "notify_number": "07900000002",
                 "content": f"message-{index + 1}",
-                "created_at": (datetime.utcnow() - timedelta(minutes=60 * hours_ago, seconds=index)).isoformat(),
+                "created_at": (datetime.now(UTC) - timedelta(minutes=60 * hours_ago, seconds=index)).isoformat(),
                 "id": str(uuid.uuid4()),
             }
             for index, hours_ago, phone_number in (
@@ -529,11 +529,11 @@ def notification_json(  # noqa: C901
         else:
             to = "07123456789"
     if sent_at is None:
-        sent_at = str(datetime.utcnow().time())
+        sent_at = str(datetime.now(UTC).time())
     if created_at is None:
         created_at = datetime.now(UTC).isoformat()
     if updated_at is None:
-        updated_at = str((datetime.utcnow() + timedelta(minutes=1)).time())
+        updated_at = str((datetime.now(UTC) + timedelta(minutes=1)).time())
     if status is None:
         status = "delivered"
     links = {}
@@ -602,11 +602,11 @@ def single_notification_json(
     if template is None:
         template = template_json(service_id=service_id, id_=str(generate_uuid()))
     if sent_at is None:
-        sent_at = str(datetime.utcnow())
+        sent_at = str(datetime.now(UTC))
     if created_at is None:
-        created_at = str(datetime.utcnow())
+        created_at = str(datetime.now(UTC))
     if updated_at is None:
-        updated_at = str(datetime.utcnow() + timedelta(minutes=1))
+        updated_at = str(datetime.now(UTC) + timedelta(minutes=1))
     if status is None:
         status = "delivered"
     job_payload = None

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import ANY
 
 import pytest
@@ -429,7 +429,7 @@ def test_verified_org_user_redirects_to_dashboard(
     client_request.logout()
     invited_org_user = InvitedOrgUser(sample_org_invite)
     with client_request.session_transaction() as session:
-        session["expiry_date"] = str(datetime.utcnow() + timedelta(hours=1))
+        session["expiry_date"] = str(datetime.now(UTC) + timedelta(hours=1))
         session["user_details"] = {"email": invited_org_user.email_address, "id": invited_org_user.id}
         session["organisation_id"] = invited_org_user.organisation
 

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import Mock
 
 import pytest
@@ -214,7 +214,7 @@ def test_view_conversation_with_empty_inbound(
                     "user_number": "07900000001",
                     "notify_number": "07900000002",
                     "content": "",
-                    "created_at": datetime.utcnow().isoformat(),
+                    "created_at": datetime.now(UTC).isoformat(),
                     "id": fake_uuid,
                 }
             ],

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1,6 +1,6 @@
 import copy
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from flask import url_for
@@ -469,7 +469,7 @@ def test_download_inbox_strips_formulae(
                     "user_number": "elevenchars",
                     "notify_number": "foo",
                     "content": message_content,
-                    "created_at": datetime.utcnow().isoformat(),
+                    "created_at": datetime.now(UTC).isoformat(),
                     "id": fake_uuid,
                 }
             ],

--- a/tests/app/main/views/test_make_your_service_live.py
+++ b/tests/app/main/views/test_make_your_service_live.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import ANY, PropertyMock, call
 from uuid import uuid4
 
@@ -246,7 +246,7 @@ def test_should_check_for_sending_things_right(
         service_id=service_one["id"],
         email_address="invited_user@test.gov.uk",
         permissions="view_activity,send_messages,manage_service,manage_api_keys",
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
         status="pending",
         auth_type="sms_auth",
         folder_permissions=[],

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1,6 +1,6 @@
 import copy
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from flask import url_for
@@ -1859,9 +1859,9 @@ def service_join_request_get_data(request_id, status, mock_requester, status_cha
             "email_address": mock_requester.get("email_address"),
         },
         "service_id": SERVICE_ONE_ID,
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(UTC),
         "status": status,
-        "status_changed_at": datetime.utcnow(),
+        "status_changed_at": datetime.now(UTC),
         "status_changed_by": (
             {"id": status_changed_by.get("id"), "name": status_changed_by.get("name"), "belongs_to_service": []}
             if status_changed_by
@@ -2003,7 +2003,7 @@ def test_service_join_request_approved(
     assert f"{mock_requester['name']} has already joined your service" in page.text.strip()
     assert f"{mock_requester['name']} has already joined your service" in page.select_one("h1").text.strip()
 
-    today_date = format_date_short(datetime.utcnow())
+    today_date = format_date_short(datetime.now(UTC))
     assert f"{mock_service_user['name']} approved this request on {today_date}" in page.select_one("p").text.strip()
 
 
@@ -2049,7 +2049,7 @@ def test_service_join_request_rejected(
     assert f"{mock_requester['name']} join your service" in page.text.strip()
     assert f"{mock_requester['name']} join your service" in page.select_one("h1").text.strip()
 
-    today_date = format_date_short(datetime.utcnow())
+    today_date = format_date_short(datetime.now(UTC))
     assert (
         f"{mock_service_user['name']} already refused this request on {today_date}" in page.select_one("p").text.strip()
     )

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from flask import url_for
@@ -24,7 +24,7 @@ def test_should_render_new_password_template(
         "app.user_api_client.update_user_attribute",
         return_value=user,
     )
-    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.utcnow())})
+    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.now(UTC))})
     token = generate_token(data, notify_admin.config["SECRET_KEY"], notify_admin.config["DANGEROUS_SALT"])
 
     page = client_request.get_url(url_for_endpoint_with_token(".new_password", token=token))
@@ -39,7 +39,7 @@ def test_should_return_404_when_email_address_does_not_exist(
     mock_get_user_by_email_not_found,
 ):
     client_request.logout()
-    data = json.dumps({"email": "no_user@d.gov.uk", "created_at": str(datetime.utcnow())})
+    data = json.dumps({"email": "no_user@d.gov.uk", "created_at": str(datetime.now(UTC))})
     token = generate_token(data, notify_admin.config["SECRET_KEY"], notify_admin.config["DANGEROUS_SALT"])
     client_request.get_url(
         url_for_endpoint_with_token(".new_password", token=token),
@@ -64,7 +64,7 @@ def test_should_redirect_to_two_factor_when_password_reset_is_successful(
 ):
     client_request.logout()
     user = mock_get_user_by_email_request_password_reset.return_value
-    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.utcnow())})
+    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.now(UTC))})
     token = generate_token(data, notify_admin.config["SECRET_KEY"], notify_admin.config["DANGEROUS_SALT"])
     client_request.post_url(
         url_for_endpoint_with_token(".new_password", token=token, next=redirect_url),
@@ -92,7 +92,7 @@ def test_should_redirect_to_two_factor_webauthn_when_password_reset_is_successfu
     client_request.logout()
     user = mock_get_user_by_email_request_password_reset.return_value
     user["auth_type"] = "webauthn_auth"
-    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.utcnow())})
+    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.now(UTC))})
     token = generate_token(data, notify_admin.config["SECRET_KEY"], notify_admin.config["DANGEROUS_SALT"])
     client_request.post_url(
         url_for_endpoint_with_token(".new_password", token=token, next=redirect_url),
@@ -114,7 +114,7 @@ def test_should_redirect_index_if_user_has_already_changed_password(
 ):
     client_request.logout()
     user = mock_get_user_by_email_user_changed_password.return_value
-    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.utcnow())})
+    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.now(UTC))})
     token = generate_token(data, notify_admin.config["SECRET_KEY"], notify_admin.config["DANGEROUS_SALT"])
     client_request.post_url(
         url_for_endpoint_with_token(".new_password", token=token),
@@ -151,7 +151,7 @@ def test_should_sign_in_when_password_reset_is_successful_for_email_auth(
     user = mock_get_user_by_email_request_password_reset.return_value
     mock_get_user = mocker.patch("app.user_api_client.get_user", return_value=api_user_active)
     user["auth_type"] = "email_auth"
-    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.utcnow())})
+    data = json.dumps({"email": user["email_address"], "created_at": str(datetime.now(UTC))})
     token = generate_token(data, notify_admin.config["SECRET_KEY"], notify_admin.config["DANGEROUS_SALT"])
 
     client_request.post_url(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import copy
 import json
 import os
 from contextlib import contextmanager
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from unittest import mock
 from unittest.mock import Mock, PropertyMock
 from uuid import UUID, uuid4
@@ -86,7 +86,7 @@ def multiple_reply_to_email_addresses(mocker):
                 "service_id": service_id,
                 "email_address": "test@example.com",
                 "is_default": True,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "updated_at": None,
             },
             {
@@ -94,7 +94,7 @@ def multiple_reply_to_email_addresses(mocker):
                 "service_id": service_id,
                 "email_address": "test2@example.com",
                 "is_default": False,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "updated_at": None,
             },
             {
@@ -102,7 +102,7 @@ def multiple_reply_to_email_addresses(mocker):
                 "service_id": service_id,
                 "email_address": "test3@example.com",
                 "is_default": False,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "updated_at": None,
             },
         ]
@@ -130,7 +130,7 @@ def single_reply_to_email_address(notify_admin, mocker):
                 "service_id": service_id,
                 "email_address": "test@example.com",
                 "is_default": True,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "updated_at": None,
             }
         ]
@@ -146,7 +146,7 @@ def get_default_reply_to_email_address(notify_admin, mocker):
             "service_id": service_id,
             "email_address": "test@example.com",
             "is_default": True,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "updated_at": None,
         }
 
@@ -161,7 +161,7 @@ def get_non_default_reply_to_email_address(notify_admin, mocker):
             "service_id": service_id,
             "email_address": "test@example.com",
             "is_default": False,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "updated_at": None,
         }
 
@@ -193,7 +193,7 @@ def multiple_letter_contact_blocks(notify_admin, mocker):
                 "service_id": service_id,
                 "contact_block": "1 Example Street",
                 "is_default": True,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "updated_at": None,
             },
             {
@@ -201,7 +201,7 @@ def multiple_letter_contact_blocks(notify_admin, mocker):
                 "service_id": service_id,
                 "contact_block": "2 Example Street",
                 "is_default": False,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "updated_at": None,
             },
             {
@@ -209,7 +209,7 @@ def multiple_letter_contact_blocks(notify_admin, mocker):
                 "service_id": service_id,
                 "contact_block": "3 Example Street",
                 "is_default": False,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "updated_at": None,
             },
         ]
@@ -234,7 +234,7 @@ def single_letter_contact_block(notify_admin, mocker):
                 "service_id": service_id,
                 "contact_block": "1 Example Street",
                 "is_default": True,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "updated_at": None,
             }
         ]
@@ -251,7 +251,7 @@ def injected_letter_contact_block(notify_admin, mocker):
                 "service_id": service_id,
                 "contact_block": "foo\nbar<script>alert(1);</script>",
                 "is_default": True,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "updated_at": None,
             }
         ]
@@ -267,7 +267,7 @@ def get_default_letter_contact_block(notify_admin, mocker):
             "service_id": service_id,
             "contact_block": "1 Example Street",
             "is_default": True,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "updated_at": None,
         }
 
@@ -283,7 +283,7 @@ def mock_add_letter_contact(notify_admin, mocker):
                 "service_id": service_id,
                 "contact_block": "1 Example Street",
                 "is_default": True,
-                "created_at": str(datetime.utcnow()),
+                "created_at": str(datetime.now(UTC)),
                 "updated_at": None,
             }
         }
@@ -308,7 +308,7 @@ def multiple_sms_senders(notify_admin, mocker):
                 "service_id": service_id,
                 "sms_sender": "Example",
                 "is_default": True,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "inbound_number_id": "1234",
                 "updated_at": None,
             },
@@ -317,7 +317,7 @@ def multiple_sms_senders(notify_admin, mocker):
                 "service_id": service_id,
                 "sms_sender": "Example 2",
                 "is_default": False,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "inbound_number_id": None,
                 "updated_at": None,
             },
@@ -326,7 +326,7 @@ def multiple_sms_senders(notify_admin, mocker):
                 "service_id": service_id,
                 "sms_sender": "Example 3",
                 "is_default": False,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "inbound_number_id": None,
                 "updated_at": None,
             },
@@ -344,7 +344,7 @@ def multiple_sms_senders_with_diff_default(notify_admin, mocker):
                 "service_id": service_id,
                 "sms_sender": "Example",
                 "is_default": True,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "inbound_number_id": None,
                 "updated_at": None,
             },
@@ -353,7 +353,7 @@ def multiple_sms_senders_with_diff_default(notify_admin, mocker):
                 "service_id": service_id,
                 "sms_sender": "Example 2",
                 "is_default": False,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "inbound_number_id": None,
                 "updated_at": None,
             },
@@ -362,7 +362,7 @@ def multiple_sms_senders_with_diff_default(notify_admin, mocker):
                 "service_id": service_id,
                 "sms_sender": "Example 3",
                 "is_default": False,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "inbound_number_id": "12354",
                 "updated_at": None,
             },
@@ -380,7 +380,7 @@ def multiple_sms_senders_no_inbound(notify_admin, mocker):
                 "service_id": service_id,
                 "sms_sender": "Example",
                 "is_default": True,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "inbound_number_id": None,
                 "updated_at": None,
             },
@@ -389,7 +389,7 @@ def multiple_sms_senders_no_inbound(notify_admin, mocker):
                 "service_id": service_id,
                 "sms_sender": "Example 2",
                 "is_default": False,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "inbound_number_id": None,
                 "updated_at": None,
             },
@@ -415,7 +415,7 @@ def single_sms_sender(notify_admin, mocker):
                 "service_id": service_id,
                 "sms_sender": "GOVUK",
                 "is_default": True,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(UTC),
                 "inbound_number_id": None,
                 "updated_at": None,
             }
@@ -432,7 +432,7 @@ def get_default_sms_sender(notify_admin, mocker):
             "service_id": service_id,
             "sms_sender": "GOVUK",
             "is_default": True,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "inbound_number_id": None,
             "updated_at": None,
         }
@@ -448,7 +448,7 @@ def get_non_default_sms_sender(notify_admin, mocker):
             "service_id": service_id,
             "sms_sender": "GOVUK",
             "is_default": False,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "inbound_number_id": None,
             "updated_at": None,
         }
@@ -1311,7 +1311,7 @@ def api_user_changed_password(fake_uuid):
     return create_user(
         id=fake_uuid,
         failed_login_count=5,
-        password_changed_at=str(datetime.utcnow() + timedelta(minutes=1)),
+        password_changed_at=str(datetime.now(UTC) + timedelta(minutes=1)),
     )
 
 
@@ -2124,7 +2124,7 @@ def mock_get_inbound_sms_summary(notify_admin, mocker):
     def _get_inbound_sms_summary(
         service_id,
     ):
-        return {"count": 9999, "most_recent": datetime.utcnow().isoformat()}
+        return {"count": 9999, "most_recent": datetime.now(UTC).isoformat()}
 
     return mocker.patch(
         "app.service_api_client.get_inbound_sms_summary",
@@ -2230,7 +2230,7 @@ def sample_invite(mocker, service_one):
     email_address = "invited_user@test.gov.uk"
     service_id = service_one["id"]
     permissions = "view_activity,send_emails,send_letters,send_texts,manage_settings,manage_users,manage_api_keys"
-    created_at = str(datetime.utcnow())
+    created_at = str(datetime.now(UTC))
     auth_type = "sms_auth"
     folder_permissions = []
 
@@ -2276,7 +2276,7 @@ def mock_get_invites_without_manage_permission(mocker, service_one, sample_invit
                 email_address="invited_user@test.gov.uk",
                 service_id=service_one["id"],
                 permissions="view_activity,send_messages,manage_api_keys",
-                created_at=str(datetime.utcnow()),
+                created_at=str(datetime.now(UTC)),
                 auth_type="sms_auth",
                 folder_permissions=[],
                 status="pending",
@@ -2351,7 +2351,7 @@ def mock_get_monthly_notification_stats(notify_admin, mocker, service_one, fake_
     def _stats(service_id, year):
         return {
             "data": {
-                datetime.utcnow().strftime("%Y-%m"): {
+                datetime.now(UTC).strftime("%Y-%m"): {
                     "email": {
                         "sending": 1,
                         "delivered": 1,
@@ -3598,7 +3598,7 @@ def sample_org_invite(mocker, organisation_one):
     invited_by = organisation_one["users"][0]
     email_address = "invited_user@test.gov.uk"
     organisation = organisation_one["id"]
-    created_at = str(datetime.utcnow())
+    created_at = str(datetime.now(UTC))
     status = "pending"
     permissions = ["can_make_services_live"]
 
@@ -4069,7 +4069,7 @@ def create_user(**overrides):
         "organisation_permissions": {},
         "platform_admin": False,
         "auth_type": "sms_auth",
-        "password_changed_at": str(datetime.utcnow()),
+        "password_changed_at": str(datetime.now(UTC)),
         "services": [],
         "organisations": [],
         "current_session_id": None,
@@ -4101,7 +4101,7 @@ def create_multiple_email_reply_to_addresses(service_id="abcd"):
             "service_id": service_id,
             "email_address": "test@example.com",
             "is_default": True,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "updated_at": None,
         },
         {
@@ -4109,7 +4109,7 @@ def create_multiple_email_reply_to_addresses(service_id="abcd"):
             "service_id": service_id,
             "email_address": "test2@example.com",
             "is_default": False,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "updated_at": None,
         },
         {
@@ -4117,7 +4117,7 @@ def create_multiple_email_reply_to_addresses(service_id="abcd"):
             "service_id": service_id,
             "email_address": "test3@example.com",
             "is_default": False,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "updated_at": None,
         },
     ]
@@ -4150,7 +4150,7 @@ def create_multiple_sms_senders(service_id="abcd"):
             "service_id": service_id,
             "sms_sender": "Example",
             "is_default": True,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "inbound_number_id": "1234",
             "updated_at": None,
         },
@@ -4159,7 +4159,7 @@ def create_multiple_sms_senders(service_id="abcd"):
             "service_id": service_id,
             "sms_sender": "Example 2",
             "is_default": False,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "inbound_number_id": None,
             "updated_at": None,
         },
@@ -4168,7 +4168,7 @@ def create_multiple_sms_senders(service_id="abcd"):
             "service_id": service_id,
             "sms_sender": "Example 3",
             "is_default": False,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "inbound_number_id": None,
             "updated_at": None,
         },
@@ -4200,7 +4200,7 @@ def create_multiple_letter_contact_blocks(service_id="abcd"):
             "service_id": service_id,
             "contact_block": "1 Example Street",
             "is_default": True,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "updated_at": None,
         },
         {
@@ -4208,7 +4208,7 @@ def create_multiple_letter_contact_blocks(service_id="abcd"):
             "service_id": service_id,
             "contact_block": "2 Example Street",
             "is_default": False,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "updated_at": None,
         },
         {
@@ -4216,7 +4216,7 @@ def create_multiple_letter_contact_blocks(service_id="abcd"):
             "service_id": service_id,
             "contact_block": "foo\n\n<bar>\n\nbaz",
             "is_default": False,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(UTC),
             "updated_at": None,
         },
     ]


### PR DESCRIPTION
`datetime.utcnow` is deprecated as of Python 3.12: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

The docs say:
> Use `datetime.now()` with `datetime.UTC` instead.

There are a few cases where we pass serialised datetimes to the API. Because the API might be expecting datetimes in a particular format I’ve written a couple of helper methods to deal with this. In the future we could investigate whether the API really needs datetimes in those exact formats.

I’ve changed the tests as a separate commit so it’s easy to see that:
- the changes to the app code pass the existing tests
- the changes to the tests don’t break the app code

You can verify this by running `git rebase origin/main -ix "make test"`