### PR TITLE
Use `notifications_utils.file_types.mime_type_from_extension`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.2.0
+# This file was automatically copied from notifications-utils@115.3.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/models/template_email_file.py
+++ b/app/models/template_email_file.py
@@ -1,5 +1,4 @@
 import math
-import mimetypes
 import uuid
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
@@ -8,6 +7,7 @@ from typing import Any
 import boto3
 from flask import abort, current_app, url_for
 from notifications_utils.base64_uuid import uuid_to_base64
+from notifications_utils.file_types import mime_type_from_extension
 from notifications_utils.s3 import s3download
 from notifications_utils.serialised_model import SerialisedModelCollection
 from notifications_utils.template import Template
@@ -103,7 +103,7 @@ class TemplateEmailFile(JSONModel):
 
     @property
     def mimetype(self):
-        return mimetypes.types_map[f".{self.extension}"]
+        return mime_type_from_extension(self.extension)
 
     @property
     def file_contents(self):

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.3.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -728,7 +728,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ee41d2202592cf80f4148447cfe07283ee1f03e3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c835456a288c7a4bd42857060c2cab02d851980d
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -907,7 +907,7 @@ moto==5.1.22 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ee41d2202592cf80f4148447cfe07283ee1f03e3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c835456a288c7a4bd42857060c2cab02d851980d
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.2.0
+# This file was automatically copied from notifications-utils@115.3.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.2.0
+# This file was automatically copied from notifications-utils@115.3.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/main/views/test_document_download.py
+++ b/tests/app/main/views/test_document_download.py
@@ -624,10 +624,28 @@ def test_document_download_download_document_displays_the_right_file_metadata(
     ]
 
 
+@pytest.mark.parametrize(
+    "filename, expected_content_type, expected_content_disposition",
+    (
+        (
+            "test_file_1.pdf",
+            "application/pdf",
+            "attachment; filename=test_file_1.pdf",
+        ),
+        (
+            "test_file_1.DOCX",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "attachment; filename=test_file_1.DOCX",
+        ),
+    ),
+)
 def test_document_download_download_document_enables_download(
     client_request,
     fake_uuid,
     mocker,
+    filename,
+    expected_content_type,
+    expected_content_disposition,
 ):
     mocker.patch(
         "app.service_api_client.get_service",
@@ -640,7 +658,7 @@ def test_document_download_download_document_enables_download(
         email_files=[
             {
                 "id": fake_uuid,
-                "filename": "test_file_1.pdf",
+                "filename": filename,
                 "link_text": "file link",
                 "retention_period": 90,
                 "validate_users_email": True,
@@ -664,7 +682,7 @@ def test_document_download_download_document_enables_download(
     )
     assert response.status_code == 200
     assert response.data == expected_content
-    assert response.headers["Content-Type"] == "application/pdf"
+    assert response.headers["Content-Type"] == expected_content_type
     # Ensure that the file is made available for download only and not displayed in the browser
-    assert response.headers["Content-Disposition"] == "attachment; filename=test_file_1.pdf"
+    assert response.headers["Content-Disposition"] == expected_content_disposition
     mock_get_content.assert_called_once()

--- a/tests/app/main/views/test_document_download.py
+++ b/tests/app/main/views/test_document_download.py
@@ -678,7 +678,6 @@ def test_document_download_download_document_enables_download(
         document_id=fake_uuid,
         key=uuid_to_base64(fake_uuid),
         download="True",
-        mimetype="application/pdf",
     )
     assert response.status_code == 200
     assert response.data == expected_content

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.2.0
+# This file was automatically copied from notifications-utils@115.3.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
Fixes https://trello.com/c/yjn6AtsA/598-fix-mimetype-error-for-docx-files-when-downloading-from-preview-endpoint

***

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/1357