### PR TITLE
Update the error messages for errors archiving a user or removing them from a service

### DIFF
--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -41,7 +41,8 @@ def archive_user(user_id):
         try:
             user_api_client.archive_user(user_id)
         except HTTPError as e:
-            if e.status_code == 400 and "manage_settings" in e.message:
+            new_msg = "User cannot be removed from a service"
+            if e.status_code == 400 and ("manage_settings" in e.message or new_msg in e.message):
                 flash(
                     "User can’t be removed from a service - "
                     "check all services have another team member with manage_settings"

--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -1,5 +1,6 @@
 from flask import abort, flash, redirect, render_template, request, url_for
 from flask_login import current_user
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 
 from app import user_api_client
@@ -44,8 +45,22 @@ def archive_user(user_id):
             new_msg = "User cannot be removed from a service"
             if e.status_code == 400 and ("manage_settings" in e.message or new_msg in e.message):
                 flash(
-                    "User can’t be removed from a service - "
-                    "check all services have another team member with manage_settings"
+                    Markup(
+                        """
+                        <h2 class='govuk-heading-m'>You cannot archive this user</h2>
+                        <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
+                            They have the ‘manage settings’ permission for at least one service.
+                        </p>
+                        <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
+                            If the user wants us to delete their service(s), follow the guidance in the support manual,
+                            then try again.
+                        </p>
+                        <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
+                            If they do not, ask them to add new team members or update the permissions for their
+                            team(s), then try again.
+                        </p>
+                        """
+                    )
                 )
                 return redirect(url_for("main.user_information", user_id=user_id))
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 
 from flask import abort, flash, redirect, render_template, request, session, url_for
 from flask_login import current_user
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 
 from app import current_service, service_api_client
@@ -318,7 +319,42 @@ def remove_user_from_service(service_id, user_id):
         msg = "You cannot remove the only user for a service"
         new_msg = "User cannot be removed from the service"
         if e.status_code == 400 and (msg in e.message or new_msg in e.message):
-            flash(msg, "info")
+            if current_user.platform_admin:
+                flash(
+                    Markup(
+                        """
+                        <h2 class='govuk-heading-m'>You cannot remove this team member</h2>
+                        <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
+                            A service needs at least 2 team members:
+                        </p>
+                        <ul class='govuk-list govuk-list--bullet error-text-colour govuk-!-font-weight-bold'>
+                            <li>from a public sector organisation</li>
+                            <li>with the ‘manage settings, team and usage’ permission</li>
+                        </ul>
+                        <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
+                            Ask the user to add new team members or update the permissions for their team.
+                        </p>
+                        """
+                    )
+                )
+            else:
+                flash(
+                    Markup(
+                        """
+                        <h2 class='govuk-heading-m'>You cannot remove this team member</h2>
+                        <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
+                            Your service needs at least 2 team members:
+                        </p>
+                        <ul class='govuk-list govuk-list--bullet error-text-colour govuk-!-font-weight-bold'>
+                            <li>from your organisation</li>
+                            <li>with the ‘manage settings, team and usage’ permission</li>
+                        </ul>
+                        <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
+                            Add new team members or update the permissions for your team, then try again.
+                        </p>
+                        """
+                    )
+                )
             return redirect(url_for(".manage_users", service_id=service_id))
         else:
             abort(500, e)

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -316,7 +316,8 @@ def remove_user_from_service(service_id, user_id):
         service_api_client.remove_user_from_service(service_id, user_id)
     except HTTPError as e:
         msg = "You cannot remove the only user for a service"
-        if e.status_code == 400 and msg in e.message:
+        new_msg = "User cannot be removed from the service"
+        if e.status_code == 400 and (msg in e.message or new_msg in e.message):
             flash(msg, "info")
             return redirect(url_for(".manage_users", service_id=service_id))
         else:

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -337,9 +337,8 @@ def test_archive_user_shows_error_message_if_user_cannot_be_archived(
 
     assert normalize_spaces(page.select_one("h1").text) == "Platform admin user"
     assert (
-        normalize_spaces(page.select_one(".banner-dangerous").text)
-        == "User can’t be removed from a service - check all services have another team member with manage_settings"
-    )
+        "You cannot archive this user They have the ‘manage settings’ permission for at least one service."
+    ) in normalize_spaces(page.select_one(".banner-dangerous").text)
 
 
 def test_archive_user_does_not_create_event_if_user_client_raises_unexpected_exception(

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -299,10 +299,18 @@ def test_archive_user_posts_to_user_client(
     assert mock_events.called
 
 
+@pytest.mark.parametrize(
+    "api_error_message",
+    [
+        "User can’t be removed from a service - check all services have another team member with manage_settings",
+        "User cannot be removed from a service",
+    ],
+)
 def test_archive_user_shows_error_message_if_user_cannot_be_archived(
     client_request,
     platform_admin_user,
     api_user_active,
+    api_error_message,
     mocker,
     mock_get_non_empty_organisations_and_services_for_user,
 ):
@@ -313,12 +321,10 @@ def test_archive_user_shows_error_message_if_user_cannot_be_archived(
                 status_code=400,
                 json={
                     "result": "error",
-                    "message": "User can’t be removed from a service - check all services have another "
-                    "team member with manage_settings",
+                    "message": api_error_message,
                 },
             ),
-            message="User can’t be removed from a service - check all services have another team member "
-            "with manage_settings",
+            message=api_error_message,
         ),
     )
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 from flask import url_for
 from flask_login import current_user
+from notifications_python_client.errors import HTTPError
 
 import app
 from app.constants import SERVICE_JOIN_REQUEST_APPROVED, SERVICE_JOIN_REQUEST_REJECTED
@@ -1502,6 +1503,45 @@ def test_remove_user_from_service(
         removed_by_id=api_user_active["id"],
         service_id=service_one["id"],
     )
+
+
+@pytest.mark.parametrize(
+    "api_error_message",
+    [
+        "You cannot remove the only user for a service",
+        "User cannot be removed from the service",
+    ],
+)
+def test_remove_user_from_service_when_user_api_gives_error(
+    client_request,
+    active_user_with_permissions,
+    service_one,
+    mock_get_users_by_service,
+    mock_get_invites_for_service,
+    mock_get_template_folders,
+    api_error_message,
+    mocker,
+):
+    mocker.patch(
+        "app.service_api_client.remove_user_from_service",
+        side_effect=HTTPError(
+            response=mocker.Mock(status_code=400, json={"result": "error", "message": api_error_message}),
+            message=api_error_message,
+        ),
+    )
+    mock_event_handler = mocker.patch("app.main.views.manage_users.Events.remove_user_from_service")
+
+    page = client_request.post(
+        "main.remove_user_from_service",
+        service_id=service_one["id"],
+        user_id=active_user_with_permissions["id"],
+        _follow_redirects=True,
+    )
+
+    assert "You cannot remove the only user for a service" in normalize_spaces(
+        page.select_one(".banner-dangerous").text
+    )
+    assert not mock_event_handler.called
 
 
 def test_can_invite_user_as_platform_admin(

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1538,9 +1538,50 @@ def test_remove_user_from_service_when_user_api_gives_error(
         _follow_redirects=True,
     )
 
-    assert "You cannot remove the only user for a service" in normalize_spaces(
-        page.select_one(".banner-dangerous").text
+    assert (
+        "You cannot remove this team member Your service needs at least 2 team members: from your organisation"
+    ) in normalize_spaces(page.select_one(".banner-dangerous").text)
+    assert not mock_event_handler.called
+
+
+@pytest.mark.parametrize(
+    "api_error_message",
+    [
+        "You cannot remove the only user for a service",
+        "User cannot be removed from the service",
+    ],
+)
+def test_remove_user_from_service_when_user_api_gives_error_for_platform_admin_user(
+    client_request,
+    active_user_with_permissions,
+    platform_admin_user,
+    service_one,
+    mock_get_users_by_service,
+    mock_get_invites_for_service,
+    mock_get_template_folders,
+    api_error_message,
+    mocker,
+):
+    mocker.patch(
+        "app.service_api_client.remove_user_from_service",
+        side_effect=HTTPError(
+            response=mocker.Mock(status_code=400, json={"result": "error", "message": api_error_message}),
+            message=api_error_message,
+        ),
     )
+    mock_event_handler = mocker.patch("app.main.views.manage_users.Events.remove_user_from_service")
+
+    client_request.login(platform_admin_user)
+    page = client_request.post(
+        "main.remove_user_from_service",
+        service_id=service_one["id"],
+        user_id=active_user_with_permissions["id"],
+        _follow_redirects=True,
+    )
+
+    assert (
+        "You cannot remove this team member A service needs at least 2 team members: from a public sector organisation"
+    ) in normalize_spaces(page.select_one(".banner-dangerous").text)
     assert not mock_event_handler.called
 
 


### PR DESCRIPTION
We're changing the logic around when a user can be removed from a service or archived. Previously, we required there to be at least one active user with the `manage_settings` permission, but we're changing this requirement to two users with the permission, unless the service is in trial mode and hasn't made a go-live request.

This updates the code to have the new error messages we want to display. The error messages that the API will raise if a user can't be removed or archived will change, so we support both API error messages while the change is rolled out. When the API change is made, we can simplify the code here to only check for the new message.

[Trello card](https://trello.com/c/ZVJ7qdu1/1692-error-for-removing-a-penultimate-user-with-manage-settings-permissions)

---
# Screenshots

## Error when trying to archive a user
This will only be seen by platform admin users, since only they have the permission to archive a user
<img width="500" height="350" alt="Screenshot 2026-04-28 at 11 24 35" src="https://github.com/user-attachments/assets/eb180374-d4bc-42a9-996b-039a9be3e195" />

## Error when trying to remove a user from a service - platform admin user version
<img width="500" height="300" alt="Screenshot 2026-04-28 at 16 31 22" src="https://github.com/user-attachments/assets/8449b3e9-ff92-4ed0-957c-deeeb80cb34f" />

## Error when trying to remove a user from a service - standard user version
<img width="500" height="300" alt="Screenshot 2026-04-28 at 16 30 57" src="https://github.com/user-attachments/assets/5e1979f0-8d62-4a6e-90a0-6dba67953b59" />
