### PR TITLE
Release ‘send files by email’

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -76,7 +76,6 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = {
     "inbound_sms": {"title": "Receive inbound SMS", "requires": "sms", "endpoint": ".service_set_inbound_number"},
     "email_auth": {"title": "Email authentication"},
     "sms_to_uk_landlines": {"title": "Sending SMS to UK landlines"},
-    "send_files_via_ui": {"title": "Send files via email using admin ui"},
 }
 
 THANKS_FOR_BRANDING_REQUEST_MESSAGE = (

--- a/app/main/views/template_email_files.py
+++ b/app/main/views/template_email_files.py
@@ -12,12 +12,10 @@ from app.main.forms import (
     TemplateEmailFilesUploadForm,
 )
 from app.models.template_email_file import TemplateEmailFile
-from app.utils import service_has_permission
 from app.utils.user import user_has_permissions
 
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/files", methods=["GET"])
-@service_has_permission("send_files_via_ui")
 @user_has_permissions("manage_templates")
 def template_email_files(template_id, service_id):
     template = current_service.get_template_with_user_permission_or_403(
@@ -47,7 +45,6 @@ def template_email_files(template_id, service_id):
 
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/files/setup", methods=["GET", "POST"])
-@service_has_permission("send_files_via_ui")
 @user_has_permissions("manage_templates")
 def setup_template_email_files(template_id, service_id):
     template = current_service.get_template_with_user_permission_or_403(
@@ -72,7 +69,6 @@ def setup_template_email_files(template_id, service_id):
     "/services/<uuid:service_id>/templates/<uuid:template_id>/files/<uuid:template_email_file_id>",
     methods=["GET", "POST"],
 )
-@service_has_permission("send_files_via_ui")
 @user_has_permissions("manage_templates")
 def manage_a_template_email_file(service_id, template_id, template_email_file_id):
     template = current_service.get_template_with_user_permission_or_403(
@@ -112,7 +108,6 @@ def manage_a_template_email_file(service_id, template_id, template_email_file_id
     "/services/<uuid:service_id>/templates/<uuid:template_id>/files/<uuid:template_email_file_id>/make-live",
     methods=["POST"],
 )
-@service_has_permission("send_files_via_ui")
 @user_has_permissions("manage_templates")
 def make_file_live(service_id, template_id, template_email_file_id):
     template = current_service.get_template_with_user_permission_or_403(
@@ -136,7 +131,6 @@ def make_file_live(service_id, template_id, template_email_file_id):
 
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/files/upload", methods=["GET", "POST"])
-@service_has_permission("send_files_via_ui")
 @user_has_permissions("manage_templates")
 def upload_template_email_files(template_id, service_id):
     template = current_service.get_template_with_user_permission_or_403(
@@ -175,7 +169,6 @@ def upload_template_email_files(template_id, service_id):
     "/services/<uuid:service_id>/templates/<uuid:template_id>/files/<uuid:template_email_file_id>/change-link-text",
     methods=["GET", "POST"],
 )
-@service_has_permission("send_files_via_ui")
 @user_has_permissions("manage_templates")
 def change_link_text(service_id, template_id, template_email_file_id):
     template = current_service.get_template_with_user_permission_or_403(
@@ -211,7 +204,6 @@ def change_link_text(service_id, template_id, template_email_file_id):
     "/services/<uuid:service_id>/templates/<uuid:template_id>/files/<uuid:template_email_file_id>/change-data-retention",
     methods=["GET", "POST"],
 )
-@service_has_permission("send_files_via_ui")
 @user_has_permissions("manage_templates")
 def change_data_retention_period(service_id, template_id, template_email_file_id):
     template = current_service.get_template_with_user_permission_or_403(
@@ -248,7 +240,6 @@ def change_data_retention_period(service_id, template_id, template_email_file_id
     "/services/<uuid:service_id>/templates/<uuid:template_id>/files/<uuid:template_email_file_id>/change-email-validation",
     methods=["GET", "POST"],
 )
-@service_has_permission("send_files_via_ui")
 @user_has_permissions("manage_templates")
 def change_email_validation(service_id, template_id, template_email_file_id):
     template = current_service.get_template_with_user_permission_or_403(

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -74,7 +74,6 @@ class Service(JSONModel):
         "inbound_sms",
         "international_letters",
         "international_sms",
-        "send_files_via_ui",
         "sms_to_uk_landlines",
     )
 

--- a/app/templates/partials/templates/guidance-send-files-by-email.html
+++ b/app/templates/partials/templates/guidance-send-files-by-email.html
@@ -2,9 +2,8 @@
   Send files by email
 </h2>
 <p class="govuk-body">
-  Use double brackets to add a placeholder field to your template. This will contain a secure link to download the file.
-</p>
-<pre class="formatting-example"><code class="lang-md">Download your file at: ((link_to_file))
-</code></pre>
+ Upload a file, then send your recipients a link to download it. 
+ </p>
+<p class="govuk-body">Select <b class="govuk-!-font-weight-bold">‘Attach files’</b> when you edit a template and follow the instructions. </p>
+<p class="govuk-body">If you use the Notify API to send emails, follow the ‘Send a file by email’ instructions in the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a>.</p>
 
-Next, use the API to upload your file. Follow the instructions to send a file by email in the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a>.

--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -1,4 +1,5 @@
 {% extends "content_template.html" %}
+{% from "components/service-link.html" import service_link %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Using Notify' %}
@@ -13,29 +14,29 @@
 
   <p class="govuk-body">Notify offers a safe and reliable way to send files by email.</p>
 
-  <p class="govuk-body">Upload a file using our API, then send users an email with a link to download it.</p>
+  <p class="govuk-body">Upload a file, then send users an email with a link to download it.</p>
+<p class="govuk-body">Notify uses encrypted links instead of email attachments because:</p>
 
-  <p class="govuk-body">Notify uses encrypted links instead of email attachments because:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>they’re more secure</li>
+  <li>email attachments are often marked as spam</li></ul>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li>they’re more secure</li>
-    <li>email attachments are often marked as spam</li>
-  </ul>
 
-  <h2 class="heading-medium">Protect personal information about your users</h2>
-  <p class="govuk-body">When the recipient clicks the link in the email, they will need to enter their email address. Only someone who knows the recipient’s email address can download the file. This security feature is optional.</p>
-  <p class="govuk-body">You can also choose the length of time that a file is available to download. When deciding this, you should consider:</p>
+  <p class="govuk-body">To send a file by email:</p>
+ <ol class="govuk-list govuk-list--number">
+   <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
+   <li>Add a new email template or choose an existing one.</li>
+   <li>Select <b class="govuk-!-font-weight-bold">Attach files</b>.</li>
+   <li>Upload your file.</li>
+ </ol>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li>the need to protect the recipient’s personal information</li>
-    <li>whether the recipient will need to download the file again later</li>
-  </ul>
+  <p class="govuk-body">For security, choose how long the file is available for and ask recipients to confirm their email address before they can download it.</p>
 
-  <h2 class="heading-medium">How to send files by email</h2>
-  <p class="govuk-body">This is currently an API-only feature. You’ll need a developer on your team to set it up for you.</p>
+  <h2 class="heading-medium">If you use the Notify API</h2>
   <p class="govuk-body">
-    To send a file by email, follow the instructions in our
-    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a>.
-  </p>
+    Follow the instructions in our
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_api_documentation') }}">API documentation</a>.</p>
+  <p class="govuk-body">You’ll need a developer on your team to set it up for you.</p>
+
 
 {% endblock %}

--- a/app/templates/views/service-settings/send-files-by-email.html
+++ b/app/templates/views/service-settings/send-files-by-email.html
@@ -16,26 +16,17 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
       {{ page_header('Send files by email') }}
-      {% if current_service.has_permission('send_files_via_ui') %}
-        <p class="govuk-body">
-          To send a file by email, either:
-        </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>
-            choose a template and select ‘Attach files’
-          </li>
-          <li>
-            or follow the instructions in our <a class="govuk-link govuk-link--no-visited-state" href={{ url_for('main.guidance_api_documentation') }}>API documentation</a>
-          </li>
-        </ul>
-      {% else %}
-        <p class="govuk-body">
-          This is an API-only feature.
-        </p>
-        <p class="govuk-body">
-          To send a file by email, follow the instructions in our <a class="govuk-link govuk-link--no-visited-state" href={{ url_for('main.guidance_api_documentation') }}>API documentation</a>.
-        </p>
-      {% endif %}
+      <p class="govuk-body">
+        To send a file by email, either:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          choose a template and select ‘Attach files’
+        </li>
+        <li>
+          or follow the instructions in our <a class="govuk-link govuk-link--no-visited-state" href={{ url_for('main.guidance_api_documentation') }}>API documentation</a>
+        </li>
+      </ul>
       <h2 class="heading-medium">{% if current_service.contact_link %}Change contact details for{% else %}Add contact details to{% endif %} the file download page</h2>
       <p class="govuk-body">
         You need to include contact details for your service so your users can get in touch if there’s a problem. For example, if the link to download the file you sent them has expired.

--- a/app/templates/views/templates/_email_or_sms_template.html
+++ b/app/templates/views/templates/_email_or_sms_template.html
@@ -17,7 +17,7 @@
 
 {{ template|string }}
 
-{% if template.template_type == "email" and current_service.has_permission("send_files_via_ui") %}
+{% if template.template_type == "email" %}
   <h2 class="govuk-visually-hidden">Added Files</h2>
   <div class="govuk-!-margin-bottom-2">
     <div class="js-stick-at-bottom-when-scrolling">

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -150,7 +150,6 @@ FAKE_TEMPLATE_ID = uuid4()
                 "Receive inbound SMS Off Change your settings for Receive inbound SMS",
                 "Email authentication Off Change your settings for Email authentication",
                 "Sending SMS to UK landlines Off Change your settings for Sending SMS to UK landlines",
-                "Send files via email using admin ui Off Change your settings for Send files via email using admin ui",
             ],
         ),
         (
@@ -184,7 +183,6 @@ FAKE_TEMPLATE_ID = uuid4()
                 "Custom data retention Email – 7 days Change data retention",
                 "Email authentication Off Change your settings for Email authentication",
                 "Sending SMS to UK landlines Off Change your settings for Sending SMS to UK landlines",
-                "Send files via email using admin ui Off Change your settings for Send files via email using admin ui",
             ],
         ),
     ],
@@ -4426,46 +4424,22 @@ def test_cant_archive_inactive_service(
     assert "Delete service" not in {a.text for a in page.select("a.button")}
 
 
-@pytest.mark.parametrize(
-    "extra_permissions, expected_paragraphs",
-    (
-        (
-            [],
-            [
-                "This is an API-only feature.",
-                "To send a file by email, follow the instructions in our API documentation.",
-                "You need to include contact details for your service so your users can get in touch if "
-                "there’s a problem. For example, if the link to download the file you sent them has expired.",
-            ],
-        ),
-        (
-            ["send_files_via_ui"],
-            [
-                "To send a file by email, either:",
-                "choose a template and select ‘Attach files’",
-                "or follow the instructions in our API documentation",
-                "You need to include contact details for your service so your users can get in touch if "
-                "there’s a problem. For example, if the link to download the file you sent them has expired.",
-            ],
-        ),
-    ),
-)
-def test_send_files_by_email_in_page_guidance(
-    client_request,
-    service_one,
-    extra_permissions,
-    expected_paragraphs,
-):
-    service_one["permissions"] += extra_permissions
+def test_send_files_by_email_in_page_guidance(client_request):
     page = client_request.get("main.send_files_by_email_contact_details", service_id=SERVICE_ONE_ID)
-    assert [normalize_spaces(p.text) for p in page.select("main p, main li")] == expected_paragraphs
+    assert [normalize_spaces(p.text) for p in page.select("main p, main li")] == [
+        "To send a file by email, either:",
+        "choose a template and select ‘Attach files’",
+        "or follow the instructions in our API documentation",
+        "You need to include contact details for your service so your users can get in touch if "
+        "there’s a problem. For example, if the link to download the file you sent them has expired.",
+    ]
 
 
 @pytest.mark.parametrize(
-    "endpoint, extra_permissions, extra_args",
+    "endpoint, extra_args",
     (
-        ("main.send_files_by_email_contact_details", [], {}),
-        ("main.setup_template_email_files", ["send_files_via_ui"], {"template_id": sample_uuid()}),
+        ("main.send_files_by_email_contact_details", {}),
+        ("main.setup_template_email_files", {"template_id": sample_uuid()}),
     ),
 )
 @pytest.mark.parametrize(
@@ -4483,11 +4457,9 @@ def test_send_files_by_email_contact_details_prefills_the_form_with_the_existing
     contact_details_type,
     contact_details_value,
     endpoint,
-    extra_permissions,
     extra_args,
 ):
     service_one["contact_link"] = contact_details_value
-    service_one["permissions"] += extra_permissions
 
     page = client_request.get(endpoint, service_id=SERVICE_ONE_ID, **extra_args)
     assert page.select_one(f"input[name=contact_details_type][value={contact_details_type}]").has_attr("checked")
@@ -4495,17 +4467,15 @@ def test_send_files_by_email_contact_details_prefills_the_form_with_the_existing
 
 
 @pytest.mark.parametrize(
-    "endpoint, extra_permissions, extra_args, expected_redirect_endpoint",
+    "endpoint, extra_args, expected_redirect_endpoint",
     (
         (
             "main.send_files_by_email_contact_details",
-            [],
             {},
             "main.service_settings",
         ),
         (
             "main.setup_template_email_files",
-            ["send_files_via_ui"],
             {"template_id": sample_uuid()},
             "main.template_email_files",
         ),
@@ -4532,12 +4502,10 @@ def test_send_files_by_email_contact_details_updates_contact_details_and_redirec
     old_value,
     new_value,
     endpoint,
-    extra_permissions,
     extra_args,
     expected_redirect_endpoint,
 ):
     service_one["contact_link"] = old_value
-    service_one["permissions"] += extra_permissions
 
     client_request.post(
         endpoint,
@@ -4553,17 +4521,15 @@ def test_send_files_by_email_contact_details_updates_contact_details_and_redirec
 
 
 @pytest.mark.parametrize(
-    "endpoint, extra_permissions, extra_args, expected_redirect_endpoint",
+    "endpoint, extra_args, expected_redirect_endpoint",
     (
         (
             "main.send_files_by_email_contact_details",
-            [],
             {},
             "main.service_settings",
         ),
         (
             "main.setup_template_email_files",
-            ["send_files_via_ui"],
             {"template_id": sample_uuid()},
             "main.template_email_files",
         ),
@@ -4579,12 +4545,10 @@ def test_send_files_by_email_contact_details_uses_the_selected_field_when_multip
     no_letter_contact_blocks,
     single_sms_sender,
     endpoint,
-    extra_permissions,
     extra_args,
     expected_redirect_endpoint,
 ):
     service_one["contact_link"] = "http://www.old-url.com"
-    service_one["permissions"] += extra_permissions
 
     client_request.post(
         endpoint,
@@ -4625,10 +4589,10 @@ def test_send_files_by_email_contact_details_page(
 
 
 @pytest.mark.parametrize(
-    "endpoint, extra_permissions, extra_args",
+    "endpoint, extra_args",
     (
-        ("main.send_files_by_email_contact_details", [], {}),
-        ("main.setup_template_email_files", ["send_files_via_ui"], {"template_id": sample_uuid()}),
+        ("main.send_files_by_email_contact_details", {}),
+        ("main.setup_template_email_files", {"template_id": sample_uuid()}),
     ),
 )
 def test_send_files_by_email_contact_details_displays_error_message_when_no_radio_button_selected(
@@ -4636,10 +4600,8 @@ def test_send_files_by_email_contact_details_displays_error_message_when_no_radi
     service_one,
     mock_get_service_email_template,
     endpoint,
-    extra_permissions,
     extra_args,
 ):
-    service_one["permissions"] += extra_permissions
     page = client_request.post(
         endpoint,
         service_id=SERVICE_ONE_ID,
@@ -4657,10 +4619,10 @@ def test_send_files_by_email_contact_details_displays_error_message_when_no_radi
 
 
 @pytest.mark.parametrize(
-    "endpoint, extra_permissions, extra_args",
+    "endpoint, extra_args",
     (
-        ("main.send_files_by_email_contact_details", [], {}),
-        ("main.setup_template_email_files", ["send_files_via_ui"], {"template_id": sample_uuid()}),
+        ("main.send_files_by_email_contact_details", {}),
+        ("main.setup_template_email_files", {"template_id": sample_uuid()}),
     ),
 )
 @pytest.mark.parametrize(
@@ -4679,12 +4641,10 @@ def test_send_files_by_email_contact_details_does_not_update_invalid_contact_det
     invalid_value,
     error,
     endpoint,
-    extra_permissions,
     extra_args,
     mocker,
 ):
     service_one["contact_link"] = "http://example.com/"
-    service_one["permissions"] += extra_permissions
 
     page = client_request.post(
         endpoint,

--- a/tests/app/main/views/test_template_email_files.py
+++ b/tests/app/main/views/test_template_email_files.py
@@ -56,7 +56,6 @@ def test_template_email_files_manage_files_page_displays_the_right_files_in_the_
     template_content,
     expected_filenames_on_page,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     service_one["contact_link"] = "https://example.gov.uk"
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -90,7 +89,6 @@ def test_template_email_files_manage_files_page_raises_an_error_for_invalid_temp
     fake_uuid,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     mocker.patch(
         "app.service_api_client.get_service_template",
         side_effect=HTTPError(response=Mock(status_code=404)),
@@ -110,8 +108,6 @@ def test_template_email_files_manage_files_page_if_service_has_no_contact_link(
     fake_uuid,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
-
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={
@@ -139,7 +135,6 @@ def test_template_email_files_manage_files_page_when_there_are_no_files_to_displ
     fake_uuid,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     service_one["contact_link"] = "https://example.gov.uk"
 
     mocker.patch(
@@ -171,8 +166,6 @@ def test_manage_a_template_email_file(
     test_data_for_a_template_email_file,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
-
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={
@@ -240,7 +233,6 @@ def test_post_delete_to_manage_a_template_email_file_updates_and_redirects(
     test_data_for_a_template_email_file,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={
@@ -283,7 +275,6 @@ def test_manage_a_template_email_file_raises_404_for_invalid_template_email_file
     client_request,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={
@@ -336,7 +327,6 @@ def test_file_settings_pages_for_link_text_and_retention_period(
     path_segment,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     template_id = fake_uuid
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -375,7 +365,6 @@ def test_file_settings_pages_for_email_validation(
     test_template_email_files_data,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     template_id = fake_uuid
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -438,7 +427,6 @@ def test_file_settings_page_post_the_right_data_for_retention_period_and_link_te
     test_data_for_a_template_email_file,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={
@@ -490,7 +478,6 @@ def test_validate_retention_period(
     expected_error_message,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={
@@ -529,7 +516,6 @@ def test_file_settings_page_post_the_right_data_for_email_validation(
     test_data_for_a_template_email_file,
     mocker,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={
@@ -575,7 +561,6 @@ def test_create_file_redirects_to_manage_files_page(
     mock_update_service,
     mock_get_service_email_template,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     service_one["contact_link"] = "htttps://example.gov.uk"
     active_user_with_permissions["permissions"][SERVICE_ONE_ID] = ["view_activity", "manage_templates"]
     client_request.login(active_user_with_permissions)
@@ -622,7 +607,6 @@ def test_create_file_redirects_to_manage_files_page(
 
 
 def test_make_live_is_post_only(client_request, service_one, fake_uuid):
-    service_one["permissions"] += ["send_files_via_ui"]
     client_request.get(
         "main.make_file_live",
         service_id=SERVICE_ONE_ID,
@@ -662,7 +646,6 @@ def test_make_live_endpoint_calls_update_with_correct_args(
     template_content,
     expected_calls,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={
@@ -712,7 +695,6 @@ def test_change_retention_period_page(
 ):
     test_template_email_files_data[0]["pending"] = pending
     test_template_email_files_data[1]["pending"] = pending
-    service_one["permissions"] += ["send_files_via_ui"]
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={
@@ -749,7 +731,6 @@ def test_setup_template_email_files_page(
     fake_uuid,
     mock_get_service_email_template,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     page = client_request.get(
         "main.setup_template_email_files",
         service_id=SERVICE_ONE_ID,
@@ -773,7 +754,6 @@ def test_setup_template_email_files_page_without_manage_service_permission(
     active_user_with_permissions,
     mock_update_service,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     active_user_with_permissions["permissions"][SERVICE_ONE_ID] = ["view_activity", "manage_templates"]
     client_request.login(active_user_with_permissions)
     page = client_request.get(
@@ -804,28 +784,20 @@ def test_setup_template_email_files_page_without_manage_service_permission(
 
 
 @pytest.mark.parametrize(
-    "extra_permissions, template_type, contact_link, expected_status",
+    "template_type, contact_link, expected_status",
     (
-        # Without correct permission
-        ([], "email", "", 403),
-        ([], "sms", "", 403),
-        ([], "letter", "", 403),
-        ([], "email", "http://example.com", 403),
-        ([], "sms", "http://example.com", 403),
-        ([], "letter", "http://example.com", 403),
-        # With permission but missing contact link
-        (["send_files_via_ui"], "email", "", 403),
-        # With permission but different template types
-        (["send_files_via_ui"], "email", "http://example.com", 200),
-        (["send_files_via_ui"], "sms", "http://example.com", 404),
-        (["send_files_via_ui"], "letter", "http://example.com", 404),
+        # Missing contact link
+        ("email", "", 403),
+        # With different template types
+        ("email", "http://example.com", 200),
+        ("sms", "http://example.com", 404),
+        ("letter", "http://example.com", 404),
     ),
 )
 def test_get_upload_file_page(
     client_request,
     service_one,
     fake_uuid,
-    extra_permissions,
     template_type,
     contact_link,
     expected_status,
@@ -840,7 +812,6 @@ def test_get_upload_file_page(
             )
         },
     )
-    service_one["permissions"] += extra_permissions
     service_one["contact_link"] = contact_link
     page = client_request.get(
         "main.upload_template_email_files",
@@ -869,7 +840,6 @@ def test_get_upload_file_page(
 
 
 def test_get_upload_file_page_404s_if_invalid_template_id(client_request, service_one, fake_uuid, mocker):
-    service_one["permissions"] += ["send_files_via_ui"]
     mocker.patch(
         "app.notify_client.service_api_client.service_api_client.get_service_template",
         side_effect=HTTPError(response=Mock(status_code=404)),
@@ -888,7 +858,6 @@ def test_upload_file_page_requires_file(
     service_one,
     mock_get_service_email_template,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     service_one["contact_link"] = "https://example.com"
     page = client_request.post(
         "main.upload_template_email_files",
@@ -929,7 +898,6 @@ def test_upload_file_page_validates_extentions(
     mock_s3 = mocker.patch("app.s3_client.s3_template_email_file_upload_client.utils_s3upload")
     mock_post = mocker.patch("app.template_email_file_client.post")
     mock_template_update = mocker.patch("app.service_api_client.update_service_template")
-    service_one["permissions"] += ["send_files_via_ui"]
     service_one["contact_link"] = "https://example.com"
     if not expected_error_message:
         with open(test_file, "rb") as file:
@@ -980,7 +948,6 @@ def test_upload_file_does_not_update_template_content(
     mocker,
     template_content,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     service_one["contact_link"] = "https://example.com"
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -1043,7 +1010,6 @@ def test_upload_file_returns_error_if_file_with_same_name_exists(
     mocker,
     existing_filename,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     service_one["contact_link"] = "https://example.com"
     mocker.patch(
         "app.service_api_client.get_service_template",
@@ -1098,7 +1064,6 @@ def test_upload_file_returns_error_if_placeholder_exists_in_subject(
     mocker,
     subject,
 ):
-    service_one["permissions"] += ["send_files_via_ui"]
     service_one["contact_link"] = "https://example.com"
     mocker.patch(
         "app.service_api_client.get_service_template",

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -4778,14 +4778,16 @@ def test_letter_attachment_preview_image_shows_overlay_when_content_outside_prin
 
 
 @pytest.mark.parametrize(
-    "extra_permissions, template_type, email_files, expected_button_text, expected_button_endpoint, expected_hint",
+    "template_type, email_files, expected_button_text, expected_button_endpoint, expected_hint",
     (
-        ([], "email", None, None, None, None),
-        ([], "sms", None, None, None, None),
-        ([], "letter", None, "Attach pages", "main.letter_template_attach_pages", None),
-        (["send_files_via_ui"], "email", None, "Attach files", "main.template_email_files", "No files added"),
         (
-            ["send_files_via_ui"],
+            "email",
+            None,
+            "Attach files",
+            "main.template_email_files",
+            "No files added",
+        ),
+        (
             "email",
             [
                 {
@@ -4800,7 +4802,6 @@ def test_letter_attachment_preview_image_shows_overlay_when_content_outside_prin
             "1 file added",
         ),
         (
-            ["send_files_via_ui"],
             "email",
             [
                 {
@@ -4820,8 +4821,20 @@ def test_letter_attachment_preview_image_shows_overlay_when_content_outside_prin
             "main.template_email_files",
             "2 files added",
         ),
-        (["send_files_via_ui"], "sms", None, None, None, None),
-        (["send_files_via_ui"], "letter", None, "Attach pages", "main.letter_template_attach_pages", None),
+        (
+            "sms",
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "letter",
+            None,
+            "Attach pages",
+            "main.letter_template_attach_pages",
+            None,
+        ),
     ),
 )
 def test_attach_files_button(
@@ -4831,7 +4844,6 @@ def test_attach_files_button(
     mock_get_page_counts_for_letter,
     single_letter_contact_block,
     fake_uuid,
-    extra_permissions,
     template_type,
     email_files,
     expected_button_text,
@@ -4849,7 +4861,6 @@ def test_attach_files_button(
             )
         },
     )
-    service_one["permissions"] += extra_permissions
     page = client_request.get(
         "main.view_template",
         service_id=SERVICE_ONE_ID,
@@ -4862,7 +4873,7 @@ def test_attach_files_button(
     if expected_button_text or expected_button_endpoint:
         assert button["href"] == url_for(expected_button_endpoint, service_id=SERVICE_ONE_ID, template_id=fake_uuid)
         assert normalize_spaces(button.text) == expected_button_text
-        if template_type == "email" and extra_permissions:
+        if template_type == "email":
             assert normalize_spaces(page.select_one("h2.govuk-visually-hidden").text) == "Added Files"
     else:
         assert button is None


### PR DESCRIPTION
_🚨 Do not merge until we are ready to launch 🚨_

***

This releases the feature to all services by removing the permission checks.

It assumes we no longer want the ability to switch the feature on or off on a per-service basis.

The API does not check for the permission anywhere: https://github.com/search?q=repo%3Aalphagov%2Fnotifications-api%20send_files_via_ui&type=code