### PR TITLE
Revert "Dockerfile: use `base` image for `frontend_build`"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /home/vcap/app
 ARG NOTIFY_ENVIRONMENT=development
 
 FROM --platform=linux/amd64 node:22-slim AS node
-FROM base AS frontend_build
+FROM --platform=linux/amd64 python:3.11-slim AS frontend_build
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Reverts alphagov/notifications-admin#5572

This appears to cause some problems with static asset upload paths