### PR TITLE
Add version of error when removing service team members for non-gov users

### DIFF
--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -42,8 +42,7 @@ def archive_user(user_id):
         try:
             user_api_client.archive_user(user_id)
         except HTTPError as e:
-            new_msg = "User cannot be removed from a service"
-            if e.status_code == 400 and ("manage_settings" in e.message or new_msg in e.message):
+            if e.status_code == 400 and "User cannot be removed from a service" in e.message:
                 flash(
                     Markup(
                         """

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -316,9 +316,7 @@ def remove_user_from_service(service_id, user_id):
     try:
         service_api_client.remove_user_from_service(service_id, user_id)
     except HTTPError as e:
-        msg = "You cannot remove the only user for a service"
-        new_msg = "User cannot be removed from the service"
-        if e.status_code == 400 and (msg in e.message or new_msg in e.message):
+        if e.status_code == 400 and "User cannot be removed from the service" in e.message:
             if current_user.platform_admin:
                 flash(
                     Markup(

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -338,13 +338,13 @@ def remove_user_from_service(service_id, user_id):
             else:
                 flash(
                     Markup(
-                        """
+                        f"""
                         <h2 class='govuk-heading-m'>You cannot remove this team member</h2>
                         <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
                             Your service needs at least 2 team members:
                         </p>
                         <ul class='govuk-list govuk-list--bullet error-text-colour govuk-!-font-weight-bold'>
-                            <li>from your organisation</li>
+                            <li>from {"your" if current_user.is_gov_user else "a public sector"} organisation</li>
                             <li>with the ‘manage settings, team and usage’ permission</li>
                         </ul>
                         <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -299,18 +299,10 @@ def test_archive_user_posts_to_user_client(
     assert mock_events.called
 
 
-@pytest.mark.parametrize(
-    "api_error_message",
-    [
-        "User can’t be removed from a service - check all services have another team member with manage_settings",
-        "User cannot be removed from a service",
-    ],
-)
 def test_archive_user_shows_error_message_if_user_cannot_be_archived(
     client_request,
     platform_admin_user,
     api_user_active,
-    api_error_message,
     mocker,
     mock_get_non_empty_organisations_and_services_for_user,
 ):
@@ -321,10 +313,10 @@ def test_archive_user_shows_error_message_if_user_cannot_be_archived(
                 status_code=400,
                 json={
                     "result": "error",
-                    "message": api_error_message,
+                    "message": "User cannot be removed from a service",
                 },
             ),
-            message=api_error_message,
+            message="User cannot be removed from a service",
         ),
     )
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1505,13 +1505,6 @@ def test_remove_user_from_service(
     )
 
 
-@pytest.mark.parametrize(
-    "api_error_message",
-    [
-        "You cannot remove the only user for a service",
-        "User cannot be removed from the service",
-    ],
-)
 def test_remove_user_from_service_when_user_api_gives_error(
     client_request,
     active_user_with_permissions,
@@ -1519,14 +1512,15 @@ def test_remove_user_from_service_when_user_api_gives_error(
     mock_get_users_by_service,
     mock_get_invites_for_service,
     mock_get_template_folders,
-    api_error_message,
     mocker,
 ):
     mocker.patch(
         "app.service_api_client.remove_user_from_service",
         side_effect=HTTPError(
-            response=mocker.Mock(status_code=400, json={"result": "error", "message": api_error_message}),
-            message=api_error_message,
+            response=mocker.Mock(
+                status_code=400, json={"result": "error", "message": "User cannot be removed from the service"}
+            ),
+            message="User cannot be removed from the service",
         ),
     )
     mock_event_handler = mocker.patch("app.main.views.manage_users.Events.remove_user_from_service")
@@ -1544,13 +1538,6 @@ def test_remove_user_from_service_when_user_api_gives_error(
     assert not mock_event_handler.called
 
 
-@pytest.mark.parametrize(
-    "api_error_message",
-    [
-        "You cannot remove the only user for a service",
-        "User cannot be removed from the service",
-    ],
-)
 def test_remove_user_from_service_when_user_api_gives_error_for_platform_admin_user(
     client_request,
     active_user_with_permissions,
@@ -1559,14 +1546,15 @@ def test_remove_user_from_service_when_user_api_gives_error_for_platform_admin_u
     mock_get_users_by_service,
     mock_get_invites_for_service,
     mock_get_template_folders,
-    api_error_message,
     mocker,
 ):
     mocker.patch(
         "app.service_api_client.remove_user_from_service",
         side_effect=HTTPError(
-            response=mocker.Mock(status_code=400, json={"result": "error", "message": api_error_message}),
-            message=api_error_message,
+            response=mocker.Mock(
+                status_code=400, json={"result": "error", "message": "User cannot be removed from the service"}
+            ),
+            message="User cannot be removed from the service",
         ),
     )
     mock_event_handler = mocker.patch("app.main.views.manage_users.Events.remove_user_from_service")

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1505,15 +1505,29 @@ def test_remove_user_from_service(
     )
 
 
-def test_remove_user_from_service_when_user_api_gives_error(
+@pytest.mark.parametrize(
+    "user_is_gov_user, expected_error_msg",
+    [
+        (True, "Your service needs at least 2 team members: from your organisation"),
+        (False, "Your service needs at least 2 team members: from a public sector organisation"),
+    ],
+)
+def test_remove_user_from_service_when_user_api_gives_error_x(
     client_request,
     active_user_with_permissions,
     service_one,
-    mock_get_users_by_service,
+    mock_get_organisations,
+    api_nongov_user_active,
     mock_get_invites_for_service,
     mock_get_template_folders,
+    user_is_gov_user,
+    expected_error_msg,
     mocker,
 ):
+    mocker.patch(
+        "app.models.user.Users._get_items",
+        return_value=[active_user_with_permissions, api_nongov_user_active],
+    )
     mocker.patch(
         "app.service_api_client.remove_user_from_service",
         side_effect=HTTPError(
@@ -1525,16 +1539,19 @@ def test_remove_user_from_service_when_user_api_gives_error(
     )
     mock_event_handler = mocker.patch("app.main.views.manage_users.Events.remove_user_from_service")
 
+    if not user_is_gov_user:
+        client_request.login(api_nongov_user_active)
+
     page = client_request.post(
         "main.remove_user_from_service",
         service_id=service_one["id"],
         user_id=active_user_with_permissions["id"],
         _follow_redirects=True,
     )
+    error_message = normalize_spaces(page.select_one(".banner-dangerous").text)
 
-    assert (
-        "You cannot remove this team member Your service needs at least 2 team members: from your organisation"
-    ) in normalize_spaces(page.select_one(".banner-dangerous").text)
+    assert error_message.startswith("You cannot remove this team member")
+    assert expected_error_msg in error_message
     assert not mock_event_handler.called
 
 


### PR DESCRIPTION
**Stop checking for old error messages when removing / archiving user**
We [changed the error messages](https://github.com/alphagov/notifications-api/pull/4831) that the API returns when removing a user from a service or archiving them, which meant we had to temporarily support the existing ones and the new messages. Now that the API is always returning the new error messages, we can simplify the code by only checking for these.

**Add version of error when removing service team members for non-gov users**
We had two versions of the error when removing a team member from a service - one for platform admin users and one for standard users.

This splits the version for standard users into two very slightly different versions - one for if the user has a known government email address and one for if they don't.

[Trello card](https://trello.com/c/ZVJ7qdu1/1692-error-for-removing-a-penultimate-user-with-manage-settings-permissions)

**Merge after**
- [x] https://github.com/alphagov/notifications-api/pull/4831

---
Version for users with a public sector email address

<img width="828" height="526" alt="Screenshot 2026-04-29 at 11 20 59" src="https://github.com/user-attachments/assets/9e1b603f-1a5b-4d9b-96df-8a822bc3699e" />

Version for users without a public sector email address

<img width="819" height="525" alt="Screenshot 2026-04-29 at 11 21 45" src="https://github.com/user-attachments/assets/f9032980-1703-44c4-a6da-76c6e8baca8e" />