### PR TITLE
Add custom 404 for notification not found

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -432,6 +432,15 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
         if error_code == 404 and request.view_args and "service_id" in request.view_args and g.current_service:
             template_file = "error/404-service-page.html"
 
+        if (
+            error_code == 404
+            and request.view_args
+            and "service_id" in request.view_args
+            and g.current_service
+            and "notification_id" in request.view_args
+        ):
+            template_file = "error/404-notifications-page.html"
+
         if error_page_template:
             template_file = f"error/{error_page_template}.html"
 

--- a/app/templates/error/404-notifications-page.html
+++ b/app/templates/error/404-notifications-page.html
@@ -1,0 +1,26 @@
+{% extends "withnav_template.html" %}
+{% block per_page_title %}Page not found{% endblock %}
+{% block maincolumn_content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-five-sixths">
+      <h1 class="heading-large">
+        Page not found
+      </h1>
+      <p class="govuk-body">
+        If you typed the web address, check it is correct.
+      </p>
+      <p class="govuk-body">
+        If you pasted the web address, check you copied the entire URL.
+      </p>
+      <p class="govuk-body">
+       If the web address is correct, the page you’re looking for may no longer exist.
+       </p>
+       <p class="govuk-body">
+       For security, GOV.UK Notify only keeps a temporary record of the emails, text messages and letters you send.
+       </p>
+       <p class="govuk-body">
+       For more information, see: <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_data_retention_period') }}">Data retention period</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -1,5 +1,8 @@
+from unittest.mock import Mock
+
 import pytest
 from flask import Flask, url_for
+from notifications_python_client.errors import HTTPError
 
 from app import create_app
 from app.navigation import (
@@ -711,3 +714,28 @@ def test_navigation_displayed_on_service_page_404(
     assert normalize_spaces(page.select_one("h1").text) == "Page not found"
     assert normalize_spaces(page.select_one(".navigation-service-name").text) == "service one"
     assert len(page.select("nav.navigation .navigation__item")) == 8
+
+
+def test_navigation_and_custom_error_displayed_on_notification_page_404(
+    client_request,
+    mocker,
+    fake_uuid,
+):
+    mock_get_notification = mocker.patch(
+        "app.notification_api_client.get_notification",
+        side_effect=HTTPError(response=Mock(status_code=404)),
+    )
+
+    page = client_request.get(
+        "main.view_notification",
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+        _expected_status=404,
+    )
+    assert normalize_spaces(page.select_one("h1").text) == "Page not found"
+    assert normalize_spaces(page.select_one(".navigation-service-name").text) == "service one"
+    assert len(page.select("nav.navigation .navigation__item")) == 8
+    assert page.select_one('a:contains("Data retention period")')["href"] == url_for(
+        "main.guidance_data_retention_period"
+    )
+    mock_get_notification.assert_called_once()


### PR DESCRIPTION


This adds a custom 404 page if the page erroring has a notification_id request.

We are adding this because we might often get this if a user has bookmarked or remembered a notification.

So we want to be clear about the likely cause of this.

<img width="983" height="462" alt="Screenshot 2026-06-02 at 14 03 30" src="https://github.com/user-attachments/assets/c6601a3e-8ba6-4631-9329-4060af80dd9c" />
