### PR TITLE
Add two team members banner

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -35,6 +35,11 @@ from app.utils.user_permissions import permission_options, translate_permissions
 @main.route("/services/<uuid:service_id>/users")
 @user_has_permissions(allow_org_user=True)
 def manage_users(service_id):
+    active_users_with_manage_service_permission = current_service.active_users_with_permission("manage_service")
+    active_gov_users_with_manage_service_permission = [
+        user for user in active_users_with_manage_service_permission if user.is_gov_user
+    ]
+
     return render_template(
         "views/manage-users.html",
         users=current_service.team_members,
@@ -43,6 +48,7 @@ def manage_users(service_id):
         form=SearchUsersForm(),
         permissions=permission_options,
         extra_spacing_around_flash_messages=False,
+        active_gov_users_with_manage_service_permission_count=len(active_gov_users_with_manage_service_permission),
     )
 
 

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -2,6 +2,8 @@
 {% from "components/tick-cross.html" import tick_cross %}
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+
 
 {% block service_page_title %}
   Team members
@@ -9,11 +11,34 @@
 
 {% block maincolumn_content %}
 
+{% if active_gov_users_with_manage_service_permission_count < 2 %}
+    {% call govukNotificationBanner({
+      "titleText": "Finish setting up your team",
+      "classes": "govuk-!-margin-bottom-4"
+    }) %}
+      <p class="govuk-body govuk-!-font-weight-bold">
+        {% if current_user.is_gov_user %}
+          You need to add a team member from your organisation.
+        {% elif active_gov_users_with_manage_service_permission_count == 0 %}
+          You need to add at least two team members from a public sector organisation.
+        {% else %}
+          You need to add a team member from a public sector organisation.
+        {% endif %}
+      </p>
+      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+        Give them the ‘manage settings, team and usage’ permission.
+      </p>
+    {% endcall %}
+  {% endif %}
+
+
   <h1 class="heading-large">
     Team members
   </h1>
 
-  <p class="govuk-body">You must have at least 2 team members with the ‘manage settings’ permission.</p>
+  {% if active_gov_users_with_manage_service_permission_count >= 2 %}
+    <p class="govuk-body">You must have at least 2 team members with the ‘manage settings’ permission.</p>
+  {% endif %}
 
   {% if show_search_box %}
     <div data-notify-module="autofocus">

--- a/app/templates/views/request-to-go-live.html
+++ b/app/templates/views/request-to-go-live.html
@@ -47,7 +47,7 @@
           },
           {
             "title": {
-              "text": "Give another team member the ‘manage settings’ permission",
+              "text": "Finish setting up your team",
               "classes": "govuk-link--no-visited-state",
             },
             "href": url_for('main.manage_users', service_id=current_service.id),

--- a/tests/app/main/views/test_make_your_service_live.py
+++ b/tests/app/main/views/test_make_your_service_live.py
@@ -292,9 +292,9 @@ def test_should_check_for_email_from_name_on_go_live(
 @pytest.mark.parametrize(
     "count_of_users_with_manage_service,count_of_invites_with_manage_service,expected_user_checklist_item",
     [
-        (1, 0, "Give another team member the ‘manage settings’ permission Incomplete"),
-        (2, 0, "Give another team member the ‘manage settings’ permission Completed"),
-        (1, 1, "Give another team member the ‘manage settings’ permission Completed"),
+        (1, 0, "Finish setting up your team Incomplete"),
+        (2, 0, "Finish setting up your team Completed"),
+        (1, 1, "Finish setting up your team Completed"),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -177,6 +177,94 @@ def test_should_show_overview_page(
 
 
 @pytest.mark.parametrize(
+    "current_user_email, other_user_emails, expected_banner_text",
+    [
+        pytest.param(
+            "test@example.gov.uk",
+            [],
+            "You need to add a team member from your organisation.",
+        ),
+        pytest.param(
+            "test@example.gov.uk",
+            ["test@example.com"],
+            "You need to add a team member from your organisation.",
+        ),
+        pytest.param(
+            "test@example.gov.uk",
+            ["test2@example.gov.uk"],
+            None,
+        ),
+        pytest.param(
+            "test@example.com",
+            [],
+            "You need to add at least two team members from a public sector organisation.",
+        ),
+        pytest.param(
+            "test@example.com",
+            ["test2@example.com"],
+            "You need to add at least two team members from a public sector organisation.",
+        ),
+        pytest.param(
+            "test@example.com",
+            ["test@example.gov.uk"],
+            "You need to add a team member from a public sector organisation.",
+        ),
+        pytest.param(
+            "test@example.com",
+            ["test@example.gov.uk", "test2@school.com"],
+            None,
+        ),
+    ],
+)
+def test_manage_users_shows_add_team_member_banner(
+    client_request,
+    mocker,
+    mock_get_invites_for_service,
+    mock_get_template_folders,
+    service_one,
+    expected_banner_text,
+    current_user_email,
+    other_user_emails,
+):
+    current_user = create_user(
+        id=uuid.uuid4(),
+        email_address=current_user_email,
+        services=[SERVICE_ONE_ID],
+        permissions={SERVICE_ONE_ID: ["manage_service"]},
+    )
+
+    users = [current_user]
+
+    for email in other_user_emails:
+        other_user = create_user(
+            id=uuid.uuid4(),
+            email_address=email,
+            services=[SERVICE_ONE_ID],
+            permissions={SERVICE_ONE_ID: ["manage_service"]},
+        )
+        users.append(other_user)
+
+    mocker.patch(
+        "app.models.user.Users._get_items",
+        return_value=users,
+    )
+
+    mocker.patch("app.utils.user.organisations_client.get_domains", return_value=["example.gov.uk", "school.com"])
+
+    client_request.login(current_user)
+    page = client_request.get("main.manage_users", service_id=SERVICE_ONE_ID)
+
+    if expected_banner_text:
+        assert "Finish setting up your team" in page.text
+        assert expected_banner_text in page.text
+        assert "Give them the ‘manage settings, team and usage’ permission." in page.text
+        assert "You must have at least 2 team members with the ‘manage settings’ permission." not in page.text
+    else:
+        assert "Finish setting up your team" not in page.text
+        assert "You must have at least 2 team members with the ‘manage settings’ permission." in page.text
+
+
+@pytest.mark.parametrize(
     "state",
     (
         "active",


### PR DESCRIPTION
This PR contains two changes:
- Add banner to instruct add two team members on manage users page
- Update make your service live members permission task content
[Card](https://trello.com/c/ibKTkPPy/1770-new-two-team-members-with-the-manage-settings-permission-instruction) for more details

Service with less than 2 gov domain users with manage settings permissions and logged in user is gov user
<img width="819" height="617" alt="Screenshot 2026-05-13 at 12 11 32" src="https://github.com/user-attachments/assets/90f86fec-8f08-4a7e-b290-2b2b12baca9c" />


Service with only 1 gov domain users with manage settings permissions and logged in user is third-party user
<img width="819" height="617" alt="image" src="https://github.com/user-attachments/assets/0d3b300f-12f0-46e7-a25d-d692a88e3afb" />


Service with no gov domain users with manage settings permissions and logged in user is third-party user
<img width="819" height="617" alt="image" src="https://github.com/user-attachments/assets/455f4143-7712-4862-ab09-23f80e8e7e24" />


Service with two or more gov users with manage settings permissions
<img width="819" height="155" alt="image" src="https://github.com/user-attachments/assets/f7a0906b-433e-44ab-adfe-d36ffa5205f7" />
