### PR TITLE
upgrade utils to 100.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.8.0
+# This file was automatically copied from notifications-utils@100.1.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.8.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@100.1.0
 
 govuk-frontend-jinja==3.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@e4635d7b91db5d8cfe7aa23cf20887f1687f05bd
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx
@@ -110,7 +110,7 @@ ordered-set==4.1.0
     # via notifications-utils
 packaging==23.1
     # via gunicorn
-phonenumbers==8.13.50
+phonenumbers==9.0.9
     # via notifications-utils
 pillow==11.3.0
     # via -r requirements.in
@@ -141,8 +141,10 @@ pyjwt==2.4.0
     # via notifications-python-client
 pypdf==3.13.0
     # via notifications-utils
-python-dateutil==2.8.2
-    # via botocore
+python-dateutil==2.9.0.post0
+    # via
+    #   botocore
+    #   notifications-utils
 python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -163,7 +163,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@e4635d7b91db5d8cfe7aa23cf20887f1687f05bd
     # via -r requirements.txt
 openpyxl==3.1.5
     # via
@@ -178,7 +178,7 @@ packaging==23.1
     #   -r requirements.txt
     #   gunicorn
     #   pytest
-phonenumbers==8.13.50
+phonenumbers==9.0.9
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -236,12 +236,13 @@ pytest-testmon==2.1.1
     # via -r requirements_for_test_common.in
 pytest-xdist==3.6.1
     # via -r requirements_for_test_common.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
     #   botocore
     #   freezegun
     #   moto
+    #   notifications-utils
 python-json-logger==3.3.0
     # via
     #   -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.8.0
+# This file was automatically copied from notifications-utils@100.1.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.8.0
+# This file was automatically copied from notifications-utils@100.1.0
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
adds the latest version of libphonenumber, 9.0.9, to utils. Ensures metadata is kept up to date