### PR TITLE
When report does not exist into s3 redirects to report-request unavailable page

### DIFF
--- a/app/main/views/report_requests.py
+++ b/app/main/views/report_requests.py
@@ -61,6 +61,11 @@ def report_request(service_id, report_request_id):
 def report_ready(service_id, report_request_id):
     validate_report_request_enabled()
 
+    if not ReportRequest.exists_in_s3(report_request_id):
+        return render_template(
+            "views/csv-report/unavailable.html",
+        )
+
     try:
         report_request = ReportRequest.from_id(service_id, report_request_id)
     except HTTPError as e:

--- a/app/models/report_request.py
+++ b/app/models/report_request.py
@@ -6,6 +6,7 @@ from notifications_utils.s3 import s3download
 
 from app import report_request_api_client
 from app.models import JSONModel
+from app.s3_client import check_s3_object_exists
 
 
 class ReportRequest(JSONModel):
@@ -31,6 +32,13 @@ class ReportRequest(JSONModel):
     @staticmethod
     def download(report_request_id):
         return s3download(
+            bucket_name=ReportRequest.get_bucket_name(),
+            filename=f"notifications_report/{report_request_id}.csv",
+        )
+
+    @staticmethod
+    def exists_in_s3(report_request_id):
+        return check_s3_object_exists(
             bucket_name=ReportRequest.get_bucket_name(),
             filename=f"notifications_report/{report_request_id}.csv",
         )

--- a/app/s3_client/__init__.py
+++ b/app/s3_client/__init__.py
@@ -1,6 +1,21 @@
-from boto3 import resource
+from boto3 import client, resource
+from botocore.exceptions import ClientError
+from flask import current_app
 
 
 def get_s3_object(bucket_name, filename):
     s3 = resource("s3")
     return s3.Object(bucket_name, filename)
+
+
+def check_s3_object_exists(bucket_name, filename):
+    try:
+        s3 = client("s3")
+        s3.head_object(Bucket=bucket_name, Key=filename)
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            return False
+        else:
+            current_app.logger.error("Error when checking file %s in bucket %s", filename, bucket_name)
+            raise e

--- a/tests/app/models/test_report_request.py
+++ b/tests/app/models/test_report_request.py
@@ -14,3 +14,22 @@ def test_report_request_download(notify_admin):
     csv_file = ReportRequest.download("abcd")
 
     assert csv_file.read().decode("utf-8") == "csv_content"
+
+
+@mock_aws
+def test_exists_in_s3_should_return_true_when_report_exists(notify_admin):
+    bucket_name = ReportRequest.get_bucket_name()
+    s3 = boto3.client("s3", region_name="eu-west-1")
+    s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+    s3.put_object(Bucket=bucket_name, Key="notifications_report/abcd.csv", Body=b"csv_content")
+
+    assert ReportRequest.exists_in_s3("abcd")
+
+
+@mock_aws
+def test_exists_in_s3_should_return_false_when_report_does_not_exist(notify_admin):
+    bucket_name = ReportRequest.get_bucket_name()
+    s3 = boto3.client("s3", region_name="eu-west-1")
+    s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+
+    assert ReportRequest.exists_in_s3("abcd") is False


### PR DESCRIPTION
Check if the report-request file exists in S3 before rendering the report-request ready page and download option. If the file does not exist, redirect to the report-request unavailable page.

Tested by generating new report and tried to access to old report which does not exit into S3 bucket, both cases handled as expected.