### PR TITLE
Remove unused Javascript from main.js

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -7,8 +7,4 @@ if (document.body.classList.contains('govuk-frontend-supported')) {
   $(() => GOVUK.notifyModules.start());
 
   $(() => $('.error-message, .govuk-error-message').eq(0).parent('label').next('input').trigger('focus'));
-
-  $(() => $('.govuk-header__container').on('click', function() {
-    $(this).css('border-color', '#1d70b8');
-  }));
 }


### PR DESCRIPTION
Introduced in https://github.com/alphagov/notifications-admin/commit/6f389d044e65dc1446178a581d56d33da6195d18

Now no longer needed as rebrand removed the header container bottom border.