### PR TITLE
Add and update community pharmacy guidance

### DIFF
--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -65,7 +65,7 @@
 
 <h2 class="govuk-heading-m" id="gp">Pharmacies</h2>
   <p class="govuk-body">
-    Pharmacies based in a hospital and funded by an Integrated Care Board (ICB) or NHS Trust can use GOV.UK Notify.
+    Pharmacies that are based in a hospital and funded by an Integrated Care Board (ICB) or NHS Trust can use GOV.UK Notify.
   </p>
   <p class="govuk-body">
     Community pharmacies are not eligible to use Notify. This is because they are privately owned and operated by sole traders, partnerships or corporate bodies.

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -16,6 +16,10 @@
   ) }}
 
   <p class="govuk-body">
+    Only public sector organisations can accept our data processing and financial agreement.
+  </p>
+
+  <p class="govuk-body">
     GOV.UK Notify is available to teams from:
   </p>
   <ul class="govuk-list govuk-list--bullet">
@@ -75,7 +79,7 @@
     Community pharmacies cannot use GOV.UK Notify because they are privately owned.
   </p>
   <p class="govuk-body">
-    Only public sector organisations can accept our data processing and financial agreement. NHS Trusts and ICBs cannot accept the agreement on behalf of a community pharmacy.
+    NHS Trusts and ICBs cannot accept our data processing and financial agreement on behalf of a community pharmacy.
   </p>
 
   <h2 class="govuk-heading-m" id="public">Members of the public</h2>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -63,15 +63,19 @@
     <li>cannot send any text messages in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a></li>
   </ul>
 
-<h2 class="govuk-heading-m" id="gp">Pharmacies</h2>
+<h2 class="govuk-heading-m" id="pharmacy">Pharmacies</h2>
   <p class="govuk-body">
-    Pharmacies that are based in a hospital and funded by an Integrated Care Board (ICB) or NHS Trust can use GOV.UK Notify.
+    The only pharmacies that can use GOV.UK Notify are:
+  </p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>hospital pharmacies funded by an Integrated Care Board (ICB) or NHS Trust</li>
+    <li>military pharmacies, owned and run by the Ministry of Defence (MoD)</li>
+  </ul>
+  <p class="govuk-body">
+    Community pharmacies cannot use GOV.UK Notify because they are privately owned.
   </p>
   <p class="govuk-body">
-    Community pharmacies are not eligible to use Notify. This is because they are privately owned and operated by sole traders, partnerships or corporate bodies.
-  </p>
-  <p>
-    Public sector bodies like the Department of Health and Social Care (DHSC), NHS Trusts or ICBs cannot accept our Data Processing and Financial agreement on behalf of a community pharmacy.
+    Only public sector organisations can accept our data processing and financial agreement. NHS Trusts and ICBs cannot accept the agreement on behalf of a community pharmacy.
   </p>
 
   <h2 class="govuk-heading-m" id="public">Members of the public</h2>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -67,7 +67,7 @@
     <li>cannot send any text messages in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a></li>
   </ul>
 
-<h2 class="govuk-heading-m" id="pharmacy">Pharmacies</h2>
+<h2 class="govuk-heading-m" id="pharmacies">Pharmacies</h2>
   <p class="govuk-body">
     The only pharmacies that can use GOV.UK Notify are:
   </p>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -24,7 +24,7 @@
     <li>the armed forces</li>
     <li>the NHS</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#gp">GP surgeries</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#gp">pharmacies</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#pharmacies">hospital pharmacies</a></li>
     <li>the emergency services</li>
     <li>state-funded schools</li>
   </ul>
@@ -39,6 +39,7 @@
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>charities</li>
+    <li>community pharmacies</li>
     <li>hospices</li>
     <li>housing associations</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#public">members of the public</a></li>
@@ -53,14 +54,25 @@
     Someone from the public sector organisation you’re working with needs to create an account and add the service first. Then they can invite you to join as a team member.
   </p>
 
-<h2 class="govuk-heading-m" id="gp">GP surgeries and pharmacies</h2>
+<h2 class="govuk-heading-m" id="gp">GP surgeries</h2>
   <p class="govuk-body">
-    NHS-funded GP surgeries and pharmacies can use GOV.UK Notify, but they:
+    NHS-funded GP surgeries can use GOV.UK Notify, but they:
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>do not get an <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages') }}">annual allowance of free text messages</a></li>
     <li>cannot send any text messages in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_trial_mode') }}">trial mode</a></li>
   </ul>
+
+<h2 class="govuk-heading-m" id="gp">Pharmacies</h2>
+  <p class="govuk-body">
+    Pharmacies based in a hospital and funded by an Integrated Care Board (ICB) or NHS Trust can use GOV.UK Notify.
+  </p>
+  <p class="govuk-body">
+    Community pharmacies are not eligible to use Notify. This is because they are privately owned and operated by sole traders, partnerships or corporate bodies.
+  </p>
+  <p>
+    Public sector bodies like the Department of Health and Social Care (DHSC), NHS Trusts or ICBs cannot accept our Data Processing and Financial agreement on behalf of a community pharmacy.
+  </p>
 
   <h2 class="govuk-heading-m" id="public">Members of the public</h2>
   <p class="govuk-body">

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -39,7 +39,7 @@
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>charities</li>
-    <li>community pharmacies</li>
+    <li><li><a class="govuk-link govuk-link--no-visited-state" href="#pharmacies">community pharmacies</a></li>
     <li>hospices</li>
     <li>housing associations</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#public">members of the public</a></li>

--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -43,7 +43,7 @@
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>charities</li>
-    <li><li><a class="govuk-link govuk-link--no-visited-state" href="#pharmacies">community pharmacies</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#pharmacies">community pharmacies</a></li>
     <li>hospices</li>
     <li>housing associations</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#public">members of the public</a></li>

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -43,7 +43,7 @@ Text message pricing
         (central_government_organisations_text, '30,000 free text message'),
         ('Local authorities and regional organisations', '10,000 free text messages'),
         ('State-funded schools', '5,000 free text messages'),
-        ('GP surgeries and NHS pharmacies', 'No free allowance'),
+        ('GP surgeries', 'No free allowance'),
         ('Other organisations', '5,000 free text messages'),
       ] %}
         {% call row() %}


### PR DESCRIPTION
This PR updates the ‘Who can use Notify’ page to explain why community pharmacies are not eligible to use GOV.​UK Notify.