### PR TITLE
`TemplateAndFoldersSelectionForm`: make rendering of `templates_and_folders` and `move_to` fields interruptible

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -114,7 +114,7 @@ from app.utils.govuk_frontend_field import (
     render_govuk_frontend_macro,
 )
 from app.utils.image_processing import CorruptImage, ImageProcessor, WrongImageFormat
-from app.utils.interruptible_io import interruptible_iter
+from app.utils.interruptible_io import InterruptibleIterableList, interruptible_iter
 from app.utils.user_permissions import (
     all_ui_permissions,
     organisation_user_permission_names,
@@ -723,6 +723,25 @@ class GovukCheckboxesField(GovukFrontendWidgetMixin, SelectMultipleField):
         }
 
         return params
+
+
+class InterruptibleItemsFieldMixin:
+    def __init__(self, *args, items_iteration_interruptible_every=32, **kwargs):
+        self.items_iteration_interruptible_every = items_iteration_interruptible_every
+        super().__init__(*args, **kwargs)
+
+    def get_items_from_options(self, field):
+        r = InterruptibleIterableList(super().get_items_from_options(field))
+        r.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.items_iteration_interruptible_every
+        r.INTERRUPTIBLE_ITERABLE_LABEL_OVERRIDE = self.__class__.__name__
+        # the returned InterruptibleIterableList *usually* survives an encounter with
+        # merge_jsonlike, but arbitrary processing steps are liable to replace it with
+        # a regular list or other Sequence, defeating its purpose
+        return r
+
+
+class InterruptibleItemsGovukCheckboxesField(InterruptibleItemsFieldMixin, GovukCheckboxesField):
+    pass
 
 
 # Wraps checkboxes rendering in HTML needed by the collapsible JS
@@ -2852,7 +2871,7 @@ class TemplateAndFoldersSelectionForm(OrderableFieldsForm):
             return self.move_to_new_folder_name.data
         return None
 
-    templates_and_folders = GovukCheckboxesField(
+    templates_and_folders = InterruptibleItemsGovukCheckboxesField(
         "Choose templates or folders",
         validators=[required_for_ops("move-to-new-folder", "move-to-existing-folder")],
         choices=[],  # added to keep order of arguments, added properly in __init__

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -467,7 +467,9 @@ class NestedFieldMixin:
         child_map = {None: [option for option in options if option.data == self.NONE_OPTION_VALUE]}
 
         # add entries for all other children
-        for option in interruptible_iter(options, self.CHILD_MAP_ITERATION_INTERRUPTIBLE_EVERY):
+        for option in interruptible_iter(
+            options, self.CHILD_MAP_ITERATION_INTERRUPTIBLE_EVERY, label="child map iteration"
+        ):
             # assign all options with a NONE_OPTION_VALUE (not always None) to the None key
             if option.data == self.NONE_OPTION_VALUE:
                 child_ids = [folder["id"] for folder in self.all_template_folders if folder["parent_id"] is None]

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -3,7 +3,7 @@ from contextlib import suppress
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from functools import partial
-from itertools import chain
+from itertools import chain, repeat
 from math import ceil
 from numbers import Number
 from zipfile import BadZipFile
@@ -510,6 +510,18 @@ class NestedFieldMixin:
         return render_govuk_frontend_macro(self.govuk_frontend_component_name, params=params)
 
 
+class InterruptibleChildRenderingNestedFieldMixin:
+    def __init__(self, *args, child_rendering_interruptible_every=32, **kwargs):
+        self.child_rendering_interruptible_dummy_iterator = interruptible_iter(
+            repeat(None), child_rendering_interruptible_every, label=self.__class__.__name__
+        )
+        super().__init__(*args, **kwargs)
+
+    def render_children(self, *args, **kwargs):
+        next(self.child_rendering_interruptible_dummy_iterator)
+        return super().render_children(*args, **kwargs)
+
+
 class NestedCheckboxesField(SelectMultipleField, NestedFieldMixin):
     NONE_OPTION_VALUE = None
 
@@ -916,6 +928,12 @@ class GovukNestedRadiosField(NestedFieldMixin, GovukRadiosFieldWithNoneOption):
             params["items"].append(item)
 
         return render_govuk_frontend_macro(self.govuk_frontend_component_name, params=params)
+
+
+class InterruptibleChildRenderingGovukNestedRadiosField(
+    InterruptibleChildRenderingNestedFieldMixin, GovukNestedRadiosField
+):
+    pass
 
 
 class GovukRadiosWithImagesField(GovukRadiosField):
@@ -2881,7 +2899,7 @@ class TemplateAndFoldersSelectionForm(OrderableFieldsForm):
     # if no default set, it is set to None, which process_data transforms to '__NONE__'
     # this means '__NONE__' (self.ALL_TEMPLATES option) is selected when no form data has been submitted
     # set default to empty string so process_data method doesn't perform any transformation
-    move_to = GovukNestedRadiosField(
+    move_to = InterruptibleChildRenderingGovukNestedRadiosField(
         "Choose a folder", default="", validators=[required_for_ops("move-to-existing-folder"), Optional()]
     )
 

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -41,7 +41,9 @@ class TemplateList:
 
     @property
     def interruptible_iter(self):
-        return interruptible_io.interruptible_iter(self, self.INTERRUPTIBLE_ITER_INTERRUPTIBLE_EVERY)
+        return interruptible_io.interruptible_iter(
+            self, self.INTERRUPTIBLE_ITER_INTERRUPTIBLE_EVERY, label=self.__class__.__name__
+        )
 
     @cached_property
     def items(self):

--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -6,7 +6,6 @@ from flask import current_app, templating
 from markupsafe import Markup
 
 from app.utils import merge_jsonlike
-from app.utils.interruptible_io import interruptible_every
 
 
 class GovukFrontendWidgetMixin(ABC):
@@ -98,7 +97,6 @@ class GovukFrontendWidgetMixin(ABC):
         return render_govuk_frontend_macro(self.govuk_frontend_component_name, params)
 
 
-@interruptible_every(32)
 def render_govuk_frontend_macro(component, params):
     """
     jinja needs a template to render but govuk_frontend_jinja only provides macros

--- a/app/utils/interruptible_io.py
+++ b/app/utils/interruptible_io.py
@@ -5,6 +5,14 @@ from time import sleep
 from zipfile import ZipFile
 
 
+def _interruptible(label: str) -> None:
+    """
+    Wrapping our `sleep(0)` calls in a wrapper makes them more instrumentable,
+    especially if a useful `label` is supplied.
+    """
+    sleep(0)
+
+
 class InterruptibleRawIOWrapper(RawIOBase):
     """
     A fileobj wrapper that will make itself "interruptible" by calling sleep(0)
@@ -43,13 +51,13 @@ class InterruptibleRawIOWrapper(RawIOBase):
         return self._wrapped.readable(*args, **kwargs)
 
     def readline(self, size=-1, /):
-        sleep(0)
+        _interruptible(self.__class__.__name__)
         if size >= 0:
             size = min(self._read_limit, size)
         return self._wrapped.readline(size)
 
     def readlines(self, hint=-1, /):
-        sleep(0)
+        _interruptible(self.__class__.__name__)
         if hint >= 0:
             hint = min(self._read_limit, hint)
         return self._wrapped.readlines(hint)
@@ -70,28 +78,28 @@ class InterruptibleRawIOWrapper(RawIOBase):
         return self._wrapped.writable(*args, **kwargs)
 
     def writelines(self, *args, **kwargs):
-        sleep(0)
+        _interruptible(self.__class__.__name__)
         return self._wrapped.writelines(*args, **kwargs)
 
     def __del__(self, *args, **kwargs):
         return self._wrapped.__del__(*args, **kwargs)
 
     def read(self, size=-1, /):
-        sleep(0)
+        _interruptible(self.__class__.__name__)
         if size >= 0:
             size = min(self._read_limit, size)
         return self._wrapped.read(size)
 
     def readall(self, *args, **kwargs):
-        sleep(0)
+        _interruptible(self.__class__.__name__)
         return self._wrapped.readall(*args, **kwargs)
 
     def readinto(self, *args, **kwargs):
-        sleep(0)
+        _interruptible(self.__class__.__name__)
         return self._wrapped.readinto(*args, **kwargs)
 
     def write(self, *args, **kwargs):
-        sleep(0)
+        _interruptible(self.__class__.__name__)
         return self._wrapped.write(*args, **kwargs)
 
 
@@ -105,7 +113,9 @@ class InterruptibleIOZipFile(ZipFile):
         return InterruptibleRawIOWrapper(super().open(*args, **kwargs), read_limit=8_192)
 
 
-def interruptible_every[**A, R](iterations: int) -> Callable[[Callable[A, R]], Callable[A, R]]:
+def interruptible_every[**A, R](
+    iterations: int, *, label: str = "interruptible_every"
+) -> Callable[[Callable[A, R]], Callable[A, R]]:
     """
     Returns a decorator that, applied to a function, will keep a global counter of invocations
     and yield before every `iterations`'th call.
@@ -118,7 +128,7 @@ def interruptible_every[**A, R](iterations: int) -> Callable[[Callable[A, R]], C
         def interruptible_wrapper(*args, **kwargs):
             nonlocal i
             if i >= iterations:
-                sleep(0)
+                _interruptible(label)
                 i = 0
 
             i += 1
@@ -130,7 +140,9 @@ def interruptible_every[**A, R](iterations: int) -> Callable[[Callable[A, R]], C
     return interruptible_decorator
 
 
-def interruptible_iter[T](it: Iterable[T], interruptible_every: int) -> Iterable[T]:
+def interruptible_iter[T](
+    it: Iterable[T], interruptible_every: int, *, label: str = "interruptible_iter"
+) -> Iterable[T]:
     """
     Given an iterable `it`, will yield its contents, calling sleep(0) before yielding each
     `interruptible_every`'th iteration.
@@ -138,7 +150,7 @@ def interruptible_iter[T](it: Iterable[T], interruptible_every: int) -> Iterable
     i = 0
     for item in it:
         if i >= interruptible_every:
-            sleep(0)
+            _interruptible(label)
             i = 0
 
         yield item
@@ -154,9 +166,14 @@ class InterruptibleIterableMixin:
     """
 
     INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY: int = 32
+    INTERRUPTIBLE_ITERABLE_LABEL_OVERRIDE: str | None = None
 
     def __iter__(self) -> Iterator:
-        return interruptible_iter(super().__iter__(), self.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY)
+        return interruptible_iter(
+            super().__iter__(),
+            self.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY,
+            label=self.INTERRUPTIBLE_ITERABLE_LABEL_OVERRIDE or self.__class__.__name__,
+        )
 
 
 class InterruptibleIterableList(InterruptibleIterableMixin, list):

--- a/app/utils/interruptible_io.py
+++ b/app/utils/interruptible_io.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from functools import wraps
 from io import RawIOBase
 from time import sleep
@@ -144,3 +144,20 @@ def interruptible_iter[T](it: Iterable[T], interruptible_every: int) -> Iterable
         yield item
 
         i += 1
+
+
+class InterruptibleIterableMixin:
+    """
+    A mixin for an Iterable that will yield the GIL or greenthread every
+    INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY iterations when its iterator
+    is iterated through
+    """
+
+    INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY: int = 32
+
+    def __iter__(self) -> Iterator:
+        return interruptible_iter(super().__iter__(), self.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY)
+
+
+class InterruptibleIterableList(InterruptibleIterableMixin, list):
+    pass

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2,6 +2,7 @@ import json
 import uuid
 from functools import partial
 from io import BytesIO
+from itertools import count, cycle, islice
 from unittest.mock import ANY, Mock
 
 import pytest
@@ -348,6 +349,61 @@ def test_should_show_new_template_choices_if_service_has_folder_permission(
     assert normalize_spaces(page.select_one("#add_new_template_form fieldset legend").text) == "New template"
     assert [choice["value"] for choice in page.select("#add_new_template_form input[type=radio]")] == expected_values
     assert [normalize_spaces(choice.text) for choice in page.select("#add_new_template_form label")] == expected_labels
+
+
+def test_choose_template_interruptible(
+    client_request,
+    service_one,
+    mock_get_no_api_keys,
+    mocker,
+):
+    # generate an interesting mixture of folder depths and contained template counts in a
+    # fizzbuzz-style fashion
+    c = count()
+    folders = [_folder(f"folder {i}", str(uuid.uuid4())) for i in islice(c, 0, 100)]
+    folders.extend(
+        _folder(f"folder {i}", str(uuid.uuid4()), parent=parent["id"])
+        for parent, i in zip(folders[::2], c, strict=False)
+    )
+    folders.extend(
+        _folder(f"folder {i}", str(uuid.uuid4()), parent=parent["id"])
+        for parent, i in zip(folders[::3], c, strict=False)
+    )
+    folders.extend(
+        _folder(f"folder {i}", str(uuid.uuid4()), parent=parent["id"])
+        for parent, i in zip(folders[::5], c, strict=False)
+    )
+
+    c = count()
+    templates = [_template("sms", f"sms template {i}") for i in islice(c, 0, 500)]
+    templates.extend(
+        _template("sms", f"sms template {i}", folder["id"])
+        for folder, i in zip(islice(cycle(folders), 0, 2000, 7), c, strict=False)
+    )
+
+    mocker.patch(
+        "app.template_folder_api_client.get_template_folders",
+        return_value=folders,
+    )
+    mocker.patch(
+        "app.service_api_client.get_service_templates",
+        return_value={
+            "data": templates,
+        },
+    )
+
+    mock_interruptible = mocker.patch("app.utils.interruptible_io._interruptible")
+
+    client_request.get("main.choose_template", service_id=SERVICE_ONE_ID, _test_page_title=False)
+
+    # assert this view calls _interruptible in all the expected ways at least once. this may need
+    # updating if class names, inheritance or the view structure changes, but this is here to avoid
+    # nullification of one of the forms of interruptibility without noticing. of course, it doesn't
+    # test that they're all called an appropriate number of times and in the right *places*.
+    assert mocker.call("child map iteration") in mock_interruptible.mock_calls
+    assert mocker.call("UserTemplateList") in mock_interruptible.mock_calls
+    assert mocker.call("InterruptibleItemsGovukCheckboxesField") in mock_interruptible.mock_calls
+    assert mocker.call("InterruptibleChildRenderingGovukNestedRadiosField") in mock_interruptible.mock_calls
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Using two new `Field` mixins - `InterruptibleChildRenderingNestedFieldMixin` which effectively wraps the `render_children` method to yield interruptibly every N calls. Not done with the `@interruptible_every` decorator as this way we can keep a separate counter for each instance and customise the `child_rendering_interruptible_every` at construction time.

`InterruptibleItemsFieldMixin` simply causes the `get_items_from_options` method to return an `InterruptibleIterableList` - a `list` subclass whose iterator is interruptible. This is not 100% foolproof because of how list objects can get replaced with vanilla ones by later processing steps, but it does seem to work correctly most the time.

I tracked this down and analyzed this by extending the sleep calls to print timestamps and used the `setitimer` signal to breakpoint long pauses between sleeps. Tested on a local machine with realistic data, the only remaining ~300ms pause appears to be during the escaping & re-indenting process performed on the final massive html generated.