### PR TITLE
bump utils to 101.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@101.0.0
+# This file was automatically copied from notifications-utils@101.1.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2==1.1.3
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@101.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@101.1.0
 
 govuk-frontend-jinja==3.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@4201823031adc5c557d52809c511be2f876dc79d
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8a998cf82afe070c9cb2f33913560d67b99a25c8
     # via -r requirements.in
 openpyxl==3.1.5
     # via pyexcel-xlsx

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -163,7 +163,7 @@ moto==5.1.0
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@4201823031adc5c557d52809c511be2f876dc79d
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8a998cf82afe070c9cb2f33913560d67b99a25c8
     # via -r requirements.txt
 openpyxl==3.1.5
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@101.0.0
+# This file was automatically copied from notifications-utils@101.1.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@101.0.0
+# This file was automatically copied from notifications-utils@101.1.0
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
Adds updated redis_client with token bucket algorithm. Needed for the work on migrating from sliding window to token bucket for rate limiting. The version bump alone doesn't change how we are doing rate limiting, the redis_client wrapper method for token bucket needs to be explicitly called.