### PR TITLE
fix http security headers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -354,7 +354,8 @@ def make_nonce_before_request():
 #  https://www.owasp.org/index.php/List_of_useful_HTTP_headers
 def useful_headers_after_request(response):
     response.headers.add("X-Content-Type-Options", "nosniff")
-    response.headers.add("X-XSS-Protection", "1; mode=block")
+    response.headers.add("X-Frame-Options", "SAMEORIGIN")
+    response.headers.add("X-Permitted-Cross-Domain-Policies", "none")
     response.headers.add(
         "Content-Security-Policy",
         (
@@ -385,9 +386,10 @@ def useful_headers_after_request(response):
     if "Cache-Control" in response.headers:
         del response.headers["Cache-Control"]
     response.headers.add("Cache-Control", "no-store, no-cache, private, must-revalidate")
+    response.headers.add("Pragma", "no-cache")
     for key, value in response.headers:
         response.headers[key] = SanitiseASCII.encode(value)
-    response.headers.add("Strict-Transport-Security", "max-age=31536000; preload")
+    response.headers.add("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
     response.headers.add("Referrer-Policy", "strict-origin-when-cross-origin")
     response.headers.add(
         "Cross-Origin-Embedder-Policy",

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -12,7 +12,8 @@ def test_owasp_useful_headers_set(
     response = client_request.get_response(".index")
 
     assert response.headers["X-Content-Type-Options"] == "nosniff"
-    assert response.headers["X-XSS-Protection"] == "1; mode=block"
+    assert response.headers["X-Frame-Options"] == "SAMEORIGIN"
+    assert response.headers["X-Permitted-Cross-Domain-Policies"] == "none"
     assert response.headers["Content-Security-Policy"] == (
         "default-src 'self' static.example.com 'unsafe-inline';"
         "script-src 'self' static.example.com 'nonce-TESTs5Vr8v3jgRYLoQuVwA';"
@@ -29,7 +30,9 @@ def test_owasp_useful_headers_set(
     assert response.headers["Link"] == (
         "<https://static.example.com>; rel=dns-prefetch, <https://static.example.com>; rel=preconnect"
     )
-    assert response.headers["Strict-Transport-Security"] == "max-age=31536000; preload"
+    assert response.headers["Cache-Control"] == "no-store, no-cache, private, must-revalidate"
+    assert response.headers["Pragma"] == "no-cache"
+    assert response.headers["Strict-Transport-Security"] == "max-age=31536000; includeSubDomains; preload"
     assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
     assert response.headers["Cross-Origin-Embedder-Policy"] == "require-corp static.example.com;"
     assert response.headers["Cross-Origin-Opener-Policy"] == "same-origin static.example.com;"


### PR DESCRIPTION
ITHC recommended to update following HTTP security headers. [Card](https://trello.com/c/dsELskPf/1247-missing-http-security-headers) for the more detail.
- Add X-Permitted-Cross-Domain-Policies: none
- Add X-Frame-Options: SAMEORIGIN for legacy browser support
- Add Pragma: no-cache for HTTP/1.0 compatibility
- Update Strict-Transport-Security to include includeSubDomains
- Remove deprecated X-XSS-Protection header
