### PR TITLE
Replace cbor-js package

### DIFF
--- a/app/assets/javascripts/esm/authenticate-security-key.mjs
+++ b/app/assets/javascripts/esm/authenticate-security-key.mjs
@@ -1,9 +1,10 @@
 import { isSupported } from 'govuk-frontend';
 import ErrorBanner from './error-banner.mjs';
 import { locationAssign } from '../utils/location.mjs';
+import { decode, encode } from 'cbor2';
 
 // This new way of writing Javascript components is based on the GOV.UK Frontend skeleton Javascript coding standard
-// that uses ES 015 Classes -
+// that uses ES 2015 Classes -
 // https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/js.md#skeleton
 //
 // It replaces the previously used way of setting methods on the component's `prototype`.
@@ -14,7 +15,7 @@ import { locationAssign } from '../utils/location.mjs';
 
 class AuthenticateSecurityKey {
   constructor($module) {
-    if (!isSupported()) {
+    if (!isSupported() || !window.TextEncoder) {
       return this;
     }
     this.authenticationEndpoint = '/webauthn/authenticate';
@@ -44,7 +45,7 @@ class AuthenticateSecurityKey {
     }
 
     const data = await response.arrayBuffer();
-    return window.CBOR.decode(data);
+    return decode(new Uint8Array(data));
   }
 
   async getCredential(options) {
@@ -70,7 +71,7 @@ class AuthenticateSecurityKey {
     return fetch(authenticateURL, {
       method: 'POST',
       headers: { 'X-CSRFToken': this.$module.dataset.csrfToken },
-      body: window.CBOR.encode({
+      body: encode({
         credentialId: new Uint8Array(credential.rawId),
         authenticatorData: new Uint8Array(credential.response.authenticatorData),
         signature: new Uint8Array(credential.response.signature),
@@ -85,7 +86,7 @@ class AuthenticateSecurityKey {
     }
 
     const cbor = await response.arrayBuffer();
-    const data = window.CBOR.decode(cbor);
+    const data = decode(new Uint8Array(cbor));
 
     // Redirect the user on successful authentication
     locationAssign(data.redirect_url);

--- a/app/assets/javascripts/esm/register-security-key.mjs
+++ b/app/assets/javascripts/esm/register-security-key.mjs
@@ -1,10 +1,21 @@
 import { isSupported } from 'govuk-frontend';
 import ErrorBanner from './error-banner.mjs';
 import { locationReload } from '../utils/location.mjs';
+import { decode, encode } from 'cbor2';
+
+// This new way of writing Javascript components is based on the GOV.UK Frontend skeleton Javascript coding standard
+// that uses ES 2015 Classes -
+// https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/js.md#skeleton
+//
+// It replaces the previously used way of setting methods on the component's `prototype`.
+// We use a class declaration way of defining classes -
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/class
+//
+// More on ES2015 Classes at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
 
 class RegisterSecurityKey {
   constructor($module) {
-    if (!isSupported()) {
+    if (!isSupported() || !window.TextEncoder) {
       return this;
     }
     this.registerAuthenticationEndpoint = '/webauthn/register';
@@ -34,7 +45,7 @@ class RegisterSecurityKey {
     }
 
     const data = await response.arrayBuffer();
-    return window.CBOR.decode(data);
+    return decode(new Uint8Array(data));
   }
 
   createCredential(options) {
@@ -46,7 +57,7 @@ class RegisterSecurityKey {
     return fetch(this.registerAuthenticationEndpoint, {
       method: 'POST',
       headers: { 'X-CSRFToken': this.$module.dataset.csrfToken },
-      body: window.CBOR.encode({
+      body: encode({
         attestationObject: new Uint8Array(credential.response.attestationObject),
         clientDataJSON: new Uint8Array(credential.response.clientDataJSON),
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "cbor-js": "0.1.0",
+        "cbor2": "2.3.0",
         "govuk-frontend": "6.1.0",
         "jquery": "3.5.0",
         "morphdom": "2.6.1",
@@ -731,6 +731,15 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/@cto.af/wtf8": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@cto.af/wtf8/-/wtf8-0.0.5.tgz",
+      "integrity": "sha512-LfUFi+Vv4eDzj+XAtR89e3wwjXA/NZjUSwU5NhwbBrLecxPaBYFy3exCuc1j+D4UZeOVdqlsl8G7LmOt18V0tg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@dual-bundle/import-meta-resolve": {
@@ -3677,11 +3686,17 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cbor-js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz",
-      "integrity": "sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw==",
-      "license": "MIT"
+    "node_modules/cbor2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cbor2/-/cbor2-2.3.0.tgz",
+      "integrity": "sha512-76WB3hq8BoaGkMkBVJ27fW5LJU+qqDLEpgRNCG/SYKhODWXpVPOTD4UcUto3IEzYLA52nsvbhb0wabhHDn3qXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cto.af/wtf8": "0.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
-    "cbor-js": "0.1.0",
+    "cbor2": "2.3.0",
     "govuk-frontend": "6.1.0",
     "jquery": "3.5.0",
     "morphdom": "2.6.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -124,7 +124,6 @@ export default [
           paths.npm + 'jquery/dist/jquery.min.js',
           paths.npm + 'timeago/jquery.timeago.js',
           paths.npm + 'textarea-caret/index.js',
-          paths.npm + 'cbor-js/cbor.js',
           paths.src + 'javascripts/modules.js',
           paths.src + 'javascripts/stick-to-window-when-scrolling.js',
           paths.src + 'javascripts/templateFolderForm.js',

--- a/tests/javascripts/authenticate-security-key.test.mjs
+++ b/tests/javascripts/authenticate-security-key.test.mjs
@@ -1,21 +1,24 @@
 import { jest } from '@jest/globals';
 import ErrorBanner from '../../app/assets/javascripts/esm/error-banner.mjs';
 
+
 jest.unstable_mockModule('../../app/assets/javascripts/utils/location.mjs', () => ({
   locationAssign: jest.fn()
 }));
+
 
 let AuthenticateSecurityKey;
 let locationAssign;
 
 beforeAll( async() => {
-  const CBOR = await import('../../node_modules/cbor-js/cbor.js');
+  const CBOR = await import('cbor2');
   const authenticateSecurityKeyModule = await import('../../app/assets/javascripts/esm/authenticate-security-key.mjs');
   const locationUtilModule = await import('../../app/assets/javascripts/utils/location.mjs');
 
   AuthenticateSecurityKey = authenticateSecurityKeyModule.default;
   locationAssign = locationUtilModule.locationAssign;
-  window.CBOR = CBOR.default || CBOR;
+  decode = CBOR.decode;
+  encode = CBOR.encode;
 })
 
 describe('Authenticate with security key', () => {
@@ -74,8 +77,8 @@ describe('Authenticate with security key', () => {
     // mock WebAuthn browser API
     window.navigator.credentials = mockBrowserCredentials;
 
-    mockWebauthnOptions = window.CBOR.encode('someArbitraryOptions');
-    mockLoginResponse = window.CBOR.encode({ redirect_url: '/foo' });
+    mockWebauthnOptions = encode('someArbitraryOptions');
+    mockLoginResponse = encode({ redirect_url: '/foo' });
     // instantiate class
     authenticateKeyInstance = new AuthenticateSecurityKey(button);
     
@@ -113,7 +116,7 @@ describe('Authenticate with security key', () => {
 
     expect(mockBrowserCredentials.get.mock.calls[0][0]).toEqual('someArbitraryOptions')
 
-    const decodedData = window.CBOR.decode(mockFetchOptions.body)
+    const decodedData = decode(mockFetchOptions.body)
     expect(decodedData.credentialId).toEqual(new Uint8Array([1, 1, 1]))
     expect(decodedData.authenticatorData).toEqual(new Uint8Array([2, 2, 2]))
     expect(decodedData.signature).toEqual(new Uint8Array([3, 3, 3]))

--- a/tests/javascripts/register-security-key.test.mjs
+++ b/tests/javascripts/register-security-key.test.mjs
@@ -9,13 +9,14 @@ let RegisterSecurityKey;
 let locationReload;
 
 beforeAll( async() => {
-  const CBOR = await import('../../node_modules/cbor-js/cbor.js');
+  const CBOR = await import('cbor2');
   const registerSecurityKeyModule = await import('../../app/assets/javascripts/esm/register-security-key.mjs');
   const locationUtilModule = await import('../../app/assets/javascripts/utils/location.mjs');
 
   RegisterSecurityKey = registerSecurityKeyModule.default;
   locationReload = locationUtilModule.locationReload;
-  window.CBOR = CBOR.default || CBOR;
+  decode = CBOR.decode;
+  encode = CBOR.encode;
 })
 
 describe('Register security key', () => {
@@ -70,7 +71,7 @@ describe('Register security key', () => {
     // mock WebAuthn browser API
     window.navigator.credentials = mockBrowserCredentials;
 
-    mockWebauthnOptions = window.CBOR.encode('options');
+    mockWebauthnOptions = encode('options');
     // instantiate class
     registerKeyInstance = new RegisterSecurityKey(button);
   })
@@ -106,7 +107,7 @@ describe('Register security key', () => {
     expect(mockFetchOptions.headers['X-CSRFToken']).toBe();
     expect(mockFetchOptions.method).toBe('POST');
 
-    const decodedData = window.CBOR.decode(mockFetchOptions.body);
+    const decodedData = decode(mockFetchOptions.body);
     expect(decodedData.attestationObject).toEqual(new Uint8Array([1, 2, 3]));
     expect(decodedData.clientDataJSON).toEqual(new Uint8Array([4, 5, 6]));
  

--- a/tests/javascripts/support/setup.js
+++ b/tests/javascripts/support/setup.js
@@ -1,6 +1,12 @@
 // Polyfill holes in JSDOM
 require('./polyfills.js');
 
+// jsdom does not implement the Encoding API (TextEncoder)
+// so we need to import it from node utils
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
 // set up jQuery
 window.jQuery = require('jquery');
 $ = window.jQuery;


### PR DESCRIPTION
Replace [cbor-js](https://www.npmjs.com/package/cbor-js) with [cbor2](https://www.npmjs.com/package/cbor2)

## Why

We're moving to ES Modules so need to update/replace it as cbor-js is now 10 years old not compatible with ES Modules

## Testing

This is used for authenticating and registering security keys.
