### PR TITLE
Break long words in error summary and error message

### DIFF
--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -12,6 +12,7 @@
   &-label .govuk-error-message,
   &-button-label.govuk-error-message {
     padding: 0;
+    word-break: break-word;
   }
 
   &-field {

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -329,3 +329,9 @@ $govuk-touch-target-size: ($govuk-checkboxes-size + $govuk-touch-target-gutter);
     background: govuk-functional-colour(border);
   }
 }
+
+// break long text in the error summary link
+// file upload error for 100+ character file name return the file name in the error
+.govuk-error-summary__list a {
+  word-break: break-word;
+}


### PR DESCRIPTION
File upload error for a file that's longer than 100 characters will show the file name in the error messages and break out of the container.

**Before**
<img width="1085" height="493" alt="Screenshot 2026-05-22 at 11 29 47" src="https://github.com/user-attachments/assets/4f6fa983-cb8d-4a0f-bf12-668ce083d935" />


**After**
<img width="766" height="500" alt="Screenshot 2026-05-22 at 11 22 32" src="https://github.com/user-attachments/assets/75e601c2-5684-4b1b-9a8d-d92b3e73bbe6" />
