### PR TITLE
Don’t put user name in guest list

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -609,9 +609,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, emergency_c
         max_initial_rows_shown=50,
         max_errors_shown=50,
         guestlist=(
-            itertools.chain.from_iterable(
-                [user.name, user.mobile_number, user.email_address] for user in Users(service_id)
-            )
+            itertools.chain.from_iterable([user.mobile_number, user.email_address] for user in Users(service_id))
             if current_service.trial_mode
             else None
         ),

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -31,6 +31,7 @@ from tests.conftest import (
     create_active_user_with_permissions,
     create_multiple_email_reply_to_addresses,
     create_multiple_sms_senders,
+    create_service_one_admin,
     create_template,
     do_mock_get_page_counts_for_letter,
     mock_get_service_email_template,
@@ -3623,6 +3624,13 @@ def test_check_messages_shows_too_many_international_sms_messages_errors(
         ),
     ),
 )
+@pytest.mark.parametrize(
+    "user_name",
+    (
+        "07900900321",
+        "not-in-team@example.gov.uk",
+    ),
+)
 def test_check_messages_shows_trial_mode_error(
     client_request,
     mock_s3_get_metadata,
@@ -3635,6 +3643,7 @@ def test_check_messages_shows_trial_mode_error(
     template_type,
     file_contents,
     expected_error,
+    user_name,
     fake_uuid,
     mocker,
 ):
@@ -3644,6 +3653,12 @@ def test_check_messages_shows_trial_mode_error(
         return_value={"data": template},
     )
     mocker.patch("app.main.views.send.s3download", return_value=file_contents)
+    mocker.patch(
+        "app.models.user.Users._get_items",
+        return_value=[
+            create_service_one_admin(name=user_name),
+        ],
+    )
 
     with client_request.session_transaction() as session:
         session["file_uploads"] = {

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3602,6 +3602,27 @@ def test_check_messages_shows_too_many_international_sms_messages_errors(
     assert normalize_spaces(page.select("div.banner-dangerous p")[1]) == expected_msg
 
 
+@pytest.mark.parametrize(
+    "template_type, file_contents, expected_error",
+    (
+        (
+            "sms",
+            "phone number,\n07900900321",
+            (
+                "You cannot send to this phone number "
+                "In trial mode you can only send to yourself and members of your team"
+            ),
+        ),
+        (
+            "email",
+            "email address,\nnot-in-team@example.gov.uk",
+            (
+                "You cannot send to this email address "
+                "In trial mode you can only send to yourself and members of your team"
+            ),
+        ),
+    ),
+)
 def test_check_messages_shows_trial_mode_error(
     client_request,
     mock_s3_get_metadata,
@@ -3611,10 +3632,18 @@ def test_check_messages_shows_trial_mode_error(
     mock_get_service_statistics,
     mock_get_job_doesnt_exist,
     mock_get_jobs,
+    template_type,
+    file_contents,
+    expected_error,
     fake_uuid,
     mocker,
 ):
-    mocker.patch("app.main.views.send.s3download", return_value=("phone number,\n07900900321"))  # Not in team
+    template = create_template(template_type=template_type)
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template},
+    )
+    mocker.patch("app.main.views.send.s3download", return_value=file_contents)
 
     with client_request.session_transaction() as session:
         session["file_uploads"] = {
@@ -3631,9 +3660,7 @@ def test_check_messages_shows_trial_mode_error(
         _test_page_title=False,
     )
 
-    assert " ".join(page.select_one("div.banner-dangerous").text.split()) == (
-        "You cannot send to this phone number In trial mode you can only send to yourself and members of your team"
-    )
+    assert normalize_spaces(page.select_one("div.banner-dangerous")) == expected_error
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Looks like when we first did letters we thought there might be an equivalent of the guest list where you could send to an address with your own name:
https://github.com/alphagov/notifications-admin/commit/88631a680c88df49672ee61ddb3054e4ba40a465#diff-7365e34b1112e69a28e0c0ff051358e5bb02b41796dc9fadf259f7cff070cc0cR54-R240

However this means that if you change your name on your profile to a valid email address or phone number you can now send to that name or email address from the admin app.

Not a huge deal since ~~it would only let you send one message at a time~~ [the API would stop the message from actually going out](https://github.com/alphagov/notifications-api/blob/17e2ca2677e8ba99d9fdcdc247260d471d6e8b26/app/celery/tasks.py#L428), but probably not a loophole we should allow.