### PR TITLE
Hide the new crown in the footer

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -90,3 +90,8 @@ $link-colour-on-grey-background: #1852ab;
   position: relative;
   z-index: 1;
 }
+
+
+.govuk-footer__crown {
+  display: none;
+}


### PR DESCRIPTION
It takes up space and we don’t think it’s applicable for admin interfaces.

# Before

<img width="1107" alt="image" src="https://github.com/user-attachments/assets/1c02ded1-9ed2-4299-85c2-c292f1cc27ea" />

# Before with `govukRebrand = true`

<img width="1125" alt="image" src="https://github.com/user-attachments/assets/dc45b672-1c0a-4b18-8295-81fe566f530d" />

# After

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/3bc283e5-6aab-4e3c-8bc0-49c20d0b67ac" />
