### PR TITLE
Tidy up after improvements to fragment counter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@116.1.0
+# This file was automatically copied from notifications-utils@117.1.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -163,18 +163,18 @@ class OnlySMSCharacters:
     def __call__(self, form, field):
         non_sms_characters = sorted(SanitiseSMS.get_non_compatible_characters(field.data))
         if non_sms_characters:
+            list_of_characters = formatted_list(
+                non_sms_characters,
+                conjunction="or",
+                before_each="",
+                after_each="",
+                max_items_shown=3,
+                word_for_items_not_shown="similar characters",
+            )
+            it_or_these = "It" if len(non_sms_characters) == 1 else "These characters"
             raise ValidationError(
-                "You cannot use {} in text messages. {} will not display properly on some phones.".format(
-                    formatted_list(
-                        non_sms_characters,
-                        conjunction="or",
-                        before_each="",
-                        after_each="",
-                        max_items_shown=3,
-                        word_for_items_not_shown="similar characters",
-                    ),
-                    ("It" if len(non_sms_characters) == 1 else "These characters"),
-                )
+                f"You cannot use {list_of_characters} in text messages. "
+                f"{it_or_these} will not display properly on some phones."
             )
 
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -165,7 +165,14 @@ class OnlySMSCharacters:
         if non_sms_characters:
             raise ValidationError(
                 "You cannot use {} in text messages. {} will not display properly on some phones.".format(
-                    formatted_list(non_sms_characters, conjunction="or", before_each="", after_each=""),
+                    formatted_list(
+                        non_sms_characters,
+                        conjunction="or",
+                        before_each="",
+                        after_each="",
+                        max_items_shown=3,
+                        word_for_items_not_shown="similar characters",
+                    ),
                     ("It" if len(non_sms_characters) == 1 else "These characters"),
                 )
             )

--- a/app/templates/partials/templates/content-count-message.html
+++ b/app/templates/partials/templates/content-count-message.html
@@ -7,24 +7,18 @@
       (not including personalisation)
     {% endif %}
 
-    {% if template.non_gsm_characters | length > 3 %}
-      {% set list_of_non_gsm_characters = template.non_gsm_characters[:2] | list + ["similar characters"] %}
-    {% else %}
-      {% set list_of_non_gsm_characters = template.non_gsm_characters %}
-    {% endif %}
-
-    {% if list_of_non_gsm_characters and template.fragment_count > 1 %}
+    {% if template.non_gsm_characters and template.fragment_count > 1 %}
       <p class="govuk-hint govuk-!-margin-top-2 govuk-!-margin-bottom-1">
         Reduce the cost of sending this message by:
       </p>
       <ul class="govuk-hint govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-        <li>removing {{ list_of_non_gsm_characters | formatted_list(before_each="", after_each="") }}</li>
+        <li>removing {{ template.non_gsm_characters | formatted_list(before_each="", after_each="", max_items_shown=3, word_for_items_not_shown="similar characters") }}</li>
         <li>removing {{ template.count_of_characters_above_previous_fragment_boundary | character_count }}</li>
       </ul>
-    {% elif list_of_non_gsm_characters %}
+    {% elif template.non_gsm_characters %}
       <p class="govuk-hint govuk-!-margin-bottom-0">
         Reduce the cost of sending this message by removing
-        {{ list_of_non_gsm_characters | formatted_list(before_each="", after_each="") }}
+        {{ template.non_gsm_characters | formatted_list(before_each="", after_each="", max_items_shown=3, word_for_items_not_shown="similar characters") }}
       </p>
     {% elif template.fragment_count > 1 %}
       <p class="govuk-hint govuk-!-margin-bottom-0">

--- a/app/templates/partials/templates/content-count-message.html
+++ b/app/templates/partials/templates/content-count-message.html
@@ -15,11 +15,6 @@
         <li>removing {{ template.non_gsm_characters | formatted_list(before_each="", after_each="", max_items_shown=3, word_for_items_not_shown="similar characters") }}</li>
         <li>removing {{ template.count_of_characters_above_previous_fragment_boundary | character_count }}</li>
       </ul>
-    {% elif template.non_gsm_characters %}
-      <p class="govuk-hint govuk-!-margin-bottom-0">
-        Reduce the cost of sending this message by removing
-        {{ template.non_gsm_characters | formatted_list(before_each="", after_each="", max_items_shown=3, word_for_items_not_shown="similar characters") }}
-      </p>
     {% elif template.fragment_count > 1 %}
       <p class="govuk-hint govuk-!-margin-bottom-0">
         Reduce the cost of sending this message by removing {{ template.count_of_characters_above_previous_fragment_boundary | character_count }}

--- a/app/templates/views/uploads/contact-list/too-many-columns.html
+++ b/app/templates/views/uploads/contact-list/too-many-columns.html
@@ -45,7 +45,7 @@
           It needs to have 1 column, called ‘email address’ or ‘phone number’.
         </p>
         <p class="govuk-body">
-          Right now it has {{ recipients._raw_column_headers|length }} columns called {{ recipients._raw_column_headers[:512] | formatted_list }}.
+          Right now it has {{ recipients._raw_column_headers|length }} columns called {{ recipients._raw_column_headers | formatted_list(max_items_shown=512, word_for_items_not_shown="more")  }}.
         </p>
 
       {% endif %}

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@116.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@117.1.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -728,7 +728,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79a5807653c2752e61db68e63acbc7bcab0d69c2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@05d6c304a7b4900ee299fd3407aa14168846ed39
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \
@@ -1000,10 +1000,6 @@ six==1.17.0 \
 smartypants==2.0.2 \
     --hash=sha256:39d64ce1d7cc6964b698297bdf391bc12c3251b7f608e6e55d857cd7c5f800c6 \
     --hash=sha256:9471578606e8ee0740065bf8771f55fec8c83313cb98c5d1c1864ddd389d0f3a
-    # via notifications-utils
-statsd==4.0.1 \
-    --hash=sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128 \
-    --hash=sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093
     # via notifications-utils
 texttable==1.7.0 \
     --hash=sha256:2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -907,7 +907,7 @@ moto==5.1.22 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79a5807653c2752e61db68e63acbc7bcab0d69c2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@05d6c304a7b4900ee299fd3407aa14168846ed39
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \
@@ -1290,12 +1290,6 @@ soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via beautifulsoup4
-statsd==4.0.1 \
-    --hash=sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128 \
-    --hash=sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093
-    # via
-    #   -r requirements.txt
-    #   notifications-utils
 texttable==1.7.0 \
     --hash=sha256:2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638 \
     --hash=sha256:72227d592c82b3d7f672731ae73e4d1f88cd8e2ef5b075a7a7f01a23a3743917

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@116.1.0
+# This file was automatically copied from notifications-utils@117.1.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@116.1.0
+# This file was automatically copied from notifications-utils@117.1.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -119,6 +119,13 @@ def test_sms_character_validation(client_request, msg):
     "data, err_msg",
     [
         (
+            "∆ abc 📲 def 📵 ghi 🤪",
+            (
+                "You cannot use ∆, 📲 or similar characters in text messages. "
+                "These characters will not display properly on some phones."
+            ),
+        ),
+        (
             "∆ abc 📲 def 📵 ghi",
             "You cannot use ∆, 📲 or 📵 in text messages. These characters will not display properly on some phones.",
         ),

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -4863,27 +4863,39 @@ def test_set_template_sender_escapes_letter_contact_block_names(
         (
             False,
             "Ẅ" * 70,
-            "Will be charged as 1 text message Reduce the cost of sending this message by removing Ẅ",
+            "Will be charged as 1 text message",
             None,
         ),
         (
             False,
-            "Ẅÿ",
-            "Will be charged as 1 text message Reduce the cost of sending this message by removing Ẅ and ÿ",
-            None,
-        ),
-        (
-            False,
-            "ẄÿÈ",
-            "Will be charged as 1 text message Reduce the cost of sending this message by removing Ẅ, ÿ and È",
-            None,
-        ),
-        (
-            False,
-            "ẄÿÈẅ",
+            "Ẅÿ" * 36,
             (
-                "Will be charged as 1 text message "
-                "Reduce the cost of sending this message by removing Ẅ, ÿ and similar characters"
+                "Will be charged as 2 text messages "
+                "Reduce the cost of sending this message by: "
+                "removing Ẅ and ÿ "
+                "removing 2 characters"
+            ),
+            None,
+        ),
+        (
+            False,
+            "ẄÿÈ" * 24,
+            (
+                "Will be charged as 2 text messages "
+                "Reduce the cost of sending this message by: "
+                "removing Ẅ, ÿ and È "
+                "removing 2 characters"
+            ),
+            None,
+        ),
+        (
+            False,
+            "ẄÿÈẅ" * 36,
+            (
+                "Will be charged as 3 text messages "
+                "Reduce the cost of sending this message by: "
+                "removing Ẅ, ÿ and similar characters "
+                "removing 10 characters"
             ),
             None,
         ),

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@116.1.0
+# This file was automatically copied from notifications-utils@117.1.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
## Use `max_items_shown` argument of `formatted_list` 

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/1365

## Remove prompt about non-GSM characters if message is already 1 fragment 

There’s no way to make the message cheaper at this point.