### PR TITLE
Refactor character counting message into Jinja

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -52,6 +52,7 @@ from app.config import Config, configs
 from app.event_handlers import Events
 from app.extensions import antivirus_client, redis_client, zendesk_client  # noqa
 from app.formatters import (
+    character_count,
     convert_to_boolean,
     extract_path_from_url,
     format_auth_type,
@@ -593,6 +594,7 @@ def setup_event_handlers():
 
 def add_template_filters(application):
     for fn in [
+        character_count,
         format_auth_type,
         format_billions,
         format_datetime,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -38,7 +38,6 @@ from app import (
     template_statistics_client,
 )
 from app.constants import QR_CODE_TOO_LONG, LetterLanguageOptions
-from app.formatters import character_count, message_count
 from app.main import main, no_cookie
 from app.main.forms import (
     CopyTemplateForm,
@@ -128,15 +127,10 @@ def view_template(service_id, template_id):
     if should_skip_template_page(template):
         return redirect(url_for(".set_sender", service_id=service_id, template_id=template_id))
 
-    content_count_message = None
-    if template.template_type == "sms":
-        content_count_message = _get_fragment_count_message_for_sms_template(template)
-
     return render_template(
         "views/templates/template.html",
         template=template,
         user_has_template_permission=user_has_template_permission,
-        content_count_message=content_count_message,
         extra_spacing_around_flash_messages=False,
     )
 
@@ -826,38 +820,23 @@ def edit_service_template(service_id, template_id, language=None):  # noqa
 )
 @user_has_permissions()
 def count_content_length(service_id):
-    error, message = _get_content_count_error_and_message_for_sms_template(
-        get_template(
-            {
-                "template_type": "sms",
-                "content": request.form.get("template_content", ""),
-            },
-            current_service,
-        )
+    template = get_template(
+        {
+            "template_type": "sms",
+            "content": request.form.get("template_content", ""),
+        },
+        current_service,
     )
 
     return jsonify(
         {
             "html": render_template(
                 "partials/templates/content-count-message.html",
-                error=error,
-                message=message,
+                template=template,
+                sms_char_count_limit=SMS_CHAR_COUNT_LIMIT,
             )
         }
     )
-
-
-def _get_content_count_error_and_message_for_sms_template(template):
-    if template.is_message_too_long():
-        return True, (
-            f"You have {character_count(template.content_count_without_prefix - SMS_CHAR_COUNT_LIMIT)} too many"
-        )
-    return False, _get_fragment_count_message_for_sms_template(template)
-
-
-def _get_fragment_count_message_for_sms_template(template):
-    personalisation_hint = " (not including personalisation)" if template.placeholders else ""
-    return f"Will be charged as {message_count(template.fragment_count, template.template_type)}{personalisation_hint}"
 
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/delete", methods=["GET", "POST"])

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -128,7 +128,9 @@ def view_template(service_id, template_id):
     if should_skip_template_page(template):
         return redirect(url_for(".set_sender", service_id=service_id, template_id=template_id))
 
-    content_count_message = _get_fragment_count_message_for_template(template)
+    content_count_message = None
+    if template.template_type == "sms":
+        content_count_message = _get_fragment_count_message_for_sms_template(template)
 
     return render_template(
         "views/templates/template.html",
@@ -819,18 +821,15 @@ def edit_service_template(service_id, template_id, language=None):  # noqa
 
 
 @main.route(
-    "/services/<uuid:service_id>/templates/count-<template_type:template_type>-length",
+    "/services/<uuid:service_id>/templates/count-sms-length",
     methods=["POST"],
 )
 @user_has_permissions()
-def count_content_length(service_id, template_type):
-    if template_type != "sms":
-        abort(404)
-
-    error, message = _get_content_count_error_and_message_for_template(
+def count_content_length(service_id):
+    error, message = _get_content_count_error_and_message_for_sms_template(
         get_template(
             {
-                "template_type": template_type,
+                "template_type": "sms",
                 "content": request.form.get("template_content", ""),
             },
             current_service,
@@ -848,18 +847,15 @@ def count_content_length(service_id, template_type):
     )
 
 
-def _get_content_count_error_and_message_for_template(template):
-    if template.template_type == "sms":
-        if template.is_message_too_long():
-            return True, (
-                f"You have {character_count(template.content_count_without_prefix - SMS_CHAR_COUNT_LIMIT)} too many"
-            )
-        return False, _get_fragment_count_message_for_template(template)
+def _get_content_count_error_and_message_for_sms_template(template):
+    if template.is_message_too_long():
+        return True, (
+            f"You have {character_count(template.content_count_without_prefix - SMS_CHAR_COUNT_LIMIT)} too many"
+        )
+    return False, _get_fragment_count_message_for_sms_template(template)
 
 
-def _get_fragment_count_message_for_template(template):
-    if template.template_type != "sms":
-        return None
+def _get_fragment_count_message_for_sms_template(template):
     personalisation_hint = " (not including personalisation)" if template.placeholders else ""
     return f"Will be charged as {message_count(template.fragment_count, template.template_type)}{personalisation_hint}"
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -18,7 +18,6 @@ from flask import (
 )
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
-from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.formatters import formatted_list
 from notifications_utils.pdf import pdf_page_count
 from notifications_utils.s3 import s3download
@@ -833,7 +832,6 @@ def count_content_length(service_id):
             "html": render_template(
                 "partials/templates/content-count-message.html",
                 template=template,
-                sms_char_count_limit=SMS_CHAR_COUNT_LIMIT,
             )
         }
     )

--- a/app/templates/partials/templates/content-count-message.html
+++ b/app/templates/partials/templates/content-count-message.html
@@ -1,6 +1,6 @@
 <span {% if template.is_message_too_long() %}class="govuk-error-message"{% endif %}>
   {% if template.is_message_too_long() %}
-    You have {{ (template.content_count_without_prefix - sms_char_count_limit) | character_count }} too many
+    You have {{ template.count_of_characters_above_limit | character_count }} too many
   {% else %}
     Will be charged as {{ template.fragment_count | message_count(template.template_type) }}
     {% if template.placeholders %}

--- a/app/templates/partials/templates/content-count-message.html
+++ b/app/templates/partials/templates/content-count-message.html
@@ -1,3 +1,10 @@
-<span {% if error %}class="govuk-error-message"{% endif %}>
-  {{ message }}
+<span {% if template.is_message_too_long() %}class="govuk-error-message"{% endif %}>
+  {% if template.is_message_too_long() %}
+    You have {{ (template.content_count_without_prefix - sms_char_count_limit) | character_count }} too many
+  {% else %}
+    Will be charged as {{ template.fragment_count | message_count(template.template_type) }}
+    {% if template.placeholders %}
+      (not including personalisation)
+    {% endif %}
+  {% endif %}
 </span>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -66,8 +66,13 @@
     {% include 'views/templates/_letter_template.html' %}
   {% endif %}
 
-  {% if content_count_message and current_user.has_permissions('manage_templates', 'manage_service', 'manage_api_keys') %}
-    <p class="govuk-body govuk-hint govuk-!-margin-bottom-5">{{ content_count_message }}</p>
+  {% if template.template_type == "sms" and current_user.has_permissions('manage_templates', 'manage_service', 'manage_api_keys') %}
+    <p class="govuk-body govuk-hint govuk-!-margin-bottom-5">
+      Will be charged as {{ template.fragment_count | message_count(template.template_type) }}
+      {% if template.placeholders %}
+        (not including personalisation)
+      {% endif %}
+    </p>
   {% endif %}
 
   <div class="govuk-!-margin-bottom-3">

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -4811,27 +4811,6 @@ def test_content_count_json_endpoint(
 
 
 @pytest.mark.parametrize(
-    "template_type",
-    (
-        "email",
-        "letter",
-        "banana",
-    ),
-)
-def test_content_count_json_endpoint_for_unsupported_template_types(
-    client_request,
-    template_type,
-):
-    client_request.post(
-        "main.count_content_length",
-        service_id=SERVICE_ONE_ID,
-        template_type=template_type,
-        content="foo",
-        _expected_status=404,
-    )
-
-
-@pytest.mark.parametrize(
     "invalid_pages, page_requested, overlay_expected",
     (
         ("[1, 2]", 1, True),

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -330,7 +330,7 @@
     "/services/<uuid:service_id>/templates/copy/from-folder/<uuid:from_folder>",
     "/services/<uuid:service_id>/templates/copy/from-service/<uuid:from_service>",
     "/services/<uuid:service_id>/templates/copy/from-service/<uuid:from_service>/from-folder/<uuid:from_folder>",
-    "/services/<uuid:service_id>/templates/count-<template_type:template_type>-length",
+    "/services/<uuid:service_id>/templates/count-sms-length",
     "/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>",
     "/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>/add-<template_type:template_type>",
     "/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>/delete",


### PR DESCRIPTION
Jinja is a better place to be composing and formatting strings into output text.

It means if we want to make this output richer in the future we have a more flexible place to do so.

***

Also makes use of the new `SMSPreviewTemplate.count_of_characters_above_limit` property from https://github.com/alphagov/notifications-utils/pull/1362