### PR TITLE
redis: configure 5s socket timeouts

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -88,6 +88,8 @@ class Config:
 
     REDIS_URL = os.environ.get("REDIS_URL")
     REDIS_ENABLED = False if os.environ.get("REDIS_ENABLED") == "0" else True
+    REDIS_SOCKET_TIMEOUT = 5
+    REDIS_SOCKET_CONNECT_TIMEOUT = 5
 
     ASSET_DOMAIN = os.environ.get("ASSET_DOMAIN", "")
     ASSET_PATH = os.environ.get("ASSET_PATH", "/static/")


### PR DESCRIPTION
Possible now we have https://github.com/alphagov/notifications-utils/pull/1353

We're supposed to be semi-robust to redis outages, and if our requests time out after 30s of waiting for a redis connection during an outage, we're not doing that.