### PR TITLE
refactor: rename edit template button to 'Save and preview'

### DIFF
--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -48,7 +48,7 @@
             }
           }) }}
           {{ sticky_page_footer(
-            'Save'
+            'Save and preview'
           ) }}
         </div>
         <div class="govuk-grid-column-full">

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -64,7 +64,7 @@
             }
           }) }}
           {{ sticky_page_footer(
-            'Save'
+            'Save and preview'
           ) }}
 
         </div>

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -46,7 +46,7 @@
               &nbsp;
             </div>
           </div>
-          {{ page_footer('Save') }}
+          {{ page_footer('Save and preview') }}
         </div>
         <div class="govuk-grid-column-full">
           {% include "partials/templates/guidance-personalisation.html" %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -637,6 +637,47 @@ def test_add_email_template_should_add_unsubscribe(
     )
 
 
+@pytest.mark.parametrize(
+    "template_type",
+    (
+        "email",
+        "sms",
+        "letter",
+    ),
+)
+def test_add_service_template_should_include_save_and_preview_button(
+    client_request,
+    service_one,
+    template_type,
+):
+    if template_type == "letter":
+        service_one["permissions"].append("letter")
+
+    page = client_request.get(
+        ".add_service_template",
+        service_id=SERVICE_ONE_ID,
+        template_type=template_type,
+    )
+    assert "Save and preview" in page.text
+
+
+@pytest.mark.parametrize(
+    "template_type",
+    (
+        "email",
+        "sms",
+        "letter",
+    ),
+)
+def test_edit_service_template_should_include_save_and_preview_button(
+    client_request, template_type, mock_get_service_letter_template, fake_uuid, service_one
+):
+    service_one["permissions"].append("letter")
+    page = client_request.get(".edit_service_template", service_id=SERVICE_ONE_ID, template_id=fake_uuid)
+
+    assert "Save and preview" in page.text
+
+
 def test_editing_letter_template_should_have_hidden_name_field(
     client_request, mock_get_service_letter_template, fake_uuid, service_one
 ):


### PR DESCRIPTION
### Summary
For template editing (letters, sms and emails) we should rename the button from 'Save' to 'Save and preview'

**Email Template**
<img width="750" height="753" alt="Screenshot 2025-09-17 at 14 16 02" src="https://github.com/user-attachments/assets/2427a0b1-8d01-4dc2-af2e-c96c3b5d1693" />

**Text Message Template**
<img width="650" height="508" alt="Screenshot 2025-09-17 at 14 16 33" src="https://github.com/user-attachments/assets/3bb311e3-428e-4eb8-8bb5-10c9bc5e51bb" />

**Letter Template**
<img width="803" height="527" alt="Screenshot 2025-09-17 at 14 23 20" src="https://github.com/user-attachments/assets/2e9c6468-6820-4ad1-9285-e10ea0d3bbf9" />

### Ticket
[Onboarding - Rename the ‘Save and preview’ button on template edit page](https://trello.com/c/LM6ho8xx/1465-onboarding-rename-the-save-and-preview-button-on-template-edit-page)
