### PR TITLE
Don’t allow overriding of page counts

### DIFF
--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -141,10 +141,9 @@ class TemplatedLetterImageTemplate(BaseLetterImageTemplate):
         image_url=None,
         contact_block=None,
         include_letter_edit_ui_overlay=False,
-        page_counts=None,
     ):
         super().__init__(template, values, image_url=image_url, page_count=None, contact_block=contact_block)
-        self._all_page_counts = page_counts
+        self._all_page_counts = None
         self.include_letter_edit_ui_overlay = include_letter_edit_ui_overlay
 
     @property


### PR DESCRIPTION
This doesn’t seem to be used anywhere.

If it was used it could cause performance issues because the browser would start requesting PNGs before the underlying PDF was in the cache, causing the PDF to be generated as many times as it has pages.