### PR TITLE
Upgrade Pillow to the latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ humanize==4.4.0
 Flask-WTF==1.2.1
 Flask-Login==0.6.3
 
-Pillow==11.2.1
+Pillow==11.3.0
 
 pyexcel==0.7.1
 pyexcel-io==0.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,7 +112,7 @@ packaging==23.1
     # via gunicorn
 phonenumbers==8.13.50
     # via notifications-utils
-pillow==11.2.1
+pillow==11.3.0
     # via -r requirements.in
 prometheus-client==0.15.0
     # via

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -182,7 +182,7 @@ phonenumbers==8.13.50
     # via
     #   -r requirements.txt
     #   notifications-utils
-pillow==11.2.1
+pillow==11.3.0
     # via -r requirements.txt
 pluggy==1.5.0
     # via pytest


### PR DESCRIPTION
Addresses CVE-2025-48379

Closes https://github.com/alphagov/notifications-admin/pull/5529