### PR TITLE
CustomProxyFix: don't trust `x-forwarded-host` header

### DIFF
--- a/app/proxy_fix.py
+++ b/app/proxy_fix.py
@@ -3,7 +3,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 class CustomProxyFix:
     def __init__(self, app, forwarded_proto):
-        self.app = ProxyFix(app, x_for=1, x_proto=1, x_host=1, x_port=0, x_prefix=0)
+        self.app = ProxyFix(app, x_for=1, x_proto=1, x_host=0, x_port=0, x_prefix=0)
         self.forwarded_proto = forwarded_proto
 
     def __call__(self, environ, start_response):


### PR DESCRIPTION
https://trello.com/c/eYCdsDtF/1142-ensure-end-user-can-not-set-x-rewrite-url-x-original-url-x-forwarded-host-to-override-url

This is not used or stripped by cloudfront/ALBs, so not safe to trust.

Tested requesting admin root page in firefox with added garbage `X-Forwarded-Host` header which causes production to 500.