### PR TITLE
Pass created datetime to template preview when showing preview of notification

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -171,6 +171,7 @@ def view_letter_notification_as_preview(service_id, notification_id, filetype, w
             values=notification.personalisation,
             page=request.args.get("page"),
             service=current_service,
+            date=notification.created_at,
         )
 
     image_data = get_letter_file_data(service_id, notification_id, filetype, with_metadata)

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -42,6 +42,7 @@ class TemplatePreviewClient:
         page=None,
         branding_filename=None,
         service=None,
+        date=None,
     ):
         if db_template["is_precompiled_letter"]:
             raise ValueError
@@ -54,6 +55,7 @@ class TemplatePreviewClient:
             "template": db_template,
             "values": values,
             "filename": branding_filename or (service.letter_branding.filename if service else None),
+            "date": date.isoformat() if date else None,
         }
         response = self.requests_session.post(
             "{}/preview.{}{}".format(

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -1,4 +1,5 @@
 import base64
+from datetime import UTC, datetime
 from functools import partial
 from unittest.mock import Mock, mock_open
 
@@ -575,6 +576,7 @@ def test_notification_page_shows_page_for_other_postage_classes(
         create_active_caseworking_user(),
     ],
 )
+@freeze_time("2026-02-06")
 def test_should_show_image_of_letter_notification(
     client_request,
     fake_uuid,
@@ -607,6 +609,7 @@ def test_should_show_image_of_letter_notification(
             values=notification["personalisation"],
             page=None,
             service=RestrictedAny(lambda s: s.id == SERVICE_ONE_ID),
+            date=datetime(2026, 2, 6, 0, 0, 0, tzinfo=UTC),
         ),
     ]
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2242,6 +2242,7 @@ def test_letter_branding_preview_image(
             },
             "values": None,
             "filename": "example",
+            "date": None,
         },
         headers={
             "Authorization": "Token my-secret-key",

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -1,4 +1,5 @@
 import base64
+from datetime import UTC, datetime
 from unittest.mock import Mock
 
 import pytest
@@ -31,6 +32,14 @@ from tests.conftest import create_notification
     "letter_branding, expected_filename",
     [(LetterBranding({"filename": "hm-government"}), "hm-government"), (LetterBranding.from_id(None), None)],
 )
+@pytest.mark.parametrize(
+    "date_kwargs, expected_date_string_in_json",
+    (
+        ({}, None),
+        ({"date": None}, None),
+        ({"date": datetime(2021, 2, 3, 4, 5, 6, tzinfo=UTC)}, "2021-02-03T04:05:06+00:00"),
+    ),
+)
 def test_get_preview_for_templated_letter_makes_request(
     client_request,
     mocker,
@@ -39,6 +48,8 @@ def test_get_preview_for_templated_letter_makes_request(
     expected_url,
     letter_branding,
     expected_filename,
+    date_kwargs,
+    expected_date_string_in_json,
     mock_get_service_letter_template,
     mock_onwards_request_headers,
 ):
@@ -50,7 +61,7 @@ def test_get_preview_for_templated_letter_makes_request(
     response = template_preview_client.get_preview_for_templated_letter(
         db_template=template,
         service=service,
-        **extra_kwargs,
+        **(extra_kwargs | date_kwargs),
     )
 
     assert response[0] == "a"
@@ -62,6 +73,7 @@ def test_get_preview_for_templated_letter_makes_request(
         "template": template,
         "values": None,
         "filename": expected_filename,
+        "date": expected_date_string_in_json,
     }
     headers = {
         "Authorization": "Token my-secret-key",
@@ -131,6 +143,7 @@ def test_get_preview_for_templated_letter_from_notification_has_correct_args(
         "template": notification["template"],
         "values": {"name": "Jo"},
         "filename": "hm-government",
+        "date": None,
     }
     headers = {
         "Authorization": "Token my-secret-key",


### PR DESCRIPTION
At the moment the date shown on a letter in the admin app will always be the curent date.

This is incorrect for letters which have already be printed or sent.

Template preview can already accept a `date` field: https://github.com/alphagov/notifications-template-preview/blob/7c8c597bf4c5f8d1da68c51ffd98d7b4c6862f33/app/preview.py#L207

This commit makes sure we pass a value in that `date` field when previewing a notification.

Viewing a template will continue to show the current date, which is correct.