### PR TITLE
models: make more of these "interruptible" using `InterruptibleIterableMixin`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.6.1
+# This file was automatically copied from notifications-utils@114.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -20,7 +20,7 @@ from app.extensions import redis_client
 from app.formatters import format_date_numeric, format_datetime_numeric, format_phone_number_human_readable
 from app.main import json_updates, main
 from app.main.forms import SearchNotificationsForm
-from app.models.notification import InboundSMSMessages, Notifications
+from app.models.notification import InboundSMSMessages, InterruptibleNotifications
 from app.statistics_utils import get_formatted_percentage
 from app.utils import (
     DELIVERED_STATUSES,
@@ -301,7 +301,7 @@ def _get_notifications_dashboard_partials_data(service_id, message_type):
     if message_type is not None:
         service_data_retention_days = current_service.get_days_of_retention(message_type)
 
-    notifications = Notifications(
+    notifications = InterruptibleNotifications(
         service_id=service_id,
         page=page,
         template_type=[message_type] if message_type else [],

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -58,7 +58,7 @@ from app.main.forms import (
 )
 from app.main.views.send import get_sender_details
 from app.models.service import Service
-from app.models.template_list import TemplateList, UserTemplateList, UserTemplateLists
+from app.models.template_list import InterruptibleUserTemplateList, InterruptibleUserTemplateLists, TemplateList
 from app.s3_client.s3_letter_upload_client import (
     backup_original_letter_to_s3,
     get_attachment_pdf_and_metadata,
@@ -154,11 +154,13 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
     user_has_template_folder_permission = current_user.has_template_folder_permission(
         template_folder, service=current_service
     )
-    template_list = UserTemplateList(
+    template_list = InterruptibleUserTemplateList(
         service=current_service, template_type=template_type, template_folder_id=template_folder_id, user=current_user
     )
 
-    all_template_folders = UserTemplateList(service=current_service, user=current_user).all_template_folders
+    all_template_folders = InterruptibleUserTemplateList(
+        service=current_service, user=current_user
+    ).all_template_folders
     option_hints = {template_folder_id: "current folder"}
     templates_and_folders_form = TemplateAndFoldersSelectionForm(
         all_template_folders=all_template_folders,
@@ -418,7 +420,7 @@ def choose_template_to_copy(
 
         return render_template(
             "views/templates/copy.html",
-            services_templates_and_folders=UserTemplateList(
+            services_templates_and_folders=InterruptibleUserTemplateList(
                 service=service, template_folder_id=from_folder, user=current_user
             ),
             template_folder_path=service.get_template_folder_path(from_folder),
@@ -430,7 +432,7 @@ def choose_template_to_copy(
     else:
         return render_template(
             "views/templates/copy.html",
-            services_templates_and_folders=UserTemplateLists(current_user),
+            services_templates_and_folders=InterruptibleUserTemplateLists(current_user),
             _search_form=SearchTemplatesForm(current_service.api_keys),
             to_folder_id=to_folder_id,
         )

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -14,6 +14,7 @@ from app.models.api_key import APIKey
 from app.notify_client.notification_api_client import notification_api_client
 from app.notify_client.service_api_client import service_api_client
 from app.utils import DELIVERED_STATUSES, FAILURE_STATUSES
+from app.utils.interruptible_io import InterruptibleIterableMixin
 from app.utils.letters import get_letter_printing_statement
 from app.utils.templates import EmailPreviewTemplate
 
@@ -178,6 +179,10 @@ class Notifications(ModelList):
         self.items = resp["notifications"]
         self.prev = resp.get("links", {}).get("prev", None)
         self.next = resp.get("links", {}).get("next", None)
+
+
+class InterruptibleNotifications(InterruptibleIterableMixin, Notifications):
+    pass
 
 
 class NotificationForCSV(Notification):

--- a/app/models/template_email_file.py
+++ b/app/models/template_email_file.py
@@ -130,8 +130,8 @@ class TemplateEmailFiles(SerialisedModelCollection):
 
         super().__init__(template._template.get("email_files", []))
 
-    def __getitem__(self, index):
-        return self.model(self.items[index] | {"service_id": self.service_id, "template": self.template})
+    def _get_model_instance_from_item(self, item):
+        return super()._get_model_instance_from_item(item | {"service_id": self.service_id, "template": self.template})
 
     @property
     def as_personalisation(self):

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -1,7 +1,7 @@
 from werkzeug.utils import cached_property
 
 from app import format_notification_type
-from app.utils import interruptible_io
+from app.utils.interruptible_io import InterruptibleIterableMixin
 
 
 class TemplateList:
@@ -23,8 +23,6 @@ class TemplateList:
     comments on those classes for more details.
     """
 
-    INTERRUPTIBLE_ITER_INTERRUPTIBLE_EVERY = 32
-
     def __init__(
         self,
         *,
@@ -38,12 +36,6 @@ class TemplateList:
 
     def __iter__(self):
         yield from self.items
-
-    @property
-    def interruptible_iter(self):
-        return interruptible_io.interruptible_iter(
-            self, self.INTERRUPTIBLE_ITER_INTERRUPTIBLE_EVERY, label=self.__class__.__name__
-        )
 
     @cached_property
     def items(self):
@@ -208,6 +200,12 @@ class UserTemplateList(TemplateList):
         return user_folders
 
 
+# why not just mix this in to `UserTemplateList`? we always want to apply it "on top" of any
+# __iter__ implementations that subclasses or wrapper classes might override
+class InterruptibleUserTemplateList(InterruptibleIterableMixin, UserTemplateList):
+    pass
+
+
 class ServiceTemplateList(UserTemplateList):
     """
     Represents a list of templates and folders for a service,
@@ -272,6 +270,10 @@ class UserTemplateLists:
     @property
     def templates_to_show(self):
         return bool(self.services)
+
+
+class InterruptibleUserTemplateLists(InterruptibleIterableMixin, UserTemplateLists):
+    pass
 
 
 class TemplateListItem:

--- a/app/models/unsubscribe_requests_report.py
+++ b/app/models/unsubscribe_requests_report.py
@@ -100,8 +100,8 @@ class UnsubscribeRequestsReports(ModelList):
     def _get_items(*args, **kwargs):
         return service_api_client.get_unsubscribe_reports_summary(*args, **kwargs)
 
-    def __getitem__(self, index):
-        instance = super().__getitem__(index)
+    def _get_model_instance_from_item(self, item):
+        instance = super()._get_model_instance_from_item(item)
         instance.all_reports = self
         return instance
 

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -14,7 +14,7 @@
   <div id="template-list" class="{{ 'govuk-!-margin-top-1' if (not show_template_nav and not show_search_box) else 'govuk-!-margin-top-6' }}">
     {% set checkboxes_data = [] %}
 
-    {% for item in template_list.interruptible_iter %}
+    {% for item in template_list %}
       {% set item_num = loop.index %}
       {% set item_link_content %}
         {% for ancestor in item.ancestors %}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -45,7 +45,7 @@
     {{ live_search(target_selector='#template-list .template-list-item', show=True, form=_search_form) }}
 
     <div id="template-list">
-      {% for item in templates_and_folders.interruptible_iter %}
+      {% for item in templates_and_folders %}
         {% set item_num = loop.index %}
         <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
           {% for ancestor in item.ancestors %}

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.6.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@114.0.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c720a3fc2cf724dd6f4c3a0f45dabd87012491b3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9f8a1e58f4b254302997c2786373ccfac8fa3e23
     # via -r requirements.in
 openpyxl==3.1.5
     # via -r requirements.in

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -163,7 +163,7 @@ moto==5.1.22
     # via -r requirements_for_test.in
 notifications-python-client==10.0.1
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c720a3fc2cf724dd6f4c3a0f45dabd87012491b3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9f8a1e58f4b254302997c2786373ccfac8fa3e23
     # via -r requirements.txt
 openpyxl==3.1.5
     # via -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.6.1
+# This file was automatically copied from notifications-utils@114.0.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.6.1
+# This file was automatically copied from notifications-utils@114.0.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -233,6 +233,28 @@ def test_can_show_notifications_if_data_retention_not_available(
     assert page.select_one("h1").text.strip() == "Messages"
 
 
+def test_view_notifications_interruptible(
+    client_request,
+    mock_get_notifications_with_previous_next,
+    mock_get_service_statistics,
+    mock_get_service_data_retention,
+    mock_has_no_jobs,
+    mock_get_no_api_keys,
+    mock_get_notifications_count_for_service,
+    mocker,
+):
+    mock_interruptible = mocker.patch("app.utils.interruptible_io._interruptible")
+
+    client_request.get(
+        "main.view_notifications",
+        service_id=SERVICE_ONE_ID,
+    )
+
+    # assert this view calls _interruptible in the expected way at least once. this may need
+    # updating if class names, inheritance or the view structure changes.
+    assert mocker.call("InterruptibleNotifications") in mock_interruptible.mock_calls
+
+
 @pytest.mark.parametrize(
     "user, query_parameters, notifications_count,expected_download_link",
     [

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -42,6 +42,47 @@ from tests.conftest import (
 )
 
 
+@pytest.fixture()
+def mock_complex_templates_and_folders(
+    notify_admin,
+    mocker,
+):
+    # generate an interesting mixture of folder depths and contained template counts in a
+    # fizzbuzz-style fashion
+    c = count()
+    folders = [_folder(f"folder {i}", str(uuid.uuid4())) for i in islice(c, 0, 100)]
+    folders.extend(
+        _folder(f"folder {i}", str(uuid.uuid4()), parent=parent["id"])
+        for parent, i in zip(folders[::2], c, strict=False)
+    )
+    folders.extend(
+        _folder(f"folder {i}", str(uuid.uuid4()), parent=parent["id"])
+        for parent, i in zip(folders[::3], c, strict=False)
+    )
+    folders.extend(
+        _folder(f"folder {i}", str(uuid.uuid4()), parent=parent["id"])
+        for parent, i in zip(folders[::5], c, strict=False)
+    )
+
+    c = count()
+    templates = [_template("sms", f"sms template {i}") for i in islice(c, 0, 500)]
+    templates.extend(
+        _template("sms", f"sms template {i}", folder["id"])
+        for folder, i in zip(islice(cycle(folders), 0, 2000, 7), c, strict=False)
+    )
+
+    mocker.patch(
+        "app.template_folder_api_client.get_template_folders",
+        return_value=folders,
+    )
+    mocker.patch(
+        "app.service_api_client.get_service_templates",
+        return_value={
+            "data": templates,
+        },
+    )
+
+
 @pytest.mark.parametrize(
     "permissions, expected_message",
     (
@@ -355,43 +396,9 @@ def test_choose_template_interruptible(
     client_request,
     service_one,
     mock_get_no_api_keys,
+    mock_complex_templates_and_folders,
     mocker,
 ):
-    # generate an interesting mixture of folder depths and contained template counts in a
-    # fizzbuzz-style fashion
-    c = count()
-    folders = [_folder(f"folder {i}", str(uuid.uuid4())) for i in islice(c, 0, 100)]
-    folders.extend(
-        _folder(f"folder {i}", str(uuid.uuid4()), parent=parent["id"])
-        for parent, i in zip(folders[::2], c, strict=False)
-    )
-    folders.extend(
-        _folder(f"folder {i}", str(uuid.uuid4()), parent=parent["id"])
-        for parent, i in zip(folders[::3], c, strict=False)
-    )
-    folders.extend(
-        _folder(f"folder {i}", str(uuid.uuid4()), parent=parent["id"])
-        for parent, i in zip(folders[::5], c, strict=False)
-    )
-
-    c = count()
-    templates = [_template("sms", f"sms template {i}") for i in islice(c, 0, 500)]
-    templates.extend(
-        _template("sms", f"sms template {i}", folder["id"])
-        for folder, i in zip(islice(cycle(folders), 0, 2000, 7), c, strict=False)
-    )
-
-    mocker.patch(
-        "app.template_folder_api_client.get_template_folders",
-        return_value=folders,
-    )
-    mocker.patch(
-        "app.service_api_client.get_service_templates",
-        return_value={
-            "data": templates,
-        },
-    )
-
     mock_interruptible = mocker.patch("app.utils.interruptible_io._interruptible")
 
     client_request.get("main.choose_template", service_id=SERVICE_ONE_ID, _test_page_title=False)
@@ -401,7 +408,7 @@ def test_choose_template_interruptible(
     # nullification of one of the forms of interruptibility without noticing. of course, it doesn't
     # test that they're all called an appropriate number of times and in the right *places*.
     assert mocker.call("child map iteration") in mock_interruptible.mock_calls
-    assert mocker.call("UserTemplateList") in mock_interruptible.mock_calls
+    assert mocker.call("InterruptibleUserTemplateList") in mock_interruptible.mock_calls
     assert mocker.call("InterruptibleItemsGovukCheckboxesField") in mock_interruptible.mock_calls
     assert mocker.call("InterruptibleChildRenderingGovukNestedRadiosField") in mock_interruptible.mock_calls
 
@@ -2617,6 +2624,47 @@ def test_choose_a_template_to_copy_from_folder_within_service(
         template_id=TEMPLATE_ONE_ID,
         from_service=SERVICE_ONE_ID,
     )
+
+
+def test_choose_template_to_copy_interruptible(
+    client_request,
+    service_one,
+    mock_get_no_api_keys,
+    mock_complex_templates_and_folders,
+    mock_get_just_services_for_user,
+    mocker,
+):
+    mock_interruptible = mocker.patch("app.utils.interruptible_io._interruptible")
+
+    client_request.get(
+        "main.choose_template_to_copy",
+        service_id=SERVICE_ONE_ID,
+    )
+
+    # assert this view calls _interruptible in the expected way at least once. this may need
+    # updating if class names, inheritance or the view structure changes.
+    assert mocker.call("InterruptibleUserTemplateLists") in mock_interruptible.mock_calls
+
+
+def test_choose_template_to_copy_from_service_interruptible(
+    client_request,
+    service_one,
+    mock_get_no_api_keys,
+    mock_complex_templates_and_folders,
+    mock_get_just_services_for_user,
+    mocker,
+):
+    mock_interruptible = mocker.patch("app.utils.interruptible_io._interruptible")
+
+    client_request.get(
+        "main.choose_template_to_copy",
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_ONE_ID,
+    )
+
+    # assert this view calls _interruptible in the expected way at least once. this may need
+    # updating if class names, inheritance or the view structure changes.
+    assert mocker.call("InterruptibleUserTemplateList") in mock_interruptible.mock_calls
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
First this removes the `interruptible_iter` property of `TemplateList` in favour of using a `InterruptibleIterableMixin`-using subclass when we want that behaviour.

Then this makes `Notifications` iteration interruptible in the same way. This requires a change in `SerialisedModelCollection` from utils, which is what requires the 114.0.0 bump.