### PR TITLE
render_govuk_frontend_macro: add `@interruptible_every` decorator to yield every 32 calls

### DIFF
--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -5,6 +5,7 @@ from flask import render_template_string
 from markupsafe import Markup
 
 from app.utils import merge_jsonlike
+from app.utils.interruptible_io import interruptible_every
 
 
 class GovukFrontendWidgetMixin(ABC):
@@ -96,6 +97,7 @@ class GovukFrontendWidgetMixin(ABC):
         return render_govuk_frontend_macro(self.govuk_frontend_component_name, params)
 
 
+@interruptible_every(32)
 def render_govuk_frontend_macro(component, params):
     """
     jinja needs a template to render but govuk_frontend_jinja only provides macros

--- a/app/utils/interruptible_io.py
+++ b/app/utils/interruptible_io.py
@@ -1,4 +1,5 @@
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from functools import wraps
 from io import RawIOBase
 from time import sleep
 from zipfile import ZipFile
@@ -102,6 +103,31 @@ class InterruptibleIOZipFile(ZipFile):
 
     def open(self, *args, **kwargs) -> RawIOBase:
         return InterruptibleRawIOWrapper(super().open(*args, **kwargs), read_limit=8_192)
+
+
+def interruptible_every[**A, R](iterations: int) -> Callable[[Callable[A, R]], Callable[A, R]]:
+    """
+    Returns a decorator that, applied to a function, will keep a global counter of invocations
+    and yield before every `iterations`'th call.
+    """
+
+    def interruptible_decorator(inner: Callable[A, R]) -> Callable[A, R]:
+        i = 0
+
+        @wraps(inner)
+        def interruptible_wrapper(*args, **kwargs):
+            nonlocal i
+            if i >= iterations:
+                sleep(0)
+                i = 0
+
+            i += 1
+
+            return inner(*args, **kwargs)
+
+        return interruptible_wrapper
+
+    return interruptible_decorator
 
 
 def interruptible_iter[T](it: Iterable[T], interruptible_every: int) -> Iterable[T]:

--- a/tests/utils/test_interruptible_io.py
+++ b/tests/utils/test_interruptible_io.py
@@ -2,7 +2,35 @@ from itertools import count, islice
 
 import pytest
 
-from app.utils.interruptible_io import interruptible_iter
+from app.utils.interruptible_io import interruptible_every, interruptible_iter
+
+
+def test_interruptible_every(mocker):
+    mock_sleep = mocker.patch("app.utils.interruptible_io.sleep")
+
+    c = count()
+
+    @interruptible_every(3)
+    def my_func(a):
+        return a + next(c)
+
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 5
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 6
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 7
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 8
+    assert len(mock_sleep.mock_calls) == 1
+    assert my_func(5) == 9
+    assert len(mock_sleep.mock_calls) == 1
+    assert my_func(5) == 10
+    assert len(mock_sleep.mock_calls) == 1
+    assert my_func(5) == 11
+    assert len(mock_sleep.mock_calls) == 2
+    assert my_func(5) == 12
+    assert len(mock_sleep.mock_calls) == 2
 
 
 def test_interruptible_iter(mocker):


### PR DESCRIPTION
This is a little bit weird, but it's tricky to inject `sleep(0)`s into form rendering, and some of our forms can (in extreme cases) have thousands of widgets.

So this adds a decorator that will keep a global counter and `sleep(0)` before every Nth call. Why a global counter? Because marshalling a counter variable around the target code would require too much interference.