### PR TITLE
Only show "Change" buttons to users with right permissions

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -39,7 +39,7 @@
                   "visuallyHiddenText": "service name",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
           {
@@ -58,7 +58,7 @@
                   "visuallyHiddenText": "sign-in method",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
           {
@@ -77,7 +77,7 @@
                   "visuallyHiddenText": "data retention",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           }
         ]
@@ -124,7 +124,7 @@
                 "visuallyHiddenText": "your settings for sending emails",
                 "classes": "govuk-link--no-visited-state"
               }
-            ]
+            ] if current_user.has_permissions('manage_service') else []
           }
         }
       ]%}
@@ -148,7 +148,7 @@
                   "visuallyHiddenText": "email sender name",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
           {
@@ -187,7 +187,7 @@
                   "visuallyHiddenText": "email branding",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
           {
@@ -207,7 +207,7 @@
                   "visuallyHiddenText": "sending files by email",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
         ]%}
@@ -233,7 +233,7 @@
                   "visuallyHiddenText": "daily {} limit".format("email"|format_notification_type|lower),
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
         )%}
@@ -295,7 +295,7 @@
                 "visuallyHiddenText": "your settings for sending text messages",
                 "classes": "govuk-link--no-visited-state"
               }
-            ]
+            ] if current_user.has_permissions('manage_service') else []
           }
         }
       ]%}
@@ -340,7 +340,7 @@
                   "visuallyHiddenText": "your settings for starting text messages with service name",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
           {
@@ -359,7 +359,7 @@
                   "visuallyHiddenText": "your settings for receiving text messages",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
         ]%}
@@ -385,7 +385,7 @@
                   "visuallyHiddenText": "daily {} limit".format("sms"|format_notification_type|lower),
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
         )%}
@@ -409,7 +409,7 @@
                   "visuallyHiddenText": "your settings for sending international text messages",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
         )%}
@@ -436,7 +436,7 @@
                   "visuallyHiddenText": "daily international {} limit".format("sms"|format_notification_type|lower),
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
         ]%}
@@ -480,7 +480,7 @@
                 "visuallyHiddenText": "your settings for sending letters",
                 "classes": "govuk-link--no-visited-state"
               }
-            ]
+            ] if current_user.has_permissions('manage_service') else []
           }
         }
       ]%}
@@ -518,7 +518,7 @@
                   "visuallyHiddenText": "your settings for sending international letters",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
           {
@@ -558,7 +558,7 @@
                   "visuallyHiddenText": "letter branding",
                   "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
         ] %}
@@ -583,7 +583,7 @@
                 "visuallyHiddenText": "daily {} limit".format("letter"|format_notification_type|lower),
                 "classes": "govuk-link--no-visited-state"
                 }
-              ]
+              ] if current_user.has_permissions('manage_service') else []
             }
           },
         ) %}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -85,6 +85,32 @@ FAKE_TEMPLATE_ID = uuid4()
             ],
         ),
         (
+            create_active_user_no_settings_permission(),
+            ["sms", "email", "letter"],
+            [
+                "Service name Test Service",
+                "Sign-in method Text message code",
+                "Data retention period 7 days",
+                "Send emails On",
+                "Email sender name Test Service test.service@notifications.service.gov.uk",
+                "Reply-to email addresses Not set Manage reply-to email addresses",  # user will see manage button
+                "Email branding GOV.UK",
+                "Send files by email contact_us@gov.uk",
+                "Email limit 1,000 per day 1,234 sent today",
+                "Send text messages On",
+                "Text message sender IDs GOVUK Manage text message sender IDs",  # user will see manage button
+                "Start text messages with service name On",
+                "Receive text messages Off",
+                "Text message limit 1,000 per day 1,234 sent today",
+                "Send international text messages Off",
+                "Send letters On",
+                "Send international letters Off",
+                "Sender addresses Not set Manage sender addresses",  # user will see manage button
+                "Letter branding Not set",
+                "Letter limit 1,000 per day 1,234 sent today",
+            ],
+        ),
+        (
             create_platform_admin_user(),
             ["sms", "email"],
             [
@@ -155,7 +181,7 @@ FAKE_TEMPLATE_ID = uuid4()
         ),
     ],
 )
-def test_should_show_overview(
+def test_service_settings_page_visible_settings_depend_on_user_and_service_permissions(
     client_request,
     mocker,
     api_user_active,


### PR DESCRIPTION
Users who DO NOT have manage_service permission, but DO have manage_api_keys can see service settings page.

This is so that they can grap IDs for email reply-to addresses, SMS senders, and letter contact details. They can get to those pages, but if they try to click a Change button for any of the remaining settings, they will get a 404. This is not a good user experience
- how are they supposed to know which 3 out of tens of settings they are allowed to access?

So in this commit, we are hiding change buttons from them, except for the 3 that they can actually access.

This is how the settings page will now look like for a person without manage_service permission:

<img width="1065" height="764" alt="Screenshot 2025-08-22 at 12 25 45" src="https://github.com/user-attachments/assets/ac3190a4-b410-4b84-a20e-7a6076c9f0cd" />
<img width="855" height="764" alt="Screenshot 2025-08-22 at 12 25 55" src="https://github.com/user-attachments/assets/43bbde0b-08f8-4bca-b6a9-79c033583e0a" />
