### PR TITLE
Add fix for downloading report request with no status in query string

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -152,7 +152,7 @@ def view_notifications(service_id, message_type=None):
     csv_report_message_status = (
         "all"
         if request.args.get("status") == "sending,delivered,failed" or request.args.get("status") == ""
-        else request.args.get("status")
+        else request.args.get("status", "all")
     )
 
     search_term = request.form.get("to", "")


### PR DESCRIPTION
The status may not be in the query string when clicking to download a report request - we've seen this happen when clicking the download link after viewing a cached search query. We were handling the case where status in the query string existed like `status=` (and correctly setting it to "all") but not where it didn't exist at all - in these cases it was being passed to the api as `None`, which causes an error.

We now set the status to "all" if it's not in the query string.