### PR TITLE
Update links on the "Trial mode services" organisation page

### DIFF
--- a/app/templates/views/organisations/organisation/trial-mode-services.html
+++ b/app/templates/views/organisations/organisation/trial-mode-services.html
@@ -14,7 +14,7 @@
   <ul>
   {% for service in current_org.trial_services %}
     <li class="browse-list-item">
-      <a href="{{ url_for('main.service_dashboard', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service['name'] }}</a>
+      <a href="{{ url_for('main.usage', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service['name'] }}</a>
     </li>
   {% endfor %}
   </ul>

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -891,8 +891,8 @@ def test_organisation_trial_mode_services_shows_all_non_live_services(
 
     assert normalize_spaces(services[0].text) == "2"
     assert normalize_spaces(services[1].text) == "3"
-    assert services[0].find("a")["href"] == url_for("main.service_dashboard", service_id="2")
-    assert services[1].find("a")["href"] == url_for("main.service_dashboard", service_id="3")
+    assert services[0].find("a")["href"] == url_for("main.usage", service_id="2")
+    assert services[1].find("a")["href"] == url_for("main.usage", service_id="3")
 
 
 def test_organisation_trial_mode_services_is_visible_to_platform_admin(


### PR DESCRIPTION
When viewing live services for an organisation, each service links to the usage page for the service. The list of trial mode services had each service linking to the dashboard page for the service. The list of trial mode services was recently made visible to organisation team members who can approve requests to go live, but these users don't have permission to see dashboards for services they don't belong to. This changes the links to point to the usage page, which makes is consistent where we link for live services and means that we're not showing org members a link they can't access.

[Trello card](https://trello.com/c/v0TxrCuW/1815-post-mvp-trial-services-page-for-self-approving-org-team-members)