### PR TITLE
run_with_docker.sh: Remove unused STATSD_ENABLED env var

### DIFF
--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -14,7 +14,6 @@ docker run -it --rm \
   -e FLASK_DEBUG=${FLASK_DEBUG:-1} \
   -e WERKZEUG_DEBUG_PIN=${WERKZEUG_DEBUG_PIN:-"off"} \
   -e FLASK_APP=application.py \
-  -e STATSD_ENABLED= \
   -e REDIS_ENABLED=${REDIS_ENABLED:-1} \
   -e REDIS_URL=$REDIS_URL \
   -e ADMIN_BASE_URL=${ADMIN_BASE_URL:-"http://host.docker.internal:6012"} \


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

Removes unused env var `STATSD_ENABLED` from `scripts/run_with_docker.sh`.