### PR TITLE
FIx selected template counter on mobile view

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -243,7 +243,7 @@ a {
     color: $govuk-secondary-text-colour;
     margin: govuk-spacing(3) 0;
 
-    @include govuk-media-query($from: tablet) {
+    @include govuk-media-query($from: desktop) {
       position: absolute;
       right: 0;
       top: govuk-spacing(6) - 1px;


### PR DESCRIPTION
When you select templates to move, we show the number of them seelcted and a "clear" button. On smaller viewports that section overlaps the "Add to new folder button".

Adjusting the breakpoint at which the section is potionioned absolute to desktop fixes that issue.

Fixes: https://trello.com/c/KC8nldCM/209-adjust-template-select-counter-position-on-tablet-viewport

Before

<img width="544" height="547" alt="Screenshot 2025-07-17 at 13 58 47" src="https://github.com/user-attachments/assets/d85cf696-ada4-428c-873c-1eae77cc815a" />

After

<img width="556" height="425" alt="Screenshot 2025-07-17 at 13 59 07" src="https://github.com/user-attachments/assets/7094d26c-d03e-4700-9079-03d11336f02a" />
