### PR TITLE
`TemplateList`: don't use set intersection for condition in `_get_templates`

### DIFF
--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -89,7 +89,7 @@ class TemplateList:
         return [
             template
             for template in self.all_templates
-            if ({template_type} & {"all", template["template_type"]}) and template.get("folder") == template_folder_id
+            if template_type in ("all", template["template_type"]) and template.get("folder") == template_folder_id
         ]
 
     def _get_template_folders(self, template_type, parent_folder_id):


### PR DESCRIPTION
Set logic is pretty, but can be slow if called in an inner loop where it requires construction of new set objects for each iteration.

This approximately doubles the speed of `TemplateList.items` in my test dataset of many templates/folders.

We could probably make it even faster if we built/cached a mapping of folder id -> template, but ... diminishing returns.