### PR TITLE
Stop rebranded header navigation from jumping around

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -95,3 +95,15 @@ $link-colour-on-grey-background: #1852ab;
 .govuk-footer__crown {
   display: none;
 }
+
+
+.govuk-template--rebranded .govuk-header__navigation-item--active:not(:last-child) {
+
+  @include govuk-media-query($from: tablet) {
+    // These 2 lines stop the width of the item jumping so much
+    // between selected and unselected states
+    margin-right: 14.5px;
+    letter-spacing: -0.012em;
+  }
+}
+


### PR DESCRIPTION
Because the header navigation now uses bold for its active state each item changes in width when clicked.

This causes the other items to shift position which looks a bit janky.

We can use a similar trick that we do in the side navigation to make things an almost-consistent width:
https://github.com/alphagov/notifications-admin/blob/2456d714fc54f45cbd981e1717ad0533dcb5241b/app/assets/stylesheets/components/navigation.scss#L120-L123

***

Note that:
- this can be merged ahead of switching the rebrand on because it’s scoped to `.govuk-template--rebranded`
- this is temporary because we will [replace the header navigation with the service navigation component](https://github.com/alphagov/notifications-admin/pull/5484) fairly soon

***

# Before 

https://github.com/user-attachments/assets/802a4c02-4d9b-4166-a402-2c49b6278fdd

# After

https://github.com/user-attachments/assets/09241d22-7d63-4c9c-a160-2c8aacad821f