### PR TITLE
`TemplateList`: add `interruptible_iter` property, use in jinja iteration

### DIFF
--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -1,6 +1,7 @@
 from werkzeug.utils import cached_property
 
 from app import format_notification_type
+from app.utils import interruptible_io
 
 
 class TemplateList:
@@ -22,6 +23,8 @@ class TemplateList:
     comments on those classes for more details.
     """
 
+    INTERRUPTIBLE_ITER_INTERRUPTIBLE_EVERY = 32
+
     def __init__(
         self,
         *,
@@ -35,6 +38,10 @@ class TemplateList:
 
     def __iter__(self):
         yield from self.items
+
+    @property
+    def interruptible_iter(self):
+        return interruptible_io.interruptible_iter(self, self.INTERRUPTIBLE_ITER_INTERRUPTIBLE_EVERY)
 
     @cached_property
     def items(self):

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -14,7 +14,7 @@
   <div id="template-list" class="{{ 'govuk-!-margin-top-1' if (not show_template_nav and not show_search_box) else 'govuk-!-margin-top-6' }}">
     {% set checkboxes_data = [] %}
 
-    {% for item in template_list %}
+    {% for item in template_list.interruptible_iter %}
       {% set item_num = loop.index %}
       {% set item_link_content %}
         {% for ancestor in item.ancestors %}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -45,7 +45,7 @@
     {{ live_search(target_selector='#template-list .template-list-item', show=True, form=_search_form) }}
 
     <div id="template-list">
-      {% for item in templates_and_folders %}
+      {% for item in templates_and_folders.interruptible_iter %}
         {% set item_num = loop.index %}
         <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
           {% for ancestor in item.ancestors %}

--- a/app/utils/interruptible_io.py
+++ b/app/utils/interruptible_io.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from io import RawIOBase
 from time import sleep
 from zipfile import ZipFile
@@ -101,3 +102,19 @@ class InterruptibleIOZipFile(ZipFile):
 
     def open(self, *args, **kwargs) -> RawIOBase:
         return InterruptibleRawIOWrapper(super().open(*args, **kwargs), read_limit=8_192)
+
+
+def interruptible_iter[T](it: Iterable[T], interruptible_every: int) -> Iterable[T]:
+    """
+    Given an iterable `it`, will yield its contents, calling sleep(0) before yielding each
+    `interruptible_every`'th iteration.
+    """
+    i = 0
+    for item in it:
+        if i >= interruptible_every:
+            sleep(0)
+            i = 0
+
+        yield item
+
+        i += 1

--- a/tests/utils/test_interruptible_io.py
+++ b/tests/utils/test_interruptible_io.py
@@ -1,0 +1,34 @@
+from itertools import count, islice
+
+import pytest
+
+from app.utils.interruptible_io import interruptible_iter
+
+
+def test_interruptible_iter(mocker):
+    mock_sleep = mocker.patch("app.utils.interruptible_io.sleep")
+    i = interruptible_iter(islice(count(), 0, 9), 3)
+
+    assert next(i) == 0
+    assert len(mock_sleep.mock_calls) == 0
+    assert next(i) == 1
+    assert len(mock_sleep.mock_calls) == 0
+    assert next(i) == 2
+    assert len(mock_sleep.mock_calls) == 0
+    assert next(i) == 3
+    assert len(mock_sleep.mock_calls) == 1
+    assert next(i) == 4
+    assert len(mock_sleep.mock_calls) == 1
+    assert next(i) == 5
+    assert len(mock_sleep.mock_calls) == 1
+    assert next(i) == 6
+    assert len(mock_sleep.mock_calls) == 2
+    assert next(i) == 7
+    assert len(mock_sleep.mock_calls) == 2
+    assert next(i) == 8
+    assert len(mock_sleep.mock_calls) == 2
+
+    with pytest.raises(StopIteration):
+        next(i)
+
+    assert len(mock_sleep.mock_calls) == 2


### PR DESCRIPTION
For services with a very large number of templates, the `main.choose_template` view can spend a long time rendering the list, during which time it will not yield to the event loop. This may adversely affect other requests being handled by the same process.

To avoid this, give `TemplateList` an `interruptible_iter` property that produces an iterator that will automatically inject `sleep(0)`s every 32 iterations.