### PR TITLE
Stop users uploading attaching empty files to templates

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -3319,6 +3319,10 @@ class TemplateEmailFilesUploadForm(StripWhitespaceForm):
                 f"– remove (({field.data.filename})) or rename your file"
             )
 
+        if len(field.data.read()) == 0:
+            raise ValidationError("Your file is empty – check your file and try again")
+        field.data.seek(0)
+
         # hand off file to document download api to perform further validation checks,
         # antivirus scan and determination of the file mimetype
         try:

--- a/tests/app/main/views/test_template_email_files.py
+++ b/tests/app/main/views/test_template_email_files.py
@@ -1196,3 +1196,26 @@ def test_upload_file_returns_error_if_file_fails_antivirus_check(
     assert mock_template_update.call_args_list == []
     assert mock_s3.call_args_list == []
     assert mock_post.call_args_list == []
+
+
+def test_upload_file_returns_error_if_file_is_empty(
+    client_request,
+    fake_uuid,
+    service_one,
+    mock_get_service_email_template,
+    mocker,
+):
+    service_one["contact_link"] = "https://example.com"
+    mock_file_check_and_antivirus_scan = mocker.patch("app.document_download_api_client.file_check_and_antivirus_scan")
+    with open("tests/text_files/empty.txt", "rb") as file:
+        page = client_request.post(
+            "main.upload_template_email_files",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            _data={"file": file},
+            _expected_status=200,
+        )
+    assert normalize_spaces(page.select_one(".govuk-error-message").text) == (
+        "Your file is empty – check your file and try again"
+    )
+    assert mock_file_check_and_antivirus_scan.call_args_list == []

--- a/tests/text_files/without brackets.txt
+++ b/tests/text_files/without brackets.txt
@@ -1,0 +1,1 @@
+example


### PR DESCRIPTION
Why do this now? Because we cannot detect the mimetype of an empty file.

However there’s probably no need for people to be sending empty files – in fact it’s most likely testing or a mistake. And since in the UI we can warn people at the time of uploading, not sending, it seems like it doesn’t hurt to add some validation.