### PR TITLE
Remove jQuery from focusBanner

### DIFF
--- a/app/assets/javascripts/esm/all-esm.mjs
+++ b/app/assets/javascripts/esm/all-esm.mjs
@@ -148,4 +148,4 @@ if ($updateContentBlocks.length > 0) {
   });
 };
 
-const focusBanner = new FocusBanner();
+new FocusBanner();

--- a/app/assets/javascripts/esm/focus-banner.mjs
+++ b/app/assets/javascripts/esm/focus-banner.mjs
@@ -1,7 +1,7 @@
 import { isSupported } from 'govuk-frontend';
 
 // This new way of writing Javascript components is based on the GOV.UK Frontend skeleton Javascript coding standard
-// that uses ES 015 Classes -
+// that uses ES 2015 Classes -
 // https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/js.md#skeleton
 //
 // It replaces the previously used way of setting methods on the component's `prototype`.
@@ -19,23 +19,27 @@ class FocusBanner {
     }
 
     // focus any error banners when the page loads
-    this.focusBanner($('.banner-dangerous'));
+    const $bannerEl = document.querySelector('.banner-dangerous');
+    if ($bannerEl) {
+      this.focusBanner($bannerEl);
+    }
 
     // focus success and error banners when they appear in any content updates
-    document.addEventListener("updateContent.onafterupdate", function(event) {
-      const $el = event.detail.el[0];
-      this.focusBanner($(".banner-dangerous", $el));
-    }.bind(this));
+    document.addEventListener('updateContent.onafterupdate', (event) => {
+      const el = event.detail.el[0];
+      const $bannerEl = el.classList.contains("banner-dangerous") ? el : el.querySelector(".banner-dangerous");
+      if ($bannerEl) {
+        this.focusBanner($bannerEl);
+      }
+    });
   }
 
-  focusBanner ($bannerEl) {
-    if ($bannerEl.length === 0) { return; }
-
-    $bannerEl.attr('tabindex', '-1');
-    $bannerEl.trigger('focus');
-    $bannerEl.on('blur', () => {
-      $bannerEl.removeAttr('tabindex');
-    });
+  focusBanner($bannerEl) {
+    $bannerEl.setAttribute('tabindex', '-1');
+    $bannerEl.focus();
+    $bannerEl.addEventListener('blur', () => {
+      $bannerEl.removeAttribute('tabindex');
+    }, { once: true });
   }
 }
 

--- a/tests/javascripts/focus-banner.test.mjs
+++ b/tests/javascripts/focus-banner.test.mjs
@@ -14,13 +14,13 @@ describe('Focus banner', () => {
         <p>The file uploaded needs to be a PNG</p>
       </div>`;
 
-    (new FocusBanner());
+    new FocusBanner();
 
     const bannerEl = document.querySelector('.banner-dangerous');
 
     expect(document.activeElement).toBe(bannerEl);
 
-    $(bannerEl).trigger('blur');
+    bannerEl.blur();
 
     expect(bannerEl.hasAttribute('tabindex')).toBe(false);
 
@@ -36,7 +36,7 @@ describe('Focus banner', () => {
 
       const ajaxBlockContainer = document.querySelector('.ajax-block-container');
 
-      (new FocusBanner());
+      new FocusBanner();
 
       // simulate a content update event
       ajaxBlockContainer.innerHTML = `
@@ -51,7 +51,7 @@ describe('Focus banner', () => {
 
       expect(document.activeElement).toBe(bannerEl);
 
-      $(bannerEl).trigger('blur');
+      bannerEl.blur();
 
       expect(bannerEl.hasAttribute('tabindex')).toBe(false);
 


### PR DESCRIPTION
When we rewrote it to ESM we still left jQuery in there. As the goal is to remove it entirely, this PR replaces it with vanilla Javascript.

If the `update-content` module inserts html that has or contains an element with a target class, this script will focus it.

We listen for the `blur` event (as it looses focus) The `blur` event listener automatically gets removed when invoked with `once: true` optional parameter.

FocusBanner is triggered by when `updateContent.onafterupdate` event is dispatched by the `update-content` script.

This is (was?) used when verifying reply-to email address.