### PR TITLE
Copy templates also copies files

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -479,6 +479,16 @@ def copy_template(service_id, template_id):
             letter_welsh_content=template.get_raw("letter_welsh_content"),
             has_unsubscribe_link=template.get_raw("has_unsubscribe_link"),
         )["data"]
+        if template.template_type == "email":
+            if new_files := template.email_files:
+                for file in new_files:
+                    file.copy_file(
+                        destination_template_id=new_template["id"],
+                        destination_service_id=current_service.id,
+                        retention_period=file.retention_period,
+                        validate_users_email=file.validate_users_email,
+                        link_text=file.link_text,
+                    )
         if template.template_type == "letter" and template.get_raw("letter_attachment"):
             _copy_letter_attachment(from_template=template, to_template=new_template)
         return redirect(url_for(".view_template", service_id=service_id, template_id=new_template["id"]))

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -17,6 +17,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils.formatters import formatted_list
 from notifications_utils.pdf import pdf_page_count
@@ -464,6 +465,15 @@ def copy_template(service_id, template_id):
     form = CopyTemplateForm(template_id=template.id, name=template.name, parent_folder_id=to_folder_id)
 
     if request.method == "POST":
+        files_to_copy = getattr(template, "email_files", False)
+        if template.template_type == "email" and files_to_copy and not current_service.contact_link:
+            flash(
+                Markup(
+                    f"You need to add contact details for your service. "
+                    f'<p class="govuk-body govuk-!-font-weight-bold"><a href="{url_for("main.send_files_by_email_contact_details", service_id=service_id)}" class="govuk-link">Add contact details for your service</a></p>'  # noqa: E501
+                )
+            )
+            return redirect(url_for("main.choose_template_to_copy", service_id=service_id))
         new_template = service_api_client.create_service_template(
             name=form.name.data,
             type_=template.template_type,
@@ -476,6 +486,16 @@ def copy_template(service_id, template_id):
             letter_welsh_content=template.get_raw("letter_welsh_content"),
             has_unsubscribe_link=template.get_raw("has_unsubscribe_link"),
         )["data"]
+        if template.template_type == "email" and files_to_copy:
+            for file in files_to_copy:
+                file.copy_file(
+                    destination_template_id=new_template["id"],
+                    source_service_id=from_service_id,
+                    destination_service_id=current_service.id,
+                    retention_period=file.retention_period,
+                    validate_users_email=file.validate_users_email,
+                    link_text=file.link_text,
+                )
         if template.template_type == "letter" and template.get_raw("letter_attachment"):
             _copy_letter_attachment(from_template=template, to_template=new_template)
         return redirect(url_for(".view_template", service_id=service_id, template_id=new_template["id"]))

--- a/app/models/template_email_file.py
+++ b/app/models/template_email_file.py
@@ -13,7 +13,10 @@ from notifications_utils.serialised_model import SerialisedModelCollection
 from notifications_utils.template import Template
 
 from app.models import JSONModel
-from app.s3_client.s3_template_email_file_upload_client import upload_template_email_file_to_s3
+from app.s3_client.s3_template_email_file_upload_client import (
+    download_template_email_file_from_s3,
+    upload_template_email_file_to_s3,
+)
 
 
 def _get_file_location(file_id: uuid, service_id: uuid) -> str:
@@ -48,6 +51,40 @@ class TemplateEmailFile(JSONModel):
             created_by_id=current_user.id,
         )
         return file_id
+
+    def copy_file(
+        self,
+        destination_template_id,
+        source_service_id,
+        destination_service_id,
+        validate_users_email,
+        retention_period,
+        link_text,
+    ):
+        from app import current_user, template_email_file_client
+
+        destination_file_id = str(uuid.uuid4())
+        source_file_location = _get_file_location(self.id, source_service_id)
+        destination_file_bytes = download_template_email_file_from_s3(file_location=source_file_location).read()
+        destination_file_location = _get_file_location(file_id=destination_file_id, service_id=destination_service_id)
+        upload_template_email_file_to_s3(data=destination_file_bytes, file_location=destination_file_location)
+        template_email_file_client.create_file(
+            file_id=destination_file_id,
+            service_id=destination_service_id,
+            template_id=destination_template_id,
+            filename=self.filename,
+            created_by_id=current_user.id,
+        )
+
+        return template_email_file_client.update_file(
+            service_id=destination_service_id,
+            template_id=destination_template_id,
+            file_id=destination_file_id,
+            pending=False,
+            link_text=link_text,
+            retention_period=retention_period,
+            validate_users_email=validate_users_email,
+        )
 
     def update(self, **kwargs):
         from app import template_email_file_client

--- a/app/models/template_email_file.py
+++ b/app/models/template_email_file.py
@@ -13,7 +13,10 @@ from notifications_utils.serialised_model import SerialisedModelCollection
 from notifications_utils.template import Template
 
 from app.models import JSONModel
-from app.s3_client.s3_template_email_file_upload_client import upload_template_email_file_to_s3
+from app.s3_client.s3_template_email_file_upload_client import (
+    download_template_email_file_from_s3,
+    upload_template_email_file_to_s3,
+)
 
 
 def _get_file_location(file_id: uuid, service_id: uuid) -> str:
@@ -48,6 +51,40 @@ class TemplateEmailFile(JSONModel):
             created_by_id=current_user.id,
         )
         return file_id
+
+    def copy_file(
+        self,
+        destination_template_id,
+        destination_service_id,
+        validate_users_email,
+        retention_period,
+        link_text,
+    ):
+        from app import current_user, template_email_file_client
+
+        destination_file_id = str(uuid.uuid4())
+        source_file_location = _get_file_location(self.id, self.service_id)
+        destination_file_bytes = download_template_email_file_from_s3(file_location=source_file_location).read()
+        destination_file_location = _get_file_location(file_id=destination_file_id, service_id=destination_service_id)
+        upload_template_email_file_to_s3(data=destination_file_bytes, file_location=destination_file_location)
+
+        template_email_file_client.create_file(
+            file_id=destination_file_id,
+            service_id=destination_service_id,
+            template_id=destination_template_id,
+            filename=self.filename,
+            created_by_id=current_user.id,
+        )
+
+        return template_email_file_client.update_file(
+            service_id=destination_service_id,
+            template_id=destination_template_id,
+            file_id=destination_file_id,
+            pending=False,
+            link_text=link_text,
+            retention_period=retention_period,
+            validate_users_email=validate_users_email,
+        )
 
     def update(self, **kwargs):
         from app import template_email_file_client

--- a/app/s3_client/s3_template_email_file_upload_client.py
+++ b/app/s3_client/s3_template_email_file_upload_client.py
@@ -1,4 +1,5 @@
 from flask import current_app
+from notifications_utils.s3 import s3download as utils_s3download
 from notifications_utils.s3 import s3upload as utils_s3upload
 
 
@@ -12,3 +13,7 @@ def upload_template_email_file_to_s3(data, file_location):
         file_location=file_location,
         metadata=metadata,
     )
+
+
+def download_template_email_file_from_s3(file_location):
+    return utils_s3download(bucket_name=current_app.config["S3_BUCKET_TEMPLATE_EMAIL_FILES"], filename=file_location)

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2735,6 +2735,81 @@ def test_post_copy_template(
     ]
 
 
+def test_post_copy_template_with_file(
+    client_request,
+    active_user_with_permissions,
+    mock_get_service,
+    multiple_sms_senders,
+    mock_get_service_email_template_with_file,
+    mock_get_service_templates,
+    mock_get_organisations_and_services_for_user,
+    fake_uuid,
+    mock_create_service_template,
+    mocker,
+):
+    active_user_with_permissions["services"].append(SERVICE_TWO_ID)
+    active_user_with_permissions["permissions"][SERVICE_TWO_ID] = active_user_with_permissions["permissions"][
+        SERVICE_ONE_ID
+    ]
+    s3_upload_mock = mocker.patch("app.s3_client.s3_template_email_file_upload_client.utils_s3upload")
+    s3_download_mock = mocker.patch("app.s3_client.s3_template_email_file_upload_client.utils_s3download")
+    template_email_file_client_create_file_mock = mocker.patch(
+        "app.notify_client.template_email_file_client.TemplateEmailFileClient.create_file"
+    )
+    template_email_file_client_update_file_mock = mocker.patch(
+        "app.notify_client.template_email_file_client.TemplateEmailFileClient.update_file"
+    )
+    mocker.patch("uuid.uuid4", return_value=fake_uuid)
+    client_request.post(
+        "main.copy_template",
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_TWO_ID,
+        template_id=TEMPLATE_ONE_ID,
+        _data={
+            "service": SERVICE_ONE_ID,
+            "name": "Two week reminder (copy)",
+        },
+        _expected_status=302,
+    )
+    assert mock_create_service_template.call_args_list == [
+        mocker.call(
+            name="Two week reminder (copy)",
+            type_="email",
+            service_id=SERVICE_ONE_ID,
+            parent_folder_id=None,
+            subject="Your ((thing)) is due soon",
+            content="Your vehicle tax expires on ((date)). Please click the file ((example.pdf))",
+            letter_languages=None,
+            letter_welsh_subject=None,
+            letter_welsh_content=None,
+            has_unsubscribe_link=None,
+        )
+    ]
+    assert template_email_file_client_create_file_mock.call_args_list == [
+        mocker.call(
+            file_id=fake_uuid,
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            filename="example.pdf",
+            created_by_id=active_user_with_permissions["id"],
+        )
+    ]
+    assert template_email_file_client_update_file_mock.call_args_list == [
+        mocker.call(
+            file_id=fake_uuid,
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            pending=False,
+            link_text="example file",
+            retention_period=12,
+            validate_users_email=True,
+        )
+    ]
+
+    s3_upload_mock.assert_called_once()
+    s3_download_mock.assert_called_once()
+
+
 def test_post_copy_template_into_folder(
     client_request,
     active_user_with_permissions,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -17,6 +17,7 @@ from app.models.service import Service
 from tests import (
     NotifyBeautifulSoup,
     sample_uuid,
+    service_json,
     template_json,
     template_version_json,
     validate_route_permission,
@@ -2838,6 +2839,124 @@ def test_post_copy_template(
             has_unsubscribe_link=None,
         )
     ]
+
+
+def test_post_copy_template_with_email_files_without_contact_link_redirects(
+    client_request,
+    active_user_with_permissions,
+    mock_get_service,
+    multiple_sms_senders,
+    mock_get_service_email_template_with_file,
+    mock_get_service_templates,
+    mock_get_organisations_and_services_for_user,
+    mock_create_service_template,
+    mock_get_no_api_keys,
+    mock_s3_download,
+    mocker,
+):
+    active_user_with_permissions["services"].append(SERVICE_TWO_ID)
+    active_user_with_permissions["permissions"][SERVICE_TWO_ID] = active_user_with_permissions["permissions"][
+        SERVICE_ONE_ID
+    ]
+    page = client_request.post(
+        "main.copy_template",
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_TWO_ID,
+        template_id=TEMPLATE_ONE_ID,
+        _data={
+            "service": SERVICE_ONE_ID,
+            "name": "Two week reminder (copy)",
+        },
+        _expected_status=200,
+        _follow_redirects=True,
+    )
+    assert not mock_create_service_template.call_args_list
+    assert (
+        normalize_spaces(page.select_one(".banner-dangerous"))
+        == "You need to add contact details for your service. Add contact details for your service"
+    )
+    assert normalize_spaces(page.select_one(".heading-large")) == "Choose an existing template to copy"
+
+
+@pytest.mark.parametrize("copy_to_different_service", [True, False])
+def test_post_copy_template_with_file(
+    client_request,
+    active_user_with_permissions,
+    mock_get_service,
+    multiple_sms_senders,
+    mock_get_service_email_template_with_file,
+    mock_get_service_templates,
+    mock_get_organisations_and_services_for_user,
+    fake_uuid,
+    mock_create_service_template,
+    mocker,
+    copy_to_different_service,
+):
+    active_user_with_permissions["services"].append(SERVICE_TWO_ID)
+    active_user_with_permissions["permissions"][SERVICE_TWO_ID] = active_user_with_permissions["permissions"][
+        SERVICE_ONE_ID
+    ]
+    mocker.patch(
+        "app.service_api_client.get_service",
+        side_effect=lambda service_id: {"data": service_json(service_id, contact_link="https://example.com")},
+    )
+    s3_upload_mock = mocker.patch("app.s3_client.s3_template_email_file_upload_client.utils_s3upload")
+    s3_download_mock = mocker.patch("app.s3_client.s3_template_email_file_upload_client.utils_s3download")
+    template_email_file_client_create_file_mock = mocker.patch(
+        "app.notify_client.template_email_file_client.TemplateEmailFileClient.create_file"
+    )
+    template_email_file_client_update_file_mock = mocker.patch(
+        "app.notify_client.template_email_file_client.TemplateEmailFileClient.update_file"
+    )
+    mocker.patch("uuid.uuid4", return_value=fake_uuid)
+    client_request.post(
+        "main.copy_template",
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_TWO_ID if copy_to_different_service else SERVICE_ONE_ID,
+        template_id=TEMPLATE_ONE_ID,
+        _data={
+            "service": SERVICE_ONE_ID,
+            "name": "Two week reminder (copy)",
+        },
+        _expected_status=302,
+    )
+    assert mock_create_service_template.call_args_list == [
+        mocker.call(
+            name="Two week reminder (copy)",
+            type_="email",
+            service_id=SERVICE_ONE_ID,
+            parent_folder_id=None,
+            subject="Your ((thing)) is due soon",
+            content="Your vehicle tax expires on ((date)). Please click the file ((example.pdf))",
+            letter_languages=None,
+            letter_welsh_subject=None,
+            letter_welsh_content=None,
+            has_unsubscribe_link=None,
+        )
+    ]
+    assert template_email_file_client_create_file_mock.call_args_list == [
+        mocker.call(
+            file_id=fake_uuid,
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            filename="example.pdf",
+            created_by_id=active_user_with_permissions["id"],
+        )
+    ]
+    assert template_email_file_client_update_file_mock.call_args_list == [
+        mocker.call(
+            file_id=fake_uuid,
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            pending=False,
+            link_text="example file",
+            retention_period=12,
+            validate_users_email=True,
+        )
+    ]
+
+    s3_upload_mock.assert_called_once()
+    s3_download_mock.assert_called_once()
 
 
 def test_post_copy_template_into_folder(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -855,6 +855,36 @@ def mock_get_service_email_template(notify_admin, mocker):
 
 
 @pytest.fixture(scope="function")
+def mock_get_service_email_template_with_file(notify_admin, mocker):
+    def _get(service_id, template_id, version=None):
+        email_files = [
+            {
+                "service_id": SERVICE_ONE_ID,
+                "template_id": str(template_id),
+                "id": fake_uuid,
+                "filename": "example.pdf",
+                "created_by_id": str(uuid4()),
+                "link_text": "example file",
+                "retention_period": 12,
+                "validate_users_email": True,
+            }
+        ]
+        template = template_json(
+            service_id=service_id,
+            id_=template_id,
+            name="Two week reminder",
+            type_="email",
+            content="Your vehicle tax expires on ((date)). Please click the file ((example.pdf))",
+            subject="Your ((thing)) is due soon",
+            redact_personalisation=False,
+            email_files=email_files,
+        )
+        return {"data": template}
+
+    return mocker.patch("app.service_api_client.get_service_template", side_effect=_get)
+
+
+@pytest.fixture(scope="function")
 def mock_get_service_email_template_without_placeholders(notify_admin, mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -554,6 +554,26 @@ def mock_get_service(notify_admin, mocker, api_user_active, mocked_get_service_d
 
 
 @pytest.fixture(scope="function")
+def mock_get_service_with_contact_link(notify_admin, mocker, api_user_active, mocked_get_service_data):
+    def _get(service_id):
+        return {
+            "data": mocked_get_service_data.get(
+                service_id,
+                service_json(
+                    service_id,
+                    users=[api_user_active["id"]],
+                    email_message_limit=50,
+                    sms_message_limit=50,
+                    letter_message_limit=50,
+                    contact_link="https://example.com",
+                ),
+            )
+        }
+
+    return mocker.patch("app.service_api_client.get_service", side_effect=_get)
+
+
+@pytest.fixture(scope="function")
 def mock_get_service_statistics(notify_admin, mocker, api_user_active):
     def _get(service_id, limit_days=None):
         return {
@@ -848,6 +868,36 @@ def mock_get_service_email_template(notify_admin, mocker):
             content="Your vehicle tax expires on ((date))",
             subject="Your ((thing)) is due soon",
             redact_personalisation=False,
+        )
+        return {"data": template}
+
+    return mocker.patch("app.service_api_client.get_service_template", side_effect=_get)
+
+
+@pytest.fixture(scope="function")
+def mock_get_service_email_template_with_file(notify_admin, mocker):
+    def _get(service_id, template_id, version=None):
+        email_files = [
+            {
+                "service_id": SERVICE_ONE_ID,
+                "template_id": str(template_id),
+                "id": fake_uuid,
+                "filename": "example.pdf",
+                "created_by_id": str(uuid4()),
+                "link_text": "example file",
+                "retention_period": 12,
+                "validate_users_email": True,
+            }
+        ]
+        template = template_json(
+            service_id=service_id,
+            id_=template_id,
+            name="Two week reminder",
+            type_="email",
+            content="Your vehicle tax expires on ((date)). Please click the file ((example.pdf))",
+            subject="Your ((thing)) is due soon",
+            redact_personalisation=False,
+            email_files=email_files,
         )
         return {"data": template}
 


### PR DESCRIPTION
we noticed a bug where we werent' copying over files when copying over a template with files. This results in the new template having fileplaceholders interpreted as "regular" placeholders for normal personalisation. This downloads the old file from s3, creates a new entry in `template_email_files` and then makes it live.

We don't have the api endpoints to make a file live straightaway - we may wish to implement this instead of hitting the create endpoint and then the update endpoint.

Copying templates when contact link is not set:
<img width="666" height="422" alt="Screenshot 2026-05-06 at 10 34 17" src="https://github.com/user-attachments/assets/e5030b4c-1863-4588-b863-606931d8ae17" />

<img width="739" height="589" alt="Screenshot 2026-05-06 at 10 34 47" src="https://github.com/user-attachments/assets/dc7cb877-025b-4f4b-82ea-611f76c95254" />

<img width="744" height="264" alt="Screenshot 2026-05-06 at 10 34 56" src="https://github.com/user-attachments/assets/fc2fca99-6059-4518-9f1a-424927d47a29" />
