### PR TITLE
notifications-utils: 118.0.0 -> 119.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@118.0.0
+# This file was automatically copied from notifications-utils@119.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@118.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@119.0.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -728,7 +728,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8d2767c338b22d60825399191093282a6d928c0b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9a6342ba0aa90afb37c6ec2ac501a75aefed8ac3
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -907,7 +907,7 @@ moto==5.1.22 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@8d2767c338b22d60825399191093282a6d928c0b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9a6342ba0aa90afb37c6ec2ac501a75aefed8ac3
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@118.0.0
+# This file was automatically copied from notifications-utils@119.0.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@118.0.0
+# This file was automatically copied from notifications-utils@119.0.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@118.0.0
+# This file was automatically copied from notifications-utils@119.0.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
Notable change incorporated being https://github.com/alphagov/notifications-utils/pull/1369.

This should hopefully cause no user-noticeable change.