### PR TITLE
Fix example unsubscribe link

### DIFF
--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -312,7 +312,7 @@ def get_template(
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
             reply_to=email_reply_to,
-            unsubscribe_link=url_for(".unsubscribe_example") if template.get("has_unsubscribe_link") else None,
+            unsubscribe_link=url_for(".unsubscribe_example", _external=True) if template.get("has_unsubscribe_link") else None,
         )
     if "sms" == template["template_type"]:
         return SMSPreviewTemplate(

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -242,6 +242,8 @@ class EmailPreviewTemplate(BaseEmailTemplate):
         self.from_name = from_name
         self.reply_to = reply_to
         self.show_recipient = show_recipient
+        if template.get("has_unsubscribe_link"):
+            self.unsubscribe_link = url_for(".unsubscribe_example", _external=True)
 
     def __str__(self):
         return Markup(
@@ -312,7 +314,6 @@ def get_template(
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
             reply_to=email_reply_to,
-            unsubscribe_link=url_for(".unsubscribe_example", _external=True) if template.get("has_unsubscribe_link") else None,
         )
     if "sms" == template["template_type"]:
         return SMSPreviewTemplate(

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -236,9 +236,8 @@ class EmailPreviewTemplate(BaseEmailTemplate):
         reply_to=None,
         show_recipient=True,
         redact_missing_personalisation=False,
-        **kwargs,
     ):
-        super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation, **kwargs)
+        super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation)
         self.from_name = from_name
         self.reply_to = reply_to
         self.show_recipient = show_recipient

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -382,6 +382,33 @@ def test_should_show_page_for_email_template(
         ("Subject", "Your ((thing)) is due soon"),
     ]
     assert normalize_spaces(page.select_one(".email-message-body").text) == "Your vehicle tax expires on ((date))"
+    assert not page.select_one(".email-message-body a")  # No unsubscribe link
+
+
+def test_should_show_page_for_email_template_with_unsubscribe_link(
+    client_request,
+    fake_uuid,
+    mocker,
+):
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={
+            "data": create_template(
+                template_id=fake_uuid,
+                template_type="email",
+                has_unsubscribe_link=True,
+            )
+        },
+    )
+    page = client_request.get(
+        ".view_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+    unsubscribe_link = page.select_one(".email-message-body a")
+    assert unsubscribe_link["href"] == "http://localhost/unsubscribe/example"
+    assert normalize_spaces(unsubscribe_link.text) == "Unsubscribe from these emails"
 
 
 @pytest.mark.parametrize(

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -1025,7 +1025,7 @@ def test_unsubscribe_link_is_rendered():
     expected_content = (
         '<hr style="border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;">'
         '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
-        '<a style="word-wrap: break-word; color: #1D70B8;" href="https://www.example.com">'
+        '<a style="word-wrap: break-word; color: #1D70B8;" href="http://localhost/unsubscribe/example">'
         "Unsubscribe from these emails"
         "</a>"
         "</p>\n"
@@ -1034,9 +1034,13 @@ def test_unsubscribe_link_is_rendered():
     assert expected_content in (
         str(
             EmailPreviewTemplate(
-                {"content": "Hello world", "subject": "subject", "template_type": "email"},
+                {
+                    "content": "Hello world",
+                    "subject": "subject",
+                    "template_type": "email",
+                    "has_unsubscribe_link": True,
+                },
                 {},
-                unsubscribe_link="https://www.example.com",
             )
         )
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4324,6 +4324,7 @@ def create_template(
     redact_personalisation=False,
     postage=None,
     folder=None,
+    has_unsubscribe_link=False,
 ):
     return template_json(
         service_id=service_id,
@@ -4335,6 +4336,7 @@ def create_template(
         redact_personalisation=redact_personalisation,
         postage=postage,
         folder=folder,
+        has_unsubscribe_link=has_unsubscribe_link,
     )
 
 


### PR DESCRIPTION
At the moment we generate a relative URL like `/unsubscribe/example`

Our Markdown looks at this and decides it’s missing `https://`. So we end up with a link to `https:///unsubscribe/example` which doesn’t resolve.

`_external=True` forces Flask to include the protocol and domain<sup>1</sup>, so we end up with a (correct) link to `https://www.notifications.service.gov.uk/unsubscribe/example`

***

1. https://flask.palletsprojects.com/en/stable/api/#flask.Flask.url_for

***

Closes https://github.com/alphagov/notifications-admin/pull/5568