### PR TITLE
Account for empty email subject when rendering email template

### DIFF
--- a/app/templates/partials/templates/email_preview_template.jinja2
+++ b/app/templates/partials/templates/email_preview_template.jinja2
@@ -42,7 +42,8 @@
       "html": "Subject"
     },
     "value": {
-      "html": subject
+      "classes": "" if subject else "govuk-hint",
+      "html": subject or "Subject missing",
     }
 }) %}
 

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -1070,3 +1070,26 @@ def test_templates_make_quotes_smart_and_dashes_en(
 
     mock_smart_quotes.assert_has_calls(expected_calls)
     mock_en_dash_replacement.assert_has_calls(expected_calls)
+
+
+@pytest.mark.parametrize(
+    "subject, expected_subject, expected_classes",
+    (
+        ("Example", "Example", ["govuk-summary-list__value"]),
+        ("", "Subject missing", ["govuk-summary-list__value", "govuk-hint"]),
+    ),
+)
+def test_email_preview_template_doesnt_error_on_empty_subject(
+    subject,
+    expected_subject,
+    expected_classes,
+):
+    template = BeautifulSoup(
+        str(EmailPreviewTemplate({"content": "content", "subject": subject, "template_type": "email"})),
+        features="html.parser",
+    )
+
+    subject_field = template.select(".email-message-meta .govuk-summary-list__value")[1]
+
+    assert subject_field.text.strip() == expected_subject
+    assert subject_field["class"] == expected_classes


### PR DESCRIPTION
For historical/migration-related reasons some of our templates have an empty subject field.

This raises an exception in the admin app when trying to preview these templates.

This commit shows a helpful hint instead.

***

Without the changes to `email_preview_template.jinja2` the test I have added triggers the same [exception we have seen in production](https://govuk-notify-gds.sentry.io/issues/6793751806/events/latest/?project=4504949328838656):

<img width="851" height="312" alt="image" src="https://github.com/user-attachments/assets/dff0d3ce-1dff-43ec-a977-d995346d5083" />
