### PR TITLE
Add detailed instructions to the zendesk ticket for branding requests

### DIFF
--- a/app/templates/support-tickets/government-logo-branding-request.txt
+++ b/app/templates/support-tickets/government-logo-branding-request.txt
@@ -8,38 +8,26 @@ Service: {{ current_service.name }}
 
 ---
 
-<h2>Create a new government identity logo</h2>
-
-Open this link to create a new government identity logo:
-
+## Create a new government identity logo
 {% if branding_choice == "govuk_and_org" %}
 {% set create_logo_url = url_for(
-  'main.create_email_branding_government_identity_logo', text=logo_text, brand_type="both", _external=True
+'main.create_email_branding_government_identity_logo', text=logo_text, brand_type="both", _external=True
 ) %}
-{% elif branding_choice == "organisation" %}
+{% else %}
 {% set create_logo_url = url_for(
-  'main.create_email_branding_government_identity_logo', text=logo_text, _external=True
+'main.create_email_branding_government_identity_logo', text=logo_text, _external=True
 ) %}
 {% endif %}
-{{ create_logo_url }}
 
-1. Select the coat of arms or insignia for {% if current_service.organisation -%}
-  {{ current_service.organisation.name }}. If this organisation is not listed, select ‘HM Government’.
-{%- else -%}
-  the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.
-2. Select the stripe colour for {% if current_service.organisation -%}
-  {{ current_service.organisation.name }}. If this organisation is not listed, select ‘HM Government’.
-{%- else -%}
-  the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.
+Open this link to create a new government identity logo: {{ create_logo_url }}
+
+1. Select the coat of arms or insignia for {% if current_service.organisation %}{{current_service.organisation.name}}. If this organisation is not listed, select ‘HM Government’. {% else %}the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.{% endif %}
+2. Select the stripe colour for {% if current_service.organisation -%}{{current_service.organisation.name}}. If this organisation is not listed, select ‘HM Government’.{% else %}the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.{% endif %}
 3. Check that the logo text says: {{ logo_text }}
-4. Check that the brand type selected is: {{% if branding_choice == "govuk_and_org" -%}}GOV.UK and branding
-{% elif branding_choice == "organisation" %}Branding only
-{% endif %}
+4. Check that the brand type selected is: {% if branding_choice == "govuk_and_org" %}GOV.UK and branding{% else %}Branding only{% endif %}
 5. Select ‘Save’.
 
 
-<h2>Set the email branding for this service</h2>
+## Set the email branding for this service
 
-Open this link to select the new email branding for {{ current_service.name }}:
-
-{{ url_for('main.service_set_branding', service_id=current_service.id, branding_type='email', _external=True) }}
+Open this link to select the new email branding for {{ current_service.name }}: {{ url_for('main.service_set_branding', service_id=current_service.id, branding_type='email', _external=True) }}

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -940,53 +940,82 @@ def test_GET_email_branding_enter_government_identity_logo_text_protects_against
         (
             {"branding_choice": "something-else"},
             """
-        Organisation: Can’t tell (domain is user.gov.uk)
-        Service: service one
-        {service_dashboard}
+Organisation: Can’t tell (domain is user.gov.uk)
+Service: service one
+{service_dashboard}
 
-        ---
-        Government logo text requested: My lovely government identity
+---
 
-        Create this logo: {create_email_branding_government_identity_logo}
+## Create a new government identity logo\n\n
 
-        Apply branding to this service: {service_set_branding}
-    """,
+
+Open this link to create a new government identity logo: {create_email_branding_government_identity_logo}
+
+1. Select the coat of arms or insignia for the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.
+2. Select the stripe colour for the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.
+3. Check that the logo text says: My lovely government identity
+4. Check that the brand type selected is: Branding only
+5. Select ‘Save’.
+
+
+## Set the email branding for this service
+
+Open this link to select the new email branding for service one: {service_set_branding}
+            """,  # noqa
             {},
         ),
         (
             {"branding_choice": "govuk_and_org"},
             """
-        Organisation: Can’t tell (domain is user.gov.uk)
-        Service: service one
-        {service_dashboard}
+Organisation: Can’t tell (domain is user.gov.uk)
+Service: service one
+{service_dashboard}
 
-        ---
-        Government logo text requested: My lovely government identity
+---
 
-        This service requested for both GOV.UK and organisation logo to be visible.
+## Create a new government identity logo\n\n
 
-        Create this logo: {create_email_branding_government_identity_logo}
 
-        Apply branding to this service: {service_set_branding}
-    """,
+Open this link to create a new government identity logo: {create_email_branding_government_identity_logo}
+
+1. Select the coat of arms or insignia for the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.
+2. Select the stripe colour for the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.
+3. Check that the logo text says: My lovely government identity
+4. Check that the brand type selected is: GOV.UK and branding
+5. Select ‘Save’.
+
+
+## Set the email branding for this service
+
+Open this link to select the new email branding for service one: {service_set_branding}
+            """,  # noqa
             {"brand_type": "both"},
         ),
         (
             {"branding_choice": "organisation"},
             """
-        Organisation: Can’t tell (domain is user.gov.uk)
-        Service: service one
-        {service_dashboard}
+Organisation: Can’t tell (domain is user.gov.uk)
+Service: service one
+{service_dashboard}
 
-        ---
-        Government logo text requested: My lovely government identity
+---
 
-        This service requested organisation branding.
+## Create a new government identity logo\n\n
 
-        Create this logo: {create_email_branding_government_identity_logo}
 
-        Apply branding to this service: {service_set_branding}
-    """,
+Open this link to create a new government identity logo: {create_email_branding_government_identity_logo}
+
+1. Select the coat of arms or insignia for the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.
+2. Select the stripe colour for the organisation the service belongs to. If the organisation is not listed, select ‘HM Government’.
+3. Check that the logo text says: My lovely government identity
+4. Check that the brand type selected is: Branding only
+5. Select ‘Save’.
+
+
+## Set the email branding for this service
+
+Open this link to select the new email branding for service one: {service_set_branding}
+            """,  # noqa
             {},
         ),
     ],
@@ -1014,6 +1043,7 @@ def test_POST_email_branding_enter_government_identity_logo_text(
 
     assert "Thanks for your branding request." in mock_flash.call_args_list[0][0][0]
     assert mock_send_ticket_to_zendesk.call_count == 1
+
     assert (
         mock_send_ticket_to_zendesk.call_args[0][0].message
         == dedent(expected_ticket_content)


### PR DESCRIPTION
Non tech support folk do not have any guidance when adding new branding.

Things that happen with these tickets:
* left for folk who do have experience
* tagged to tech folk
* ask for help in zendesk support
* we just muddle through (not very confidently)

Guidance will help reduce burden on other team members to help and build confidence amongst colleagues who are not familiar/less experienced.