### PR TITLE
Fix file preview ordering

### DIFF
--- a/app/main/views/document_download.py
+++ b/app/main/views/document_download.py
@@ -12,10 +12,9 @@ from app.utils.user import user_has_permissions
 @user_has_permissions()
 def document_download_landing(service_id, document_id):
     template_id = base64_to_uuid_or_404(request.args.get("key"))
+    template_version = request.args.get("template_version", None)
     template = current_service.get_template_with_user_permission_or_403(
-        template_id,
-        current_user,
-        must_be_of_type="email",
+        template_id, current_user, must_be_of_type="email", version=template_version
     )
     template_email_file = template.email_files.by_id(document_id)
 
@@ -27,6 +26,7 @@ def document_download_landing(service_id, document_id):
             service_id=current_service.id,
             document_id=template_email_file.id,
             key=uuid_to_base64(template.id),
+            template_version=template.version,
         ),
     )
 
@@ -35,10 +35,12 @@ def document_download_landing(service_id, document_id):
 @user_has_permissions()
 def document_download_confirm_email_address(service_id, document_id):
     template_id = base64_to_uuid_or_404(request.args.get("key"))
+    template_version = request.args.get("template_version", None)
     template = current_service.get_template_with_user_permission_or_403(
         template_id,
         current_user,
         must_be_of_type="email",
+        version=template_version,
     )
     template_email_file = template.email_files.by_id(document_id)
 
@@ -54,6 +56,7 @@ def document_download_confirm_email_address(service_id, document_id):
                 service_id=current_service.id,
                 document_id=template_email_file.id,
                 key=uuid_to_base64(template.id),
+                template_version=template.version,
             )
         )
 
@@ -68,10 +71,9 @@ def document_download_confirm_email_address(service_id, document_id):
 @user_has_permissions()
 def document_download_download_document(service_id, document_id):
     template_id = base64_to_uuid_or_404(request.args.get("key"))
+    template_version = request.args.get("template_version", None)
     template = current_service.get_template_with_user_permission_or_403(
-        template_id,
-        current_user,
-        must_be_of_type="email",
+        template_id, current_user, must_be_of_type="email", version=template_version
     )
     template_email_file = template.email_files.by_id(document_id)
 

--- a/app/models/template_email_file.py
+++ b/app/models/template_email_file.py
@@ -79,6 +79,7 @@ class TemplateEmailFile(JSONModel):
             service_id=self.service_id,
             document_id=self.id,
             key=uuid_to_base64(self.template.id),
+            template_version=self.template.version,
             _external=True,
         )
         if self.link_text:

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -244,6 +244,7 @@ class EmailPreviewTemplate(BaseEmailTemplate):
         self.from_name = from_name
         self.reply_to = reply_to
         self.show_recipient = show_recipient
+        self.version = template.get("version")
         if template.get("has_unsubscribe_link"):
             self.unsubscribe_link = url_for("main.unsubscribe_example", _external=True)
 

--- a/tests/app/main/views/test_document_download.py
+++ b/tests/app/main/views/test_document_download.py
@@ -57,10 +57,11 @@ def test_403_if_user_does_not_have_permission_to_see_template(client_request, fa
         service_id=SERVICE_ONE_ID,
         document_id=uuid4(),
         key=uuid_to_base64(fake_uuid),
+        template_version=2,
         _expected_status=403,
     )
     assert mock_get_template.call_args_list == [
-        call(UUID(fake_uuid), RestrictedAny(lambda u: isinstance(u, User)), must_be_of_type="email"),
+        call(UUID(fake_uuid), RestrictedAny(lambda u: isinstance(u, User)), must_be_of_type="email", version="2"),
     ]
 
 
@@ -253,6 +254,7 @@ def test_landing_page(
         service_id=SERVICE_ONE_ID,
         document_id=fake_uuid,
         key=uuid_to_base64(fake_uuid),
+        template_version=email_template["version"],
     )
     assert normalize_spaces(button.text) == "Continue"
 
@@ -282,7 +284,7 @@ def test_confirm_email_page_redirects_if_confirmation_not_required(
     mocker.patch("app.service_api_client.get_service_template", return_value={"data": email_template})
     key = uuid_to_base64(fake_uuid)
     bae64_service_id = uuid_to_base64(SERVICE_ONE_ID)
-    expected_url = f"/d/{bae64_service_id}/{key}/download?key={key}"
+    expected_url = f"/d/{bae64_service_id}/{key}/download?key={key}&template_version={email_template['version']}"
     client_request.get(
         ".document_download_confirm_email_address",
         service_id=SERVICE_ONE_ID,
@@ -470,7 +472,7 @@ def test_confirm_email_page_redirects_for_correct_email(
     mocker.patch("app.service_api_client.get_service_template", return_value={"data": email_template})
     key = uuid_to_base64(fake_uuid)
     bae64_service_id = uuid_to_base64(SERVICE_ONE_ID)
-    expected_url = f"/d/{bae64_service_id}/{key}/download?key={key}"
+    expected_url = f"/d/{bae64_service_id}/{key}/download?key={key}&template_version={email_template['version']}"
     client_request.post(
         ".document_download_confirm_email_address",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -5012,21 +5012,21 @@ def test_attach_files_button(
             ],
             (
                 "For the appointment, you will need: "
-                "http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg, "
+                "http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg&template_version=1, "  # noqa: E501
                 "This is a link"
             ),
             [
                 (
                     "<a"
-                    ' href="http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg"'
+                    ' href="http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg&amp;template_version=1"'
                     ' style="word-wrap: break-word; color: #1D70B8;"'
                     ">"
-                    "http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg"
+                    "http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg&amp;template_version=1"
                     "</a>"
                 ),
                 (
                     "<a"
-                    ' href="http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAg?key=bORm0P1qEeWC9eCsy50Rpg"'
+                    ' href="http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAg?key=bORm0P1qEeWC9eCsy50Rpg&amp;template_version=1"'
                     ' style="word-wrap: break-word; color: #1D70B8;">'
                     "This is a link"
                     "</a>"
@@ -5060,21 +5060,21 @@ def test_attach_files_button(
             (
                 "This template contains a mixture of normal placeholders, and file placeholders: "
                 "((current_date)), "
-                "http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg, "
+                "http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg&template_version=1, "  # noqa: E501
                 "This is a link"
             ),
             [
                 (
                     "<a"
-                    ' href="http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg"'
+                    ' href="http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg&amp;template_version=1"'
                     ' style="word-wrap: break-word; color: #1D70B8;"'
                     ">"
-                    "http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg"
+                    "http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAQ?key=bORm0P1qEeWC9eCsy50Rpg&amp;template_version=1"
                     "</a>"
                 ),
                 (
                     "<a"
-                    ' href="http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAg?key=bORm0P1qEeWC9eCsy50Rpg"'
+                    ' href="http://localhost/d/WWNkoIWOQsiQYqj-giJg6w/AAAAAAAAQACAAAAAAAAAAg?key=bORm0P1qEeWC9eCsy50Rpg&amp;template_version=1"'
                     ' style="word-wrap: break-word; color: #1D70B8;"'
                     ">"
                     "This is a link"


### PR DESCRIPTION
Pass a query parameter to preview endpoints to fetch the correct template_version from `notifications-api` when previewing files
We currently only fetch the latest template version for the document download preview pages. This works for users interacting with the latest template, but not when looking at the history of older versions. This is an edge case use but as the document download preview pages are the only place in the UI that shows a user what they sent historically, this should reflect what actually ends up in an end users inbox.

Using a query parameter instead of a path parameter to try and preserve the structure of the document download link as far as possible.