### PR TITLE
Use `.govuk-input--extra-letter-spacing` instead of `.extra-tracking`

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -332,7 +332,13 @@ class SMSCode(GovukTextInputField):
     # the design system recommends against ever using `type="number"`. "tel" makes mobile browsers
     # show a phone keypad input rather than a full qwerty keyboard.
     input_type = "tel"
-    param_extensions = {"attributes": {"pattern": "[0-9]*"}}
+    param_extensions = {
+        "attributes": {
+            "pattern": "[0-9]*",
+            "data-notify-module": "autofocus",
+        },
+        "classes": "govuk-input govuk-input--width-5 govuk-input--extra-letter-spacing",
+    }
     validators = [
         NotifyDataRequired(thing="your text message code"),
         Regexp(regex=r"^\d+$", message="Numbers only"),

--- a/app/templates/views/manage-users/edit-user-mobile.html
+++ b/app/templates/views/manage-users/edit-user-mobile.html
@@ -19,8 +19,8 @@
   <p class="govuk-body" id="user_name">This will change the mobile number for {{ user.name }}.</p>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      {% call form_wrapper(class="extra-tracking") %}
-        {{ form.mobile_number }}
+      {% call form_wrapper() %}
+        {{ form.mobile_number(param_extensions={"classes": "govuk-input--extra-letter-spacing"}) }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -35,7 +35,7 @@
 
   {% endif %}
 
-  <div class="govuk-grid-column-full {% if message_type == 'sms' %}extra-tracking{% endif %}">
+  <div class="govuk-grid-column-full">
   {% call form_wrapper(
     action=url_for('main.view_notifications', service_id=current_service.id, message_type=message_type, search_query=search_query),
     class="govuk-grid-row notify-simple-search-form"
@@ -53,7 +53,8 @@
                 prefix='Search by',
                 prefix_plural='Search by'
               )
-            }
+            },
+            "classes": "govuk-input--extra-letter-spacing" if message_type == "sms" else ""
           }
         )
       }}

--- a/app/templates/views/organisations/organisation/settings/edit-organisation-billing-details.html
+++ b/app/templates/views/organisations/organisation/settings/edit-organisation-billing-details.html
@@ -19,10 +19,8 @@
     {% call form_wrapper() %}
       {{ form.billing_contact_names(param_extensions={"classes": "govuk-!-width-full"}) }}
       {{ form.billing_contact_email_addresses(param_extensions={"classes": "govuk-!-width-full"}) }}
-    <div class="extra-tracking">
-        {{ form.billing_reference(param_extensions={"classes": "govuk-!-width-full"}) }}
-        {{ form.purchase_order_number(param_extensions={"classes": "govuk-!-width-full"}) }}
-    </div>
+      {{ form.billing_reference(param_extensions={"classes": "govuk-!-width-full govuk-input--extra-letter-spacing"}) }}
+      {{ form.purchase_order_number(param_extensions={"classes": "govuk-!-width-full govuk-input--extra-letter-spacing"}) }}
       {{ form.notes(param_extensions={
         "classes": "govuk-!-width-full",
         "rows": "4"

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -28,12 +28,10 @@ Create an account
       </div>
       {{ form.name(param_extensions={"classes": "govuk-!-width-three-quarters"}) }}
       {% if invited_user.auth_type == 'sms_auth' %}
-        <div class="extra-tracking">
-          {{ form.mobile_number(param_extensions={
-              "classes": "govuk-!-width-three-quarters",
-              "hint": {"text": "We’ll send you a security code by text message"}
-          }) }}
-        </div>
+        {{ form.mobile_number(param_extensions={
+            "classes": "govuk-!-width-three-quarters govuk-input--extra-letter-spacing",
+            "hint": {"text": "We’ll send you a security code by text message"}
+        }) }}
       {% endif %}
       {{ form.password(param_extensions={
           "classes": "govuk-!-width-three-quarters",

--- a/app/templates/views/register-from-org-invite.html
+++ b/app/templates/views/register-from-org-invite.html
@@ -15,12 +15,10 @@ Create an account
     <p class="govuk-body">Your account will be created with this email: {{invited_org_user.email_address}}</p>
     {% call form_wrapper() %}
       {{ form.name(param_extensions={"classes": "govuk-!-width-three-quarters"}) }}
-      <div class="extra-tracking">
-        {{ form.mobile_number(param_extensions={
-            "classes": "govuk-!-width-three-quarters",
-            "hint": {"text": "We’ll send you a security code by text message"}
-        }) }}
-      </div>
+      {{ form.mobile_number(param_extensions={
+          "classes": "govuk-!-width-three-quarters govuk-input--extra-letter-spacing",
+          "hint": {"text": "We’ll send you a security code by text message"}
+      }) }}
       {{ form.password(param_extensions={
           "classes": "govuk-!-width-three-quarters",
           "hint": {"text": "At least 8 characters"},

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -21,12 +21,10 @@ Create an account
         },
         error_message_with_html=True
       ) }}
-      <div class="extra-tracking">
-        {{ form.mobile_number(param_extensions={
-          "hint": {"text": "We’ll send you a security code by text message"},
-          "classes": "govuk-!-width-three-quarters"
-        }) }}
-      </div>
+      {{ form.mobile_number(param_extensions={
+        "hint": {"text": "We’ll send you a security code by text message"},
+        "classes": "govuk-!-width-three-quarters govuk-input--extra-letter-spacing"
+      }) }}
       {{ form.password(param_extensions={"hint": {"text": "At least 8 characters"}, "classes": "govuk-!-width-three-quarters", "autocomplete": "new-password"}) }}
       {{form.auth_type}}
       {{ page_footer("Continue") }}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -22,8 +22,10 @@
     data_kwargs={'force-focus': True}
   ) %}
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}">
-        {{ form.placeholder_value(param_extensions={"classes": "govuk-!-width-full"}) }}
+      <div class="govuk-grid-column-full">
+        {{ form.placeholder_value(param_extensions={
+          "classes": "govuk-!-width-full govuk-input--extra-letter-spacing" if form.placeholder_value.label.text == "phone number" else "govuk-!-width-full"
+        }) }}
       </div>
       {% if skip_link or link_to_upload %}
         <div class="govuk-grid-column-full">

--- a/app/templates/views/service-settings/edit-service-billing-details.html
+++ b/app/templates/views/service-settings/edit-service-billing-details.html
@@ -21,10 +21,8 @@
   {% call form_wrapper() %}
     {{ form.billing_contact_names(param_extensions={"classes": "govuk-!-width-full"}) }}
     {{ form.billing_contact_email_addresses(param_extensions={"classes": "govuk-!-width-full"}) }}
-  <div class="extra-tracking">
-      {{ form.billing_reference(param_extensions={"classes": "govuk-!-width-full"}) }}
-      {{ form.purchase_order_number(param_extensions={"classes": "govuk-!-width-full"}) }}
-  </div>
+    {{ form.billing_reference(param_extensions={"classes": "govuk-!-width-full govuk-input--extra-letter-spacing"}) }}
+    {{ form.purchase_order_number(param_extensions={"classes": "govuk-!-width-full govuk-input--extra-letter-spacing"}) }}
     {{ form.notes(param_extensions={
       "classes": "govuk-!-width-full",
       "rows": "4",

--- a/app/templates/views/two-factor-sms.html
+++ b/app/templates/views/two-factor-sms.html
@@ -16,12 +16,9 @@
     <p class="govuk-body">We’ve sent you a text message with a security code.</p>
 
     <p class="govuk-body">Text messages can take a few minutes to arrive.</p>
-    
-    {% call form_wrapper(class="extra-tracking") %}
-      {{ form.sms_code(param_extensions={
-          "classes": "govuk-input govuk-input--width-5",
-          "attributes": {"data-notify-module": "autofocus"}
-      }) }}
+
+    {% call form_wrapper() %}
+      {{ form.sms_code() }}
       {{ page_footer(
         "Continue",
         secondary_link=url_for('main.check_and_resend_text_code', next=redirect_url),

--- a/app/templates/views/your-account/change.html
+++ b/app/templates/views/your-account/change.html
@@ -21,7 +21,7 @@
           {%  elif thing == "name" %}
               {{ form.new_name(param_extensions={"label": {"isPageHeading": True, "classes": "govuk-label--l"}}) }}
           {%  elif thing == "mobile number" %}
-              {{ form.mobile_number(param_extensions={"label": {"isPageHeading": True, "classes": "govuk-label--l"}}) }}
+              {{ form.mobile_number(param_extensions={"label": {"isPageHeading": True, "classes": "govuk-label--l"}, "classes": "govuk-input--extra-letter-spacing govuk-input--width-10"}) }}
            {%  endif %}
         {% if current_user.auth_type == 'email_auth' and (current_user.mobile_number and thing == "mobile number") %}
           {{ page_footer(

--- a/app/templates/views/your-account/confirm.html
+++ b/app/templates/views/your-account/confirm.html
@@ -22,11 +22,7 @@
         We’ve sent a security code to your new {{ thing }}.
       </p>
       {% call form_wrapper() %}
-        {{ form_field(param_extensions={
-            "classes": "govuk-input govuk-input--width-5",
-            "attributes": {"data-notify-module": "autofocus"}
-        }) }}
-
+        {{ form_field() }}
         {{ page_footer('Confirm') }}
       {% endcall %}
     </div>


### PR DESCRIPTION
We implemented `.extra-tracking` in https://github.com/alphagov/notifications-admin/pull/1545

This eventually became `.govuk-input--extra-letter-spacing` via https://github.com/alphagov/govuk-frontend/pull/1222 and https://github.com/alphagov/govuk-frontend/pull/2230

This pull request moves all existing uses of `.extra-tracking` to `.govuk-input--extra-letter-spacing`

It also moves the definition of `classes` on the `SMSCode` field to `forms.py` so the same classes are used consistently wherever this field is used.