### PR TITLE
Update the ‘Confirm your service is unique’ guidance

### DIFF
--- a/app/templates/views/confirm-your-service-is-unique.html
+++ b/app/templates/views/confirm-your-service-is-unique.html
@@ -5,7 +5,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 
-{% set title = "Confirm that your service is unique" %}
+{% set title = "Confirm your service name" %}
 
 {% block service_page_title %}
     {{ title }}

--- a/app/templates/views/confirm-your-service-is-unique.html
+++ b/app/templates/views/confirm-your-service-is-unique.html
@@ -22,25 +22,38 @@
         <div class="govuk-grid-column-five-sixths">
 
             <p class="govuk-body">
-                Our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.terms_of_use') }}">terms of use</a> say that your service must be the only one of its kind in your organisation.
+                Your service name helps us to decide if you’re eligible for an annual allowance of free text messages.
             </p>
 
             <p class="govuk-body">
-                To help us check this, choose a service name that’s easy to understand.
+                The free allowance is discretionary. To qualify for it, your service must be the only one of its kind in your organisation.
             </p>
 
             <p class="govuk-body">
-                Do not include:
+                You can still use Notify if your service is not eligible for a free allowance.
             </p>
 
+            <h2 class="heading-medium">
+                If you do not plan to send text messages
+            </h2>
+
+            <p class="govuk-body">
+                You still need to confirm your service name.
+            </p>
+
+            <h2 class="heading-medium">
+                Choose a service name that’s easy to understand
+            </h2>
+
+            <p class="govuk-body">
+                Your service name must not include:
+            </p>
+
+            
             <ul class="govuk-list govuk-list--bullet">
                 <li>acronyms, initialisms or abbreviations</li>
                 <li>your own name or the name of someone on your team</li>
             </ul>
-
-            <p class="govuk-body">
-                If we cannot confirm that your service is unique, we may refuse your request to go live.
-            </p>
             
             {% call form_wrapper() %}
                 {{ form.name }}

--- a/app/templates/views/request-to-go-live.html
+++ b/app/templates/views/request-to-go-live.html
@@ -31,7 +31,7 @@
         {% set task_list_items =
           [{
             "title": {
-              "text": "Confirm that your service is unique",
+              "text": "Confirm your service name",
               "classes": "govuk-link--no-visited-state",
             },
             "href": url_for('main.confirm_service_is_unique', service_id=current_service.id),

--- a/tests/app/main/views/test_make_your_service_live.py
+++ b/tests/app/main/views/test_make_your_service_live.py
@@ -111,8 +111,8 @@ def test_route_for_platform_admin(
 @pytest.mark.parametrize(
     "confirmed_unique, expected_status_text",
     [
-        (False, "Confirm that your service is unique Incomplete"),
-        (True, "Confirm that your service is unique Completed"),
+        (False, "Confirm your service name Incomplete"),
+        (True, "Confirm your service name Completed"),
     ],
 )
 def test_should_check_confirm_service_is_unique_task(


### PR DESCRIPTION
One of the mandatory tasks we make users complete before they go live is ‘Confirm your service is unique’.

We introduced this page as part of the ‘onboarding’ epic. It was good enough for MVP, but now it needs to change.

It’s biggest weaknesses are:

* the concept of a ‘unique service’ is abstract
* we don’t explain why we want your service to be ‘unique’ (the free allowance)
* there’s a disconnect between the title/h1 and the interaction (text field, green button)

The new page design:

* makes a stronger connection between the title/h1 and the interaction
* explains that this is all about the free allowance

It’s not perfect, but it’s a reasonable first step and sets us up well for the work we’ll do in Q2.

This PR also changes the link on the ‘Make your service live’ task list page, so it matches the new h1.