### PR TITLE
Streamline 404 error for notifications

### DIFF
--- a/app/templates/error/404-notifications-page.html
+++ b/app/templates/error/404-notifications-page.html
@@ -7,19 +7,13 @@
         Page not found
       </h1>
       <p class="govuk-body">
-        If you typed the web address, check it is correct.
+        If the web address you entered is correct, the page you’re looking for may no longer exist.
       </p>
       <p class="govuk-body">
-        If you pasted the web address, check you copied the entire URL.
+        For security, GOV.UK Notify only keeps a temporary record of the emails, text messages and letters you send.
       </p>
       <p class="govuk-body">
-       If the web address is correct, the page you’re looking for may no longer exist.
-       </p>
-       <p class="govuk-body">
-       For security, GOV.UK Notify only keeps a temporary record of the emails, text messages and letters you send.
-       </p>
-       <p class="govuk-body">
-       For more information, see: <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_data_retention_period') }}">Data retention period</a>
+        For more information, see: <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_data_retention_period') }}">Data retention period</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
As we expect this error to be seen a lot more than other 404 errors , due to people navigating to expired notifications, clean up the trouble shooting steps to highlight the likely cause for the error (notification expiry).

With @karlchillmaid