### PR TITLE
Dockerfile: Base `frontend_build` on `node` image (only)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     libcurl4 \
     curl \
-    && apt-get -y clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/*
 
 WORKDIR /home/vcap/app
 
@@ -41,7 +40,6 @@ RUN echo "Install OS dependencies for python app requirements" &&  \
     build-essential \
     git \
     libxml2-dev libxslt-dev zlib1g-dev \
-    && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 COPY requirements.txt .
@@ -92,7 +90,6 @@ RUN echo "Install OS dependencies for test build" && \
       curl \
       libxml2-dev libxslt-dev zlib1g-dev \
       git && \
-    apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 RUN usermod -aG sudo notify

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,8 +21,7 @@ WORKDIR /home/vcap/app
 ##### Frontend Build Image ###################################################
 ARG NOTIFY_ENVIRONMENT=development
 
-FROM --platform=linux/amd64 node:22-slim AS node
-FROM --platform=linux/amd64 python:3.11-slim-bookworm AS frontend_build
+FROM --platform=linux/amd64 node:22-bookworm-slim AS frontend_build
 
 SHELL ["/bin/bash", "-c"]
 
@@ -43,9 +42,6 @@ RUN apt-get update && \
         zip \
         openssh-client \
     && rm -rf /var/lib/apt/lists/*
-
-COPY --from=node /usr/local/lib /usr/local/lib
-COPY --from=node /usr/local/bin /usr/local/bin
 
 WORKDIR /usr/frontend
 COPY app app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,24 +25,6 @@ FROM --platform=linux/amd64 node:22-bookworm-slim AS frontend_build
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        # TODO: this entire block was inlined from unit-tests-image's Dockerfile.
-        # Which of these are actually dependencies of admin,
-        # which are dependencies of document-download-frontend (and can be removed)?
-        make \
-        curl \
-        rlwrap \
-        git \
-        build-essential \
-        libmagic-dev \
-        libcurl4-openssl-dev \
-        libssl-dev \
-        libpng-dev \
-        zip \
-        openssh-client \
-    && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /usr/frontend
 COPY app app
 COPY package-lock.json package.json rollup.config.mjs ./


### PR DESCRIPTION
https://trello.com/c/bY9k4JvU/1311-investigate-image-building-issues-on-admin-document-download-frontend

Previously this image was based on a Python image which had the `/usr/local/bin` and `/usr/local/lib` directories copy-pasted into it from a Node image.

This is brittle because the Node and Python images might be referencing different versions of Debian. It's also unnecessary because we don't use Python at all during frontend builds.

Also includes some drive-by refactors (see commit messages).

Tested in dev-c.