### PR TITLE
Cache `render_govuk_frontend_macro` compilation

### DIFF
--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -1,7 +1,8 @@
 import copy
 from abc import ABC, abstractmethod
+from functools import cache
 
-from flask import render_template_string
+from flask import current_app, templating
 from markupsafe import Markup
 
 from app.utils import merge_jsonlike
@@ -136,5 +137,11 @@ def render_govuk_frontend_macro(component, params):
 
         {{{{ {govuk_frontend_components[component]["macro"]}(params) }}}}
     """
+    template = compile_govuk_frontend_macro(template_string)
 
-    return Markup(render_template_string(template_string, params=params))
+    return Markup(templating._render(current_app, template, {"params": params}))
+
+
+@cache
+def compile_govuk_frontend_macro(template_string):
+    return current_app.jinja_env.from_string(template_string)

--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -130,18 +130,20 @@ def render_govuk_frontend_macro(component, params):
         },
     }
 
-    # we need to duplicate all curly braces to escape them from the f string so jinja still sees them
-    template_string = f"""
-        {{%- from '{govuk_frontend_components[component]["path"]}'
-        import {govuk_frontend_components[component]["macro"]} -%}}
-
-        {{{{ {govuk_frontend_components[component]["macro"]}(params) }}}}
-    """
-    template = compile_govuk_frontend_macro(template_string)
+    template = compile_govuk_frontend_macro(
+        govuk_frontend_components[component]["path"],
+        govuk_frontend_components[component]["macro"],
+    )
 
     return Markup(templating._render(current_app, template, {"params": params}))
 
 
 @cache
-def compile_govuk_frontend_macro(template_string):
+def compile_govuk_frontend_macro(path, macro):
+    # we need to duplicate all curly braces to escape them from the f string so jinja still sees them
+    template_string = f"""
+        {{%- from '{path}' import {macro} -%}}
+
+        {{{{ {macro}(params) }}}}
+    """
     return current_app.jinja_env.from_string(template_string)


### PR DESCRIPTION
# Problem

Compiling Jinja is somewhat expensive. A normal call to `flask.render_template` is cached, so once the app has rendered a template once, it doesn’t have to do it again.
    
However `flask.render_template_string` (which calls through to `flask.templating._render`) does not do any caching. See rationale at https://github.com/pallets/flask/issues/2402
    
We use `flask.render_template_string` to render intermediate macros for GOV.UK Frontend components. This means that for every single checkbox on a page, we have to recompile the macro. And for a page like ‘Choose templates’, which can have thousands of checkboxes, this represents a significant performance hit.

***

This profile shows that, when rendering `choose.html`, Python is spending almost all its time inside this function (highlighted in hot pink):
https://github.com/alphagov/notifications-admin/blob/4d0338c6d6fb0030b8a7f7ed5682ea3b2a7739ab/app/utils/govuk_frontend_field.py#L80

<img width="1199" height="739" alt="image" src="https://github.com/user-attachments/assets/5ddedef2-1439-4fb9-ab50-dc98999c21aa" />
    
# Fix

This commit re-factors the code so that compiling the template is  contained in a function, which can then be cached.
    
The number of cache keys is constrained by the number of different macros we have (currently 6). So I think it’s fine to make this cache unbounded, rather than using something like `functools.lru_cache`.

# Profiling

I made a page with 1,000 checkboxes:

<img width="1728" height="786" alt="image" src="https://github.com/user-attachments/assets/a1e67ea5-d510-4ecd-be27-952045b178f6" />

<details><summary>Python source</summary>

```python
@main.route("/checkboxes")
def checkboxes():
    from app.main.forms import StripWhitespaceForm, GovukCheckboxField
    class F(StripWhitespaceForm):
        def __init__(self, *args, **kwargs):
            super().__init__(*args, **kwargs)

    for i in range(1, 1001):
        setattr(F, f"checkbox_{i:03}", GovukCheckboxField(f"{i:03}"))

    return render_template("views/checkboxes.html", form=F())
```
</details>

<details><summary>Jinja source</summary>

```jinja
<html>
  <head>
    <style>
      .govuk-form-group, .govuk-checkboxes, .govuk-checkboxes__item {
        display: inline;
        font-family: monospace;
      }
    </style>
  </head>
  <body>
    {% for f in form %}
      {{ f }}
    {% endfor %}
  </body>
</html>
```
</details>

## Command 

```shell
python -m timeit -s "import requests" "requests.get('http://localhost:6012/checkboxes')"
```

## Before 

1 loop, best of 5: 544 msec per loop

## After 

1 loop, best of 5: 214 msec per loop (61% reduction)