### PR TITLE
Make "name" a required field when opening support tickets

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1695,7 +1695,7 @@ class SupportRedirect(StripWhitespaceForm):
 
 class FeedbackOrProblem(StripWhitespaceForm):
     feedback = GovukTextareaField("Your message", validators=[NotifyDataRequired(thing="your message")])
-    name = GovukTextInputField("Name (optional)")
+    name = GovukTextInputField("Name", validators=[NotifyDataRequired(thing="your name")])
     email_address = make_email_address_field(
         label="Email address", gov_user=False, required=True, thing="your email address"
     )


### PR DESCRIPTION
As part of the upcoming changes to the support form, "Name" will become a required field. This splits out this change to avoid subsequent PRs becoming too large.

**Before**
<img width="400" height="286" alt="Screenshot 2025-09-03 at 09 01 51" src="https://github.com/user-attachments/assets/abbce1b3-c891-4e70-a281-14dce155b31c" />

**After**
<img width="500" height="827" alt="Screenshot 2025-09-03 at 09 01 22" src="https://github.com/user-attachments/assets/ab460276-c71e-4c65-af7b-5ae25df19afe" />
