### PR TITLE
Set utils to v99.8 & rebrand flag to False

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.7.0
+# This file was automatically copied from notifications-utils@99.8.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -99,6 +99,7 @@ def email_template():
                 brand_logo=branding.logo_url,
                 brand_banner=branding.has_brand_banner,
                 brand_alt_text=branding.alt_text,
+                rebrand=False,
             )
         )
     )

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.7.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.8.0
 
 govuk-frontend-jinja==3.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8b39f0006709662df689d52055867bca0a897230
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -163,7 +163,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8b39f0006709662df689d52055867bca0a897230
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.7.0
+# This file was automatically copied from notifications-utils@99.8.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.7.0
+# This file was automatically copied from notifications-utils@99.8.0
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
Brings in the version of utils with the new GOV.UK branding and sets the flag that turns it on in our email previews to off.

## Notes for reviewers

Please try viewing the email branding preview when set to GOV.UK as is, then changing the `rebrand` argument to `True` and checking the branding preview changes to the new brand.