### PR TITLE
Update 'technical errors' in the support form to include sending messages  in website

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1910,7 +1910,10 @@ class SupportWhatHappenedForm(StripWhitespaceForm):
     what_happened = GovukRadiosField(
         "What happened?",
         choices=[
-            ("technical-difficulties", "I got a ‘technical difficulties’ error when I tried to upload a file"),
+            (
+                "technical-difficulties",
+                "I got a ‘technical difficulties’ error when I tried to send messages using the Notify website",
+            ),
             ("api-500-response", "I got a 500 response code from the API"),
             ("something-else", "Something else"),
         ],

--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -26,7 +26,7 @@
 
         <ul class="govuk-list govuk-list--bullet">
         <li>
-          if you did not get a ‘technical difficulties’ error when uploading a file
+          if you did not get a ‘technical difficulties’ error when sending messages using the Notify website
         </li>
         <li>
           if you did not get a 500 response code when using the API

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -32,7 +32,7 @@
       {% set emergency_criteria %}
       <p class="govuk-body">A problem is only classed as an emergency if you have a live service and:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>a ‘technical difficulties’ error appears when you try to upload a file</li>
+        <li>a ‘technical difficulties’ error appears when you try to send messages using the Notify website</li>
         <li>a 500 response code appears when you try to send messages using the API</li>
       </ul>
       {% endset %}


### PR DESCRIPTION
Update support form to include 'technical difficulties' error when sending messages in the UI