### PR TITLE
Fix custom type styling on certain text inputs

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -107,3 +107,9 @@ $link-colour-on-grey-background: #1852ab;
   }
 }
 
+// Makes numeric inputs easier to read
+.extra-tracking .govuk-input {
+  @include govuk-font(19, $tabular: true);
+  padding-left: 5px;
+  letter-spacing: 0.04em;
+}


### PR DESCRIPTION
This was accidentally deleted here:
https://github.com/alphagov/notifications-admin/commit/b1488734bc281b916db4bd05e870f60edef8e00b#diff-321e45f6d2409f33c6e6a3ccd44dce569af3a0c620fdfd95cb21a4b68ea8857fL62-L66

You can see the class is still present in lots of places here: https://github.com/search?q=repo%3Aalphagov%2Fnotifications-admin%20extra-tracking&type=code

Example showing why this is better from https://github.com/alphagov/notifications-admin/pull/2820:

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/53636086-ef1b4680-3c16-11e9-9045-dedf9076d2b9.png) | ![image](https://user-images.githubusercontent.com/355079/53636073-e62a7500-3c16-11e9-813d-e2a00882b38f.png)

