### PR TITLE
Add councillors and MPs to the ineligible list

### DIFF
--- a/app/templates/views/guidance/features/who-can-use-notify.html
+++ b/app/templates/views/guidance/features/who-can-use-notify.html
@@ -46,6 +46,8 @@
     <li><a class="govuk-link govuk-link--no-visited-state" href="#pharmacies">community pharmacies</a></li>
     <li>hospices</li>
     <li>housing associations</li>
+    <li>local councillors</li>
+    <li>members of parliament (MPs)</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#public">members of the public</a></li>
     <li>universities</li>
   </ul>


### PR DESCRIPTION
Following recent enquiries, we’ve decided to publish an update to the eligibility list:

Local councillors and MPs are not eligible to use GOV.UK Notify.