### PR TITLE
Add blueprint to `url_for` used in `EmailPreviewTemplate` class

### DIFF
--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -242,7 +242,7 @@ class EmailPreviewTemplate(BaseEmailTemplate):
         self.reply_to = reply_to
         self.show_recipient = show_recipient
         if template.get("has_unsubscribe_link"):
-            self.unsubscribe_link = url_for(".unsubscribe_example", _external=True)
+            self.unsubscribe_link = url_for("main.unsubscribe_example", _external=True)
 
     def __str__(self):
         return Markup(


### PR DESCRIPTION
We were getting an error of "Could not build url for endpoint 'json_updates.unsubscribe_example'. Did you mean 'main.unsubscribe_example'" when looking at an email job where the template had an unsubscribe link. It occurs on the AJAX request, so didn't affect what the user sees but this adds the blueprint name when getting the url for ".unsubscribe_example" to prvent the error.