### PR TITLE
Remove announcement about international text message prices

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -24,16 +24,7 @@ Text message pricing
       }
     ) }}
 
-  <div class="govuk-inset-text">
-    <p class="govuk-body">
-    International text message rates have changed.
-    </p>
-    <p class="govuk-body">
-      Find out what it costs to <a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">send text messages to international numbers</a>.
-    </p>  
-  </div>
-  
-<p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
+  <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} (plus VAT) for each text message you send.</p>
 
   <div class="bottom-gutter-3-2">

--- a/tests/app/main/views/test_pricing.py
+++ b/tests/app/main/views/test_pricing.py
@@ -39,8 +39,11 @@ def test_guidance_pricing_letters(client_request, mock_get_letter_rates):
     (
         (
             0.0233,
-            "International text message rates have changed.",
-            "Find out what it costs to send text messages to international numbers.",
+            "Each unique service you add has an annual allowance of free text messages.",
+            (
+                "When a service has used its annual allowance, it costs 2.33 pence (plus VAT) "
+                "for each text message you send."
+            ),
         ),
     ),
 )


### PR DESCRIPTION
It’s been a couple of months since international text message prices changed.

We need to remove the inset text component from the top of the text message pricing page.