### PR TITLE
Update guidance for letter delivery times

### DIFF
--- a/app/templates/views/guidance/using-notify/delivery-times.html
+++ b/app/templates/views/guidance/using-notify/delivery-times.html
@@ -31,7 +31,7 @@
   <p class="govuk-body">We send text messages through different providers. If one provider fails, Notify switches to another so that your text messages are not affected.</p>
 
   <h2 id="letters" class="heading-medium">Letters</h2>
-  <p class="govuk-body">Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday).</p>
+  <p class="govuk-body">Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday, excluding bank holidays).</p>
   <p class="govuk-body">Estimated delivery times are based on the date a letter is dispatched.</p>
 
 <div class="bottom-gutter-3-2">
@@ -42,11 +42,11 @@
       caption_visible=False
     ) %}
       {% for column_heading, description in [
-        ('First class', '1 to 2 days'),
-        ('Second class', '2 to 3 days'),
-        ('Economy mail', 'Up to 8 days'),
-        ('International (Europe)', '3 to 5 days'),
-        ('International (rest of the world)', '6 to 7 days'),
+        ('First class', '1 to 2 days (Monday to Saturday)'),
+        ('Second class', '3 to 4 working days'),
+        ('Economy mail', 'Up to 6 working days'),
+        ('International (Europe)', '3 to 5 working days'),
+        ('International (rest of the world)', '6 to 7 working days'),
         ] %}
         {% call row() %}
           {{ text_field(column_heading) }}
@@ -56,7 +56,6 @@
     {% endcall %}
   </div>
 
-  <p class="govuk-body">Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
   <p class="govuk-body">See a list of <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_letters') }}">postage prices</a>.</p>
 
   <h2 id="returned-mail" class="heading-medium">Returned letters</h2>


### PR DESCRIPTION
Royal Mail is changing the second class service.

We need to update the estimated delivery times for second class.

Economy mail is also affected, because Royal Mail is changing its delivery pattern.

We also need to make clear that Saturday deliveries are only for first class letters. Everything else is only delivered on a working day.