### PR TITLE
Refactor rendering of template checkboxes to build data structures in Python, not Jinja

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -8,7 +8,7 @@ from math import ceil
 from numbers import Number
 from zipfile import BadZipFile
 
-from flask import request
+from flask import render_template, request
 from flask_login import current_user
 from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileAllowed, FileSize
@@ -2794,8 +2794,13 @@ class TemplateAndFoldersSelectionForm(OrderableFieldsForm):
         super().__init__(*args, **kwargs)
 
         self.available_template_types = available_template_types
+        template_type = kwargs.get("template_type")
+
+        self.links = [self.get_link(item, template_type) for item in template_list]
 
         self.templates_and_folders.choices = [(item.id, item.name) for item in template_list]
+
+        self.templates_and_folders.param_extensions["items"] = [self.get_checkbox_item(item) for item in template_list]
 
         self.op = None
         self.is_move_op = self.is_add_folder_op = self.is_add_template_op = False
@@ -2817,6 +2822,45 @@ class TemplateAndFoldersSelectionForm(OrderableFieldsForm):
                     ("letter", "Letter") if "letter" in available_template_types else None,
                     ("copy-existing", "Copy an existing template") if allow_adding_copy_of_template else None,
                 ],
+            )
+        )
+
+    @staticmethod
+    def get_checkbox_item(item, template_type):
+        return {
+            "html": render_template(
+                "views/templates/template-list/item-label-content.html",
+                item=item,
+            ),
+            "label": {
+                "classes": "template-list-item-label",
+            },
+            "id": f"templates-or-folder-{item.id}",
+            "classes": "template-list-item template-list-item-with-checkbox {}".format(
+                "template-list-item-hidden-by-default" if item.ancestors else "template-list-item-without-ancestors"
+            ),
+            "after": Markup(
+                render_template(
+                    "views/templates/template-list/item-link.html",
+                    item=item,
+                    template_type=template_type,
+                    wrapping_div=False,
+                )
+            ),
+            # This needs to be added when govuk-frontend-jinja supports it
+            # "attributes": {
+            #     "aria-describedby": f"{item.id}-hint",
+            # }
+        }
+
+    @staticmethod
+    def get_link(item, template_type):
+        return Markup(
+            render_template(
+                "views/templates/template-list/item-link.html",
+                item=item,
+                template_type=template_type,
+                wrapping_div=True,
             )
         )
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2788,22 +2788,26 @@ class TemplateAndFoldersSelectionForm(OrderableFieldsForm):
         available_template_types,
         allow_adding_copy_of_template,
         option_hints,
+        has_manage_template_permission,
         *args,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
 
+        self.op = None
+        self.is_move_op = self.is_add_folder_op = self.is_add_template_op = False
+
         self.available_template_types = available_template_types
         template_type = kwargs.get("template_type")
 
-        self.links = [self.get_link(item, template_type) for item in template_list]
+        if not has_manage_template_permission:
+            self.links = [self.get_link(item, template_type) for item in template_list]
+            return
 
         self.templates_and_folders.choices = [(item.id, item.name) for item in template_list]
-
-        self.templates_and_folders.param_extensions["items"] = [self.get_checkbox_item(item) for item in template_list]
-
-        self.op = None
-        self.is_move_op = self.is_add_folder_op = self.is_add_template_op = False
+        self.templates_and_folders.param_extensions["items"] = [
+            self.get_checkbox_item(item, template_type) for item in template_list
+        ]
 
         self.move_to.all_template_folders = all_template_folders
 
@@ -2907,13 +2911,17 @@ class TemplateAndFoldersSelectionForm(OrderableFieldsForm):
     # this means '__NONE__' (self.ALL_TEMPLATES option) is selected when no form data has been submitted
     # set default to empty string so process_data method doesn't perform any transformation
     move_to = GovukNestedRadiosField(
-        "Choose a folder", default="", validators=[required_for_ops("move-to-existing-folder"), Optional()]
+        "Choose a folder",
+        choices=[],  # Overridden in __init__
+        default="",
+        validators=[required_for_ops("move-to-existing-folder"), Optional()],
     )
 
     add_new_folder_name = GovukTextInputField("Folder name", validators=[required_for_ops("add-new-folder")])
     move_to_new_folder_name = GovukTextInputField("Folder name", validators=[required_for_ops("move-to-new-folder")])
     add_template_by_template_type = GovukRadiosFieldWithRequiredMessage(
         "New template",
+        choices=[],  # Overridden in __init__
         validators=[
             required_for_ops("add-new-template"),
             Optional(),

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -167,6 +167,7 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
         available_template_types=current_service.available_template_types,
         allow_adding_copy_of_template=(current_service.all_templates or len(current_user.service_ids) > 1),
         option_hints=option_hints,
+        has_manage_template_permission=current_user.has_permissions("manage_templates"),
     )
 
     if request.method == "POST" and templates_and_folders_form.validate_on_submit():

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -9,16 +9,15 @@
 {% else %}
   <div id="template-list" class="{{ 'govuk-!-margin-top-1' if (not show_template_nav and not show_search_box) else 'govuk-!-margin-top-6' }}">
 
-    {% for link in form.links %}
-      {% if not current_user.has_permissions('manage_templates') %}
-        {{ link }}
-      {% endif %}
-    {% endfor %}
-
     {% if current_user.has_permissions('manage_templates') %}
       {{ form.templates_and_folders(param_extensions={
         "formGroup": {"classes": "govuk-!-margin-bottom-0"}
       }) }}
+    {% else %}
+      {% for link in form.links %}
+        {{ link }}
+      {% endfor %}
     {% endif %}
+
   </div>
 {% endif %}

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -1,7 +1,3 @@
-{% from "components/folder-path.html" import format_template_name %}
-
-{% import "components/svgs.html" as svgs %}
-
 {% if template_list.template_folder_id and not template_list.templates_to_show %}
   <p class="template-list-empty">
     {% if template_list.folder_is_empty %}
@@ -12,74 +8,15 @@
   </p>
 {% else %}
   <div id="template-list" class="{{ 'govuk-!-margin-top-1' if (not show_template_nav and not show_search_box) else 'govuk-!-margin-top-6' }}">
-    {% set checkboxes_data = [] %}
 
-    {% for item in template_list.interruptible_iter %}
-      {% set item_num = loop.index %}
-      {% set item_link_content %}
-        {% for ancestor in item.ancestors %}
-          <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-            {{ svgs.folder(classes="template-list-folder__icon") }}
-            {{- format_template_name(ancestor.name) -}}
-          </a> <span class="message-name-separator"></span>
-        {% endfor %}
-        {% if item.is_folder %}
-          <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-            {{ svgs.folder(classes="template-list-folder__icon") }}
-            <span class="live-search-relevant">{{- format_template_name(item.name) -}}</span>
-          </a>
-        {% else %}
-          <a href="{{ url_for('main.view_template', service_id=current_service.id, template_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-template">
-            <span class="live-search-relevant">
-              {%- if current_service.api_keys -%}
-                <span class="govuk-!-display-none">{{ item.id }} </span>
-              {%- endif -%}
-              {{- format_template_name(item.name) -}}
-            </span>
-          </a>
-        {% endif %}
-      {% endset %}
-
-      {% set label_content %}
-        <span class="govuk-visually-hidden">
-          {%- for ancestor in item.ancestors %}{{ format_template_name(ancestor.name, separators=False) }} {% endfor -%}
-          {{ format_template_name(item.name, separators=False) -}}
-        </span>
-      {% endset %}
-
-      {% set item_meta %}
-        <span id="{{ item.id }}-item-hint" class="govuk-hint govuk-checkboxes__hint template-list-item-hint">
-          {{ item.hint }}
-        </span>
-      {% endset %}
-
-      {# create the item config now to include the label content -#}
-      {# TODO: "attributes": { "aria-describedby": item.id ~ "-hint" } needs to be added but govuk-frontend-jinja doesn't currently support this -#}
-      {% set checkbox_config = {
-        "html": label_content,
-        "label": {
-          "classes": "template-list-item-label",
-        },
-        "id": "templates-or-folder-" ~ item.id,
-        "classes": "template-list-item template-list-item-with-checkbox {}".format(
-          "template-list-item-hidden-by-default" if item.ancestors else "template-list-item-without-ancestors"),
-        "after": item_link_content ~ item_meta
-      } %}
-      {% do checkboxes_data.append(checkbox_config) %}
-
+    {% for link in form.links %}
       {% if not current_user.has_permissions('manage_templates') %}
-        <div class="template-list-item {%- if item.ancestors %} template-list-item-hidden-by-default {%- else %} template-list-item-without-ancestors{%- endif %}">
-          {{ item_link_content }}
-          <p class="template-list-item-hint govuk-!-margin-bottom-4">
-            {{ item.hint }}
-          </p>
-        </div>
+        {{ link }}
       {% endif %}
     {% endfor %}
 
     {% if current_user.has_permissions('manage_templates') %}
       {{ form.templates_and_folders(param_extensions={
-        "items": checkboxes_data,
         "formGroup": {"classes": "govuk-!-margin-bottom-0"}
       }) }}
     {% endif %}

--- a/app/templates/views/templates/template-list/item-label-content.html
+++ b/app/templates/views/templates/template-list/item-label-content.html
@@ -1,0 +1,6 @@
+{% from "components/folder-path.html" import format_template_name %}
+
+<span class="govuk-visually-hidden">
+    {%- for ancestor in item.ancestors %}{{ format_template_name(ancestor.name, separators=False) }} {% endfor -%}
+    {{ format_template_name(item.name, separators=False) -}}
+</span>

--- a/app/templates/views/templates/template-list/item-link.html
+++ b/app/templates/views/templates/template-list/item-link.html
@@ -1,0 +1,39 @@
+{% from "components/folder-path.html" import format_template_name %}
+{% import "components/svgs.html" as svgs %}
+
+{% if wrapping_div %}
+<div class="template-list-item {%- if item.ancestors %} template-list-item-hidden-by-default {%- else %} template-list-item-without-ancestors{%- endif %}">
+{% endif %}
+
+{% for ancestor in item.ancestors %}
+    <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+    {{ svgs.folder(classes="template-list-folder__icon") }}
+    {{- format_template_name(ancestor.name) -}}
+    </a> <span class="message-name-separator"></span>
+{% endfor %}
+{% if item.is_folder %}
+    <a href="{{ url_for('main.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+    {{ svgs.folder(classes="template-list-folder__icon") }}
+    <span class="live-search-relevant">{{- format_template_name(item.name) -}}</span>
+    </a>
+{% else %}
+    <a href="{{ url_for('main.view_template', service_id=current_service.id, template_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-template">
+    <span class="live-search-relevant">
+        {%- if current_service.api_keys -%}
+        <span class="govuk-!-display-none">{{ item.id }} </span>
+        {%- endif -%}
+        {{- format_template_name(item.name) -}}
+    </span>
+    </a>
+{% endif %}
+
+{% if wrapping_div %}
+    <p class="template-list-item-hint govuk-!-margin-bottom-4">
+        {{ item.hint }}
+    </p>
+</div>
+{% else %}
+    <span id="{{ item.id }}-item-hint" class="govuk-hint govuk-checkboxes__hint template-list-item-hint">
+        {{ item.hint }}
+    </span>
+{% endif %}

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -1159,6 +1159,7 @@ def test_should_be_able_to_move_to_existing_folder(
     mock_get_service_templates,
     mock_get_template_folders,
     mock_move_to_template_folder,
+    mock_get_api_keys,
 ):
     FOLDER_TWO_ID = str(uuid.uuid4())
     mock_get_template_folders.return_value = [
@@ -1194,7 +1195,7 @@ def test_should_be_able_to_move_to_existing_folder(
 @pytest.mark.parametrize(
     "user, expected_status, expected_called",
     [
-        (create_active_user_view_permissions(), 403, False),
+        (create_active_user_view_permissions(), 200, False),  # Fails form validation
         (create_active_user_with_permissions(), 302, True),
     ],
 )
@@ -1203,6 +1204,7 @@ def test_should_not_be_able_to_move_to_existing_folder_if_dont_have_permission(
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_api_keys,
     mock_move_to_template_folder,
     user,
     expected_status,
@@ -1414,6 +1416,7 @@ def test_new_folder_is_created_if_only_new_folder_is_filled_out(
     mock_get_template_folders,
     mock_move_to_template_folder,
     mock_create_template_folder,
+    mock_get_api_keys,
 ):
     data = {"move_to_new_folder_name": "", "add_new_folder_name": "new folder", "operation": "add-new-folder"}
 
@@ -1441,6 +1444,7 @@ def test_should_be_able_to_move_to_new_folder(
     mock_get_template_folders,
     mock_move_to_template_folder,
     mock_create_template_folder,
+    mock_get_api_keys,
 ):
     new_folder_id = mock_create_template_folder.return_value
     FOLDER_TWO_ID = str(uuid.uuid4())

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2255,6 +2255,7 @@ def test_choosing_to_copy_redirects(
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_api_keys,
 ):
     client_request.post(
         "main.choose_template",
@@ -2296,6 +2297,7 @@ def test_choosing_letter_creates(
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_api_keys,
     mock_create_service_template,
     fake_uuid,
 ):
@@ -2947,6 +2949,7 @@ def test_should_not_allow_creation_of_template_through_form_without_correct_perm
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_api_keys,
     service_permissions,
     data,
     expected_error,


### PR DESCRIPTION
This should be faster because:
- it’s in a lower-level language
- we can add logic to only compute the data for the checkboxes if the user has the `manage_templates` permission 

That said, I can’t produce a test case which shows this is faster.