### PR TITLE
fix: Preserve WebAuthn as Auth Type on Service Join Approval

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1043,14 +1043,6 @@ class JoinServiceRequestApproveForm(StripWhitespaceForm):
     )
 
 
-class JoinServiceRequestSetPermissionsForm(PermissionsForm):
-    custom_field_order: tuple = (
-        "permissions_field",
-        "folder_permissions",
-        "login_authentication",
-    )
-
-
 class OrganisationUserPermissionsForm(StripWhitespaceForm):
     permissions_field = GovukCheckboxesField(
         "Permissions",

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -27,6 +27,8 @@
       This user will login with a security key.
     </p>
   {% else %}
-    {{ form.login_authentication }}
+      {% if form.login_authentication %}
+          {{ form.login_authentication }}
+      {% endif %}
   {% endif %}
 {% endif %}


### PR DESCRIPTION
## Summary:
Previously, if a user with WebAuthn (webauthn_auth) requested to join a service, their authentication method could be unintentionally overridden when an approver selected a different sign-in method (e.g. SMS or email) during approval.

This change ensures that when a user already uses WebAuthn, their auth type is preserved regardless of what’s selected in the form. The form field is removed before submission, and the backend no longer updates auth_type in these cases.

### Ticket:
[When approving a service join request, don't change the auth type for users who use Yubikeys
](https://trello.com/c/ZRUAzuh8/214-when-approving-a-service-join-request-dont-change-the-auth-type-for-users-who-use-yubikeys)