### PR TITLE
NestedFieldMixin: cache options when building child map

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -456,11 +456,14 @@ class RadioFieldWithNoneOption(FieldWithNoneOption, RadioField):
 
 class NestedFieldMixin:
     def children(self):
+        # beginning iteration through a Field is surprisingly expensive - cache the list of options
+        options = tuple(self)
+
         # start map with root option as a single child entry
-        child_map = {None: [option for option in self if option.data == self.NONE_OPTION_VALUE]}
+        child_map = {None: [option for option in options if option.data == self.NONE_OPTION_VALUE]}
 
         # add entries for all other children
-        for option in self:
+        for option in options:
             # assign all options with a NONE_OPTION_VALUE (not always None) to the None key
             if option.data == self.NONE_OPTION_VALUE:
                 child_ids = [folder["id"] for folder in self.all_template_folders if folder["parent_id"] is None]
@@ -469,7 +472,7 @@ class NestedFieldMixin:
                 child_ids = [folder["id"] for folder in self.all_template_folders if folder["parent_id"] == option.data]
                 key = option.data
 
-            child_map[key] = [option for option in self if option.data in child_ids]
+            child_map[key] = [option for option in options if option.data in child_ids]
 
         return child_map
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -114,6 +114,7 @@ from app.utils.govuk_frontend_field import (
     render_govuk_frontend_macro,
 )
 from app.utils.image_processing import CorruptImage, ImageProcessor, WrongImageFormat
+from app.utils.interruptible_io import interruptible_iter
 from app.utils.user_permissions import (
     all_ui_permissions,
     organisation_user_permission_names,
@@ -455,6 +456,8 @@ class RadioFieldWithNoneOption(FieldWithNoneOption, RadioField):
 
 
 class NestedFieldMixin:
+    CHILD_MAP_ITERATION_INTERRUPTIBLE_EVERY = 128
+
     def children(self):
         # beginning iteration through a Field is surprisingly expensive - cache the list of options
         options = tuple(self)
@@ -463,7 +466,7 @@ class NestedFieldMixin:
         child_map = {None: [option for option in options if option.data == self.NONE_OPTION_VALUE]}
 
         # add entries for all other children
-        for option in options:
+        for option in interruptible_iter(options, self.CHILD_MAP_ITERATION_INTERRUPTIBLE_EVERY):
             # assign all options with a NONE_OPTION_VALUE (not always None) to the None key
             if option.data == self.NONE_OPTION_VALUE:
                 child_ids = [folder["id"] for folder in self.all_template_folders if folder["parent_id"] is None]


### PR DESCRIPTION
Instead of directly iterating through the `Field` object each time we need to scan through the options, cache the option
list at the beginning of `.children(...)` and iterate through that. This brings a significant performance improvement
for large numbers of template folders.

In a test using a realistic large & complex tree of template folders, this reduced the time spent in `NestedFieldMixin.get_items_from_options` from around 5 seconds to under a second.

Also make the main iteration in `NestedFieldMixin.children(...)` interruptible for the worst case scenarios.