### PR TITLE
notifications-utils: 113.1.0 -> 113.5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.1.0
+# This file was automatically copied from notifications-utils@113.5.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ notifications-python-client==10.0.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.5.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,9 @@ charset-normalizer==3.4.4
 click==8.3.1
     # via flask
 cryptography==44.0.3
-    # via fido2
+    # via
+    #   fido2
+    #   notifications-utils
 dnspython==2.8.0
     # via eventlet
 docopt==0.6.2
@@ -100,7 +102,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@38f6a108f6bab59de8ec5d1bb89f813cc1f2ef52
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@e4fa60ffd42a92d3d7526133d218442a09e18c0c
     # via -r requirements.in
 openpyxl==3.1.5
     # via -r requirements.in

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -52,6 +52,7 @@ cryptography==44.0.3
     #   -r requirements.txt
     #   fido2
     #   moto
+    #   notifications-utils
 dnspython==2.8.0
     # via
     #   -r requirements.txt
@@ -162,7 +163,7 @@ moto==5.1.21
     # via -r requirements_for_test.in
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@38f6a108f6bab59de8ec5d1bb89f813cc1f2ef52
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@e4fa60ffd42a92d3d7526133d218442a09e18c0c
     # via -r requirements.txt
 openpyxl==3.1.5
     # via -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.1.0
+# This file was automatically copied from notifications-utils@113.5.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.1.0
+# This file was automatically copied from notifications-utils@113.5.0
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
This should stop views like `main.check_messages` from hogging a process for 30s (or more, sometimes resulting in a process getting killed) when processing big CSVs.