### PR TITLE
Remove `download` attribute from anchor tags

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -471,7 +471,7 @@ def inbox_download(service_id):
         mimetype="text/csv",
         headers={
             "Content-Disposition": (
-                f'inline; filename="Received text messages {format_date_numeric(datetime.now(UTC))}.csv"'
+                f'attachment; filename="Received text messages {format_date_numeric(datetime.now(UTC))}.csv"'
             )
         },
     )

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -76,7 +76,9 @@ def manage_users_download(service_id):
         200,
         {
             "Content-Type": "text/csv; charset=utf-8",
-            "Content-Disposition": (f'inline; filename="Team members {format_date_numeric(datetime.now(UTC))}.csv"'),
+            "Content-Disposition": (
+                f'attachment; filename="Team members {format_date_numeric(datetime.now(UTC))}.csv"'
+            ),
         },
     )
 

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -191,7 +191,7 @@ def download_organisation_usage_report(org_id):
         {
             "Content-Type": "text/csv; charset=utf-8",
             "Content-Disposition": (
-                'inline;filename="{} organisation usage report for year {} - generated on {}.csv"'.format(
+                'attachment;filename="{} organisation usage report for year {} - generated on {}.csv"'.format(
                     current_organisation.name, selected_year, datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                 )
             ),

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -122,7 +122,9 @@ def live_services_csv():
         200,
         {
             "Content-Type": "text/csv; charset=utf-8",
-            "Content-Disposition": f'inline; filename="{format_date_numeric(datetime.now())} live services report.csv"',
+            "Content-Disposition": (
+                f'attachment; filename="{format_date_numeric(datetime.now())} live services report.csv"'
+            ),
         },
     )
 
@@ -710,7 +712,7 @@ def platform_admin_users_list():
         200,
         {
             "Content-Type": "text/csv; charset=utf-8",
-            "Content-Disposition": f'inline; filename="{format_date_numeric(datetime.now())}_users_list.csv"',
+            "Content-Disposition": f'attachment; filename="{format_date_numeric(datetime.now())}_users_list.csv"',
         },
     )
 

--- a/app/main/views/returned_letters.py
+++ b/app/main/views/returned_letters.py
@@ -65,6 +65,6 @@ def returned_letters_report(service_id, reported_at):
         200,
         {
             "Content-Type": "text/csv; charset=utf-8",
-            "Content-Disposition": f'inline; filename="{reported_at} returned letters.csv"',
+            "Content-Disposition": f'attachment; filename="{reported_at} returned letters.csv"',
         },
     )

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -158,7 +158,7 @@ def get_example_csv(service_id, template_id):
         200,
         {
             "Content-Type": "text/csv; charset=utf-8",
-            "Content-Disposition": f'inline; filename="{template.name}.csv"',
+            "Content-Disposition": f'attachment; filename="{template.name}.csv"',
         },
     )
 

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -64,7 +64,10 @@ class TemplatePreviewClient:
             json=data,
             headers=self._get_outbound_headers(),
         )
-        return response.content, response.status_code, self.get_allowed_headers(response.headers)
+        headers = list(self.get_allowed_headers(response.headers))
+        if filetype == "pdf":
+            headers.append(("Content-Disposition", "attachment"))
+        return response.content, response.status_code, headers
 
     def get_png_for_valid_pdf_page(self, pdf_file, page):
         pdf_page = extract_page_from_pdf(BytesIO(pdf_file), int(page) - 1)

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -4,7 +4,7 @@
 <div class="ajax-block-container">
   {% if messages %}
     <p class="bottom-gutter-2-3 top-gutter-1-2">
-      <a href="{{ url_for('main.inbox_download', service_id=current_service.id) }}" download class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download all messages</a>
+      <a href="{{ url_for('main.inbox_download', service_id=current_service.id) }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download all messages</a>
     </p>
   {% endif %}
   {% call(item, row_number) list_table(

--- a/app/templates/views/document-download/download.html
+++ b/app/templates/views/document-download/download.html
@@ -15,7 +15,7 @@
   </p>
 
   <p class="govuk-body">
-    <a href="{{download_link}}" download class="govuk-link govuk-link--no-visited-state" rel="noreferrer">Download this {{ template_email_file.extension|format_file_type }} ({{ template_email_file.size|format_file_size }}) to your device</a>
+    <a href="{{download_link}}" class="govuk-link govuk-link--no-visited-state" rel="noreferrer">Download this {{ template_email_file.extension|format_file_type }} ({{ template_email_file.size|format_file_size }}) to your device</a>
   </p>
 
 {% endblock %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -62,7 +62,7 @@
           {% if scheduled_recipients|length > scheduled_recipients.displayed_rows|list|length %}
             <p class="govuk-!-margin-bottom-1">Only showing the first {{ scheduled_recipients.displayed_rows|list|length }} rows</p>
           {% endif %}
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.view_job_original_file_csv', service_id=current_service.id, job_id=job.id) }}" download>Download this file (CSV)</a>
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.view_job_original_file_csv', service_id=current_service.id, job_id=job.id) }}">Download this file (CSV)</a>
         </div>
       </div>
     {% endif %}

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -82,7 +82,7 @@
         {{ govukButton({ "text": button_text }) }}
       {% endif %}
       {% if template.template_type == 'letter' %}
-        <a href="{{ url_for('no_cookie.check_notification_preview', service_id=current_service.id, template_id=template.id, filetype='pdf') }}" download class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link{% if error %}-without-button{% endif %}">Download as a PDF</a>
+        <a href="{{ url_for('no_cookie.check_notification_preview', service_id=current_service.id, template_id=template.id, filetype='pdf') }}" class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link{% if error %}-without-button{% endif %}">Download as a PDF</a>
       {% endif %}
     </form>
   </div>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -98,7 +98,7 @@
           {% else %}
             <div>&nbsp;</div>
           {% endif %}
-          <a class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link-without-button" href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification.id, filetype='pdf') }}" download>Download as a PDF</a>
+          <a class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link-without-button" href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification.id, filetype='pdf') }}">Download as a PDF</a>
         </div>
       </div>
     {% elif template.template_type == 'email' %}

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -120,7 +120,7 @@
   {% else %}
     <div class="js-stick-at-bottom-when-scrolling">
       <p class="govuk-!-margin-bottom-1">
-        <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
+        <a href="{{ download_link }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
       </p>
     </div>
   {% endif %}

--- a/app/templates/views/returned-letters.html
+++ b/app/templates/views/returned-letters.html
@@ -23,7 +23,7 @@
 {% endif %}
 
 <p class="bottom-gutter">
-  <a download href="{{ url_for('main.returned_letters_report', service_id=current_service.id, reported_at=reported_at) }}" class="govuk-link govuk-link--no-visited-state heading-small">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
+  <a href="{{ url_for('main.returned_letters_report', service_id=current_service.id, reported_at=reported_at) }}" class="govuk-link govuk-link--no-visited-state heading-small">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
 </p>
 
 <div class="dashboard-table">

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -50,7 +50,7 @@
     {% endcall %}
   </div>
   <p class="table-show-more-link">
-    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.get_example_csv', service_id=current_service.id, template_id=template.id) }}" download>Download this example (<abbr title="Comma separated values">CSV</abbr>)</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.get_example_csv', service_id=current_service.id, template_id=template.id) }}">Download this example (<abbr title="Comma separated values">CSV</abbr>)</a>
   </p>
 
   <h2 class="heading-medium">Your file will populate this template ({{ template.name }})</h2>

--- a/app/templates/views/unsubscribe-request-report.html
+++ b/app/templates/views/unsubscribe-request-report.html
@@ -40,7 +40,7 @@
     <p class="govuk-body" id="report-unsubscribe-requests-count">
         {{ report.count|format_thousands}} unsubscribe {{ report.count | message_count_label('request', suffix='') }}
     </p>
-    <p class="bottom-gutter"><a download href="{{ url_for('main.download_unsubscribe_request_report', service_id=current_service.id, batch_id=report.batch_id) }}" class="govuk-link govuk-link--no-visited-state heading-small" >
+    <p class="bottom-gutter"><a href="{{ url_for('main.download_unsubscribe_request_report', service_id=current_service.id, batch_id=report.batch_id) }}" class="govuk-link govuk-link--no-visited-state heading-small" >
         Download the report</a>
     </p>
 

--- a/app/templates/views/uploads/contact-list/contact-list.html
+++ b/app/templates/views/uploads/contact-list/contact-list.html
@@ -130,7 +130,7 @@
           <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.delete_contact_list', service_id=current_service.id, contact_list_id=contact_list.id) }}">Delete this contact list</a>
         </span>
       {% endif %}
-      <a class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link-without-button" download href="{{ url_for('main.download_contact_list', service_id=current_service.id, contact_list_id=contact_list.id) }}">Download this contact list (<abbr title="Comma separated values">CSV</abbr>)</a>
+      <a class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link-without-button" href="{{ url_for('main.download_contact_list', service_id=current_service.id, contact_list_id=contact_list.id) }}">Download this contact list (<abbr title="Comma separated values">CSV</abbr>)</a>
     </div>
   </div>
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -765,7 +765,7 @@ def test_organisation_services_links_to_downloadable_report(
     client_request.login(active_user_with_permissions)
     page = client_request.get(".organisation_dashboard", org_id=ORGANISATION_ID)
 
-    link_to_report = page.select_one("a[download]")
+    link_to_report = page.select_one(".js-stick-at-bottom-when-scrolling a")
     assert normalize_spaces(link_to_report.text) == "Download this report (CSV)"
     assert link_to_report.attrs["href"] == url_for(
         ".download_organisation_usage_report", org_id=ORGANISATION_ID, selected_year=2021

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -428,7 +428,7 @@ def test_download_inbox(
         service_id=SERVICE_ONE_ID,
     )
     assert response.headers["Content-Type"] == "text/csv; charset=utf-8"
-    assert response.headers["Content-Disposition"] == ('inline; filename="Received text messages 2016-07-01.csv"')
+    assert response.headers["Content-Disposition"] == ('attachment; filename="Received text messages 2016-07-01.csv"')
     assert response.get_data(as_text=True) == (
         "Phone number,Message,Received\r\n"
         "07900 900000,message-1,2016-07-01 13:00\r\n"

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -296,7 +296,7 @@ def test_inbox_showing_inbound_messages(
     rows = page.select("tbody tr")
     assert len(rows) == 8
     assert normalize_spaces(rows[index].text) == expected_row
-    assert page.select_one("a[download]")["href"] == url_for(
+    assert page.select_one("[data-key=messages] a.govuk-\\!-font-weight-bold")["href"] == url_for(
         "main.inbox_download",
         service_id=SERVICE_ONE_ID,
     )

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -786,7 +786,7 @@ def test_notification_page_has_link_to_download_letter(
     )
 
     try:
-        download_link = page.select_one("a[download]")["href"]
+        download_link = page.select_one("a.page-footer-right-aligned-link-without-button")["href"]
     except TypeError:
         download_link = None
 

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, call
 
 import pytest
 from flask import url_for
+from freezegun import freeze_time
 
 from app.main.views.platform_admin import build_live_service_permissions_for_users_list
 from tests.conftest import SERVICE_ONE_ID, SERVICE_TWO_ID, create_user, normalize_spaces
@@ -965,6 +966,7 @@ def test_platform_admin_users_list_when_no_results_for_filters(client_request, p
     assert normalize_spaces(error.text) == "No results for filters selected"
 
 
+@freeze_time("2020-2-02")
 def test_platform_admin_users_list_csv_export(client_request, platform_admin_user, mocker):
     client_request.login(platform_admin_user)
 
@@ -995,7 +997,7 @@ def test_platform_admin_users_list_csv_export(client_request, platform_admin_use
     )
 
     assert response.content_type == "text/csv; charset=utf-8"
-    assert response.headers["Content-Disposition"].startswith('inline; filename="')
+    assert response.headers["Content-Disposition"] == 'attachment; filename="2020-02-02_users_list.csv"'
 
     csv_content = response.get_data(as_text=True)
 

--- a/tests/app/main/views/test_returned_letters.py
+++ b/tests/app/main/views/test_returned_letters.py
@@ -211,6 +211,8 @@ def test_returned_letters_reports(client_request, mocker):
     response = client_request.get_response(
         "main.returned_letters_report", service_id=SERVICE_ONE_ID, reported_at="2019-12-24"
     )
+    assert response.headers["Content-Type"] == "text/csv; charset=utf-8"
+    assert response.headers["Content-Disposition"] == ('attachment; filename="2019-12-24 returned letters.csv"')
 
     report = response.get_data(as_text=True)
     mock.assert_called_once_with(SERVICE_ONE_ID, "2019-12-24")

--- a/tests/app/main/views/test_returned_letters.py
+++ b/tests/app/main/views/test_returned_letters.py
@@ -168,8 +168,10 @@ def test_returned_letters_page_with_many_letters(
     )
 
     assert len(page.select("tbody tr")) == 50
-    assert page.select_one("a[download]").text == "Download this report (CSV)"
-    assert page.select_one("a[download]")["href"] == url_for(
+
+    download_link = page.select_one("main a")
+    assert normalize_spaces(download_link.text) == "Download this report (CSV)"
+    assert download_link["href"] == url_for(
         ".returned_letters_report",
         service_id=SERVICE_ONE_ID,
         reported_at="2019-12-24",

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -4022,7 +4022,13 @@ def test_letters_from_csv_files_dont_have_download_link(
     assert not page.select("a[download]")
 
 
-@pytest.mark.parametrize("restricted", [True, False])
+@pytest.mark.parametrize(
+    "restricted, expected_link_selector",
+    [
+        (True, "a.page-footer-right-aligned-link-without-button"),
+        (False, "a.page-footer-right-aligned-link"),
+    ],
+)
 def test_one_off_letters_have_download_link(
     client_request,
     mocker,
@@ -4031,6 +4037,7 @@ def test_one_off_letters_have_download_link(
     fake_uuid,
     mock_get_service_statistics,
     restricted,
+    expected_link_selector,
     service_one,
 ):
     service_one["restricted"] = restricted
@@ -4055,13 +4062,14 @@ def test_one_off_letters_have_download_link(
 
     assert len(page.select(".letter img")) == 5
 
-    assert page.select_one("a[download]")["href"] == url_for(
+    download_link = page.select_one(expected_link_selector)
+    assert download_link["href"] == url_for(
         "no_cookie.check_notification_preview",
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
         filetype="pdf",
     )
-    assert page.select_one("a[download]").text == "Download as a PDF"
+    assert normalize_spaces(download_link) == "Download as a PDF"
 
 
 @pytest.mark.parametrize("filetype", ("png", "pdf"))
@@ -4141,7 +4149,7 @@ def test_send_one_off_letter_errors_in_trial_mode(
 
     assert not page.select("form button")
     assert page.select_one(".govuk-back-link").text.strip() == "Back"
-    assert page.select_one("a[download]").text == "Download as a PDF"
+    assert page.select_one("a.page-footer-right-aligned-link-without-button").text == "Download as a PDF"
 
 
 def test_send_one_off_letter_errors_if_letter_longer_than_10_pages(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -6,7 +6,7 @@ from io import BytesIO
 from itertools import repeat
 from os import path
 from random import randbytes
-from unittest.mock import ANY
+from unittest.mock import ANY, Mock
 from uuid import uuid4
 from zipfile import BadZipFile
 
@@ -4062,6 +4062,48 @@ def test_one_off_letters_have_download_link(
         filetype="pdf",
     )
     assert page.select_one("a[download]").text == "Download as a PDF"
+
+
+@pytest.mark.parametrize("filetype", ("png", "pdf"))
+def test_one_off_letters_pdf_download(
+    client_request,
+    mocker,
+    mock_get_service_letter_template,
+    mock_has_permissions,
+    fake_uuid,
+    mock_get_service_statistics,
+    filetype,
+):
+    mocker.patch(
+        "app.template_preview_client.requests_session.post",
+        return_value=Mock(content=b"foo", status_code=200, headers={"content-type": "foo/bar"}),
+    )
+
+    do_mock_get_page_counts_for_letter(mocker, count=5)
+
+    with client_request.session_transaction() as session:
+        session["recipient"] = None
+        session["placeholders"] = {
+            "address_line_1": "First Last",
+            "address_line_2": "123 Street",
+            "postcode": "SW1 1AA",
+        }
+
+    response = client_request.get_response(
+        "no_cookie.check_notification_preview",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        filetype=filetype,
+    )
+
+    assert response.get_data() == b"foo"
+    assert response.headers["content-type"] == "foo/bar"  # Whatever we get from template preview
+
+    if filetype == "pdf":
+        assert response.headers["Content-Disposition"] == "attachment"
+    else:
+        assert "Content-Disposition" not in response.headers
+    assert response.headers["Content-Length"] == "3"
 
 
 def test_send_one_off_letter_errors_in_trial_mode(

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -534,6 +534,10 @@ def test_download_unsubscribe_request_report(client_request, mocker):
     response = client_request.get_response(
         "main.download_unsubscribe_request_report", service_id=SERVICE_ONE_ID, batch_id=report_data["batch_id"]
     )
+    assert response.headers["Content-Type"] == "text/csv; charset=utf-8"
+    assert response.headers["Content-Disposition"] == (
+        'attachment; filename="Email unsubscribe requests 2024-07-18 to 2024-07-20.csv'
+    )
 
     mock_get_report.assert_called_once_with(SERVICE_ONE_ID, report_data["batch_id"])
     report = response.get_data(as_text=True)

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -324,7 +324,9 @@ def test_unsubscribe_request_report_for_processed_batched_reports(client_request
     availability_date = page.select("#unsubscribe_report_availability")[0].text
     "completed_unsubscribe_report_main_text"
     update_button = page.select("#process_unsubscribe_report")
-    assert page.select_one("p a[download]")["href"] == url_for(
+    download_link = page.select_one("main a")
+    assert normalize_spaces(download_link.text) == "Download the report"
+    assert download_link["href"] == url_for(
         "main.download_unsubscribe_request_report",
         service_id=SERVICE_ONE_ID,
         batch_id=test_data[0]["batch_id"],

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -454,7 +454,9 @@ def test_view_contact_list(
     assert normalize_spaces(page.select("main p")[0].text) == "Uploaded by Test User on 3 March at 12:12pm."
     assert normalize_spaces(page.select("main p")[1].text) == expected_empty_message
     assert normalize_spaces(page.select_one("main h2").text) == "51 saved email addresses"
-    assert page.select_one(".js-stick-at-bottom-when-scrolling a[download]")["href"] == url_for(
+    download_link = page.select_one(".js-stick-at-bottom-when-scrolling .page-footer-right-aligned-link-without-button")
+    assert normalize_spaces(download_link.text) == "Download this contact list (CSV)"
+    assert download_link["href"] == url_for(
         "main.download_contact_list",
         service_id=SERVICE_ONE_ID,
         contact_list_id=fake_uuid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3056,6 +3056,8 @@ def client_request(request, _logged_in_client, mocker, service_one, fake_nonce):
 
             ClientRequest._test_for_duplicate_ids(page)
 
+            ClientRequest._test_download_attribute_on_links(page)
+
             return page
 
         @staticmethod
@@ -3252,6 +3254,10 @@ def client_request(request, _logged_in_client, mocker, service_one, fake_nonce):
                 assert ids.count(id) == 1, f"Duplicate id `{id}` found on these elements:\n    " + ", ".join(
                     f"<{element.name}>" for element in page.select(f"*[id='{id}']")
                 )
+
+        @staticmethod
+        def _test_download_attribute_on_links(page):
+            assert not page.select("a[download]"), "Don’t use <a download> (set the Content-Disposition header instead)"
 
     return ClientRequest
 


### PR DESCRIPTION
The `download` attribute forces the browsers to download the file, rather than try to display it.

This is fine and good, unless you get signed out in between viewing the page and clicking the link. In this case your browser will download the sign in page as `sign-in.html`. That’s confusing.

Files should still be forced to download because we are also setting the `Content-Disposition: attachment` HTTP header, which is [widely supported](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Disposition#browser_compatibility) and deferred to if the `download` attribute is not present.