### PR TITLE
Display correct text direction for RTL text in sms template edit and preview

### DIFF
--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -14,6 +14,11 @@ $tail-angle: 20deg;
   margin: 0 0 govuk-spacing(6) 0;
   clear: both;
   word-wrap: break-word;
+  // align text to logical start
+  text-align: start;
+  // This forces the HTML layout engine to calculate bidirectional text runs 
+  // character-by-character exactly like a native <textarea> does.
+  unicode-bidi: plaintext;
 
   &:after {
     content: "";

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -201,6 +201,15 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
       color: transparent;
     }
   }
+
+  // apply only to sms template editor
+  &__textbox--sms + &__background {
+    // align text to logical start
+    text-align: start;
+    // This forces the HTML layout engine to calculate bidirectional text runs 
+    // character-by-character exactly like a native <textarea> does.
+    unicode-bidi: plaintext; 
+  }
 }
 
 // colour preview widget adjecent to govuk-input field

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -28,10 +28,11 @@
             "hint": {"text": "Your recipients will not see this"}
           }) }}
           {{ form.template_content(param_extensions={
-            "classes": "govuk-!-width-full govuk-textarea-highlight__textbox",
+            "classes": "govuk-!-width-full govuk-textarea-highlight__textbox govuk-textarea-highlight__textbox--sms",
             "attributes": {
               "data-notify-module": "enhanced-textbox",
-              "data-highlight-placeholders": "true"
+              "data-highlight-placeholders": "true",
+              "dir": "auto"
             },
             "rows": "5",
             "hint": content_hint,


### PR DESCRIPTION
## What
Display right-to-left text correctly in SMS template edit and message preview. 

We make use of [dir="auto"](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/dir) HTML attribute and [unicode-bidi](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/unicode-bidi) CSS property to let the browser determine text-direction for each line.

## Why

We will be looking to enable support for SMS in other language so it would be nice to correctly display text direction if any RTL language is used.

## How to review

As SMS support isn't switched on yet, you'll need to manually edit DOM for the message preview. You can use the following test markup to put in the `.sms-message-wrapper`

```
  The quick brown fox jumps over the <span class="placeholder">((animal))</span>.<br>
  TСъешь же ещё этих мягких французских булок, да <span class="placeholder">((animal))</span>.<br>
  نص شكلي يستخدم في صناعات الطباعة والتنضي <span class="placeholder">((animal))</span>.<br>
  Θέλω να μάθω αν η ζωή έχει κάποιο <span class="placeholder">((animal))</span>.<br>
  Pchnąć w tę łódź jeża lub ośm <span class="placeholder">((animal))</span>.
```

## Visuals

### Template edit
<img width="485" height="218" alt="sms-edit" src="https://github.com/user-attachments/assets/b1191838-f35f-4f54-8cc4-904b9351c9c9" />

### Message preview
<img width="537" height="218" alt="sms-preview" src="https://github.com/user-attachments/assets/2c528df4-3c80-4de5-b523-98a4c0a92551" />

