### PR TITLE
Format ‘sent today’ counts with thousands separator

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -103,7 +103,7 @@
       {% set email_limit_html %}
         {{ "{} per day".format(current_service.get_message_limit("email")|format_thousands) }}
         <div class="govuk-hint">
-          {{ current_service.sent_today("email")|string + " sent today" }}
+          {{ current_service.sent_today("email")|format_thousands + " sent today" }}
         </div>
       {% endset %}
 
@@ -262,14 +262,14 @@
       {% set text_message_limit_html %}
         {{ "{} per day".format(current_service.get_message_limit("sms")|format_thousands) }}
         <div class="govuk-hint">
-          {{ current_service.sent_today("sms")|string + " sent today" }}
+          {{ current_service.sent_today("sms")|format_thousands + " sent today" }}
         </div>
       {% endset %}
 
       {% set international_text_message_limit_html %}
         {{ "{} per day".format(current_service.get_message_limit("international_sms")|format_thousands) }}
         <div class="govuk-hint">
-          {{ current_service.sent_today("international_sms")|string + " sent today" }}
+          {{ current_service.sent_today("international_sms")|format_thousands + " sent today" }}
         </div>
       {% endset %}
 
@@ -455,7 +455,7 @@
     {% set letter_limit_html %}
       {{ "{} per day".format(current_service.get_message_limit("letter")|format_thousands) }}
       <div class="govuk-hint">
-        {{ current_service.sent_today("letter")|string + " sent today" }}
+        {{ current_service.sent_today("letter")|format_thousands + " sent today" }}
       </div>
     {% endset %}
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -58,12 +58,12 @@ FAKE_TEMPLATE_ID = uuid4()
                 "Reply-to email addresses Not set Manage reply-to email addresses",
                 "Email branding GOV.UK Change email branding",
                 "Send files by email contact_us@gov.uk Manage sending files by email",
-                "Email limit 1,000 per day 0 sent today Change daily email limit",
+                "Email limit 1,000 per day 1,234 sent today Change daily email limit",
                 "Send text messages On Change your settings for sending text messages",
                 "Text message sender IDs GOVUK Manage text message sender IDs",
                 "Start text messages with service name On Change your settings for starting text messages with service name",  # noqa
                 "Receive text messages Off Change your settings for receiving text messages",
-                "Text message limit 1,000 per day 0 sent today Change daily text message limit",
+                "Text message limit 1,000 per day 1,234 sent today Change daily text message limit",
                 "Send international text messages Off Change your settings for sending international text messages",
                 "Send letters Off Change your settings for sending letters",
             ],
@@ -81,7 +81,7 @@ FAKE_TEMPLATE_ID = uuid4()
                 "Send international letters Off Change your settings for sending international letters",
                 "Sender addresses Not set Manage sender addresses",
                 "Letter branding Not set Change letter branding",
-                "Letter limit 1,000 per day 0 sent today Change daily letter limit",
+                "Letter limit 1,000 per day 1,234 sent today Change daily letter limit",
             ],
         ),
         (
@@ -96,12 +96,12 @@ FAKE_TEMPLATE_ID = uuid4()
                 "Reply-to email addresses Not set Manage reply-to email addresses",
                 "Email branding GOV.UK Change email branding",
                 "Send files by email contact_us@gov.uk Manage sending files by email",
-                "Email limit 1,000 per day 0 sent today Change daily email limit",
+                "Email limit 1,000 per day 1,234 sent today Change daily email limit",
                 "Send text messages On Change your settings for sending text messages",
                 "Text message sender IDs GOVUK Manage text message sender IDs",
                 "Start text messages with service name On Change your settings for starting text messages with service name",  # noqa
                 "Receive text messages Off Change your settings for receiving text messages",
-                "Text message limit 1,000 per day 0 sent today Change daily text message limit",
+                "Text message limit 1,000 per day 1,234 sent today Change daily text message limit",
                 "Send international text messages Off Change your settings for sending international text messages",
                 "Send letters Off Change your settings for sending letters",
                 "Live On Change service status",
@@ -135,7 +135,7 @@ FAKE_TEMPLATE_ID = uuid4()
                 "Send international letters Off Change your settings for sending international letters",
                 "Sender addresses Not set Manage sender addresses",
                 "Letter branding Not set Change letter branding",
-                "Letter limit 1,000 per day 0 sent today Change daily letter limit",
+                "Letter limit 1,000 per day 1,234 sent today Change daily letter limit",
                 "Live On Change service status",
                 "Count in list of live services Yes Change if service is counted in list of live services",
                 "Billing details None Change billing details for service",
@@ -176,6 +176,7 @@ def test_should_show_overview(
         restricted=False,
     )
     mocker.patch("app.service_api_client.get_service", return_value={"data": service_one})
+    mocker.patch("app.service_api_client.get_notification_count", return_value=1_234)
 
     client_request.login(user, service_one)
     page = client_request.get("main.service_settings", service_id=SERVICE_ONE_ID)


### PR DESCRIPTION
# Before 

<img width="735" alt="image" src="https://github.com/user-attachments/assets/0495c0d3-8f0c-4aa8-acf8-321ce97da6b0" />

# After 

<img width="733" alt="image" src="https://github.com/user-attachments/assets/8b3b4db0-a4b7-4ffd-a6c2-dddb83c62e2a" />
