### PR TITLE
Remove CSS for ‘live broadcast’ indicator

### DIFF
--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -241,22 +241,3 @@ details .arrow {
 .form--inline {
   display: inline-flex;
 }
-
-@keyframes live-pulse {
-  0%   {
-    background: govuk-colour("red");
-    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px govuk-colour("white");
-  }
-  40%   {
-    background: govuk-colour("red");
-    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px govuk-colour("white");
-  }
-  50% {
-    background: govuk-colour("white");
-    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 2px govuk-colour("white");
-  }
-  100% {
-    background: govuk-colour("white");
-    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px govuk-colour("white");
-  }
-}


### PR DESCRIPTION
This was added for Emergency Alerts in https://github.com/alphagov/notifications-admin/pull/3532