### PR TITLE
Use tabular numbers for live-updating count of messages

### DIFF
--- a/app/templates/partials/daily-limits/remaining-limit.html
+++ b/app/templates/partials/daily-limits/remaining-limit.html
@@ -5,7 +5,7 @@
 
 <div class="ajax-block-container">
     {{ govukInsetText({
-        "text": "You have sent {} today ({} remaining).".format(
+        "html": "You have sent <span class='tabular-numbers'>{}</span> today (<span class='tabular-numbers'>{}</span> remaining).".format(
             sent_today|message_count(daily_limit_type),
             remaining_limit|format_thousands
         ),

--- a/app/templates/views/service-settings/daily-message-limit.html
+++ b/app/templates/views/service-settings/daily-message-limit.html
@@ -20,7 +20,7 @@
     <div class="govuk-grid-column-five-sixths">
         {{ page_header(page_title) }}
         <p class="govuk-body">
-            You can send up to {{ current_service.get_message_limit(daily_limit_type)|message_count(daily_limit_type) }} per day.
+            You can send up to <span class="tabular-numbers">{{ current_service.get_message_limit(daily_limit_type)|message_count(daily_limit_type) }}</span> per day.
         </p>
 
         {{ ajax_block(partials, updates_url, 'remaining_limit') }}


### PR DESCRIPTION
Tabular numbers have a fix width. This ensures they don’t jump around so much as the count updates.