### PR TITLE
Feature flag for request report phase 1a

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -27,6 +27,9 @@ REPORT_REQUEST_DELETED = "deleted"
 # Error codes from the API
 QR_CODE_TOO_LONG = "qr-code-too-long"
 
+# Allow upto 800,000 notifications to be requested in a report for phase 1a
+REPORT_REQUEST_MAX_NOTIFICATIONS = 800_000
+
 
 # Language options supported for bilingual letter templates
 class LetterLanguageOptions(str, enum.Enum):

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -15,7 +15,7 @@ from app import (
     service_api_client,
     template_statistics_client,
 )
-from app.constants import MAX_NOTIFICATION_FOR_DOWNLOAD
+from app.constants import MAX_NOTIFICATION_FOR_DOWNLOAD, REPORT_REQUEST_MAX_NOTIFICATIONS
 from app.extensions import redis_client
 from app.formatters import format_date_numeric, format_datetime_numeric, format_phone_number_human_readable
 from app.main import json_updates, main
@@ -136,6 +136,11 @@ def view_notifications(service_id, message_type=None):
     can_download = notifications_count <= MAX_NOTIFICATION_FOR_DOWNLOAD
     download_link = None
 
+    # Feature flag to enable request report for phase 1a deployment
+    report_request_feature_flag = (
+        REPORT_REQUEST_MAX_NOTIFICATIONS > 0 and notifications_count <= REPORT_REQUEST_MAX_NOTIFICATIONS
+    )
+
     if can_download:
         download_link = url_for(
             ".download_notifications_csv",
@@ -197,6 +202,7 @@ def view_notifications(service_id, message_type=None):
         }.get(bool(current_service.api_keys)),
         download_link=download_link,
         can_download=can_download,
+        report_request_feature_flag=report_request_feature_flag,
     )
 
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -73,7 +73,7 @@
     {% set retention_text %}
       Data available for {{ partials.service_data_retention_days }} days
     {% endset %}
-    {% if current_user.platform_admin %}
+    {% if report_request_feature_flag or current_user.platform_admin %}
       <div class="govuk-button-group govuk-button-group--flex-start">
         {% call form_wrapper(class='csv-request-form form--inline') %}
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">


### PR DESCRIPTION
For phase 1a of the request report feature, a feature flag has been added that allows all users to request and download reports for up to 800,000 notifications. If the number of notifications exceeds 800,000, users will be directed to a support form to request the report. See card for the more details.

Added more test cases and updated existing ones to check the new logic. We would keep an eye on logs and number of requests for a week. If we need to go back to using the CSV download link, we can set `REPORT_REQUEST_MAX_NOTIFICATIONS` to `0` and deploy or roll back the changes.

