### PR TITLE
Add prompts telling editors how to reduce the cost of their text messages

### DIFF
--- a/app/templates/partials/templates/content-count-message.html
+++ b/app/templates/partials/templates/content-count-message.html
@@ -6,6 +6,20 @@
     {% if template.placeholders %}
       (not including personalisation)
     {% endif %}
+
+    {% if template.non_gsm_characters | length > 3 %}
+      {% set list_of_non_gsm_characters = template.non_gsm_characters[:2] | list + ["similar characters"] %}
+    {% else %}
+      {% set list_of_non_gsm_characters = template.non_gsm_characters %}
+    {% endif %}
+
+    {% if list_of_non_gsm_characters %}
+      <p class="govuk-hint govuk-!-margin-bottom-0">
+        Reduce the cost of sending this message by removing
+        {{ list_of_non_gsm_characters | formatted_list(before_each="", after_each="") }}
+      </p>
+    {% endif %}
+
     {% if template.fragment_count > 1 %}
       <p class="govuk-hint govuk-!-margin-bottom-0">
         Reduce the cost of sending this message by removing {{ template.count_of_characters_above_previous_fragment_boundary | character_count }}

--- a/app/templates/partials/templates/content-count-message.html
+++ b/app/templates/partials/templates/content-count-message.html
@@ -6,5 +6,10 @@
     {% if template.placeholders %}
       (not including personalisation)
     {% endif %}
+    {% if template.fragment_count > 1 %}
+      <p class="govuk-hint govuk-!-margin-bottom-0">
+        Reduce the cost of sending this message by removing {{ template.count_of_characters_above_previous_fragment_boundary | character_count }}
+      </p>
+    {% endif %}
   {% endif %}
 </span>

--- a/app/templates/partials/templates/content-count-message.html
+++ b/app/templates/partials/templates/content-count-message.html
@@ -13,14 +13,20 @@
       {% set list_of_non_gsm_characters = template.non_gsm_characters %}
     {% endif %}
 
-    {% if list_of_non_gsm_characters %}
+    {% if list_of_non_gsm_characters and template.fragment_count > 1 %}
+      <p class="govuk-hint govuk-!-margin-top-2 govuk-!-margin-bottom-1">
+        Reduce the cost of sending this message by:
+      </p>
+      <ul class="govuk-hint govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+        <li>removing {{ list_of_non_gsm_characters | formatted_list(before_each="", after_each="") }}</li>
+        <li>removing {{ template.count_of_characters_above_previous_fragment_boundary | character_count }}</li>
+      </ul>
+    {% elif list_of_non_gsm_characters %}
       <p class="govuk-hint govuk-!-margin-bottom-0">
         Reduce the cost of sending this message by removing
         {{ list_of_non_gsm_characters | formatted_list(before_each="", after_each="") }}
       </p>
-    {% endif %}
-
-    {% if template.fragment_count > 1 %}
+    {% elif template.fragment_count > 1 %}
       <p class="govuk-hint govuk-!-margin-bottom-0">
         Reduce the cost of sending this message by removing {{ template.count_of_characters_above_previous_fragment_boundary | character_count }}
       </p>

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -4892,8 +4892,7 @@ def test_set_template_sender_escapes_letter_contact_block_names(
             "Ẅ" * 71,
             (
                 "Will be charged as 2 text messages "
-                "Reduce the cost of sending this message by removing Ẅ "
-                "Reduce the cost of sending this message by removing 1 character"
+                "Reduce the cost of sending this message by: removing Ẅ removing 1 character"
             ),
             None,
         ),
@@ -4902,8 +4901,7 @@ def test_set_template_sender_escapes_letter_contact_block_names(
             "Ẅ" * 918,
             (
                 "Will be charged as 14 text messages "
-                "Reduce the cost of sending this message by removing Ẅ "
-                "Reduce the cost of sending this message by removing 47 characters"
+                "Reduce the cost of sending this message by: removing Ẅ removing 47 characters"
             ),
             None,
         ),
@@ -4956,6 +4954,32 @@ def test_content_count_json_endpoint(
         assert snippet["class"] == [expected_class]
     else:
         assert expected_class is None
+
+
+def test_content_count_json_endpoint_formats_multiple_suggestions_as_list(
+    client_request,
+):
+    response = client_request.post_response(
+        "main.count_content_length",
+        service_id=SERVICE_ONE_ID,
+        template_type="sms",
+        _data={
+            "template_content": ("ẄÿÈ" * 25),
+        },
+        _expected_status=200,
+    )
+
+    html = json.loads(response.get_data(as_text=True))["html"]
+    snippet = NotifyBeautifulSoup(html, "html.parser").select_one("span")
+
+    assert [normalize_spaces(p) for p in snippet.select("p.govuk-hint")] == [
+        "Reduce the cost of sending this message by:",
+    ]
+
+    assert [normalize_spaces(li) for li in snippet.select("ul.govuk-list.govuk-list--bullet.govuk-hint li")] == [
+        "removing Ẅ, ÿ and È",
+        "removing 18 characters",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -4806,7 +4806,7 @@ def test_set_template_sender_escapes_letter_contact_block_names(
         (
             False,
             "a" * 161,
-            "Will be charged as 2 text messages",
+            "Will be charged as 2 text messages Reduce the cost of sending this message by removing 1 character",
             None,
         ),
         (
@@ -4820,13 +4820,13 @@ def test_set_template_sender_escapes_letter_contact_block_names(
             # service name takes 13 characters, 148 + 13 = 161
             True,
             "a" * 148,
-            "Will be charged as 2 text messages",
+            "Will be charged as 2 text messages Reduce the cost of sending this message by removing 1 character",
             None,
         ),
         (
             False,
             "a" * 918,
-            "Will be charged as 6 text messages",
+            "Will be charged as 6 text messages Reduce the cost of sending this message by removing 153 characters",
             None,
         ),
         (
@@ -4834,7 +4834,7 @@ def test_set_template_sender_escapes_letter_contact_block_names(
             # against total character limit
             True,
             "a" * 918,
-            "Will be charged as 7 text messages",
+            "Will be charged as 7 text messages Reduce the cost of sending this message by removing 13 characters",
             None,
         ),
         (
@@ -4869,13 +4869,13 @@ def test_set_template_sender_escapes_letter_contact_block_names(
         (
             False,
             "Ẅ" * 71,
-            "Will be charged as 2 text messages",
+            "Will be charged as 2 text messages Reduce the cost of sending this message by removing 1 character",
             None,
         ),
         (
             False,
             "Ẅ" * 918,
-            "Will be charged as 14 text messages",
+            "Will be charged as 14 text messages Reduce the cost of sending this message by removing 47 characters",
             None,
         ),
         (

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -4863,19 +4863,48 @@ def test_set_template_sender_escapes_letter_contact_block_names(
         (
             False,
             "Ẅ" * 70,
-            "Will be charged as 1 text message",
+            "Will be charged as 1 text message Reduce the cost of sending this message by removing Ẅ",
+            None,
+        ),
+        (
+            False,
+            "Ẅÿ",
+            "Will be charged as 1 text message Reduce the cost of sending this message by removing Ẅ and ÿ",
+            None,
+        ),
+        (
+            False,
+            "ẄÿÈ",
+            "Will be charged as 1 text message Reduce the cost of sending this message by removing Ẅ, ÿ and È",
+            None,
+        ),
+        (
+            False,
+            "ẄÿÈẅ",
+            (
+                "Will be charged as 1 text message "
+                "Reduce the cost of sending this message by removing Ẅ, ÿ and similar characters"
+            ),
             None,
         ),
         (
             False,
             "Ẅ" * 71,
-            "Will be charged as 2 text messages Reduce the cost of sending this message by removing 1 character",
+            (
+                "Will be charged as 2 text messages "
+                "Reduce the cost of sending this message by removing Ẅ "
+                "Reduce the cost of sending this message by removing 1 character"
+            ),
             None,
         ),
         (
             False,
             "Ẅ" * 918,
-            "Will be charged as 14 text messages Reduce the cost of sending this message by removing 47 characters",
+            (
+                "Will be charged as 14 text messages "
+                "Reduce the cost of sending this message by removing Ẅ "
+                "Reduce the cost of sending this message by removing 47 characters"
+            ),
             None,
         ),
         (


### PR DESCRIPTION
## One fragment

<img width="750" height="344" alt="image" src="https://github.com/user-attachments/assets/a12a3c01-1323-4151-9550-ea31edfaa818" />

## Multiple fragments

<img width="750" height="373" alt="image" src="https://github.com/user-attachments/assets/7ab9ebfe-cd28-4d2c-9ae0-da95ea8e399d" />

## One fragment with a non-GSM-7 character

<img width="750" height="372" alt="image" src="https://github.com/user-attachments/assets/bf76ca16-72d1-4787-9784-52934f56f82b" />

## One fragment with multiple non-GSM-7 characters

<img width="750" height="367" alt="image" src="https://github.com/user-attachments/assets/50486cec-54d4-4670-9142-b4830d617127" />

## Multiple fragments with multiple non-GSM-7 characters

<img width="750" height="444" alt="image" src="https://github.com/user-attachments/assets/1e63f303-f38b-49c9-bf80-0e89cce83997" />



