### PR TITLE
Be stricter with undefined values in Jinja templates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -633,6 +633,14 @@ def init_jinja(application):
 
 
 class NotifyJinjaUndefined(jinja2.Undefined):
+    """
+    The same as jinja2.StrictUndefined with a few exceptions, noted
+    in specific comments.
+
+    For more context see:
+    https://jinja.palletsprojects.com/en/stable/api/#undefined-types
+    """
+
     __slots__ = ()
     __iter__ = jinja2.Undefined._fail_with_undefined_error
     __len__ = jinja2.Undefined._fail_with_undefined_error

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -635,3 +635,4 @@ def init_jinja(application):
 class NotifyJinjaUndefined(jinja2.Undefined):
     __slots__ = ()
     __iter__ = jinja2.Undefined._fail_with_undefined_error
+    __len__ = jinja2.Undefined._fail_with_undefined_error

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -638,6 +638,7 @@ class NotifyJinjaUndefined(jinja2.Undefined):
     __len__ = jinja2.Undefined._fail_with_undefined_error
     __hash__ = jinja2.Undefined._fail_with_undefined_error
     # __bool__: UndefinedErrors remain supressed
+    __contains__ = jinja2.Undefined._fail_with_undefined_error
 
     def __eq__(self, other):
         if isinstance(self._undefined_obj, dict):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -634,3 +634,4 @@ def init_jinja(application):
 
 class NotifyJinjaUndefined(jinja2.Undefined):
     __slots__ = ()
+    __iter__ = jinja2.Undefined._fail_with_undefined_error

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -636,3 +636,4 @@ class NotifyJinjaUndefined(jinja2.Undefined):
     __slots__ = ()
     __iter__ = jinja2.Undefined._fail_with_undefined_error
     __len__ = jinja2.Undefined._fail_with_undefined_error
+    __hash__ = jinja2.Undefined._fail_with_undefined_error

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -637,3 +637,4 @@ class NotifyJinjaUndefined(jinja2.Undefined):
     __iter__ = jinja2.Undefined._fail_with_undefined_error
     __len__ = jinja2.Undefined._fail_with_undefined_error
     __hash__ = jinja2.Undefined._fail_with_undefined_error
+    # __bool__: UndefinedErrors remain supressed

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -638,3 +638,23 @@ class NotifyJinjaUndefined(jinja2.Undefined):
     __len__ = jinja2.Undefined._fail_with_undefined_error
     __hash__ = jinja2.Undefined._fail_with_undefined_error
     # __bool__: UndefinedErrors remain supressed
+
+    def __eq__(self, other):
+        if isinstance(self._undefined_obj, dict):
+            # Accessing a missing field on a dict, we do this too
+            # often to be strict about it
+            return super().__eq__(other)
+
+        if isinstance(other, NotifyJinjaUndefined):
+            # Comparing to something else which is undefined, you are
+            # probably doing this on purpose
+            return True
+
+        if isinstance(self._undefined_obj, jinja2.utils._MissingType):
+            # Comparing to an internal Jinja type, you are probably
+            # doing this on purpose
+            return False
+
+        # In any other case comparing undefined to something is bad
+        # so raise an exception
+        jinja2.Undefined._fail_with_undefined_error(self, other)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -629,3 +629,8 @@ def init_jinja(application):
 
     application.jinja_env.filters["format_provider"] = format_provider
     application.jinja_env.add_extension("jinja2.ext.do")
+    application.jinja_env.undefined = NotifyJinjaUndefined
+
+
+class NotifyJinjaUndefined(jinja2.Undefined):
+    __slots__ = ()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -639,6 +639,7 @@ class NotifyJinjaUndefined(jinja2.Undefined):
     __hash__ = jinja2.Undefined._fail_with_undefined_error
     # __bool__: UndefinedErrors remain supressed
     __contains__ = jinja2.Undefined._fail_with_undefined_error
+    __str__ = jinja2.Undefined._fail_with_undefined_error
 
     def __eq__(self, other):
         if isinstance(self._undefined_obj, dict):

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -127,6 +127,7 @@ def uploaded_letters(service_id, letter_print_day):
             service_id=current_service.id,
             from_uploaded_letters=letter_print_day,
         ),
+        limit_days=None,
     )
 
 

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -25,7 +25,12 @@ def verify():
         session.pop("user_details", None)
         return activate_user(user_id)
 
-    return render_template("views/two-factor-sms.html", form=form, error_summary_enabled=True)
+    return render_template(
+        "views/two-factor-sms.html",
+        form=form,
+        error_summary_enabled=True,
+        redirect_url=None,
+    )
 
 
 @main.route("/verify-email/<string:token>")

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -113,6 +113,7 @@ class Organisation(JSONModel):
             self.name = None
             self.crown = None
             self.agreement_signed = None
+            self.agreement_signed_by_id = None
             self.domains = []
             self.organisation_type = None
             self.request_to_go_live_notes = None

--- a/app/templates/components/copy-to-clipboard.html
+++ b/app/templates/components/copy-to-clipboard.html
@@ -1,12 +1,12 @@
 {% macro copy_to_clipboard(value, name, thing) %}
-  {% if name|lower == thing|lower %}
+  {% if name and name|lower == thing|lower %}
     <h2 class="copy-to-clipboard__name">
       {{ name }}
     </h2>
   {% endif %}
-  <div data-notify-module="copy-to-clipboard" data-value="{{ value }}" data-thing="{{ thing }}" data-name="{{ name }}">
+  <div data-notify-module="copy-to-clipboard" data-value="{{ value }}" data-thing="{{ thing }}" data-name="{{ name or "" }}">
     <span class="copy-to-clipboard__value">
-      {%- if name|lower != thing|lower %}<span class="govuk-visually-hidden">{{ thing }}: </span>{% endif %}{{ value -}}
+      {%- if name and name|lower != thing|lower %}<span class="govuk-visually-hidden">{{ thing }}: </span>{% endif %}{{ value -}}
     </span>
     <span class="copy-to-clipboard__notice" aria-live="assertive"></span>
   </div>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -47,7 +47,7 @@
 
       {% call(item, row_number) list_table(
         notifications,
-        caption=uploaded_file_name,
+        caption=job.original_file_name,
         caption_visible=False,
         empty_message='No messages to show yet…' if job.awaiting_processing_or_recently_processed else job.processing_started | message_finished_processing_notification(service_data_retention_days),
         field_headings=[

--- a/app/templates/views/inbound-sms-admin.html
+++ b/app/templates/views/inbound-sms-admin.html
@@ -52,7 +52,9 @@ Inbound SMS
               {% endif %}
               </td>
               <td>
-                  <a href="{{ url_for('main.service_dashboard', service_id=value.service.id) }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-24 govuk-!-font-weight-bold">{{ value.service.name }}</a>
+                  {% if value.service %}
+                    <a href="{{ url_for('main.service_dashboard', service_id=value.service.id) }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-24 govuk-!-font-weight-bold">{{ value.service.name }}</a>
+                  {% endif %}
               </td>
           </tr>
           {% endfor %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -37,9 +37,9 @@
                 </span>&ensp;
               {%- endif -%}
               <span class="hint">
-              {%- if user.status == 'pending' -%}
+              {%- if user.is_invited_user and user.status == 'pending' -%}
                 <span class="live-search-relevant">{{ user.email_address }}</span> (invited)
-              {%- elif user.status == 'cancelled' -%}
+              {%- elif user.is_invited_user and user.status == 'cancelled' -%}
                 <span class="live-search-relevant">{{ user.email_address }}</span> (cancelled invite)
               {%- elif user.id == current_user.id -%}
                 <span class="live-search-relevant">(you)</span>
@@ -79,7 +79,7 @@
             </div>
             <div class="govuk-grid-column-one-quarter">
               {% if current_user.has_permissions('manage_service') %}
-                {% if user.status == 'pending' %}
+                {% if user.is_invited_user and user.status == 'pending' %}
                   <a class="user-list-edit-link govuk-link govuk-link--no-visited-state" href="{{ url_for('main.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation<span class="govuk-visually-hidden"> for {{ user.email_address }}</span></a>
                 {% elif user.is_editable_by(current_user) %}
                   <a class="user-list-edit-link govuk-link govuk-link--no-visited-state" href="{{ url_for('main.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Change details<span class="govuk-visually-hidden"> for {{ user.name }} {{ user.email_address }}</span></a>

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -28,9 +28,9 @@
                 <span class="heading-small">{{ user.name }}</span>&ensp;
               {%- endif -%}
               <span class="hint">
-                {%- if user.status == 'pending' -%}
+                {%- if user.is_invited_user and user.status == 'pending' -%}
                   {{ user.email_address }} (invited)
-                {%- elif user.status == 'cancelled' -%}
+                {%- elif user.is_invited_user and user.status == 'cancelled' -%}
                   {{ user.email_address }} (cancelled invite)
                 {%- elif user.id == current_user.id -%}
                   (you)
@@ -53,7 +53,7 @@
 
           </div>
           <div class="govuk-grid-column-one-quarter">
-            {% if user.status == 'pending' %}
+            {% if user.is_invited_user and user.status == 'pending' %}
               <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('main.cancel_invited_org_user', org_id=current_org.id, invited_user_id=user.id)}}">Cancel invitation<span class="govuk-visually-hidden"> for {{ user.email_address }}</span></a>
             {% elif user.is_editable_by(current_user) %}
               <a class="user-list-edit-link govuk-link govuk-link--no-visited-state" href="{{ url_for('main.edit_organisation_user', org_id=current_org.id, user_id=user.id)}}">Change details<span class="govuk-visually-hidden"> for {{ user.name }} {{ user.email_address }}</span></a>

--- a/app/templates/views/returned-letters.html
+++ b/app/templates/views/returned-letters.html
@@ -23,7 +23,7 @@
 <div class="dashboard-table">
   {% call(item, row_number) list_table(
       returned_letters,
-      caption="Returned letters for {}".format(today),
+      caption="Returned letters for {}".format(reported_at|format_date_normal),
       caption_visible=False,
       empty_message='If you have returned letter reports they will be listed here',
       field_headings=['Template name', 'Originally sent'],

--- a/app/templates/views/service-settings/preview-branding.html
+++ b/app/templates/views/service-settings/preview-branding.html
@@ -4,12 +4,12 @@
 {% from "components/branding-preview.html" import email_branding_preview, letter_branding_preview %}
 
 {% block per_page_title %}
-  Preview {{ branding_type }} branding
+  Preview {{ notification_type }} branding
 {% endblock %}
 
 {% block platform_admin_content %}
 
-  <h1 class="heading-large">Preview {{ branding_type }} branding</h1>
+  <h1 class="heading-large">Preview {{ notification_type }} branding</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {% if notification_type == 'email' %}

--- a/app/templates/views/support/form.html
+++ b/app/templates/views/support/form.html
@@ -24,7 +24,7 @@
             GOV.UK Notify status page</a>.</p>
           <p class="govuk-body">You do not need to contact us if your problem is already listed on that page.</p>
           {% endset %}
-          {{ govukInsetText({"html": insetHtml, classes: "govuk-!-margin-top-0 govuk-!-margin-bottom-3"}) }}
+          {{ govukInsetText({"html": insetHtml, "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"}) }}
         {% endif %}
         {% call form_wrapper() %}
             {{ form.feedback(param_extensions={

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -25,13 +25,15 @@
   {{ govukErrorSummary({
     "classes": "webauthn__api-missing",
     "titleText": "There’s a problem",
-    "descriptionText": "Your browser does not support security keys. Try signing in to Notify using a different browser."
+    "descriptionText": "Your browser does not support security keys. Try signing in to Notify using a different browser.",
+    "errorList": [],
   }) }}
 
   {{ govukErrorSummary({
     "classes": "webauthn__no-js",
     "titleText": "There’s a problem",
-    "descriptionText": "JavaScript is not available for this page. Security keys need JavaScript to work."
+    "descriptionText": "JavaScript is not available for this page. Security keys need JavaScript to work.",
+    "errorList": [],
   }) }}
 
   {% set keyProblemDescription %}
@@ -43,7 +45,8 @@
     "classes": "govuk-!-display-none",
     "attributes": { "aria-live": "polite", "tabindex":"-1" },
     "titleText": "There’s a problem with your security keys",
-    "descriptionHtml": keyProblemDescription
+    "descriptionHtml": keyProblemDescription,
+    "errorList": [],
   }) }}
 {% endset %}
 

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -53,7 +53,7 @@
 
     {% if status == 'valid' %}
     <div class="js-stick-at-bottom-when-scrolling">
-      <p class="top-gutter-0 bottom-gutter-1-2 send-recipient" title="{{ recipient }}">
+      <p class="top-gutter-0 bottom-gutter-1-2 send-recipient" title="{{ postal_address.as_single_line }}">
         Recipient: {{ postal_address.as_single_line }}
       </p>
 

--- a/app/templates/views/your-account/security-keys.html
+++ b/app/templates/views/your-account/security-keys.html
@@ -39,13 +39,15 @@
   {{ govukErrorSummary({
     "classes": "webauthn__api-missing",
     "titleText": "There’s a problem",
-    "descriptionText": "Your browser does not support security keys. Try signing in to Notify using a different browser."
+    "descriptionText": "Your browser does not support security keys. Try signing in to Notify using a different browser.",
+    "errorList": [],
   }) }}
 
   {{ govukErrorSummary({
     "classes": "webauthn__no-js",
     "titleText": "There’s a problem",
-    "descriptionText": "JavaScript is not available for this page. Security keys need JavaScript to work."
+    "descriptionText": "JavaScript is not available for this page. Security keys need JavaScript to work.",
+    "errorList": [],
   }) }}
 
   {% set keyProblemDescription %}
@@ -57,7 +59,8 @@
     "classes": "govuk-!-display-none",
     "attributes": { "aria-live": "polite", "tabindex":"-1" },
     "titleText": "There’s a problem with your security keys",
-    "descriptionHtml": keyProblemDescription
+    "descriptionHtml": keyProblemDescription,
+    "errorList": [],
   }) }}
 {% endset %}
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -520,6 +520,7 @@ def notification_json(  # noqa: C901
     client_reference=None,
     created_by_name=None,
     postage=None,
+    key_name=None,
 ):
     if template is None:
         template = template_json(service_id=service_id, id_=str(generate_uuid()), type_=template_type)
@@ -581,6 +582,7 @@ def notification_json(  # noqa: C901
                 "reply_to_text": reply_to_text,
                 "client_reference": client_reference,
                 "created_by_name": created_by_name,
+                "key_name": key_name,
             }
             for i in range(rows)
         ],

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -773,7 +773,7 @@ def test_email_preview_template_makes_links_out_of_URLs(url, url_with_entities_r
         f'<a style="word-wrap: break-word; color: #1D70B8;" href="{url_with_entities_replaced}">'
         f"{url_with_entities_replaced}"
         "</a>"
-    ) in str(EmailPreviewTemplate({"content": url, "subject": "", "template_type": "email"}))
+    ) in str(EmailPreviewTemplate({"content": url, "subject": "Required", "template_type": "email"}))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
By default Jinja is very forgiving with undefined variables.

For example:

```jinja
{{ something_not_defined }}
```
…will print an empty string.

Or:
```jinja
{{ something_not_defined|length }}
```
…will print 0.

This is a good way of hiding bugs.

***

Jinja has a different way of handling undefined values called [`StrictUndefined`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.StrictUndefined). This would raise an exception in either of the above examples.

However because there are some cases where we (and the `govuk-frontend-jinja` library) rely on Jinja’s non-strict undefined behaviour. So we can’t use `StrictUndefined` out of the box.

This pull requests implements a custom subclass of `Undefined` which copies [the implementation of `StrictUndefined`](https://github.com/pallets/jinja/blob/5ef70112a1ff19c05324ff889dd30405b1002044/src/jinja2/runtime.py#L1039-L1062) in most cases but is more permissive where it needs to be. It then fixes the places where this would raise an exception.
