### PR TITLE
Replace timeago jquery plugin with our own UpdateRelativeTime module 

### DIFF
--- a/app/assets/javascripts/esm/all-esm.mjs
+++ b/app/assets/javascripts/esm/all-esm.mjs
@@ -25,6 +25,7 @@ import AuthenticateSecurityKey from './authenticate-security-key.mjs';
 import RegisterSecurityKey from './register-security-key.mjs';
 import UpdateStatus from './update-status.mjs';
 import UpdateContent from './update-content.mjs';
+import UpdateRelativeTime from './update-relative-time.mjs';
 
 createAll(Button, 
   { preventDoubleClick: true }
@@ -149,3 +150,10 @@ if ($updateContentBlocks.length > 0) {
 };
 
 new FocusBanner();
+
+// if there's at least 1 element on the page initialise the class
+// multiple elements are handled by it
+const updateRelativeTimeSelector = '[data-notify-module="update-relative-time"]';
+if (document.querySelector('[data-notify-module="update-relative-time"]')) {
+  new UpdateRelativeTime(updateRelativeTimeSelector);
+}

--- a/app/assets/javascripts/esm/update-relative-time.mjs
+++ b/app/assets/javascripts/esm/update-relative-time.mjs
@@ -1,0 +1,117 @@
+import { isSupported } from 'govuk-frontend';
+
+// This new way of writing Javascript components is based on the GOV.UK Frontend skeleton Javascript coding standard
+// that uses ES2015 Classes -
+// https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/js.md#skeleton
+//
+// It replaces the previously used way of setting methods on the component's `prototype`.
+// We use a class declaration way of defining classes -
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/class
+//
+// More on ES2015 Classes at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
+
+// inspired by https://polypane.app/blog/the-intl-api-the-best-browser-api-youre-not-using/
+class UpdateRelativeTime {
+  // creating formatters is expensive so we create them once and reuse
+  static relativeFormatter = new Intl.RelativeTimeFormat('en-GB', { numeric: 'auto' });
+  static fullDateFormatter = new Intl.DateTimeFormat('en-GB', { dateStyle: 'long', timeStyle: 'short' });
+
+  constructor(selector) {
+    if (!isSupported()) {
+      return this;  
+    }
+
+    this.selector = selector;
+
+    this.init();
+  }
+
+  init() {
+    this.updateExistingElements();
+    
+    // start global 60s interval
+    setInterval(() => this.updateExistingElements(), 60000);
+  }
+
+  updateExistingElements() {
+    const $elements = document.querySelectorAll(this.selector);
+    const now = new Date();
+    $elements.forEach(($el) => this.updateTextString($el, now));
+  }
+
+  updateTextString(element, currentTime) {
+    const elementDatetimeStamp = element.getAttribute('datetime');
+    // don't run if we forgot to include the attribute
+    if (!elementDatetimeStamp) return;
+
+    const elementTime = new Date(elementDatetimeStamp);
+
+    // we only update the title attribute once with
+    // human-readible date format 
+    if (!element.hasAttribute('title')) {
+      element.setAttribute('title', UpdateRelativeTime.fullDateFormatter.format(elementTime));
+    }
+
+    const relativeTimeString = this.calculateRelativeTimeString(elementTime, currentTime);
+
+    // only update text if there's a change
+    // hours, days and longer don't need to have
+    // their text updated every minute
+    if (element.textContent !== relativeTimeString) {
+      element.textContent = relativeTimeString;
+    }
+  }
+
+  calculateRelativeTimeString(elementTime, currentTime) {
+    // thresholds to switch display units
+    // in line with what we used before and other libraries
+    // https://github.com/rmm5t/jquery-timeago/blob/master/jquery.timeago.js#L102
+    // https://day.js.org/docs/en/customization/relative-time#relative-time-thresholds-and-rounding
+    const diffInSeconds = Math.round((elementTime - currentTime) / 1000);
+    const absSeconds = Math.abs(diffInSeconds);
+
+    // Custom overrides for the immediate past
+    if (diffInSeconds <= 0) {
+      if (absSeconds < 30) {
+        return "just now";
+      }
+      if (absSeconds < 60) {
+        return "in the last minute";
+      }
+    }
+
+    // handle future seconds or cases not caught by custom past strings
+    if (diffInSeconds > 0 && absSeconds < 45) { // 0 to 44s (future)
+      return UpdateRelativeTime.relativeFormatter.format(diffInSeconds, 'second');
+    }
+
+    const diffInMinutes = Math.round(diffInSeconds / 60);
+    // ensure we are at least at 60s to avoid overlapping with "in the last minute"
+    if (absSeconds >= 60 && Math.abs(diffInMinutes) < 45) { // 60s to 44m
+      return UpdateRelativeTime.relativeFormatter.format(diffInMinutes, 'minute');
+    }
+
+    const diffInHours = Math.round(diffInMinutes / 60);
+    if (Math.abs(diffInHours) < 22) { // 45m to 21h
+      return UpdateRelativeTime.relativeFormatter.format(diffInHours, 'hour');
+    }
+
+    const diffInDays = Math.round(diffInHours / 24);
+    if (Math.abs(diffInDays) < 27) { // 22h to 26d
+      return UpdateRelativeTime.relativeFormatter.format(diffInDays, 'day');
+    }
+
+    // for months and years, we use the calendar date logic as lengths are different
+    const monthDiff = (elementTime.getFullYear() - currentTime.getFullYear()) * 12 + 
+                      (elementTime.getMonth() - currentTime.getMonth());
+
+    if (Math.abs(monthDiff) < 11) {
+      return UpdateRelativeTime.relativeFormatter.format(monthDiff, 'month');
+    }
+
+    const yearDiff = Math.round(monthDiff / 12);
+    return UpdateRelativeTime.relativeFormatter.format(yearDiff, 'year');
+  }
+}
+
+export default UpdateRelativeTime;

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,6 +1,5 @@
 
 if (document.body.classList.contains('govuk-frontend-supported')) {
-  $(() => $("time.timeago").timeago());
 
   $(() => GOVUK.stickAtTopWhenScrolling.init());
   $(() => GOVUK.stickAtBottomWhenScrolling.init());

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -57,7 +57,7 @@
             {{ notification.key_name }}
           </span>
           <span class="govuk-grid-column-one-half api-notifications-item__meta-time">
-            <time class="timeago" datetime="{{ notification.created_at }}">
+            <time data-notify-module="update-relative-time" datetime="{{ notification.created_at }}">
               {{ notification.created_at|format_delta }}
             </time>
           </span>

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -81,7 +81,7 @@
       <p class="hint">This person has never logged in</p>
       {% else %}
       <p class="govuk-body">Last logged in
-        <time class="timeago" datetime="{{ user.logged_in_at }}">
+        <time data-notify-module="update-relative-time" datetime="{{ user.logged_in_at }}">
           {{ user.logged_in_at|format_delta }}
         </time>
       </p>

--- a/app/templates/views/service-settings/receive-text-messages-stop.html
+++ b/app/templates/views/service-settings/receive-text-messages-stop.html
@@ -58,7 +58,7 @@
             <p class="hint">This number has never been used</p>
             {% else %}
             <p class="govuk-body">This number was last used
-                <time class="timeago" datetime="{{ recent_use_date}}">
+                <time data-notify-module="update-relative-time" datetime="{{ recent_use_date}}">
                     {{ recent_use_date|format_delta }}
                 </time>
             </p>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -78,7 +78,7 @@
     {% if template._template.updated_at %}
       <h2 class="heading-small bottom-gutter-2-3 heading-inline">
         Last edited
-        <time class="timeago" datetime="{{ template._template.updated_at }}">
+        <time data-notify-module="update-relative-time" datetime="{{ template._template.updated_at }}">
           {{ template._template.updated_at|format_delta }}
         </time>
       </h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "govuk-frontend": "6.1.0",
         "jquery": "3.5.0",
         "morphdom": "2.6.1",
-        "textarea-caret": "3.1.0",
-        "timeago": "1.6.5"
+        "textarea-caret": "3.1.0"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -745,9 +744,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -757,9 +756,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1797,6 +1796,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1818,6 +1820,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1839,6 +1844,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1860,6 +1868,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1881,6 +1892,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1902,6 +1916,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9461,14 +9478,6 @@
       "resolved": "https://registry.npmjs.org/textarea-caret/-/textarea-caret-3.1.0.tgz",
       "integrity": "sha512-cXAvzO9pP5CGa6NKx0WYHl+8CHKZs8byMkt3PCJBCmq2a34YA9pO1NrQET5pzeqnBjBdToF5No4rrmkDUgQC2Q==",
       "license": "MIT"
-    },
-    "node_modules/timeago": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/timeago/-/timeago-1.6.5.tgz",
-      "integrity": "sha512-6XCWVteUxczNBk4nQEcbdhBd6xvj7oS9QkZjUp1r3uyZNF4EZzYF2HMmFLucvT+IVyMVoeRf93UmiFQPzJE5cQ==",
-      "dependencies": {
-        "jquery": ">=1.2.3"
-      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "govuk-frontend": "6.1.0",
     "jquery": "3.5.0",
     "morphdom": "2.6.1",
-    "textarea-caret": "3.1.0",
-    "timeago": "1.6.5"
+    "textarea-caret": "3.1.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -122,7 +122,6 @@ export default [
     plugins: [
       concatenateFiles([
           paths.npm + 'jquery/dist/jquery.min.js',
-          paths.npm + 'timeago/jquery.timeago.js',
           paths.npm + 'textarea-caret/index.js',
           paths.npm + 'cbor-js/cbor.js',
           paths.src + 'javascripts/modules.js',

--- a/tests/javascripts/update-relative-time.test.mjs
+++ b/tests/javascripts/update-relative-time.test.mjs
@@ -1,0 +1,137 @@
+import { jest } from '@jest/globals';
+import UpdateRelativeTime from '../../app/assets/javascripts/esm/update-relative-time.mjs';
+
+describe('UpdateRelativeTime', () => {
+  const selector = '[data-notify-module="update-relative-time"]'
+  let now;
+
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.classList.add('govuk-frontend-supported');
+    document.body.innerHTML = `
+      <div id="container">
+        <time data-notify-module="update-relative-time"></time>
+      </div>
+    `;
+
+    jest.useFakeTimers();
+    now = new Date(); 
+    jest.setSystemTime(now.getTime());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  const setElementDateTime = (offsetMs) => {
+    const el = document.querySelector(selector);
+    const date = new Date(jest.now() - offsetMs);
+    el.setAttribute('datetime', date.toISOString());
+    return el;
+  };
+
+  const getCalendarOffset = (unit, value) => {
+    const d = new Date(jest.now());
+    if (unit === 'month') d.setMonth(d.getMonth() - value);
+    if (unit === 'year') d.setFullYear(d.getFullYear() - value);
+    return jest.now() - d.getTime();
+  };
+
+  describe('on page load', () => {
+    test('halts if datetime attribute is not present on the element', () => {
+      const el = document.querySelector(selector);
+      el.removeAttribute('datetime');
+      new UpdateRelativeTime(selector);
+      expect(el.textContent).toBe('');
+    });
+
+    test('updates relative time text for all elements on the page in en-GB', () => {
+      // Changed to 60s and 120s to avoid the "just now" thresholds
+      document.body.innerHTML = `
+        <time data-notify-module="update-relative-time" datetime="${new Date(jest.now() - 60000).toISOString()}"></time>
+        <time data-notify-module="update-relative-time" datetime="${new Date(jest.now() - 120000).toISOString()}"></time>
+      `;
+      new UpdateRelativeTime(selector);
+      
+      const elements = document.querySelectorAll(selector);
+      expect(elements[0].textContent).toBe('1 minute ago');
+      expect(elements[1].textContent).toBe('2 minutes ago');
+    });
+
+    test('sets a human-readable title attribute text in en-GB', () => {
+      const el = setElementDateTime(0);
+      new UpdateRelativeTime(selector);
+      
+      const expectedTitle = new Intl.DateTimeFormat('en-GB', {
+        dateStyle: 'long',
+        timeStyle: 'short'
+      }).format(new Date(jest.now()));
+
+      expect(el.getAttribute('title')).toBe(expectedTitle);
+    });
+  });
+
+  describe('for dynamically added elements', () => {
+    test('picks up elements added to the DOM after the next interval tick', () => {
+      new UpdateRelativeTime(selector);
+      const container = document.getElementById('container');
+      
+      const dynamicEl = document.createElement('time');
+      dynamicEl.setAttribute('data-notify-module', 'update-relative-time');
+      // Set to 75s so that after a 60s advance, it is 135s (2m ago)
+      dynamicEl.setAttribute('datetime', new Date(jest.now() - 75000).toISOString());
+      
+      container.appendChild(dynamicEl);
+      expect(dynamicEl.textContent).toBe('');
+
+      // Advance 60s to trigger the polling interval
+      jest.advanceTimersByTime(60000);
+
+      expect(dynamicEl.textContent).toBe('2 minutes ago');
+      expect(dynamicEl.hasAttribute('title')).toBe(true);
+    });
+
+    test('automatically updates the relative time text as time passes', () => {
+      const el = setElementDateTime(10000); // 10s ago
+      new UpdateRelativeTime(selector);
+      expect(el.textContent).toBe('just now');
+
+      jest.advanceTimersByTime(60000); // Fast forward 1m (now 70s ago)
+      expect(el.textContent).toBe('1 minute ago');
+    });
+
+    test('does not trigger a DOM update if the text content remains the same', () => {
+      const el = setElementDateTime(3600000 * 5); // 5 hours ago
+      new UpdateRelativeTime(selector);
+      
+      const spy = jest.spyOn(el, 'textContent', 'set');
+      
+      // 5h 1m still rounds to "5 hours"
+      jest.advanceTimersByTime(60000); 
+      
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('text shows correct units for specific elapsed time threshold', () => {
+    const scenarios = [
+      { label: 'just now (under 30s)', offset: 25000, expected: 'just now' },
+      { label: 'in the last minute (30s to 59s)', offset: 45000, expected: 'in the last minute' },
+      { label: 'minutes (at 60s boundary)', offset: 60000, expected: '1 minute ago' },
+      { label: 'hours (at 45m boundary)', offset: 45 * 60000, expected: '1 hour ago' },
+      { label: 'hours (21h)', offset: 21 * 3600000, expected: '21 hours ago' },
+      { label: 'yesterday (at 22h boundary)', offset: 22 * 3600000, expected: 'yesterday' },
+      { label: 'days (26 days)', offset: 26 * 86400000, expected: '26 days ago' },
+      { label: 'last month', offset: getCalendarOffset('month', 1), expected: 'last month' },
+      { label: 'last year', offset: getCalendarOffset('year', 1), expected: 'last year' },
+    ];
+
+    test.each(scenarios)('displays correct text for $label', ({ offset, expected }) => {
+      setElementDateTime(offset);
+      new UpdateRelativeTime(selector);
+      expect(document.querySelector(selector).textContent).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Why
Created as a replacement for [timeago jquery plugin](https://timeago.yarp.com/) we used before as we are moving to ES Modules and removing jQuery as a dependency.

## What
Purpose of this plugin is to update targeted `<time>` elements with how much relative time has passed since an event occurred.

It reads the element's `datetime` attribute and

- creates a title attribute with readable date and time of the event
- updates element's text with language-sensitive relative time format, like '5 minutes ago'.
- runs on a 60 second interval and keeps updating the text if required.

For relative time text format it uses [`Intl.RelativeTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) - a native Javascript feature for localised text.

`Intl.RelativeTimeFormat handles plurals` ('day(s)'), past vs future prefix/suffix ('in'...'ago') as well as the style ('1 day ago' vs 'yesterday').

It contains a set of thresholds that determine which units to display in what scenario - seconds vs minutes, minutes vs hours, etc.

## Visual changes

When hovering over the element it now accurately shows the human readable date and time of the event

**Before**
<img width="306" height="76" alt="before-tag-hover" src="https://github.com/user-attachments/assets/957991bf-baba-4ba5-8714-567cde339327" />

**After**
<img width="355" height="68" alt="after-tag-hover" src="https://github.com/user-attachments/assets/ae0842d2-bdb1-4709-a586-55727bfd7506" />

## Test
Used on the following pages

- /users/<userID> - last logged in
- /services/<serviceID>/service-settings/receive-text-messages/stop  - if inbound number present
- /services/<serviceID>/templates/<templateID> - if template was edited before
- /services/<serviceID>/api