### PR TITLE
Add org permissions to `has_permissions` decorator

### DIFF
--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -201,13 +201,8 @@ def download_organisation_usage_report(org_id):
 
 
 @main.route("/organisations/<uuid:org_id>/trial-services", methods=["GET"])
-@user_has_permissions()
+@user_has_permissions(org_permissions=[PERMISSION_CAN_MAKE_SERVICES_LIVE])
 def organisation_trial_mode_services(org_id):
-    if not current_user.platform_admin and not current_user.has_permission_for_organisation(
-        org_id, PERMISSION_CAN_MAKE_SERVICES_LIVE
-    ):
-        abort(403)
-
     return render_template(
         "views/organisations/organisation/trial-mode-services.html",
         _search_form=SearchByNameForm(),

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -19,6 +19,7 @@ from app.utils.time import is_less_than_days_ago, isoformat_no_tz
 from app.utils.user import is_gov_user
 from app.utils.user_permissions import (
     all_ui_permissions,
+    organisation_user_permission_names,
     translate_permissions_from_db_to_ui,
 )
 
@@ -239,10 +240,18 @@ class User(BaseUser, UserMixin):
     def platform_admin(self):
         return self._platform_admin and not session.get("disable_platform_admin_view", False)
 
-    def has_permissions(self, *permissions, restrict_admin_usage=False, allow_org_user=False):
-        unknown_permissions = set(permissions) - all_ui_permissions
+    def _validate_route_permissions(self, service_permissions, org_permissions):
+        unknown_permissions = set(service_permissions) - all_ui_permissions
         if unknown_permissions:
             raise TypeError(f"{list(unknown_permissions)} are not valid permissions")
+
+        unknown_org_permissions = set(org_permissions) - organisation_user_permission_names
+        if unknown_org_permissions:
+            raise TypeError(f"{list(unknown_org_permissions)} are not valid org permissions")
+
+    def has_permissions(self, *permissions, restrict_admin_usage=False, allow_org_user=False, org_permissions=None):
+        org_permissions = org_permissions or []
+        self._validate_route_permissions(service_permissions=permissions, org_permissions=org_permissions)
 
         # Service id is always set on the request for service specific views.
         service_id = _get_service_id_from_view_args()
@@ -256,6 +265,9 @@ class User(BaseUser, UserMixin):
         # platform admins should be able to do most things (except eg send messages, or create api keys)
         if self.platform_admin and not restrict_admin_usage:
             return True
+
+        if org_id and org_permissions:
+            return self.permissions_for_organisation(org_id) & set(org_permissions)
 
         if org_id:
             return self.belongs_to_organisation(org_id)

--- a/tests/app/utils/test_user.py
+++ b/tests/app/utils/test_user.py
@@ -83,7 +83,7 @@ def test_no_user_returns_redirect_to_sign_in(client_request):
     assert response.location.startswith("/sign-in?next=")
 
 
-def test_user_has_permissions_for_organisation(
+def test_user_belongs_to_organisation(
     client_request,
     api_user_active,
 ):
@@ -93,6 +93,32 @@ def test_user_has_permissions_for_organisation(
     request.view_args = {"org_id": "org_2"}
 
     @user_has_permissions()
+    def index():
+        pass
+
+    index()
+
+
+@pytest.mark.parametrize(
+    "org_permissions",
+    [
+        pytest.param({}, marks=pytest.mark.xfail(raises=Forbidden)),  # doesn't have required permission
+        {"org_2": ["can_make_services_live"]},
+    ],
+)
+def test_user_has_permissions_for_organisation(
+    client_request,
+    api_user_active,
+    org_permissions,
+):
+    api_user_active["organisations"] = ["org_1", "org_2"]
+    api_user_active["organisation_permissions"] = org_permissions
+
+    client_request.login(api_user_active)
+
+    request.view_args = {"org_id": "org_2"}
+
+    @user_has_permissions(org_permissions=["can_make_services_live"])
     def index():
         pass
 


### PR DESCRIPTION
In https://github.com/alphagov/notifications-admin/pull/5917 we started restricting a route to org users with a certain permission for the first time. This refactors the `has_permissions` decorator to accept org permissions as an argument so that we can use it in this case too.