### PR TITLE
Stop passing unencrypted proposed new user password to session cookie

### DIFF
--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -46,7 +46,6 @@ def new_password(token):
         session["user_details"] = {
             "id": user.id,
             "email": user.email_address,
-            "password": form.new_password.data,
             "new_password": encrypt_new_password(form.new_password.data),
         }
         if user.email_auth:

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -33,8 +33,6 @@ def log_in_user(user_id):
                 )
                 flash("There was a problem with your password. Please try again.")
                 return redirect(url_for("main.sign_in"))
-        elif "password" in session.get("user_details", {}):
-            user.update_password(session["user_details"]["password"])
 
         user.activate()
         user.login()

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -76,7 +76,6 @@ def test_should_redirect_to_two_factor_when_password_reset_is_successful(
 
     with client_request.session_transaction() as session:
         assert decrypt_new_password(session["user_details"]["new_password"]) == "a-new_password"
-        assert session["user_details"]["password"] == "a-new_password"
         assert session["user_details"]["id"] == user["id"]
         assert session["user_details"]["email"] == user["email_address"]
 

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -218,33 +218,6 @@ def test_two_factor_sms_should_set_password_when_new_password_exists_in_session(
     )
 
 
-def test_two_factor_sms_should_set_password_when_new_password_exists_in_session_OLD_WAY(
-    client_request,
-    api_user_active,
-    mock_update_user_password,
-    mock_email_validated_recently,
-):
-    client_request.logout()
-
-    with client_request.session_transaction() as session:
-        session["user_details"] = {
-            "id": api_user_active["id"],
-            "email": api_user_active["email_address"],
-            "password": "changedpassword",
-        }
-
-    client_request.post(
-        "main.two_factor_sms",
-        _data={"sms_code": "12345"},
-        _expected_redirect=url_for("main.show_accounts_or_dashboard"),
-    )
-
-    mock_update_user_password.assert_called_once_with(
-        api_user_active["id"],
-        "changedpassword",
-    )
-
-
 @pytest.mark.parametrize("new_password", ["just-a-string", b"bytes-string"])
 def test_two_factor_sms_should_return_error_if_new_password_not_encrypted(
     client_request,


### PR DESCRIPTION
In https://github.com/alphagov/notifications-admin/pull/5873 we started passing an encrypted version of proposed new user password to session cookie. Now that that is rolled out, we can stop passing the unencrypted version of it, and thus improve
security for our users.