### PR TITLE
Fix the platform admin search for service callbacks

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -688,9 +688,7 @@ def get_url_for_notify_record(uuid_):
             "inbound_number": _EndpointSpec(".inbound_sms_admin"),
             "api_key": _EndpointSpec(".api_keys", with_service_id=True),
             "template_folder": _EndpointSpec(".choose_template", "template_folder_id", with_service_id=True),
-            "service_inbound_api": _EndpointSpec(".received_text_messages_callback", with_service_id=True),
-            "delivery_status_callback_api": _EndpointSpec(".delivery_status_callback", with_service_id=True),
-            "returned_letters_callback_api": _EndpointSpec(".returned_letters_callback", with_service_id=True),
+            "service_callback_api": _EndpointSpec(".api_callbacks", with_service_id=True),
             "complaint": _EndpointSpec(".platform_admin_list_complaints"),
             "inbound_sms": _EndpointSpec(
                 ".conversation", "notification_id", with_service_id=True, extra={"_anchor": f"n{uuid_}"}

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -1005,16 +1005,8 @@ class TestPlatformAdminSearch:
                 "/services/abc/templates/all/folders/abcdef12-3456-7890-abcd-ef1234567890",
             ),
             (
-                {"type": "service_inbound_api", "context": {"service_id": "abc"}},
-                "/services/abc/api/callbacks/received-text-messages-callback",
-            ),
-            (
-                {"type": "delivery_status_callback_api", "context": {"service_id": "abc"}},
-                "/services/abc/api/callbacks/delivery-status-callback",
-            ),
-            (
-                {"type": "returned_letters_callback_api", "context": {"service_id": "abc"}},
-                "/services/abc/api/callbacks/returned-letters-callback",
+                {"type": "service_callback_api", "context": {"service_id": "abc"}},
+                "/services/abc/api/callbacks",
             ),
             ({"type": "complaint"}, "/platform-admin/complaints"),
             (


### PR DESCRIPTION
This code expected the `/platform-admin/find-by-uuid` api endpoint to return a different model name based on the type of service callback being searched for. However, since all types of service callback are in the `service_callback_api` table, it always returns that regardless of what type of callback id was searched for.

This updates the code to check for what the api actually returns. Making the search functionality take you to the actual type of callback would require a bit of a redesign, but as a simple fix you now get taken to the page listing all the callbacks for the service.

**To review**
Test that searching for a callback ID of each type works and takes you to the api integration page
You can also verify that the list of callback endpoints here now matches the [list returned by the api](https://github.com/alphagov/notifications-api/blob/d75cafd47ac5170c07ba62923b0c1a624092c647/app/platform_admin/rest.py#L37-L57)