### PR TITLE
Frontend bug fixes

### DIFF
--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -26,13 +26,13 @@
       "element": "a",
       "text": "Add email branding",
       "href": url_for('main.platform_admin_create_email_branding'),
-      "classes": "govuk-button--secondary"
+      "classes": "govuk-button--secondary govuk-!-margin-right-3  govuk-!-margin-bottom-3"
     }) }}
     {{ govukButton({
       "element": "a",
       "text": "Add a government identity logo",
       "href": url_for('main.create_email_branding_government_identity_logo'),
-      "classes": "govuk-button--secondary govuk-!-margin-left-3"
+      "classes": "govuk-button--secondary"
     }) }}
   </div>
 

--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -29,7 +29,7 @@
               "element": "a",
               "text": "Upload a letter",
               "href": url_for('main.upload_letter', service_id=current_service.id),
-              "classes": "govuk-button--secondary govuk-!-margin-right-3"
+              "classes": "govuk-button--secondary govuk-!-margin-right-3  govuk-!-margin-bottom-3"
             }) }}
           {% endif %}
           {{ govukButton({

--- a/app/templates/views/your-services.html
+++ b/app/templates/views/your-services.html
@@ -136,7 +136,7 @@
           "element": "a",
           "text": "Add a new service",
           "href": url_for('main.add_service'),
-          "classes": "govuk-button--secondary govuk-!-margin-right-3"
+          "classes": "govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-3"
         }) }}
         {% if current_user.default_organisation.can_ask_to_join_a_service %}
           {{ govukButton({


### PR DESCRIPTION
## Increase button spacing on /your-services page

Fixes https://trello.com/c/sbzM3VhM/206-fix-button-spacing-on-mobile-on-your-services-page

On mobile viewport button to "add a new service" and "join an existing services" have no space between them.

This adds a Design System 15px spacing class to the first button.

While this does slightly increase the hight of the container when the second button is not present, this is negligable in the wider context of that container

Before

<img width="592" height="124" alt="your-services button spacing before" src="https://github.com/user-attachments/assets/6bbf9c5a-0b80-43bb-a8e0-8952a531921e" />

After

<img width="596" height="132" alt="your-services button spacing after" src="https://github.com/user-attachments/assets/9435550a-2b98-419a-8382-866b243f263e" />

### How to test

Visit /your-services page on your local dev and switch to mobile view


## Increase button spacing on /uploads page

Fixes https://trello.com/c/3BOwWLS8/208-fix-button-spacing-on-mobile-on-uploads-page

On mobile viewport buttons to "upload a letter" and "upload an emergency contact list" have no space between them.

This adds a Design System 15px spacing class to the first button.

While this does slightly increase the hight of the container when the second button is not present, this is negligable in the wider context of that container

Before

<img width="593" height="100" alt="uploads button spacing before" src="https://github.com/user-attachments/assets/1c71258b-fc5c-4ee5-9eca-1cf7127536ca" />


After
<img width="606" height="123" alt="uploads button spacing after" src="https://github.com/user-attachments/assets/77fd9c97-f6ce-4c14-8cfe-ef52cae50cb7" />

### How to test

Visit /<serviceId>/uploads on your local dev and switch to mobile view


## Increase button spacing on /email-branding page

Fixes https://trello.com/c/05wjawoM/220-fix-button-spacing-on-platform-admin-email-branding

On mobile viewport button to "add email branding" and "add government identity logo" have no space between them.

This adds a Design System 15px spacing class to the first button.

While this does slightly increase the hight of the container when the second button is not present, this is negligable in the wider context of that container

Before

<img width="410" height="121" alt="Screenshot 2025-07-17 at 10 33 36" src="https://github.com/user-attachments/assets/2a456e77-6213-4908-95a8-9277f29215b6" />

After

<img width="333" height="127" alt="Screenshot 2025-07-17 at 10 35 45" src="https://github.com/user-attachments/assets/8bbdb7c2-aaa7-4876-b671-63605b6e5c28" />

### How to test

Visit platform admin email branding on your local dev and switch to mobile view
