### PR TITLE
Fix occasionally misaligned placeholder highlighting

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -184,6 +184,7 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
     white-space: pre-wrap;
     overflow-wrap: break-word;
     word-wrap: break-word;
+    box-sizing: border-box;
     padding: 4px 4px govuk-spacing(6) 4px;
     border: 2px solid transparent;
     z-index: 10;


### PR DESCRIPTION
The hidden copy of the template content we use to render the yellow placeholders was slightly wider than the original text.

This sometimes mean the text didn’t break onto a new line in the same place. This would cause the yellow highlight to not appear in the same place as the double brackets.

This was caused by the padding and border of the hidden copy being added to it’s width, not subtracted from its width. `box-sizing` is the CSS property which controls whether padding and borders are added to or subtracted from an element’s width.

## Before

<img width="600" height="221" alt="image" src="https://github.com/user-attachments/assets/7d581f0c-9879-4eb5-b4c8-ce61a4917ff2" />

<img width="600" height="213" alt="image" src="https://github.com/user-attachments/assets/b894d8ec-89c3-44cf-bde3-3f555c028f68" />

## After

<img width="600" height="212" alt="image" src="https://github.com/user-attachments/assets/b2fe154c-4936-47ab-be37-f9f9e0e85e7a" />

<img width="600" height="215" alt="image" src="https://github.com/user-attachments/assets/ae8db1e2-d2f0-4c35-b0d4-3321776f3356" />
