### PR TITLE
Update the guidance

### DIFF
--- a/app/templates/views/guidance/using-notify/team-members-permissions.html
+++ b/app/templates/views/guidance/using-notify/team-members-permissions.html
@@ -20,18 +20,18 @@
 
   <p class="govuk-body">Choose from the following permissions:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>manage settings, team and usage</li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#manage-settings">manage settings, team and usage</a></li>
     <li>see dashboard</li>
     <li>send messages</li>
     <li>add and edit templates</li>
     <li>manage API integration</li>
   </ul>
 
-  <p class="govuk-body">Every service you add needs at least 2 team members with the ‘manage settings, team and usage’ permission.</p>
+  <h2 class="heading-medium" id="manage-settings">About the ‘manage settings’ permission</h2>
 
-  <h2 class="heading-medium">If you have the ‘manage settings’ permission</h2>
+  <p class="govuk-body">Each service you add needs at least 2 team members with the ‘manage settings, team and usage’ permission.</p>
 
-  <p class="govuk-body">Team members with the ‘manage settings, team and usage’ permission are responsible for:</p>
+  <p class="govuk-body">Team members with the ‘manage settings’ permission are responsible for:</p>
 
   <h3 class="heading-small">The service</h3>
   <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
A couple of small improvements to the new guidance:

* move the ‘2 team members’ instruction to make it more prominent
* add an anchor link to ‘manage settings’ so we can link directly to it if we need to
* update the section heading