### PR TITLE
Replace window.GOVUK.stickAtBottomWhenScrolling.recalculate with module import

### DIFF
--- a/app/assets/javascripts/esm/copy-to-clipboard.mjs
+++ b/app/assets/javascripts/esm/copy-to-clipboard.mjs
@@ -1,4 +1,5 @@
 import { isSupported } from 'govuk-frontend';
+import { stickAtBottomWhenScrolling } from './stick-to-window-when-scrolling.mjs';
 
 // This new way of writing Javascript components is based on the GOV.UK Frontend skeleton Javascript coding standard
 // that uses ES2015 Classes -
@@ -79,9 +80,7 @@ class CopyToClipboard {
       }
     });
 
-    if ('stickAtBottomWhenScrolling' in window.GOVUK) {
-      window.GOVUK.stickAtBottomWhenScrolling.recalculate();
-    }
+    stickAtBottomWhenScrolling.recalculate();
   }
   
   updateHTML (buttonWasClicked, stateOptions, $module, $button) {

--- a/app/assets/javascripts/esm/enhanced-textbox.mjs
+++ b/app/assets/javascripts/esm/enhanced-textbox.mjs
@@ -1,4 +1,5 @@
 import { isSupported } from 'govuk-frontend';
+import { stickAtBottomWhenScrolling } from './stick-to-window-when-scrolling.mjs';
 
 // This new way of writing Javascript components is based on the GOV.UK Frontend skeleton Javascript coding standard
 // that uses ES2015 Classes -
@@ -69,9 +70,7 @@ class EnhancedTextbox {
           this.$backgroundHighlightElement.offsetHeight
       )}px`;
 
-    if ('stickAtBottomWhenScrolling' in GOVUK) {
-      window.GOVUK.stickAtBottomWhenScrolling.recalculate();
-    }
+    stickAtBottomWhenScrolling.recalculate();
   }
 
   contentEscaped () {

--- a/app/assets/javascripts/esm/fullscreen-table.mjs
+++ b/app/assets/javascripts/esm/fullscreen-table.mjs
@@ -1,4 +1,6 @@
 import { isSupported } from 'govuk-frontend';
+import { stickAtBottomWhenScrolling } from './stick-to-window-when-scrolling.mjs';
+
 
 // This new way of writing Javascript components is based on the GOV.UK Frontend skeleton Javascript coding standard
 // that uses ES2015 Classes -
@@ -47,9 +49,7 @@ class FullscreenTable {
       this.$scrollableTable.addEventListener('blur', toggleFocusStyle);
     }
 
-    if (window.GOVUK.stickAtBottomWhenScrolling.recalculate) {
-      window.GOVUK.stickAtBottomWhenScrolling.recalculate();
-    }
+    stickAtBottomWhenScrolling.recalculate();
 
     this.maintainWidth();
   }

--- a/app/assets/javascripts/esm/live-search.mjs
+++ b/app/assets/javascripts/esm/live-search.mjs
@@ -1,4 +1,5 @@
 import { isSupported } from 'govuk-frontend';
+import { stickAtBottomWhenScrolling } from './stick-to-window-when-scrolling.mjs';
 
 class LiveSearch {
   constructor($module) {
@@ -98,9 +99,7 @@ class LiveSearch {
 
     // make sticky JS recalculate its cache of the element's position
     // because live search can change the height document
-    if ('stickAtBottomWhenScrolling' in window.GOVUK) {
-      window.GOVUK.stickAtBottomWhenScrolling.recalculate();
-    }
+    stickAtBottomWhenScrolling.recalculate();
 
   }
 

--- a/app/assets/javascripts/esm/radio-select.mjs
+++ b/app/assets/javascripts/esm/radio-select.mjs
@@ -1,4 +1,5 @@
 import { isSupported } from 'govuk-frontend';
+import { stickAtBottomWhenScrolling } from './stick-to-window-when-scrolling.mjs';
 
 // This new way of writing Javascript components is based on the GOV.UK Frontend skeleton Javascript coding standard
 // that uses ES2015 Classes -
@@ -201,9 +202,7 @@ class RadioSelect {
     viewPanes[0].setAttribute('hidden', '');
     viewPanes[1].removeAttribute('hidden');
 
-    if (window.GOVUK.stickAtBottomWhenScrolling) {
-      window.GOVUK.stickAtBottomWhenScrolling.recalculate();
-    }
+    stickAtBottomWhenScrolling.recalculate();
   }
 
   selectDayAndTime() {

--- a/tests/javascripts/copy-to-clipboard.test.mjs
+++ b/tests/javascripts/copy-to-clipboard.test.mjs
@@ -1,9 +1,22 @@
 import * as helpers from './support/helpers.js';
-import CopyToClipboard from '../../app/assets/javascripts/esm/copy-to-clipboard.mjs';
 import { beforeEach, jest } from '@jest/globals';
 
+jest.unstable_mockModule('../../app/assets/javascripts/esm/stick-to-window-when-scrolling.mjs', () => ({
+  stickAtBottomWhenScrolling: {
+    recalculate: jest.fn()
+  }
+}));
 
-beforeAll(() => {
+let CopyToClipboard;
+let stickAtBottomWhenScrolling;
+
+
+beforeAll( async() => {
+  ({ stickAtBottomWhenScrolling } = await import('../../app/assets/javascripts/esm/stick-to-window-when-scrolling.mjs'));
+  const copyToClipboardModule = await import('../../app/assets/javascripts/esm/copy-to-clipboard.mjs');
+
+  CopyToClipboard = copyToClipboardModule.default;
+
   document.body.classList.add('govuk-frontend-supported');
 });
 
@@ -29,16 +42,12 @@ describe('copy to clipboard', () => {
   };
 
   beforeEach(() => {
+    stickAtBottomWhenScrolling.recalculate.mockClear();
     // mock objects used to manipulate the page selection
     rangeMock = new helpers.RangeMock(jest);
 
     // plug gaps in JSDOM's API for Range
     document.createRange = jest.fn(() => rangeMock);
-
-    // mock sticky JS
-    window.GOVUK.stickAtBottomWhenScrolling = {
-      recalculate: jest.fn(() => {})
-    }
 
   });
 
@@ -59,12 +68,6 @@ describe('copy to clipboard', () => {
   });
 
   describe("If Clipboard API is supported", () => {
-
-    beforeAll(() => {
-      // force module require to not come from cache
-      jest.resetModules();
-
-    });
 
     beforeEach(() => {
       // mock Clipboard API availability
@@ -106,7 +109,7 @@ describe('copy to clipboard', () => {
         test("It should tell any sticky JS present the page has changed", () => {
 
           // recalculate forces the sticky JS to recalculate any stored DOM position/dimensions
-          expect(window.GOVUK.stickAtBottomWhenScrolling.recalculate).toHaveBeenCalled();
+          expect(stickAtBottomWhenScrolling.recalculate).toHaveBeenCalled();
 
         });
 

--- a/tests/javascripts/fullscreen-table.test.mjs
+++ b/tests/javascripts/fullscreen-table.test.mjs
@@ -1,6 +1,23 @@
-import FullscreenTable from '../../app/assets/javascripts/esm/fullscreen-table.mjs';
 import { jest } from '@jest/globals';
 import * as helpers from './support/helpers';
+
+jest.unstable_mockModule('../../app/assets/javascripts/esm/stick-to-window-when-scrolling.mjs', () => ({
+  stickAtBottomWhenScrolling: {
+    recalculate: jest.fn()
+  }
+}));
+
+let FullscreenTable;
+let stickAtBottomWhenScrolling;
+
+beforeAll( async() => {
+  ({ stickAtBottomWhenScrolling } = await import('../../app/assets/javascripts/esm/stick-to-window-when-scrolling.mjs'));
+  const fullscreenTableModule = await import('../../app/assets/javascripts/esm/fullscreen-table.mjs');
+
+  FullscreenTable = fullscreenTableModule.default;
+
+  document.body.classList.add('govuk-frontend-supported');
+});
 
 
 describe('FullscreenTable', () => {
@@ -13,6 +30,8 @@ describe('FullscreenTable', () => {
   let fixedRowHeaders;
 
   beforeEach(() => {
+
+    stickAtBottomWhenScrolling.recalculate.mockClear();
 
     const tableHeadings = () => {
       let result = '';
@@ -80,12 +99,7 @@ describe('FullscreenTable', () => {
       scrollTop: 0
     });
 
-    window.GOVUK.stickAtBottomWhenScrolling = {
-      recalculate: jest.fn(() => {})
-    };
-
     // set up DOM
-    document.body.classList.add('govuk-frontend-supported')
     document.body.innerHTML =
       `<main>
         <div class="fullscreen-content" data-notify-module="fullscreen-table">
@@ -112,7 +126,6 @@ describe('FullscreenTable', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     screenMock.reset();
-    window.GOVUK.stickAtBottomWhenScrolling.recalculate.mockClear();
     jest.restoreAllMocks();
 
   });
@@ -135,14 +148,10 @@ describe('FullscreenTable', () => {
 
     test("it calls the sticky JS to update any cached dimensions", () => {
 
-      const stickyJSSpy = jest.spyOn(window.GOVUK.stickAtBottomWhenScrolling, 'recalculate');
-
       // start module
       new FullscreenTable(document.querySelector('[data-notify-module="fullscreen-table"]'))
 
-      expect(stickyJSSpy.mock.calls.length).toBe(1);
-
-      stickyJSSpy.mockClear();
+      expect(stickAtBottomWhenScrolling.recalculate).toHaveBeenCalled();
 
     });
 

--- a/tests/javascripts/radio-select.test.mjs
+++ b/tests/javascripts/radio-select.test.mjs
@@ -1,19 +1,25 @@
-
-import RadioSelect from '../../app/assets/javascripts/esm/radio-select.mjs';
 import * as helpers from './support/helpers.js';
 import { jest } from '@jest/globals';
 
+jest.unstable_mockModule('../../app/assets/javascripts/esm/stick-to-window-when-scrolling.mjs', () => ({
+  stickAtBottomWhenScrolling: {
+    recalculate: jest.fn()
+  }
+}));
+
 let consoleErrorSpy;
+let RadioSelect;
+let stickAtBottomWhenScrolling;
 
-beforeAll(() => {
-  // The sticky JS should be called whenever the times are shown so stub it out as a mock
-  window.GOVUK.stickAtBottomWhenScrolling = {
-    recalculate: jest.fn(() => {})
-  };
+beforeAll( async() => {
+  ({ stickAtBottomWhenScrolling } = await import('../../app/assets/javascripts/esm/stick-to-window-when-scrolling.mjs'));
+  const radioSelectModule = await import('../../app/assets/javascripts/esm/radio-select.mjs');
 
+  RadioSelect = radioSelectModule.default;
+
+  document.body.classList.add('govuk-frontend-supported');
   // spy on console.error to track JSDOM errors
   consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
 });
 
 afterAll(() => {
@@ -124,8 +130,6 @@ describe('RadioSelect', () => {
 
       return result;
     };
-
-    document.body.classList.add('govuk-frontend-supported');
     document.body.innerHTML = `
       <form method="post" enctype="multipart/form-data" action="/services/6658542f-0cad-491f-bec8-ab8457700ead/start-job/ab3080c8-f2d1-4524-b199-9718ecf6eabc">
         <fieldset class="govuk-fieldset">
@@ -151,7 +155,7 @@ describe('RadioSelect', () => {
 
   afterEach(() => {
     document.body.innerHTML = '';
-    window.GOVUK.stickAtBottomWhenScrolling.recalculate.mockClear();
+    stickAtBottomWhenScrolling.recalculate.mockClear();
   });
 
   describe("when the page has loaded", () => {
@@ -454,7 +458,7 @@ describe('RadioSelect', () => {
       const container = expandingSection.querySelector('.radio-select__confirm');
 
       expect(container.classList.contains('js-stick-at-bottom-when-scrolling')).toBe(true);
-      expect(GOVUK.stickAtBottomWhenScrolling.recalculate).toHaveBeenCalled();
+      expect(stickAtBottomWhenScrolling.recalculate).toHaveBeenCalled();
 
     });
 


### PR DESCRIPTION
We have modernised `stickAtBottomWhenScrolling` into ESM so we can now directly import it where it's needed and no longer have to rely on global scope.

This updates instance in other ES modules and updates the tests to mock this dependency