### PR TITLE
Update the ‘switch services’ link text and call-to-action

### DIFF
--- a/app/templates/views/service-already-live.html
+++ b/app/templates/views/service-already-live.html
@@ -22,8 +22,7 @@
 
       {% if prompt_to_switch_service %}
       <p class="govuk-body">
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.your_services') }}">Switch service</a>
-         if you want to make a different service live.
+        If you want to make a different service live, go to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.your_services') }}">your services</a>.
       </p>
       {% endif %}
 


### PR DESCRIPTION
The link text does not reflect the updated change in the call-to-action that we introduced when we renamed the ‘Switch service’ link in our navigation.

Instead of ‘switch services’ we want to mention ‘Your services.