### PR TITLE
chore: bump utils version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.8.0
+# This file was automatically copied from notifications-utils@100.2.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.8.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@100.2.0
 
 govuk-frontend-jinja==3.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@
 #    uv pip compile requirements.in -o requirements.txt
 ago==0.0.95
     # via -r requirements.in
-async-timeout==4.0.2
-    # via redis
 awscrt==0.20.11
     # via botocore
 blinker==1.9.0
@@ -102,7 +100,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bb31f41dd194802ced5ea814f84cc25855467234
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx
@@ -110,7 +108,7 @@ ordered-set==4.1.0
     # via notifications-utils
 packaging==23.1
     # via gunicorn
-phonenumbers==8.13.50
+phonenumbers==9.0.10
     # via notifications-utils
 pillow==11.3.0
     # via -r requirements.in
@@ -141,8 +139,10 @@ pyjwt==2.4.0
     # via notifications-python-client
 pypdf==3.13.0
     # via notifications-utils
-python-dateutil==2.8.2
-    # via botocore
+python-dateutil==2.9.0.post0
+    # via
+    #   botocore
+    #   notifications-utils
 python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,10 +2,6 @@
 #    uv pip compile requirements_for_test.in -o requirements_for_test.txt
 ago==0.0.95
     # via -r requirements.txt
-async-timeout==4.0.2
-    # via
-    #   -r requirements.txt
-    #   redis
 awscrt==0.20.11
     # via
     #   -r requirements.txt
@@ -163,7 +159,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bb31f41dd194802ced5ea814f84cc25855467234
     # via -r requirements.txt
 openpyxl==3.1.5
     # via
@@ -178,7 +174,7 @@ packaging==23.1
     #   -r requirements.txt
     #   gunicorn
     #   pytest
-phonenumbers==8.13.50
+phonenumbers==9.0.10
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -236,12 +232,13 @@ pytest-testmon==2.1.1
     # via -r requirements_for_test_common.in
 pytest-xdist==3.6.1
     # via -r requirements_for_test_common.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
     #   botocore
     #   freezegun
     #   moto
+    #   notifications-utils
 python-json-logger==3.3.0
     # via
     #   -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.8.0
+# This file was automatically copied from notifications-utils@100.2.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.8.0
+# This file was automatically copied from notifications-utils@100.2.0
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
Bump utils to 100.2.0

 ## 100.2.0

* add  fields to pre/post request flask logs

 ## 100.1.0

* Updated  to version 9.0.9 to keep phonenumber metadata uptodate

 ## 100.0.0

*  is now a required argument of  (apps have already been updated)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/99.8.0...100.2.0