### PR TITLE
Show "Trial mode services" page to users who can self-approve

### DIFF
--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -12,6 +12,7 @@ from app import (
     org_invite_api_client,
     organisations_client,
 )
+from app.constants import PERMISSION_CAN_MAKE_SERVICES_LIVE
 from app.main import main
 from app.main.forms import (
     AddGPOrganisationForm,
@@ -200,8 +201,13 @@ def download_organisation_usage_report(org_id):
 
 
 @main.route("/organisations/<uuid:org_id>/trial-services", methods=["GET"])
-@user_is_platform_admin
+@user_has_permissions()
 def organisation_trial_mode_services(org_id):
+    if not current_user.platform_admin and not current_user.has_permission_for_organisation(
+        org_id, PERMISSION_CAN_MAKE_SERVICES_LIVE
+    ):
+        abort(403)
+
     return render_template(
         "views/organisations/organisation/trial-mode-services.html",
         _search_form=SearchByNameForm(),

--- a/app/templates/org_nav.html
+++ b/app/templates/org_nav.html
@@ -4,7 +4,11 @@
     <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('team-members') }}" href="{{ url_for('main.manage_org_users', org_id=current_org.id) }}">Team members</a></li>
     {% if current_user.platform_admin %}
     <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('settings') }}" href="{{ url_for('main.organisation_settings', org_id=current_org.id) }}">Settings</a></li>
+    {% endif %}
+    {% if current_user.platform_admin or current_user.has_permission_for_organisation(current_org.id, 'can_make_services_live') %}
     <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('trial-services') }}" href="{{ url_for('main.organisation_trial_mode_services', org_id=current_org.id) }}">Trial mode services</a></li>
+    {% endif %}
+    {% if current_user.platform_admin %}
     <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('billing') }}" href="{{ url_for('main.organisation_billing', org_id=current_org.id) }}">Billing</a></li>
     {% endif %}
   </ul>

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -3,6 +3,7 @@ from flask import url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 
+from app.constants import PERMISSION_CAN_MAKE_SERVICES_LIVE
 from tests import find_element_by_tag_and_partial_text, organisation_json, service_json
 from tests.app.main.views.test_agreement import MockS3Object
 from tests.conftest import (
@@ -12,9 +13,54 @@ from tests.conftest import (
     create_active_user_with_permissions,
     create_email_branding,
     create_platform_admin_user,
+    create_user,
     normalize_spaces,
+    sample_uuid,
 )
 from tests.utils import RedisClientMock
+
+
+def test_organisation_left_hand_nav_for_platform_admin_users(
+    platform_admin_user,
+    mock_get_organisation,
+    client_request,
+    mocker,
+):
+    mocker.patch("app.organisations_client.get_services_and_usage", return_value={"services": [], "updated_at": None})
+
+    client_request.login(platform_admin_user)
+
+    page = client_request.get("main.organisation_dashboard", org_id=ORGANISATION_ID)
+    nav_items = [item.text.strip() for item in page.select("nav.navigation a")]
+    assert nav_items == ["Usage", "Team members", "Settings", "Trial mode services", "Billing"]
+
+
+@pytest.mark.parametrize(
+    "user_org_permissions, expected_nav_items",
+    [
+        ([], ["Usage", "Team members"]),
+        ([PERMISSION_CAN_MAKE_SERVICES_LIVE], ["Usage", "Team members", "Trial mode services"]),
+    ],
+)
+def test_organisation_left_hand_nav_for_org_users(
+    mock_get_organisation,
+    client_request,
+    user_org_permissions,
+    expected_nav_items,
+    mocker,
+):
+    mocker.patch("app.organisations_client.get_services_and_usage", return_value={"services": [], "updated_at": None})
+
+    org_user = create_user(
+        id=sample_uuid(),
+        organisations=[ORGANISATION_ID],
+        organisation_permissions={ORGANISATION_ID: user_org_permissions},
+    )
+    client_request.login(org_user)
+
+    page = client_request.get("main.organisation_dashboard", org_id=ORGANISATION_ID)
+    nav_items = [item.text.strip() for item in page.select("nav.navigation a")]
+    assert nav_items == expected_nav_items
 
 
 def test_organisation_page_shows_all_organisations(client_request, platform_admin_user, mocker):
@@ -849,11 +895,43 @@ def test_organisation_trial_mode_services_shows_all_non_live_services(
     assert services[1].find("a")["href"] == url_for("main.service_dashboard", service_id="3")
 
 
-def test_organisation_trial_mode_services_doesnt_work_if_not_platform_admin(
+def test_organisation_trial_mode_services_is_visible_to_platform_admin(
+    platform_admin_user,
     client_request,
     mock_get_organisation,
+    mock_get_organisation_services,
 ):
-    client_request.get(".organisation_trial_mode_services", org_id=ORGANISATION_ID, _expected_status=403)
+    client_request.login(platform_admin_user)
+    client_request.get(".organisation_trial_mode_services", org_id=ORGANISATION_ID, _test_page_title=False)
+
+
+@pytest.mark.parametrize(
+    "user_org_permissions, expected_status_code",
+    [
+        ([], 403),
+        ([PERMISSION_CAN_MAKE_SERVICES_LIVE], 200),
+    ],
+)
+def test_organisation_trial_mode_services_page_when_viewing_as_org_user(
+    client_request,
+    mock_get_organisation,
+    mock_get_organisation_services,
+    user_org_permissions,
+    expected_status_code,
+):
+    org_user = create_user(
+        id=sample_uuid(),
+        organisations=[ORGANISATION_ID],
+        organisation_permissions={ORGANISATION_ID: user_org_permissions},
+    )
+
+    client_request.login(org_user)
+    client_request.get(
+        ".organisation_trial_mode_services",
+        org_id=ORGANISATION_ID,
+        _test_page_title=False,
+        _expected_status=expected_status_code,
+    )
 
 
 @pytest.mark.parametrize("can_approve_own_go_live_requests", (True, False))


### PR DESCRIPTION
The "Trial mode services" organisation page was platform admin only, but we want to show this to organisation team members who have the permission to approve go-live requests. Organisation users without this specific permission won't see the page or any links to it. As well as changing permissions for who can view the page, the permissions for who can see the link to the page in the left hand nav have also been changed.

[Trello card](https://trello.com/c/7VpLeDV5/1782-make-a-version-of-trial-services-page-visible-to-organisations-with-self-approve-enabled-6)