### PR TITLE
Require two active members with gov email addresses to go live

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -30,6 +30,7 @@ from app.notify_client.service_api_client import service_api_client
 from app.notify_client.template_folder_api_client import template_folder_api_client
 from app.utils import get_default_sms_sender
 from app.utils.templates import get_template as get_template_as_rich_object
+from app.utils.user import is_gov_user
 
 
 class Service(JSONModel):
@@ -192,6 +193,13 @@ class Service(JSONModel):
     def active_users_with_permission(self, permission):
         return tuple(user for user in self.active_users if user.has_permission_for_service(self.id, permission))
 
+    def active_gov_users_with_permission(self, permission):
+        return tuple(
+            user
+            for user in self.active_users
+            if (user.has_permission_for_service(self.id, permission) and is_gov_user(user.email_address))
+        )
+
     @cached_property
     def team_members(self):
         return self.invited_users + self.active_users
@@ -201,7 +209,7 @@ class Service(JSONModel):
 
     @cached_property
     def has_team_members_with_manage_service_permission(self):
-        return len(self.team_members_with_permission("manage_service")) > 1
+        return len(self.active_gov_users_with_permission("manage_service")) > 1
 
     def cancel_invite(self, invited_user_id):
         if str(invited_user_id) not in {user.id for user in self.invited_users}:

--- a/tests/app/main/views/test_make_your_service_live.py
+++ b/tests/app/main/views/test_make_your_service_live.py
@@ -1,6 +1,5 @@
 from datetime import UTC, datetime
 from unittest.mock import ANY, Mock, PropertyMock, call
-from uuid import uuid4
 
 import pytest
 from flask import url_for
@@ -8,7 +7,7 @@ from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket, NotifyTicketType
 
-from tests import invite_json, organisation_json, validate_route_permission
+from tests import organisation_json, validate_route_permission
 from tests.conftest import ORGANISATION_ID, SERVICE_ONE_ID, create_template, normalize_spaces
 
 
@@ -294,7 +293,7 @@ def test_should_check_for_email_from_name_on_go_live(
     [
         (1, 0, "Give another team member the ‘manage settings’ permission Incomplete"),
         (2, 0, "Give another team member the ‘manage settings’ permission Completed"),
-        (1, 1, "Give another team member the ‘manage settings’ permission Completed"),
+        (1, 1, "Give another team member the ‘manage settings’ permission Incomplete"),
     ],
 )
 @pytest.mark.parametrize(
@@ -330,25 +329,6 @@ def test_should_check_for_sending_things_right(
             [active_user_with_permissions] * count_of_users_with_manage_service + [active_user_no_settings_permission]
         ),
     )
-    invite_one = invite_json(
-        id_=uuid4(),
-        from_user=service_one["users"][0],
-        service_id=service_one["id"],
-        email_address="invited_user@test.gov.uk",
-        permissions="view_activity,send_messages,manage_service,manage_api_keys",
-        created_at=datetime.now(UTC),
-        status="pending",
-        auth_type="sms_auth",
-        folder_permissions=[],
-    )
-
-    invite_two = invite_one.copy()
-    invite_two["permissions"] = "view_activity"
-
-    mock_get_invites = mocker.patch(
-        "app.models.user.InvitedUsers._get_items",
-        return_value=(([invite_one] * count_of_invites_with_manage_service) + [invite_two]),
-    )
 
     page = client_request.get("main.request_to_go_live", service_id=SERVICE_ONE_ID)
     assert page.select_one("h1").text == "Make your service live"
@@ -358,7 +338,6 @@ def test_should_check_for_sending_things_right(
     assert normalize_spaces(checklist_items[3].text) == expected_templates_checklist_item
 
     mock_get_users.assert_called_once_with(SERVICE_ONE_ID)
-    mock_get_invites.assert_called_once_with(SERVICE_ONE_ID)
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_make_your_service_live.py
+++ b/tests/app/main/views/test_make_your_service_live.py
@@ -1,6 +1,5 @@
 from datetime import UTC, datetime
 from unittest.mock import ANY, Mock, PropertyMock, call
-from uuid import uuid4
 
 import pytest
 from flask import url_for
@@ -8,7 +7,7 @@ from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket, NotifyTicketType
 
-from tests import invite_json, organisation_json, validate_route_permission
+from tests import organisation_json, validate_route_permission
 from tests.conftest import ORGANISATION_ID, SERVICE_ONE_ID, create_template, normalize_spaces
 
 
@@ -290,11 +289,12 @@ def test_should_check_for_email_from_name_on_go_live(
 
 
 @pytest.mark.parametrize(
-    "count_of_users_with_manage_service,count_of_invites_with_manage_service,expected_user_checklist_item",
+    "count_of_users_with_manage_service,count_of_invites_with_manage_service,count_of_non_gov_users_with_manage,expected_user_checklist_item",
     [
-        (1, 0, "Finish setting up your team Incomplete"),
-        (2, 0, "Finish setting up your team Completed"),
-        (1, 1, "Finish setting up your team Completed"),
+        (1, 0, 0, "Finish setting up your team Incomplete"),
+        (2, 0, 0, "Finish setting up your team Completed"),
+        (1, 1, 0, "Finish setting up your team Incomplete"),
+        (1, 0, 1, "Finish setting up your team Incomplete"),
     ],
 )
 @pytest.mark.parametrize(
@@ -330,25 +330,6 @@ def test_should_check_for_sending_things_right(
             [active_user_with_permissions] * count_of_users_with_manage_service + [active_user_no_settings_permission]
         ),
     )
-    invite_one = invite_json(
-        id_=uuid4(),
-        from_user=service_one["users"][0],
-        service_id=service_one["id"],
-        email_address="invited_user@test.gov.uk",
-        permissions="view_activity,send_messages,manage_service,manage_api_keys",
-        created_at=datetime.now(UTC),
-        status="pending",
-        auth_type="sms_auth",
-        folder_permissions=[],
-    )
-
-    invite_two = invite_one.copy()
-    invite_two["permissions"] = "view_activity"
-
-    mock_get_invites = mocker.patch(
-        "app.models.user.InvitedUsers._get_items",
-        return_value=(([invite_one] * count_of_invites_with_manage_service) + [invite_two]),
-    )
 
     page = client_request.get("main.request_to_go_live", service_id=SERVICE_ONE_ID)
     assert page.select_one("h1").text == "Make your service live"
@@ -358,7 +339,6 @@ def test_should_check_for_sending_things_right(
     assert normalize_spaces(checklist_items[3].text) == expected_templates_checklist_item
 
     mock_get_users.assert_called_once_with(SERVICE_ONE_ID)
-    mock_get_invites.assert_called_once_with(SERVICE_ONE_ID)
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_make_your_service_live.py
+++ b/tests/app/main/views/test_make_your_service_live.py
@@ -312,8 +312,10 @@ def test_should_check_for_sending_things_right(
     single_sms_sender,
     count_of_users_with_manage_service,
     count_of_invites_with_manage_service,
+    count_of_non_gov_users_with_manage,
     expected_user_checklist_item,
     count_of_templates,
+    api_nongov_user_active,
     expected_templates_checklist_item,
     active_user_with_permissions,
     active_user_no_settings_permission,
@@ -324,10 +326,17 @@ def test_should_check_for_sending_things_right(
         return_value={"data": [create_template(template_type="sms") for _ in range(count_of_templates)]},
     )
 
+    mocker.patch(
+        "app.organisations_client.get_domains",
+        return_value=[],
+    )
+
     mock_get_users = mocker.patch(
         "app.models.user.Users._get_items",
         return_value=(
-            [active_user_with_permissions] * count_of_users_with_manage_service + [active_user_no_settings_permission]
+            [active_user_with_permissions] * count_of_users_with_manage_service
+            + [active_user_no_settings_permission]
+            + [api_nongov_user_active] * count_of_non_gov_users_with_manage
         ),
     )
 


### PR DESCRIPTION
This changes the behaviour of the go live flow so that you need two active users with government email addresses to go live. Not just having invited people to a service.
