### PR TITLE
Bump govuk-frontend to v5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cbor-js": "0.1.0",
-        "govuk-frontend": "5.10.2",
+        "govuk-frontend": "5.11.0",
         "jquery": "3.5.0",
         "morphdom": "2.6.1",
         "textarea-caret": "3.1.0",
@@ -6002,9 +6002,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.2.tgz",
-      "integrity": "sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0.tgz",
+      "integrity": "sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor-js": "0.1.0",
-    "govuk-frontend": "5.10.2",
+    "govuk-frontend": "5.11.0",
     "jquery": "3.5.0",
     "morphdom": "2.6.1",
     "textarea-caret": "3.1.0",

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -12,7 +12,7 @@ def test_govuk_frontend_jinja_overrides_on_design_system_v5():
     govuk_frontend_jinja_version = Version(metadata.version("govuk-frontend-jinja"))
 
     # Compatibility between these two libs is defined at https://github.com/LandRegistry/govuk-frontend-jinja/
-    correct_govuk_frontend_version = Version("5.10.2") == govuk_frontend_version
+    correct_govuk_frontend_version = Version("5.11.0") == govuk_frontend_version
     correct_govuk_frontend_jinja_version = Version("3.6.0") == govuk_frontend_jinja_version
 
     assert correct_govuk_frontend_version and correct_govuk_frontend_jinja_version, (


### PR DESCRIPTION
Release notes: https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.0

- rebrand svg icon fixes
- service navigation fixes