### PR TITLE
Bump utils to 101.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@100.2.0
+# This file was automatically copied from notifications-utils@101.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@100.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@101.0.0
 
 govuk-frontend-jinja==3.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bb31f41dd194802ced5ea814f84cc25855467234
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@4201823031adc5c557d52809c511be2f876dc79d
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -163,7 +163,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bb31f41dd194802ced5ea814f84cc25855467234
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@4201823031adc5c557d52809c511be2f876dc79d
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@100.2.0
+# This file was automatically copied from notifications-utils@101.0.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@100.2.0
+# This file was automatically copied from notifications-utils@101.0.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -321,7 +321,7 @@ def test_should_show_letter_job(
         "1 Example Street template subject 1 January at 11:09am"
     )
     assert normalize_spaces(page.select(".keyline-block")[0].text) == "1 Letter"
-    assert normalize_spaces(page.select(".keyline-block")[1].text) == "7 January Estimated delivery date"
+    assert normalize_spaces(page.select(".keyline-block")[1].text) == "11 January Estimated delivery date"
     assert page.select_one("a[id=download-job-report]")["href"] == url_for(
         "main.view_job_csv",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -267,9 +267,7 @@ def test_notification_page_shows_page_for_letter_notification(
         "‘sample template’ was sent by Test User today at 1:01am"
     )
     assert normalize_spaces(page.select("main p:nth-of-type(2)")[0].text) == "Printing starts today at 5:30pm"
-    assert normalize_spaces(page.select("main p:nth-of-type(3)")[0].text) == (
-        "Estimated delivery by Thursday 7 January"
-    )
+    assert normalize_spaces(page.select("main p:nth-of-type(3)")[0].text) == "Estimated delivery by Monday 11 January"
     assert len(page.select(".letter-postage")) == 1
     assert normalize_spaces(page.select_one(".letter-postage").text) == "Postage: second class"
     assert page.select_one(".letter-postage")["class"] == ["letter-postage", "letter-postage-second"]
@@ -523,19 +521,19 @@ def test_notification_page_does_not_show_cancel_link_for_letter_which_cannot_be_
             "economy",
             "Postage: economy",
             "letter-postage-economy",
-            "Estimated delivery by Thursday 14 January",
+            "Estimated delivery by Wednesday 13 January",
         ),
         (
             "europe",
             "Postage: international",
             "letter-postage-international",
-            "Estimated delivery by Monday 11 January",
+            "Estimated delivery by Tuesday 12 January",
         ),
         (
             "rest-of-world",
             "Postage: international",
             "letter-postage-international",
-            "Estimated delivery by Wednesday 13 January",
+            "Estimated delivery by Thursday 14 January",
         ),
     ),
 )


### PR DESCRIPTION
 ## 101.0.0

* Updated the estimated letter delivery timings to take into account the change that first class letters are now the only postage class to be delivered on Saturdays, and delivery times for second class and economy mail are slower.