### PR TITLE
Fix support form typo

### DIFF
--- a/app/templates/views/support/no-email-link.html
+++ b/app/templates/views/support/no-email-link.html
@@ -24,7 +24,10 @@
       Check your spam folder.
       </li>
       <li>
-      Contact your IT department.
+      Make sure you have not accidentally blocked our email address.
+      </li>
+      <li>
+      Ask your IT department if they have blocked or quarantined any emails.  
       </li>
     </ol>
     <p class="govuk-body">

--- a/app/templates/views/support/no-security-code.html
+++ b/app/templates/views/support/no-security-code.html
@@ -33,7 +33,7 @@
       See if you can receive text messages from other numbers.  
       </li>
       <li>
-      Turn aeroplane on then off again.  
+      Turn aeroplane mode on then off again.  
       </li>
       <li>
       Turn your phone off, wait a few minutes then turn it on again.  

--- a/app/templates/views/support/no-security-code.html
+++ b/app/templates/views/support/no-security-code.html
@@ -27,7 +27,7 @@
       Make sure you have not accidentally blocked the sender ID ‘Notify’.  
       </li>
       <li>
-      Visit your mobile phone provider’s website and check their network status page.  
+      Visit your mobile phone network’s website and check their status page.  
       </li>
       <li>
       See if you can receive text messages from other numbers.  

--- a/app/templates/views/support/no-security-code.html
+++ b/app/templates/views/support/no-security-code.html
@@ -21,10 +21,19 @@
     </p>
     <ol class="govuk-list govuk-list--number">
       <li>
-      Check that you can receive text messages from other numbers.
+      Check your phone’s spam folder (if it has one).
       </li>
       <li>
-      Switch your phone off and then back on again, then wait 5 minutes.
+      Make sure you have not accidentally blocked the sender ID ‘Notify’.  
+      </li>
+      <li>
+      Visit your mobile phone provider’s website and check their network status page.  
+      </li>
+      <li>
+      See if you can receive text messages from other numbers.  
+      </li>
+      <li>
+      Turn your phone off. Remove the SIM card, wait 10 minutes then put the SIM card back in again. Turn your phone on.  
       </li>
     </ol>
     <p class="govuk-body">

--- a/app/templates/views/support/no-security-code.html
+++ b/app/templates/views/support/no-security-code.html
@@ -36,7 +36,7 @@
       Turn aeroplane on then off again.  
       </li>
       <li>
-      Turn your phone off, wait 5 minutes then turn it on again.  
+      Turn your phone off, wait a few minutes then turn it on again.  
       </li>
     </ol>
     <p class="govuk-body">

--- a/app/templates/views/support/no-security-code.html
+++ b/app/templates/views/support/no-security-code.html
@@ -33,7 +33,10 @@
       See if you can receive text messages from other numbers.  
       </li>
       <li>
-      Turn your phone off. Remove the SIM card, wait 10 minutes then put the SIM card back in again. Turn your phone on.  
+      Turn aeroplane on then off again.  
+      </li>
+      <li>
+      Turn your phone off, wait 5 minutes then turn it on again.  
       </li>
     </ol>
     <p class="govuk-body">


### PR DESCRIPTION
The word ‘mode’ is missing from the SMS troubleshooting page of the support form.

This PR fixes that.