### PR TITLE
Remove fixed StatusPage issues from A11y statement

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -12,7 +12,7 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "13 June 2025",
+      "Last updated": "15 July 2025",
       "Next review due": "31 July 2025"
     }
     ) }}
@@ -124,17 +124,8 @@
     <li>missing level 1 headings (users may not be able to accurately determine the structure of content on the page)</li>
     <li>our status incident page is missing the main heading and the status home page has an incorrect heading hierarchy – this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#info-and-relationships">success criterion 1.3.1: info and relationships</a></li>
     <li>our status page subscribe to updates forms, when submitted with incorrect data, do not inform screen reader users of the error message when it becomes available – this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#status-messages">success criterion 4.1.3: status messages</a></li>
-    <li>some form fields to subscribe to status incident updates are not correctly set up for autocomplete – this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#identify-input-purpose">success criterion 1.3.5: identify input purpose</a></li>
     <li>incident titles are colour-coded, with no other visual indication or text – this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#use-of-color">success criterion 1.4.1: use of color</a></li>
-    <li>links are identified only by colour with no other visual indication - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#use-of-color">success criterion 1.4.1: use of color</a></li>
-    <li>popup to subscribe for status incident updates is partially cut off when zoomed in at 200% - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#resize-text">success criterion 1.4.4: resize text</a></li>
-    <li>popup to subscribe for status incident updates is almost entirely cut off and unusable when zoomed in at 400% - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#reflow">success criterion 1.4.10: reflow</a></li>
-    <li>icons to subscribe to various types of status incident updates do not have enough colour contrast when in focus - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#non-text-contrast">success criterion 1.4.11: non-text contrast</a></li>
-    <li>there is no mechanism to skip to the main content on nearly all pages - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#bypass-blocks">success criterion 2.4.1: bypass blocks</a></li>
-    <li>hidden incidents in the incident history are revealed above the ‘show’ button, which means some users might miss them - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#focus-order">success criterion 2.4.3: focus order</a></li>
     <li>there is only one way to get to some pages. Many of these pages can only be reached using inaccessible controls - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#multiple-ways">success criterion  success criterion 2.4.5: multiple ways</a></li>
-    <li>subscribe buttons that do different things have identical labels - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#consistent-identification">success criterion 3.2.4: consistent identification</a></li>
-    <li>it is not clear that the button to subscribe to status incident updates for a single incident will open a popup - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#name-role-value">success criterion 4.1.2: name, role, value</a></li>
   </ul>
 
   <h2 class="heading-medium" id="how-we-tested-this-service">


### PR DESCRIPTION
We've fixed these -
https://trello.com/b/8GaCwLRw/notify-operations-doing?filter=label:Status%20page

Merge after https://trello.com/c/YTw6kldC/1364-status-page-add-skiplink-to-pages is done 