### PR TITLE
Remove fixed StatusPage issues

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -12,8 +12,8 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "15 July 2025",
-      "Next review due": "31 July 2025"
+      "Last updated": "16 September 2025",
+      "Next review due": "31 October 2025"
     }
     ) }}
     {# Last non-functional changes: 13 December 2024 #}
@@ -120,12 +120,8 @@
   </p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>an incorrect heading hierarchy which fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#info-and-relationships">success criterion 1.3.1: info and relationships</a></li>
-    <li>missing level 1 headings (users may not be able to accurately determine the structure of content on the page)</li>
-    <li>our status incident page is missing the main heading and the status home page has an incorrect heading hierarchy – this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#info-and-relationships">success criterion 1.3.1: info and relationships</a></li>
     <li>our status page subscribe to updates forms, when submitted with incorrect data, do not inform screen reader users of the error message when it becomes available – this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#status-messages">success criterion 4.1.3: status messages</a></li>
-    <li>incident titles are colour-coded, with no other visual indication or text – this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#use-of-color">success criterion 1.4.1: use of color</a></li>
-    <li>there is only one way to get to some pages. Many of these pages can only be reached using inaccessible controls - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#multiple-ways">success criterion  success criterion 2.4.5: multiple ways</a></li>
+    <li>there is only one way to get to some pages - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/TR/WCAG21/#multiple-ways">success criterion  success criterion 2.4.5: multiple ways</a></li>
   </ul>
 
   <h2 class="heading-medium" id="how-we-tested-this-service">


### PR DESCRIPTION
We've fixed these in
- https://trello.com/c/fVAVltqC/1404-status-page-add-headings-to-pages
- https://trello.com/c/ari5FjHW/1425-status-page-status-colours-convey-meaning

Removing the mention on inaccessible controls, as we onyl have next/prev controls on the history page and they have the necessary attributes

Not mentioned as an issue outright, but we've also update colour to be more distinct and unique
- https://trello.com/c/cJVIoYRP/1428-status-page-review-colours