### PR TITLE
Fix ‘today at midnight’ being labelled ‘tomorrow at midnight’ during British Summer Time

### DIFF
--- a/tests/app/main/forms/test_choose_time_form.py
+++ b/tests/app/main/forms/test_choose_time_form.py
@@ -38,6 +38,40 @@ def test_form_contains_next_7_days_in_hour_intervals(notify_admin):
         assert choices[12 + (6 * 24) + 2]  # hours left in the day  # 3 days  # magic number
 
 
+@freeze_time("2016-07-01 10:59:00.061258")
+def test_form_contains_next_7_days_in_hour_intervals_during_summer_time(notify_admin):
+    choices = ChooseTimeForm().scheduled_for.choices
+
+    # Friday
+    assert choices[0] == ("", "Now")
+    assert choices[1] == ("2016-07-01T11:00:00", "Today at midday")
+    assert choices[13] == ("2016-07-01T23:00:00", "Today at midnight")
+
+    # Saturday
+    assert choices[14] == ("2016-07-02T00:00:00", "Tomorrow at 1am")
+    assert choices[37] == ("2016-07-02T23:00:00", "Tomorrow at midnight")
+
+    # Sunday
+    assert choices[38] == ("2016-07-03T00:00:00", "Sunday 3 July at 1am")
+
+    # Monday
+    assert choices[84] == ("2016-07-04T22:00:00", "Monday 4 July at 11pm")
+    assert choices[85] == ("2016-07-04T23:00:00", "Monday 4 July at midnight")
+
+    # Tuesday
+    assert choices[86] == ("2016-07-05T00:00:00", "Tuesday 5 July at 1am")
+
+    # Wednesday
+    assert choices[110] == ("2016-07-06T00:00:00", "Wednesday 6 July at 1am")
+
+    # Thursday
+    assert choices[134] == ("2016-07-07T00:00:00", "Thursday 7 July at 1am")
+    assert choices[-1] == ("2016-07-07T23:00:00", "Thursday 7 July at midnight")
+
+    with pytest.raises(IndexError):
+        assert choices[12 + (6 * 24) + 2]  # hours left in the day  # 3 days  # magic number
+
+
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_form_defaults_to_now(notify_admin):
     assert ChooseTimeForm().scheduled_for.data == ""


### PR DESCRIPTION
`formatters.get_human_day` was expecting a UTC datetime but was being given a localized one.

This meant that during British Summer Time it was an hour out.

Our tests only covered winter, so that’s why we didn’t spot this when we retired the `forms.get_human_day` function, which silently expected a localized datetime.

***

In the admin app this showed up as an extra option at the bottom of the list. This then confused the Javascript because ‘Thursday’ wasn’t in its list of days.

<img width="792" alt="image" src="https://github.com/user-attachments/assets/7657a1fc-1218-428b-b529-9457a8f3fc5a" />
