### PR TITLE
Re-deploy Encrypt proposed new user password

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY")
     DANGEROUS_SALT = os.environ.get("DANGEROUS_SALT")
     ZENDESK_API_KEY = os.environ.get("ZENDESK_API_KEY")
+    NEW_PASSWORD_ENCRYPTION_KEY = os.environ.get("NEW_PASSWORD_ENCRYPTION_KEY")
 
     # if we're not on cloudfoundry, we can get to this app from localhost. but on cloudfoundry its different
     ADMIN_BASE_URL = os.environ.get("ADMIN_BASE_URL", "http://localhost:6012")
@@ -126,6 +127,9 @@ class Development(Config):
     ADMIN_CLIENT_SECRET = "dev-notify-secret-key"
     DANGEROUS_SALT = "dev-notify-salt"
     SECRET_KEY = "dev-notify-secret-key"
+    # Fernet key must be 32 url-safe base64-encoded bytes:
+    NEW_PASSWORD_ENCRYPTION_KEY = "vGUd-3kOibOKqJVMIdfLPOXB4OmSbzRRHr8832ItpzM="
+
     API_HOST_NAME = os.environ.get("API_HOST_NAME", "http://localhost:6011")
     ANTIVIRUS_API_HOST = os.environ.get("ANTIVIRUS_API_HOST", "http://localhost:6016")
     ANTIVIRUS_API_KEY = "test-key"

--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -14,7 +14,7 @@ from app.main import main
 from app.main.forms import NewPasswordForm
 from app.models.token import Token
 from app.models.user import User
-from app.utils.login import log_in_user
+from app.utils.login import encrypt_new_password, log_in_user
 
 
 @main.route("/new-password/<path:token>", methods=["GET", "POST"])
@@ -43,7 +43,12 @@ def new_password(token):
 
     if form.validate_on_submit():
         user.reset_failed_login_count()
-        session["user_details"] = {"id": user.id, "email": user.email_address, "password": form.new_password.data}
+        session["user_details"] = {
+            "id": user.id,
+            "email": user.email_address,
+            "password": form.new_password.data,
+            "new_password": encrypt_new_password(form.new_password.data),
+        }
         if user.email_auth:
             # they've just clicked an email link, so have done an email auth journey anyway. Just log them in.
             return log_in_user(user.id)

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -1,6 +1,7 @@
 from functools import wraps
 
-from flask import redirect, request, session, url_for
+from cryptography.fernet import Fernet, InvalidToken
+from flask import current_app, flash, redirect, request, session, url_for
 
 from app.models.user import User
 
@@ -22,8 +23,19 @@ def log_in_user(user_id):
         # the user will have a new current_session_id set by the API - store it in the cookie for future requests
         session["current_session_id"] = user.current_session_id
         # Check if coming from new password page
-        if "password" in session.get("user_details", {}):
+        if "new_password" in session.get("user_details", {}):
+            try:
+                user.update_password(decrypt_new_password(session["user_details"]["new_password"]))
+            except InvalidToken:
+                current_app.logger.warning(
+                    "Error during new password decryption for user id %s",
+                    user_id,
+                )
+                flash("There was a problem with your password. Please try again.")
+                return redirect(url_for("main.sign_in"))
+        elif "password" in session.get("user_details", {}):
             user.update_password(session["user_details"]["password"])
+
         user.activate()
         user.login()
     finally:
@@ -62,3 +74,13 @@ def is_safe_redirect_url(target):
     host_url = urlparse(request.host_url)
     redirect_url = urlparse(urljoin(request.host_url, target))
     return redirect_url.scheme in ("http", "https") and host_url.netloc == redirect_url.netloc
+
+
+def encrypt_new_password(new_password: str) -> bytes:
+    fernet = Fernet(current_app.config["NEW_PASSWORD_ENCRYPTION_KEY"].encode("utf-8"))
+    return fernet.encrypt(new_password.encode(encoding="utf-8"))
+
+
+def decrypt_new_password(new_password: bytes) -> str:
+    fernet = Fernet(current_app.config["NEW_PASSWORD_ENCRYPTION_KEY"].encode("utf-8"))
+    return fernet.decrypt(new_password).decode(encoding="utf-8")

--- a/requirements.in
+++ b/requirements.in
@@ -8,11 +8,12 @@ Flask-Login~=0.6
 
 Pillow~=12.1
 
+openpyxl~=3.1
 pyexcel~=0.7
 pyexcel-io~=0.6
 pyexcel-xls~=0.7
 pyexcel-odsr~=0.6
-openpyxl~=3.1
+
 notifications-python-client==10.0.0
 fido2~=1.1
 

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 from itsdangerous import SignatureExpired
 from notifications_utils.url_safe_token import generate_token
 
+from app.utils.login import decrypt_new_password
 from tests.conftest import SERVICE_ONE_ID, url_for_endpoint_with_token
 
 
@@ -72,6 +73,12 @@ def test_should_redirect_to_two_factor_when_password_reset_is_successful(
         _expected_redirect=url_for(".two_factor_sms", next=redirect_url),
     )
     mock_get_user_by_email_request_password_reset.assert_called_once_with(user["email_address"])
+
+    with client_request.session_transaction() as session:
+        assert decrypt_new_password(session["user_details"]["new_password"]) == "a-new_password"
+        assert session["user_details"]["password"] == "a-new_password"
+        assert session["user_details"]["id"] == user["id"]
+        assert session["user_details"]["email"] == user["email_address"]
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -1,8 +1,11 @@
+import logging
 from unittest.mock import PropertyMock
 
 import pytest
+from cryptography.fernet import Fernet
 from flask import url_for
 
+from app.utils.login import encrypt_new_password
 from tests.app.test_event_handlers import event_dict
 from tests.conftest import (
     SERVICE_ONE_ID,
@@ -200,6 +203,33 @@ def test_two_factor_sms_should_set_password_when_new_password_exists_in_session(
         session["user_details"] = {
             "id": api_user_active["id"],
             "email": api_user_active["email_address"],
+            "new_password": encrypt_new_password("changedpassword"),
+        }
+
+    client_request.post(
+        "main.two_factor_sms",
+        _data={"sms_code": "12345"},
+        _expected_redirect=url_for("main.show_accounts_or_dashboard"),
+    )
+
+    mock_update_user_password.assert_called_once_with(
+        api_user_active["id"],
+        "changedpassword",
+    )
+
+
+def test_two_factor_sms_should_set_password_when_new_password_exists_in_session_OLD_WAY(
+    client_request,
+    api_user_active,
+    mock_update_user_password,
+    mock_email_validated_recently,
+):
+    client_request.logout()
+
+    with client_request.session_transaction() as session:
+        session["user_details"] = {
+            "id": api_user_active["id"],
+            "email": api_user_active["email_address"],
             "password": "changedpassword",
         }
 
@@ -213,6 +243,70 @@ def test_two_factor_sms_should_set_password_when_new_password_exists_in_session(
         api_user_active["id"],
         "changedpassword",
     )
+
+
+@pytest.mark.parametrize("new_password", ["just-a-string", b"bytes-string"])
+def test_two_factor_sms_should_return_error_if_new_password_not_encrypted(
+    client_request,
+    api_user_active,
+    mock_update_user_password,
+    mock_email_validated_recently,
+    caplog,
+    new_password,
+):
+    client_request.logout()
+
+    with client_request.session_transaction() as session:
+        session["user_details"] = {
+            "id": api_user_active["id"],
+            "email": api_user_active["email_address"],
+            "new_password": new_password,
+        }
+    with caplog.at_level(logging.WARNING):
+        page = client_request.post(
+            "main.two_factor_sms",
+            _data={"sms_code": "12345"},
+            _follow_redirects=True,
+        )
+
+    assert "Error during new password decryption for user id 6ce466d0-fd6a-11e5-82f5-e0accb9d11a6" in caplog.messages
+
+    assert page.select_one("h1").string == "Sign in"
+    assert page.select_one(".banner-dangerous").text.strip() == (
+        "There was a problem with your password. Please try again."
+    )
+
+    mock_update_user_password.assert_not_called()
+
+
+def test_two_factor_sms_should_return_error_if_new_password_encrypted_with_wrong_key(
+    client_request, api_user_active, mock_update_user_password, mock_email_validated_recently, caplog
+):
+    client_request.logout()
+
+    wrong_key_fernet = Fernet(Fernet.generate_key())
+
+    with client_request.session_transaction() as session:
+        session["user_details"] = {
+            "id": api_user_active["id"],
+            "email": api_user_active["email_address"],
+            "new_password": wrong_key_fernet.encrypt(b"changedpassword"),
+        }
+    with caplog.at_level(logging.WARNING):
+        page = client_request.post(
+            "main.two_factor_sms",
+            _data={"sms_code": "12345"},
+            _follow_redirects=True,
+        )
+
+    assert "Error during new password decryption for user id 6ce466d0-fd6a-11e5-82f5-e0accb9d11a6" in caplog.messages
+
+    assert page.select_one("h1").string == "Sign in"
+    assert page.select_one(".banner-dangerous").text.strip() == (
+        "There was a problem with your password. Please try again."
+    )
+
+    mock_update_user_password.assert_not_called()
 
 
 def test_two_factor_sms_returns_error_when_user_is_locked(


### PR DESCRIPTION
## About this PR
This is a redeploy of a PR that [got reverted](https://github.com/alphagov/notifications-admin/pull/5867). First time round there was an issue with the deploy - `NEW_PASSWORD_ENCRYPTION_KEY` was not present in staging environment.

## How did this happen:
I run [the script to upload new credentials](https://github.com/alphagov/notifications-manuals/wiki/Deploying-a-Notify-Development-Environment#run-upload-credentials-to-set-environment-specific-variables-needed-by-the-app-at-runtime) for all environments. At the time the instructions said that I will not see output and that it's normal. It also didn't prompt me to check the credentials in AWS, and I didn't think to do it.

So I run the script, and I thought the credentials were uploaded successfully, but they were not. And when I tried to deploy, they weren't there.

## How we fixed it and ensured this issue will not happen again:
- with @emmetdev we compared how the script works on his machine vs my machine. On his machine, it showed output, and took much longer, and the new credential actually got uploaded. After some sleuthing, we found that the issue was that my path to `PASSWORD_STORE_DIR` had a tilda in it, instead of being a full path. After we changed the constant to point to a full path to credentials repository, the script started working correctly
- we checked that the new credential got uploaded correctly in AWS
- we changed the instructions [for uploading new credentials](https://github.com/alphagov/notifications-manuals/wiki/Deploying-a-Notify-Development-Environment#run-upload-credentials-to-set-environment-specific-variables-needed-by-the-app-at-runtime) to warn colleagues that the path to credentials repo needs to be a full path, to tell colleagues what should be the script output, that the script should take a while to run, and that they should check the Parameter Store to ensure their credentials uploaded successfully.

### How to review:
The code review for this has been done in the PR for the original release: https://github.com/alphagov/notifications-admin/pull/5855

If you want to be diligent, log in to staging and prod environments, go to Parameter Store, and check that new_password_encryption_key is in there.