### PR TITLE
Remove environment variables from `pytest.ini`

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -157,6 +157,8 @@ class Test(Development):
     ANTIVIRUS_API_HOST = "https://test-antivirus"
     ANTIVIRUS_API_KEY = "test-antivirus-secret"
     ANTIVIRUS_ENABLED = True
+    REDIS_ENABLED = False
+    ZENDESK_API_KEY = "test"
 
     ASSET_DOMAIN = "static.example.com"
     ASSET_PATH = "https://static.example.com/"

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,12 +4,6 @@ testpaths = tests
 log_level = 999
 env =
     NOTIFY_ENVIRONMENT=test
-    ADMIN_CLIENT_SECRET=dev-notify-secret-key
-    API_HOST_NAME=test
-    DANGEROUS_SALT=dev-notify-salt
-    SECRET_KEY=dev-notify-secret-key
-    ZENDESK_API_KEY=test
-    REDIS_ENABLED=0
 
 filterwarnings =
     error:Applying marks directly:pytest.RemovedInPytest4Warning


### PR DESCRIPTION
Most of these are ignored because they are hard coded in `Config.Test`.

Let’s be consistent so people who are adding or changing them only have to do so in one place.