### PR TITLE
Test that user with manage api key permission can see some settings views

### DIFF
--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -188,6 +188,42 @@ def test_should_show_overview(
     app.service_api_client.get_service.assert_called_with(SERVICE_ONE_ID)
 
 
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "main.service_sms_senders",
+        "main.service_settings",
+        "main.service_email_reply_to",
+        "main.service_letter_contact_details",
+    ],
+)
+def test_user_with_manage_api_keys_permission_but_no_settings_permission_can_view_certain_settings_pages(
+    client_request,
+    service_one,
+    active_user_no_settings_permission,
+    single_reply_to_email_address,
+    single_letter_contact_block,
+    mock_get_organisation,
+    single_sms_sender,
+    mocker,
+    endpoint,
+):
+    mocker.patch("app.models.user.Users._get_items", return_value=[active_user_no_settings_permission])
+    mocker.patch("app.service_api_client.get_notification_count", return_value=1_234)
+    mocker.patch("app.service_api_client.get_service", return_value={"data": service_one})
+    mocker.patch(
+        "app.service_api_client.get_service_data_retention",
+        return_value=[],
+    )
+
+    client_request.get(
+        endpoint,
+        service_id=SERVICE_ONE_ID,
+        branding_type="letter",
+        _expected_status=200,
+    )
+
+
 def test_shows_individual_data_retentions_if_different(
     client_request,
     mocker,


### PR DESCRIPTION
Test that user with `manage api keys` permission can see some settings views, even when they don't have `manage settings` permission.

While looking around, I also found that this type of user will see all settings page rows that a user with `manage settings` permission would see, but for most of them, when clicking, they would see "you are not allowed to see this page".

This is not a good experience - we don't tell users which views they can access. We should probably fix this and only show them the views that they can access.

Also while looking around the test file for service settings, I saw many unit tests that are possibly duplicated (for example we test what rows users can see with a parametrized test, and then we also have some stand alone tests testing the same). We should probably look through our tests and prune out the duplicated ones.