### PR TITLE
Update error message when trying to cancel incomplete letter job

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -137,7 +137,7 @@ def cancel_letter_job(service_id, job_id):
 
         # reduce to just == FINISHED_ALL_NOTIFICATIONS_CREATED_JOB_STATUS once api support rolled out
         if job.status not in JobApiClient.FINISHED_JOB_STATUSES or job.notifications_created < job.notification_count:
-            flash("We are still processing these letters, please try again in a minute.", "try again")
+            flash("We are still processing these letters, please try again in 5 minutes.", "try again")
             return view_job(service_id, job_id)
         try:
             number_of_letters = job.cancel()

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -699,7 +699,7 @@ def test_dont_cancel_letter_job_when_too_early_to_cancel(
     assert mock_cancel.called is False
     flash_message = normalize_spaces(page.select_one("div.banner-dangerous").text)
 
-    assert "We are still processing these letters, please try again in a minute." in flash_message
+    assert "We are still processing these letters, please try again in 5 minutes." in flash_message
 
 
 @freeze_time("2016-01-01 00:00:00.000001")


### PR DESCRIPTION
The error message used to tell the user to try in a minute, whereas it can take up to 3 minutes after all notifications are created before the job is actually cancellable.

More context in this PR:
https://github.com/alphagov/notifications-api/pull/4562

Should be merged with: https://github.com/alphagov/notifications-api/pull/4578

### The screenshot of new content:

<img width="1079" height="761" alt="Screenshot 2025-09-23 at 19 02 05" src="https://github.com/user-attachments/assets/822978fa-c14e-4fe8-8c25-49641fe851dd" />
