### PR TITLE
Stop dependabot raising normal version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
     labels:
       - dependencies
       - python


### PR DESCRIPTION
This should stop dependabot raising PRs for normal version updates while preserving the behaviour of raising PRs for security updates.

Based on the docs here:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-