### PR TITLE
Encryption for tokens

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -6,6 +6,7 @@ class Config:
     ADMIN_CLIENT_SECRET = os.environ.get("ADMIN_CLIENT_SECRET")
     API_HOST_NAME = os.environ.get("API_HOST_NAME")
     SECRET_KEY = os.environ.get("SECRET_KEY")
+    TOKEN_SECRET_KEY = os.environ.get("TOKEN_SECRET_KEY")
     DANGEROUS_SALT = os.environ.get("DANGEROUS_SALT")
     ZENDESK_API_KEY = os.environ.get("ZENDESK_API_KEY")
     NEW_PASSWORD_ENCRYPTION_KEY = os.environ.get("NEW_PASSWORD_ENCRYPTION_KEY")
@@ -130,6 +131,7 @@ class Development(Config):
     # Fernet key must be 32 url-safe base64-encoded bytes:
     NEW_PASSWORD_ENCRYPTION_KEY = "vGUd-3kOibOKqJVMIdfLPOXB4OmSbzRRHr8832ItpzM="
 
+    TOKEN_SECRET_KEY = "5YNWU0e_pN5ZyaSZvBd5uZb_sZlrVDFeOjiea6dq4zQ="
     API_HOST_NAME = os.environ.get("API_HOST_NAME", "http://localhost:6011")
     ANTIVIRUS_API_HOST = os.environ.get("ANTIVIRUS_API_HOST", "http://localhost:6016")
     ANTIVIRUS_API_KEY = "test-key"

--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -25,6 +25,7 @@ def new_password(token):
             current_app.config["SECRET_KEY"],
             current_app.config["DANGEROUS_SALT"],
             current_app.config["EMAIL_EXPIRY_SECONDS"],
+            current_app.config["TOKEN_SECRET_KEY"],
         )
     except SignatureExpired:
         flash("The link in the email we sent you has expired. Enter your email address to resend.")

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -45,6 +45,7 @@ def two_factor_email(token):
             current_app.config["SECRET_KEY"],
             current_app.config["DANGEROUS_SALT"],
             current_app.config["EMAIL_2FA_EXPIRY_SECONDS"],
+            current_app.config["TOKEN_SECRET_KEY"],
         )
     except SignatureExpired:
         return render_template("views/email-link-invalid.html", redirect_url=redirect_url)

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -42,6 +42,7 @@ def verify_email(token):
             current_app.config["SECRET_KEY"],
             current_app.config["DANGEROUS_SALT"],
             current_app.config["EMAIL_EXPIRY_SECONDS"],
+            current_app.config["TOKEN_SECRET_KEY"],
         )
     except SignatureExpired:
         flash("The link in the email we sent you has expired. We’ve sent you a new one.")

--- a/app/main/views/your_account.py
+++ b/app/main/views/your_account.py
@@ -109,6 +109,7 @@ def your_account_email_confirm(token):
         current_app.config["SECRET_KEY"],
         current_app.config["DANGEROUS_SALT"],
         current_app.config["EMAIL_EXPIRY_SECONDS"],
+        current_app.config["TOKEN_SECRET_KEY"],
     )
     token = Token(token_data)
     user = User.from_id(token.user_id)


### PR DESCRIPTION


This turns on the feature 

https://github.com/alphagov/notifications-utils/pull/1336

By passing in environment variables.

We start checking for encrypted tokens before we encrypt them.

The plan is to keep the signing code around for at least a year,
so that we don't have eny tokens in things like unsubscribe links.

Encryption has been added everywhere for simplicities sake.