### PR TITLE
error handlers: use "failsafe" mechanism to avoid risky operations rendering error pages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -304,6 +304,11 @@ def reset_memos():
 
 @login_manager.user_loader
 def load_user(user_id):
+    if g.get("failsafe"):
+        # avoid doing anything that may result in a network request and therefore another exception
+        # (sadly we're not in charge of flask-login's context processor so can't stop such attempts
+        # there)
+        return None
     return User.from_id(user_id)
 
 
@@ -420,7 +425,7 @@ def useful_headers_after_request(response):
 
 
 def register_errorhandlers(application):  # noqa (C901 too complex)
-    def _error_response(error_code, error_page_template=None):
+    def _error_response(error_code, *, error_page_template=None, failsafe=False):
         template_file = f"error/{error_code}.html"
 
         if error_code == 404 and request.view_args and "service_id" in request.view_args and g.current_service:
@@ -428,6 +433,11 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
 
         if error_page_template:
             template_file = f"error/{error_page_template}.html"
+
+        if failsafe:
+            # signal that any e.g. context processors should avoid doing things (like making external requests)
+            # that may result in more errors, which we would have trouble catching.
+            g.failsafe = True
 
         resp = make_response(render_template(template_file), error_code)
         return useful_headers_after_request(resp)
@@ -534,12 +544,12 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
         # We want the Flask in browser stacktrace
         if current_app.config.get("DEBUG", None):
             raise error
-        return _error_response(500)
+        return _error_response(500, failsafe=True)
 
     @application.errorhandler(EventletTimeout)
     def eventlet_timeout(error):
         application.logger.exception(error)
-        return _error_response(504, error_page_template=500)
+        return _error_response(504, error_page_template=500, failsafe=True)
 
 
 def setup_blueprints(application):


### PR DESCRIPTION
Specifically, this prevents a request being made (either to redis or the api) by flask-login's template context processor.

When we're rendering error pages, we've got to remember we're doing so in an error handler, and any further exceptions won't get caught and handled properly - resulting in an ugly and difficult to decipher error (both for the user and in our logs).

Here, we set a request-local flag to indicate this, and make our `user_loader` reference this before continuing to any possible requests. This is the only place I've found such a request being made in the basic rendering path, but there could be more.

Currently only using this for error pages that are likely to have arisen from availability problems as some error pages want to be able to show a full nav bar with service- and user-contextual information. They'll just have to risk it for now.

This fell out of testing performed for https://trello.com/c/PEpdGAPE/1518-implement-solution-for-failed-writes-deletes-to-redis