### PR TITLE
Fix DOM text reinterpreted as HTML in enhanced-textbox

### DIFF
--- a/app/assets/javascripts/esm/enhanced-textbox.mjs
+++ b/app/assets/javascripts/esm/enhanced-textbox.mjs
@@ -73,27 +73,51 @@ class EnhancedTextbox {
     stickAtBottomWhenScrolling.recalculate();
   }
 
-  contentEscaped () {
-    const $el = document.createElement('div');
-    $el.innerHTML = this.$textbox.value;
-    return $el.innerHTML;
-  }
-
   contentReplaced () {
-    return this.contentEscaped().replace(
-      this.tagPattern, (match, name, separator, value) => {
-        if (value && separator) {
-          return `<span class='placeholder-conditional'>((${name}??</span>${value}))`;
-        } else {
-          return `<span class='placeholder'>((${name}${value}))</span>`;
-        }
+    const fragment = document.createDocumentFragment();
+    const text = this.$textbox.value;
+    let lastIndex = 0;
+
+    for (const match of text.matchAll(this.tagPattern)) {
+      // append plain text before the placeholder starts
+      fragment.append(text.slice(lastIndex, match.index));
+
+      const [
+        fullMatch,  // index 0: full match
+        name,       // index 1: capture group 1
+        separator,  // index 2: capture group 2
+        value       // index 3: capture group 3
+      ] = match;
+      const $span = document.createElement('span');
+
+      if (value && separator) {
+        $span.className = 'placeholder-conditional';
+        $span.textContent = `((${name}??`;
+        fragment.append($span, `${value}))`);
+      } else {
+        $span.className = 'placeholder';
+        $span.textContent = `((${name}${value}))`;
+        fragment.append($span);
       }
-    );
+
+      // update with the index where the current placeholder ends
+      lastIndex = match.index + fullMatch.length;
+    }
+
+    // append any remaining trailing text
+    fragment.append(text.slice(lastIndex));
+    return fragment;
   }
 
   update () {
-    this.$backgroundHighlightElement.innerHTML =
-      this.highlightPlaceholders ? this.contentReplaced() : this.contentEscaped();
+    // clear everything that's in the container to avoid any potential XSS
+    this.$backgroundHighlightElement.textContent = '';
+
+    if (this.highlightPlaceholders) {
+      this.$backgroundHighlightElement.append(this.contentReplaced());
+    } else {
+      this.$backgroundHighlightElement.textContent = this.$textbox.value;
+    }
 
     this.resize();
   }


### PR DESCRIPTION
This is to avoid any potential XSS vectors of attack.

Resolves
https://github.com/alphagov/notifications-admin/security/code-scanning/3
https://github.com/alphagov/notifications-admin/security/code-scanning/4

`contentReplaced` method was updated to now create a `DocumentFragment` look through string of characters in the textarea and wrap any placeholders in `span` depending on their type (regular vs optional). It then returns original text (without placeholders) and placeholder values.

`contentEscaped` method can be removed as we now apply text that doesn't contain any placeholders directly in the `update` method.

`update` method was updated to use `.textContent` to apply raw text as the browser substitues < and > characters to harmless &lt; and &gt;

For text with placeholders we use `.append` which works in the same way as `.textContent`.