### PR TITLE
Use `max_items_shown` argument of `formatted_list` for `CanEncode` validator

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -36,21 +36,18 @@ class CanEncode:
 
     def __call__(self, form, field):
         if field.data:
-            unsupported = set()
+            unsupported = OrderedSet()
             for char in field.data:
                 try:
                     char.encode(self.encoding)
                 except UnicodeEncodeError:
                     unsupported.add(char)
-            unsupported_char_list = list(unsupported)
-            if unsupported_char_list:
-                unsupported_char_list.sort()
 
             field_type = "this field"
             if self.field_type is not None:
                 field_type = self.field_type
 
-            if unsupported_char_list != []:
+            if unsupported:
                 message = self.message
                 if message is None:
                     message = (

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -52,9 +52,16 @@ class CanEncode:
                 if message is None:
                     message = (
                         "You cannot use {} in {}. You must use percent encoding if you want to include {}.".format(
-                            formatted_list(unsupported_char_list, conjunction="or", before_each="", after_each=""),
+                            formatted_list(
+                                unsupported,
+                                conjunction="or",
+                                before_each="",
+                                after_each="",
+                                max_items_shown=3,
+                                word_for_items_not_shown="similar characters",
+                            ),
                             field_type,
-                            "these characters" if len(unsupported_char_list) > 1 else "this character",
+                            "these characters" if len(unsupported) > 1 else "this character",
                         )
                     )
 

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -238,6 +238,10 @@ def test_string_cannot_contain_string_with_custom_error_message():
             "∆ abc 📲",
             "You cannot use ∆ or 📲 in this field. You must use percent encoding if you want to include these characters.",  # noqa
         ),
+        (
+            "🦆🦆🦅🦅🦜🦢",
+            "You cannot use 🦆, 🦅 or similar characters in this field. You must use percent encoding if you want to include these characters.",  # noqa
+        ),
     ],
 )
 def test_can_encode_validation(data, err_msg, client_request):


### PR DESCRIPTION
Introduced in https://github.com/alphagov/notifications-utils/pull/1365

This will prevent the error message getting very long if there are loads of bad characters in the URLs.