### PR TITLE
Ensure `content_hint` variable is defined

### DIFF
--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -18,9 +18,7 @@
 
     {{ page_header('{} text message template'.format(heading_action)) }}
 
-    {% if current_service.prefix_sms %}
-      {% set content_hint = 'Your message will start with your service name' %}
-    {% endif %}
+    {% set content_hint = {"text": "Your message will start with your service name"} if current_service.prefix_sms else {} %}
 
     {% call form_wrapper() %}
       <div class="govuk-grid-row">
@@ -36,7 +34,7 @@
               "data-highlight-placeholders": "true"
             },
             "rows": "5",
-            "hint": {"text": content_hint},
+            "hint": content_hint,
             "formGroup": {
               "classes": "govuk-textarea-highlight govuk-!-margin-bottom-2",
             }

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1998,9 +1998,15 @@ def test_should_let_letter_contact_block_be_changed_for_the_template(
     )
 
 
-@pytest.mark.parametrize("prefix_sms", [True, pytest.param(False, marks=pytest.mark.xfail())])
+@pytest.mark.parametrize(
+    "prefix_sms, expected_hint",
+    [
+        (True, "Your message will start with your service name"),
+        (False, None),
+    ],
+)
 def test_should_show_message_with_prefix_hint_if_enabled_for_service(
-    client_request, mock_get_service_template, service_one, fake_uuid, prefix_sms
+    client_request, mock_get_service_template, service_one, fake_uuid, prefix_sms, expected_hint
 ):
     service_one["prefix_sms"] = prefix_sms
 
@@ -2010,7 +2016,7 @@ def test_should_show_message_with_prefix_hint_if_enabled_for_service(
         template_id=fake_uuid,
     )
 
-    assert "Your message will start with your service name" in page.text
+    assert normalize_spaces(page.select_one(".govuk-hint#template_content-hint")) == expected_hint
 
 
 @pytest.mark.parametrize("filetype", ["pdf", "png"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3210,6 +3210,8 @@ def client_request(request, _logged_in_client, mocker, service_one, fake_nonce):
 
 
 def normalize_spaces(input):
+    if input is None:
+        return None
     if isinstance(input, str):
         return " ".join(input.split())
     return normalize_spaces(" ".join(item.text for item in input))


### PR DESCRIPTION
Also makes sure this has proper test coverage, rather than just checking for an exception.

Had to modify the `normalize_spaces` function slightly so I could parametrize the test in the way I wanted. This should be useful in other places.