### PR TITLE
Prevent access to uncached children of `NestedFieldMixin`

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -458,6 +458,7 @@ class RadioFieldWithNoneOption(FieldWithNoneOption, RadioField):
 class NestedFieldMixin:
     CHILD_MAP_ITERATION_INTERRUPTIBLE_EVERY = 128
 
+    @cached_property
     def children(self):
         # beginning iteration through a Field is surprisingly expensive - cache the list of options
         options = tuple(self)
@@ -479,18 +480,13 @@ class NestedFieldMixin:
 
         return child_map
 
-    # to be used as the only version of .children once radios are converted
-    @cached_property
-    def _children(self):
-        return self.children()
-
     def get_items_from_options(self, field):
         items = []
 
-        for option in self._children[None]:
+        for option in self.children[None]:
             item = self.get_item_from_option(option)
-            if option.data in self._children:
-                item["children"] = self.render_children(field.name, option.label.text, self._children[option.data])
+            if option.data in self.children:
+                item["children"] = self.render_children(field.name, option.label.text, self.children[option.data])
             items.append(item)
 
         return items
@@ -506,8 +502,8 @@ class NestedFieldMixin:
         for option in options:
             item = self.get_item_from_option(option)
 
-            if len(self._children[option.data]):
-                item["children"] = self.render_children(name, option.label.text, self._children[option.data])
+            if len(self.children[option.data]):
+                item["children"] = self.render_children(name, option.label.text, self.children[option.data])
 
             params["items"].append(item)
 
@@ -895,8 +891,8 @@ class GovukNestedRadiosField(NestedFieldMixin, GovukRadiosFieldWithNoneOption):
                     "hint": {"text": self.option_hints.get(option.data, "")},
                 }
             )
-            if len(self._children[option.data]):
-                item["children"] = self.render_children(name, option.label.text, self._children[option.data])
+            if len(self.children[option.data]):
+                item["children"] = self.render_children(name, option.label.text, self.children[option.data])
 
             params["items"].append(item)
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -204,7 +204,7 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
         template_type=template_type,
         _search_form=SearchTemplatesForm(current_service.api_keys),
         form=templates_and_folders_form,
-        move_to_children=templates_and_folders_form.move_to.children(),
+        move_to_children=templates_and_folders_form.move_to.children,
         user_has_template_folder_permission=user_has_template_folder_permission,
         option_hints=option_hints,
         error_summary_enabled=True,


### PR DESCRIPTION
This prevents it being accessed by consumers of this class. Which is good because computing it is relatively expensive, so we want them using the cached value.