### PR TITLE
[Testing with dev env] Remove guard for scrollToRevealElement argument

### DIFF
--- a/app/assets/javascripts/esm/stick-to-window-when-scrolling.mjs
+++ b/app/assets/javascripts/esm/stick-to-window-when-scrolling.mjs
@@ -664,9 +664,6 @@ class StickAtEdge {
 
   // Public method to scroll so an element isn't covered by the sticky nav
   scrollToRevealElement ($el) {
-    // guard against previous version of this method recieving `$el` as a jQuery-wrapped DOM node
-    if ('jquery' in $el) { $el = $el.get(0); }
-
     const scrollAreaNode = $el.closest('.sticky-scroll-area');
     const matches = scrollAreas.filterBy(scrollArea => {
       return scrollArea.node === scrollAreaNode;


### PR DESCRIPTION
We removed all the uses of jQuery in this pull
request:

https://github.com/alphagov/notifications-admin/pull/5924

But the scrollToRevealElement method is used by
some JS script in the functional tests, and still
sent the argument in (a DOM node) wrapped in a
jQuery object. We added a guard when we changed
the code, to deal with this use, but the code
doing that was changed in this pull request:

https://github.com/alphagov/notifications-functional-tests/pull/657

...so we no longer need the guard.