### PR TITLE
Use `InsensitiveSet` for `EmailPreviewTemplate.placeholders`

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -792,7 +792,7 @@ def fields_to_fill_in(template, prefill_current_user=False):
         session["recipient"] = current_user.email_address
         session["placeholders"]["email address"] = current_user.email_address
 
-    return InsensitiveSet(template.placeholders)
+    return template.placeholders
 
 
 def get_normalised_placeholders_from_session():

--- a/app/main/views/template_email_files.py
+++ b/app/main/views/template_email_files.py
@@ -1,6 +1,5 @@
 from flask import abort, flash, redirect, render_template, request, url_for
 from notifications_utils.field import PlainTextField
-from notifications_utils.insensitive_dict import InsensitiveSet
 
 from app import current_service, current_user, service_api_client
 from app.main import main
@@ -118,7 +117,7 @@ def make_file_live(service_id, template_id, template_email_file_id):
     template_email_file = TemplateEmailFile.get_by_id(
         template_email_file_id=template_email_file_id, service_id=service_id, template=template
     )
-    if template_email_file.filename not in InsensitiveSet(template.placeholders):
+    if template_email_file.filename not in template.placeholders:
         new_content = template.content + f"\n\n(({template_email_file.filename}))"
         service_api_client.update_service_template(
             service_id=service_id,

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -312,7 +312,7 @@ class EmailPreviewTemplate(BaseEmailTemplate):
 
     @property
     def placeholders(self):
-        return OrderedSet([placeholder for placeholder in self.all_placeholders if placeholder not in self.filenames])
+        return self.all_placeholders - self.filenames
 
 
 class LetterAttachment(JSONModel):


### PR DESCRIPTION
`BaseTemplate` returns placeholders from a `Field`, which always returns an `InsensitiveSet`:
https://github.com/alphagov/notifications-utils/blob/f238dd966d962ed2515ae3bc436ebae287c9f3f9/notifications_utils/field.py#L162-L166

For this class to be polymorphic with respect to base class it should return the same type.

This has the additional benefit of avoiding iteration by using set operations.