### PR TITLE
returned letters: handle cases with "orphaned" returned letters, showing message

### DIFF
--- a/app/main/views/returned_letters.py
+++ b/app/main/views/returned_letters.py
@@ -19,7 +19,16 @@ def returned_letter_summary(service_id):
 @user_has_permissions("view_activity")
 def returned_letters(service_id, reported_at):
     page_size = 50
-    returned_letters = service_api_client.get_returned_letters(service_id, reported_at)
+    response = service_api_client.get_returned_letters(service_id, reported_at)
+    try:
+        # new-style (dict-wrapped) response
+        returned_letters = response["returned_letters"]
+        orphaned_count = response["orphaned_count"]
+    except TypeError:
+        # old-style (raw list) response
+        returned_letters = response
+        orphaned_count = None
+
     count_of_returned_letters = len(returned_letters)
 
     return render_template(
@@ -29,6 +38,7 @@ def returned_letters(service_id, reported_at):
         more_than_one_page=(count_of_returned_letters > page_size),
         page_size=page_size,
         count_of_returned_letters=count_of_returned_letters,
+        orphaned_count=orphaned_count,
     )
 
 
@@ -36,6 +46,13 @@ def returned_letters(service_id, reported_at):
 @user_has_permissions("view_activity")
 def returned_letters_report(service_id, reported_at):
     returned_letters = service_api_client.get_returned_letters(service_id, reported_at)
+    try:
+        # new-style (dict-wrapped) response
+        returned_letters = returned_letters["returned_letters"]
+    except TypeError:
+        # old-style (raw list) response
+        pass
+
     column_names = {
         "notification_id": "Notification ID",
         "client_reference": "Reference",

--- a/app/templates/views/returned-letters.html
+++ b/app/templates/views/returned-letters.html
@@ -16,6 +16,12 @@
 
 {{ page_header('Returned letters for {}'.format(reported_at|format_date_normal)) }}
 
+{% if orphaned_count %}
+<p class="govuk-body">
+  Your report is missing {{ orphaned_count|format_thousands }} letter{% if orphaned_count > 1 %}s{% endif %} because {% if orphaned_count > 1 %}they were{% else %}it was{% endif %} sent too long ago.
+</p>
+{% endif %}
+
 <p class="bottom-gutter">
   <a download href="{{ url_for('main.returned_letters_report', service_id=current_service.id, reported_at=reported_at) }}" class="govuk-link heading-small">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
 </p>


### PR DESCRIPTION
https://trello.com/c/CQp2fcic/1297-work-out-if-we-can-purge-history-table-and-do-it

Given an api `get_returned_letters` "new-style" response (with results wrapped in a dictionary and accompanied with an `orphaned_count`), this displays a message at the top of a returned letter listing page, explaining why the number of letters shown in this list might not be the number that summary pages had lead the user to expect.

Should continue to work as before with "old-style" api responses.

This PR running against the existing api (not able to show orphaned information because this isn't provided in the response):
<img width="975" height="679" alt="Screenshot 2025-09-09 at 15 47 14" src="https://github.com/user-attachments/assets/4128969e-10bb-4dfd-8a76-51ec4e509344" />
<img width="975" height="354" alt="Screenshot 2025-09-09 at 15 47 44" src="https://github.com/user-attachments/assets/8e1fa2cb-4a0e-4a58-ab00-e9ca139726f8" />

And against https://github.com/alphagov/notifications-api/pull/4555:
<img width="975" height="505" alt="Screenshot 2025-09-09 at 16 25 53" src="https://github.com/user-attachments/assets/5e1e3ed1-818d-42e5-bdbf-708717d1ca04" />
<img width="975" height="380" alt="Screenshot 2025-09-09 at 16 27 41" src="https://github.com/user-attachments/assets/b54bb2ca-a633-4722-8159-489e5812a76c" />

