### PR TITLE
Update technical failure error message

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -242,6 +242,7 @@ def format_notification_status_as_url(status, notification_type):
     if notification_type not in {
         "email",
         "sms",
+        "letter",
     }:
         return None
 

--- a/app/templates/views/guidance/using-notify/message-status.html
+++ b/app/templates/views/guidance/using-notify/message-status.html
@@ -90,7 +90,7 @@
         ('Sent', 'Notify has sent the letter to the provider to be printed.'),
         ('Printed', 'The provider has printed the letter. Letters are printed at 5:30pm and dispatched the next working day.'),
         ('Cancelled', 'Sending cancelled. Your letter will not be printed or dispatched.'),
-        ('Technical failure', 'Notify had an unexpected error while sending the letter to our printing provider.'),
+        ('Technical failure', 'Your letter was not sent because there was a problem between Notify and the provider. We are working on a fix. We’ll contact you if we need your help. Do not try to send the letter again.'),
         ('Permanent failure', 'The provider cannot print the letter. Your letter will not be dispatched.')
       ] %}
         {% call row() %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -59,9 +59,7 @@
          </p>
       {% elif notification.status == 'technical-failure' %}
         <p class="notification-status-cancelled">
-          Technical failure – Notify will resend once the team have
-          fixed the problem
-        </p>
+          <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.guidance_message_status', notification_type='letter') }}">Technical failure</a> – Do not try to send this letter again        </p>
       {% else %}
         {% if notification.sent_with_test_key %}
           {% if notification.is_precompiled_letter %}

--- a/tests/app/main/test_formatters.py
+++ b/tests/app/main/test_formatters.py
@@ -32,8 +32,8 @@ from tests.conftest import normalize_spaces
         ("temporary-failure", "sms", partial(url_for, "main.guidance_message_status", notification_type="sms")),
         ("permanent-failure", "sms", partial(url_for, "main.guidance_message_status", notification_type="sms")),
         ("technical-failure", "sms", partial(url_for, "main.guidance_message_status", notification_type="sms")),
-        # Letter statuses are never linked
-        ("technical-failure", "letter", lambda: None),
+        # Failed letter statuses are linked
+        ("technical-failure", "letter", partial(url_for, "main.guidance_message_status", notification_type="letter")),
         ("cancelled", "letter", lambda: None),
         ("accepted", "letter", lambda: None),
         ("received", "letter", lambda: None),

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -425,7 +425,7 @@ def test_notification_page_shows_validation_failed_precompiled_letter(
         ),
         (
             "technical-failure",
-            "Technical failure – Notify will resend once the team have fixed the problem",
+            "Technical failure – Do not try to send this letter again",
         ),
     ),
 )


### PR DESCRIPTION
When letters are rejected by DVLA we update notification status to technical-failure. During incident we found inconsistency between the API and UI and may cause services to try and resend their letter. This PR updates the error message description in the admin UI and message status guidance page to instruct users to wait for Notify to contact them.
More details on this [card](https://trello.com/c/Y7MfglOL/1733-review-and-update-technical-failure-advise-in-ui-and-api).

Admin - Notification page:
<img width="1650" height="784" alt="image" src="https://github.com/user-attachments/assets/28bf43d3-cd47-4a66-9926-085694ae3ecd" />

Admin - Using Notify guidance page:
<img width="1664" height="878" alt="image" src="https://github.com/user-attachments/assets/a0d1c180-4fff-4e58-9e57-8b2fb8655b23" />
