### PR TITLE
Add spacing between blue pills on API page

### DIFF
--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -11,14 +11,14 @@
     API integration
   </h1>
 
-  <nav class="govuk-grid-row bottom-gutter-1-2">
-    <div class="govuk-grid-column-one-third">
+  <nav class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-3">
       <a class="govuk-link govuk-link--inverse pill-separate-item" href="{{ url_for('main.api_keys', service_id=current_service.id) }}">API keys</a>
     </div>
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-3">
       <a class="govuk-link govuk-link--inverse pill-separate-item" href="{{ url_for('main.guest_list', service_id=current_service.id) }}">Guest list</a>
     </div>
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-3">
       <a class="govuk-link govuk-link--inverse pill-separate-item" href="{{ url_for(callbacks_link, service_id=current_service.id) }}">Callbacks</a>
     </div>
   </nav>

--- a/app/templates/views/templates/_email_or_sms_template.html
+++ b/app/templates/views/templates/_email_or_sms_template.html
@@ -1,13 +1,13 @@
-<div class="govuk-grid-row">
+<div class="govuk-grid-row govuk-!-margin-bottom-1">
   {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
-    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
+    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-3">
       <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
         Get ready to send<span class="govuk-visually-hidden"> a message using this template</span>
       </a>
     </div>
   {% endif %}
   {% if current_user.has_permissions('manage_templates') %}
-    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
+    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-3">
       <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
         Edit<span class="govuk-visually-hidden"> this template</span>
       </a>


### PR DESCRIPTION
Sets the gap between buttons on smaller screens as 15px, to match the existing styles on the template page.

The API page has a gap of 15px below it on larger
screens while the template page has one of 20px.
To make both consistent this makes them use an
override class with a spacing unit of 3, so they
will be 15px on all sizes of screen. Because this
removes 5px below them all on larger screens on
the templates page, this also adds an override
class of 1 to the group.

See the design system docs for details of override classes and their units:

https://design-system.service.gov.uk/styles/spacing/

## Before

<img width="361" height="312" alt="image" src="https://github.com/user-attachments/assets/e8a5ec28-19f0-40ec-8eeb-200c45a22a7b" />

## After

<img width="360" height="341" alt="image" src="https://github.com/user-attachments/assets/79683694-0a78-4bdb-9506-3485b95e66eb" />
