### PR TITLE
Don’t loop through all checkbox options to find `id`

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -700,10 +700,9 @@ class GovukCheckboxesField(GovukFrontendWidgetMixin, SelectMultipleField):
 
     @property
     def error_summary_id(self):
-        items = self.get_items_from_options(self)
-        if len(items) > 0:
-            return items[0]["id"]
-
+        for option in self:
+            # Stop looping through `self` as soon as we’ve found something
+            return option.id
         return self.id
 
     def prepare_params(self, **kwargs):
@@ -803,10 +802,9 @@ class GovukRadiosField(GovukFrontendWidgetMixin, RadioField):
 
     @property
     def error_summary_id(self):
-        items = self.get_items_from_options(self)
-        if len(items) > 0:
-            return items[0]["id"]
-
+        for option in self:
+            # Stop looping through `self` as soon as we’ve found something
+            return option.id
         return self.id
 
     def prepare_params(self, **kwargs):


### PR DESCRIPTION
Looks like we use the `id` of the first checkbox or radio in a set in order to work out where the error summary should link to.

Because we only ever care about the first item, we shouldn’t go through all the work of building a list of dictionaries for all the other items:
https://github.com/alphagov/notifications-admin/blob/f5ce6bc44d8cb8b3f8756c7fea7efdb4ef76b6df/app/main/forms.py#L689-L699

…items whose number can be many in the case of the templates page.

No idea if this will be a meaningful performance improvement but the code isn’t any worse so 🤷🏻‍♂️