### PR TITLE
Handle errors raised when changing user permissions

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -290,12 +290,50 @@ def edit_user_permissions(service_id, user_id):
     form = PermissionsForm.from_user_and_service(user, current_service)
 
     if form.validate_on_submit():
-        user.set_permissions(
-            service_id,
-            permissions=form.permissions,
-            folder_permissions=form.folder_permissions.data,
-            set_by_id=current_user.id,
-        )
+        try:
+            user.set_permissions(
+                service_id,
+                permissions=form.permissions,
+                folder_permissions=form.folder_permissions.data,
+                set_by_id=current_user.id,
+            )
+        except HTTPError as e:
+            if e.status_code == 400 and "Cannot change user permissions" in e.message:
+                service_description = "A service" if current_user.platform_admin else "Your service"
+                org_description = (
+                    "your" if current_user.is_gov_user and not current_user.platform_admin else "a public sector"
+                )
+                action_to_take = (
+                    "Ask the user to add new team members or update the permissions for their team."
+                    if current_user.platform_admin
+                    else "Add new team members or update the permissions for your team, then try again."
+                )
+
+                flash(
+                    Markup(
+                        f"""
+                        <h2 class='govuk-heading-m'>You cannot change this team member’s permissions</h2>
+                        <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
+                            {service_description} needs at least 2 team members:
+                        </p>
+                        <ul class='govuk-list govuk-list--bullet error-text-colour govuk-!-font-weight-bold'>
+                            <li>from {org_description} organisation</li>
+                            <li>with the ‘manage settings, team and usage’ permission</li>
+                        </ul>
+                        <p class='govuk-body error-text-colour govuk-!-font-weight-bold'>
+                            {action_to_take}
+                        </p>
+                        """
+                    )
+                )
+                return render_template(
+                    "views/edit-user-permissions.html",
+                    user=user,
+                    form=form,
+                )
+            else:
+                raise e
+
         # Only change the auth type if this is supported for a service. If a user logs in with a
         # security key, we generally don't want them to be able to use something less secure.
         if current_service.has_permission("email_auth") and not user.webauthn_auth:

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -837,6 +837,119 @@ def test_cant_edit_non_member_user_permissions(
     assert mock_set_user_permissions.called is False
 
 
+@pytest.mark.parametrize(
+    "user_is_gov_user, expected_error_msg",
+    [
+        (
+            True,
+            (
+                "You cannot change this team member’s permissions "
+                "Your service needs at least 2 team members: "
+                "from your organisation "
+                "with the ‘manage settings, team and usage’ permission "
+                "Add new team members or update the permissions for your team, then try again."
+            ),
+        ),
+        (
+            False,
+            (
+                "You cannot change this team member’s permissions "
+                "Your service needs at least 2 team members: "
+                "from a public sector organisation "
+                "with the ‘manage settings, team and usage’ permission "
+                "Add new team members or update the permissions for your team, then try again."
+            ),
+        ),
+    ],
+)
+def test_edit_user_permissions_when_api_gives_error_that_permissions_cannot_be_changed(
+    client_request,
+    active_user_with_permissions,
+    mock_get_users_by_service,
+    mock_get_template_folders,
+    mock_get_organisations,
+    service_one,
+    api_nongov_user_active,
+    user_is_gov_user,
+    expected_error_msg,
+    mocker,
+):
+    mocker.patch(
+        "app.models.user.User.set_permissions",
+        side_effect=HTTPError(
+            response=mocker.Mock(
+                status_code=400,
+                json={
+                    "result": "error",
+                    "message": "Cannot change user permissions - service would have too few users with manage_settings",
+                },
+            ),
+            message="Cannot change user permissions - service would have too few users with manage_settings",
+        ),
+    )
+
+    if not user_is_gov_user:
+        client_request.login(api_nongov_user_active)
+
+    page = client_request.post(
+        "main.edit_user_permissions",
+        service_id=service_one["id"],
+        user_id=active_user_with_permissions["id"],
+        _data={
+            "email_address": "test@example.com",
+            "manage_service": "y",
+        },
+        _follow_redirects=True,
+    )
+
+    assert normalize_spaces(page.select_one(".banner-dangerous").text) == expected_error_msg
+
+
+def test_edit_user_permissions_when_user_is_platform_admin_and_api_gives_error_that_permissions_cannot_be_changed(
+    client_request,
+    active_user_with_permissions,
+    mock_get_users_by_service,
+    mock_get_template_folders,
+    service_one,
+    platform_admin_user,
+    mocker,
+):
+    mocker.patch(
+        "app.models.user.User.set_permissions",
+        side_effect=HTTPError(
+            response=mocker.Mock(
+                status_code=400,
+                json={
+                    "result": "error",
+                    "message": "Cannot change user permissions - service would have too few users with manage_settings",
+                },
+            ),
+            message="Cannot change user permissions - service would have too few users with manage_settings",
+        ),
+    )
+
+    client_request.login(platform_admin_user)
+
+    page = client_request.post(
+        "main.edit_user_permissions",
+        service_id=service_one["id"],
+        user_id=active_user_with_permissions["id"],
+        _data={
+            "email_address": "test@example.com",
+            "manage_service": "y",
+        },
+        _follow_redirects=True,
+    )
+
+    assert normalize_spaces(page.select_one(".banner-dangerous").text) == (
+        "You cannot change this team member’s permissions "
+        "A service needs at least 2 team members: "
+        "from a public sector organisation "
+        "with the ‘manage settings, team and usage’ permission "
+        "Ask the user to add new team members or update the permissions for their team."
+    )
+
+
 def test_edit_user_permissions_including_authentication_with_email_auth_service(
     client_request,
     service_one,


### PR DESCRIPTION
The API will [start to return an error](https://github.com/alphagov/notifications-api/pull/4835) if removing `manage_settings` from a user would cause the service to not have enough users with that setting. This catches the error and returns a suitable error message to the user.

[Trello card](https://trello.com/c/ZVJ7qdu1/1692-error-for-removing-a-penultimate-user-with-manage-settings-permissions)

---

**Platform admin error**
<img width="876" height="498" alt="Screenshot 2026-04-30 at 11 41 44" src="https://github.com/user-attachments/assets/1fb4bfbf-c186-40b3-9fec-6ddfbb656a90" />

**User with a government email address error**
<img width="879" height="476" alt="Screenshot 2026-04-30 at 11 44 02" src="https://github.com/user-attachments/assets/0fe5fbe8-5b23-4735-89f3-5b23a293d0c2" />

**User with a non-government email address error**
<img width="905" height="468" alt="Screenshot 2026-04-30 at 11 45 35" src="https://github.com/user-attachments/assets/06a7da4d-586d-45f7-9cb7-637ff74a6a34" />