### PR TITLE
Implement `BaseLetterTemplate.too_many_pages`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@119.0.0
+# This file was automatically copied from notifications-utils@120.1.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -54,6 +54,10 @@ class BaseLetterImageTemplate(BaseLetterTemplate):
         return self._page_count
 
     @property
+    def too_many_pages(self):
+        return self.page_count > self.max_page_count
+
+    @property
     def postage(self):
         if self.postal_address.international:
             return self.postal_address.postage

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@119.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@120.1.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -728,7 +728,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9a6342ba0aa90afb37c6ec2ac501a75aefed8ac3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@6c3744d9b7eb1c7554833737cceb2d25f2944824
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -907,7 +907,7 @@ moto==5.1.22 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9a6342ba0aa90afb37c6ec2ac501a75aefed8ac3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@6c3744d9b7eb1c7554833737cceb2d25f2944824
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@119.0.0
+# This file was automatically copied from notifications-utils@120.1.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@119.0.0
+# This file was automatically copied from notifications-utils@120.1.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -36,7 +36,7 @@ def test_organisation_name_comes_from_cache(notify_admin, mocker, service_one):
     service._dict["organisation"] = ORGANISATION_ID
 
     assert service.organisation_name == "Borchester Council"
-    mock_redis_get.assert_called_once_with(f"organisation-{ORGANISATION_ID}-name")
+    mock_redis_get.assert_called_once_with(f"organisation-{ORGANISATION_ID}-name", skippable=True)
     assert mock_get_organisation.called is False
 
 
@@ -60,6 +60,7 @@ def test_organisation_name_goes_into_cache(notify_admin, mocker, service_one):
         f"organisation-{ORGANISATION_ID}-name",
         '"Test Organisation"',
         ex=2_419_200,
+        skippable=True,
     )
 
 

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -15,11 +15,12 @@ def test_get_email_branding(mocker, fake_uuid):
     )
     EmailBrandingClient(mocker.MagicMock()).get_email_branding(fake_uuid)
     mock_get.assert_called_once_with(url=f"/email-branding/{fake_uuid}")
-    mock_redis_get.assert_called_once_with(f"email_branding-{fake_uuid}")
+    mock_redis_get.assert_called_once_with(f"email_branding-{fake_uuid}", skippable=True)
     mock_redis_set.assert_called_once_with(
         f"email_branding-{fake_uuid}",
         '{"foo": "bar"}',
         ex=2_419_200,
+        skippable=True,
     )
 
 
@@ -36,11 +37,12 @@ def test_get_all_email_branding(mocker):
     )
     EmailBrandingClient(mocker.MagicMock()).get_all_email_branding()
     mock_get.assert_called_once_with(url="/email-branding")
-    mock_redis_get.assert_called_once_with("email_branding")
+    mock_redis_get.assert_called_once_with("email_branding", skippable=True)
     mock_redis_set.assert_called_once_with(
         "email_branding",
         "[1, 2, 3]",
         ex=2_419_200,
+        skippable=True,
     )
 
 

--- a/tests/app/notify_client/test_job_client.py
+++ b/tests/app/notify_client/test_job_client.py
@@ -353,6 +353,7 @@ def test_has_jobs_sets_cache(
         f"has_jobs-{fake_uuid}",
         expected_cache_value,
         ex=2_419_200,
+        skippable=True,
     )
 
 
@@ -377,4 +378,4 @@ def test_has_jobs_returns_from_cache(
 
     assert JobApiClient(mocker.MagicMock()).has_jobs(fake_uuid) is return_value
     assert not mock_get.called
-    mock_redis_get.assert_called_once_with(f"has_jobs-{fake_uuid}")
+    mock_redis_get.assert_called_once_with(f"has_jobs-{fake_uuid}", skippable=True)

--- a/tests/app/notify_client/test_letter_branding_client.py
+++ b/tests/app/notify_client/test_letter_branding_client.py
@@ -12,11 +12,12 @@ def test_get_letter_branding(mocker, fake_uuid):
     LetterBrandingClient(mocker.MagicMock()).get_letter_branding(fake_uuid)
 
     mock_get.assert_called_once_with(url=f"/letter-branding/{fake_uuid}")
-    mock_redis_get.assert_called_once_with(f"letter_branding-{fake_uuid}")
+    mock_redis_get.assert_called_once_with(f"letter_branding-{fake_uuid}", skippable=True)
     mock_redis_set.assert_called_once_with(
         f"letter_branding-{fake_uuid}",
         '{"foo": "bar"}',
         ex=2_419_200,
+        skippable=True,
     )
 
 
@@ -28,11 +29,12 @@ def test_get_all_letter_branding(mocker):
     LetterBrandingClient(mocker.MagicMock()).get_all_letter_branding()
 
     mock_get.assert_called_once_with(url="/letter-branding")
-    mock_redis_get.assert_called_once_with("letter_branding")
+    mock_redis_get.assert_called_once_with("letter_branding", skippable=True)
     mock_redis_set.assert_called_once_with(
         "letter_branding",
         "[1, 2, 3]",
         ex=2_419_200,
+        skippable=True,
     )
 
 

--- a/tests/app/notify_client/test_letter_rate_api_client.py
+++ b/tests/app/notify_client/test_letter_rate_api_client.py
@@ -15,9 +15,14 @@ def test_sets_value_in_cache(mocker):
 
     assert client.get_letter_rates() == {"data_from": "api"}
 
-    mock_redis_get.assert_called_once_with("letter-rates")
+    mock_redis_get.assert_called_once_with("letter-rates", skippable=True)
     mock_api_get.assert_called_once_with(url="/letter-rates")
-    mock_redis_set.assert_called_once_with("letter-rates", '{"data_from": "api"}', ex=3_600)
+    mock_redis_set.assert_called_once_with(
+        "letter-rates",
+        '{"data_from": "api"}',
+        ex=3_600,
+        skippable=True,
+    )
 
 
 def test_returns_value_from_cache(mocker):
@@ -36,7 +41,7 @@ def test_returns_value_from_cache(mocker):
 
     assert client.get_letter_rates() == {"data_from": "cache"}
 
-    mock_redis_get.assert_called_once_with("letter-rates")
+    mock_redis_get.assert_called_once_with("letter-rates", skippable=True)
 
     assert mock_api_get.called is False
     assert mock_redis_set.called is False

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -19,7 +19,10 @@ from tests.utils import RedisClientMock
         (
             "get_domains",
             [
-                call("domains"),
+                call(
+                    "domains",
+                    skippable=True,
+                ),
             ],
             b"""
                 [
@@ -34,8 +37,14 @@ from tests.utils import RedisClientMock
         (
             "get_domains",
             [
-                call("domains"),
-                call("organisations"),
+                call(
+                    "domains",
+                    skippable=True,
+                ),
+                call(
+                    "organisations",
+                    skippable=True,
+                ),
             ],
             None,
             [call(url="/organisations")],
@@ -44,15 +53,24 @@ from tests.utils import RedisClientMock
                     "organisations",
                     '[{"domains": ["x", "y", "z"]}]',
                     ex=2_419_200,
+                    skippable=True,
                 ),
-                call("domains", '["x", "y", "z"]', ex=2_419_200),
+                call(
+                    "domains",
+                    '["x", "y", "z"]',
+                    ex=2_419_200,
+                    skippable=True,
+                ),
             ],
             "from api",
         ),
         (
             "get_organisations",
             [
-                call("organisations"),
+                call(
+                    "organisations",
+                    skippable=True,
+                ),
             ],
             b"""
                 [
@@ -67,7 +85,10 @@ from tests.utils import RedisClientMock
         (
             "get_organisations",
             [
-                call("organisations"),
+                call(
+                    "organisations",
+                    skippable=True,
+                ),
             ],
             None,
             [call(url="/organisations")],
@@ -76,6 +97,7 @@ from tests.utils import RedisClientMock
                     "organisations",
                     '[{"domains": ["x", "y", "z"]}]',
                     ex=2_419_200,
+                    skippable=True,
                 ),
             ],
             "from api",
@@ -251,7 +273,10 @@ def test_get_letter_branding_pool(notify_admin, mocker):
     organisations_client.get_letter_branding_pool(org_id)
 
     mock_redis_set.assert_called_once_with(
-        f"organisation-{org_id}-letter-branding-pool", '{"filename": "gov.svg"}', ex=2_419_200
+        f"organisation-{org_id}-letter-branding-pool",
+        '{"filename": "gov.svg"}',
+        ex=2_419_200,
+        skippable=True,
     )
     mock_get.assert_called_with(url=f"/organisations/{org_id}/letter-branding-pool")
 

--- a/tests/app/notify_client/test_performance_platform_api_client.py
+++ b/tests/app/notify_client/test_performance_platform_api_client.py
@@ -40,7 +40,7 @@ def test_sets_value_in_cache(mocker):
         end_date=date(2022, 2, 2),
     ) == {"data_from": "api"}
 
-    mock_redis_get.assert_called_once_with("performance-stats-2021-01-01-to-2022-02-02")
+    mock_redis_get.assert_called_once_with("performance-stats-2021-01-01-to-2022-02-02", skippable=True)
     mock_api_get.assert_called_once_with(
         "/performance-dashboard", params={"start_date": "2021-01-01", "end_date": "2022-02-02"}
     )
@@ -48,6 +48,7 @@ def test_sets_value_in_cache(mocker):
         "performance-stats-2021-01-01-to-2022-02-02",
         '{"data_from": "api"}',
         ex=3600,
+        skippable=True,
     )
 
 
@@ -70,6 +71,6 @@ def test_returns_value_from_cache(mocker):
         end_date=date(2022, 2, 2),
     ) == {"data_from": "cache"}
 
-    mock_redis_get.assert_called_once_with("performance-stats-2021-01-01-to-2022-02-02")
+    mock_redis_get.assert_called_once_with("performance-stats-2021-01-01-to-2022-02-02", skippable=True)
     assert mock_api_get.called is False
     assert mock_redis_set.called is False

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -107,6 +107,7 @@ def test_get_precompiled_template(mocker):
         f"service-{SERVICE_ONE_ID}-template-precompiled",
         '{"data": "foo"}',
         ex=2_419_200,
+        skippable=True,
     )
 
 
@@ -124,7 +125,12 @@ def test_get_precompiled_template(mocker):
         (
             "get_service",
             [SERVICE_ONE_ID],
-            [call(f"service-{SERVICE_ONE_ID}")],
+            [
+                call(
+                    f"service-{SERVICE_ONE_ID}",
+                    skippable=True,
+                )
+            ],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -133,7 +139,12 @@ def test_get_precompiled_template(mocker):
         (
             "get_service",
             [SERVICE_ONE_ID],
-            [call(f"service-{SERVICE_ONE_ID}")],
+            [
+                call(
+                    f"service-{SERVICE_ONE_ID}",
+                    skippable=True,
+                )
+            ],
             None,
             [call(f"/service/{SERVICE_ONE_ID}")],
             [
@@ -141,6 +152,7 @@ def test_get_precompiled_template(mocker):
                     f"service-{SERVICE_ONE_ID}",
                     '{"data_from": "api"}',
                     ex=2_419_200,
+                    skippable=True,
                 )
             ],
             {"data_from": "api"},
@@ -148,7 +160,12 @@ def test_get_precompiled_template(mocker):
         (
             "get_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
-            [call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None")],
+            [
+                call(
+                    f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None",
+                    skippable=True,
+                )
+            ],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -158,7 +175,10 @@ def test_get_precompiled_template(mocker):
             "get_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [
-                call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None"),
+                call(
+                    f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None",
+                    skippable=True,
+                ),
             ],
             None,
             [call(f"/service/{SERVICE_ONE_ID}/template/{FAKE_TEMPLATE_ID}")],
@@ -167,6 +187,7 @@ def test_get_precompiled_template(mocker):
                     f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-None",
                     '{"data_from": "api"}',
                     ex=2_419_200,
+                    skippable=True,
                 ),
             ],
             {"data_from": "api"},
@@ -174,7 +195,12 @@ def test_get_precompiled_template(mocker):
         (
             "get_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 1],
-            [call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1")],
+            [
+                call(
+                    f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1",
+                    skippable=True,
+                )
+            ],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -184,7 +210,10 @@ def test_get_precompiled_template(mocker):
             "get_service_template",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 1],
             [
-                call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1"),
+                call(
+                    f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1",
+                    skippable=True,
+                ),
             ],
             None,
             [call(f"/service/{SERVICE_ONE_ID}/template/{FAKE_TEMPLATE_ID}/version/1")],
@@ -193,6 +222,7 @@ def test_get_precompiled_template(mocker):
                     f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-version-1",
                     '{"data_from": "api"}',
                     ex=2_419_200,
+                    skippable=True,
                 ),
             ],
             {"data_from": "api"},
@@ -200,7 +230,12 @@ def test_get_precompiled_template(mocker):
         (
             "get_service_templates",
             [SERVICE_ONE_ID],
-            [call(f"service-{SERVICE_ONE_ID}-templates")],
+            [
+                call(
+                    f"service-{SERVICE_ONE_ID}-templates",
+                    skippable=True,
+                )
+            ],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -209,7 +244,12 @@ def test_get_precompiled_template(mocker):
         (
             "get_service_templates",
             [SERVICE_ONE_ID],
-            [call(f"service-{SERVICE_ONE_ID}-templates")],
+            [
+                call(
+                    f"service-{SERVICE_ONE_ID}-templates",
+                    skippable=True,
+                )
+            ],
             None,
             [call(f"/service/{SERVICE_ONE_ID}/template")],
             [
@@ -217,6 +257,7 @@ def test_get_precompiled_template(mocker):
                     f"service-{SERVICE_ONE_ID}-templates",
                     '{"data_from": "api"}',
                     ex=2_419_200,
+                    skippable=True,
                 )
             ],
             {"data_from": "api"},
@@ -224,7 +265,12 @@ def test_get_precompiled_template(mocker):
         (
             "get_service_template_versions",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
-            [call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions")],
+            [
+                call(
+                    f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions",
+                    skippable=True,
+                )
+            ],
             b'{"data_from": "cache"}',
             [],
             [],
@@ -234,7 +280,10 @@ def test_get_precompiled_template(mocker):
             "get_service_template_versions",
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [
-                call(f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions"),
+                call(
+                    f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions",
+                    skippable=True,
+                ),
             ],
             None,
             [call(f"/service/{SERVICE_ONE_ID}/template/{FAKE_TEMPLATE_ID}/versions")],
@@ -243,6 +292,7 @@ def test_get_precompiled_template(mocker):
                     f"service-{SERVICE_ONE_ID}-template-{FAKE_TEMPLATE_ID}-versions",
                     '{"data_from": "api"}',
                     ex=2_419_200,
+                    skippable=True,
                 ),
             ],
             {"data_from": "api"},
@@ -250,7 +300,12 @@ def test_get_precompiled_template(mocker):
         (
             "get_returned_letter_summary",
             [SERVICE_ONE_ID],
-            [call(f"service-{SERVICE_ONE_ID}-returned-letters-summary")],
+            [
+                call(
+                    f"service-{SERVICE_ONE_ID}-returned-letters-summary",
+                    skippable=True,
+                )
+            ],
             None,
             [call(f"service/{SERVICE_ONE_ID}/returned-letter-summary")],
             [
@@ -258,6 +313,7 @@ def test_get_precompiled_template(mocker):
                     f"service-{SERVICE_ONE_ID}-returned-letters-summary",
                     '{"data_from": "api"}',
                     ex=2_419_200,
+                    skippable=True,
                 )
             ],
             {"data_from": "api"},
@@ -265,7 +321,12 @@ def test_get_precompiled_template(mocker):
         (
             "get_returned_letter_statistics",
             [SERVICE_ONE_ID],
-            [call(f"service-{SERVICE_ONE_ID}-returned-letters-statistics")],
+            [
+                call(
+                    f"service-{SERVICE_ONE_ID}-returned-letters-statistics",
+                    skippable=True,
+                )
+            ],
             None,
             [call(f"service/{SERVICE_ONE_ID}/returned-letter-statistics")],
             [
@@ -273,6 +334,7 @@ def test_get_precompiled_template(mocker):
                     f"service-{SERVICE_ONE_ID}-returned-letters-statistics",
                     '{"data_from": "api"}',
                     ex=2_419_200,
+                    skippable=True,
                 )
             ],
             {"data_from": "api"},

--- a/tests/app/notify_client/test_status_api_client.py
+++ b/tests/app/notify_client/test_status_api_client.py
@@ -25,9 +25,14 @@ def test_sets_value_in_cache(mocker):
 
     assert client.get_count_of_live_services_and_organisations() == {"data_from": "api"}
 
-    mock_redis_get.assert_called_once_with("live-service-and-organisation-counts")
+    mock_redis_get.assert_called_once_with("live-service-and-organisation-counts", skippable=True)
     mock_api_get.assert_called_once_with("/_status/live-service-and-organisation-counts")
-    mock_redis_set.assert_called_once_with("live-service-and-organisation-counts", '{"data_from": "api"}', ex=3600)
+    mock_redis_set.assert_called_once_with(
+        "live-service-and-organisation-counts",
+        '{"data_from": "api"}',
+        ex=3600,
+        skippable=True,
+    )
 
 
 def test_returns_value_from_cache(mocker):
@@ -46,7 +51,7 @@ def test_returns_value_from_cache(mocker):
 
     assert client.get_count_of_live_services_and_organisations() == {"data_from": "cache"}
 
-    mock_redis_get.assert_called_once_with("live-service-and-organisation-counts")
+    mock_redis_get.assert_called_once_with("live-service-and-organisation-counts", skippable=True)
 
     assert mock_api_get.called is False
     assert mock_redis_set.called is False

--- a/tests/app/notify_client/test_template_folder_client.py
+++ b/tests/app/notify_client/test_template_folder_client.py
@@ -42,9 +42,14 @@ def test_get_template_folders_calls_correct_api_endpoint(mocker):
 
     assert ret == {"a": "b"}
 
-    mock_redis_get.assert_called_once_with(redis_key)
+    mock_redis_get.assert_called_once_with(redis_key, skippable=True)
     mock_api_get.assert_called_once_with(expected_url)
-    mock_redis_set.assert_called_once_with(redis_key, '{"a": "b"}', ex=2_419_200)
+    mock_redis_set.assert_called_once_with(
+        redis_key,
+        '{"a": "b"}',
+        ex=2_419_200,
+        skippable=True,
+    )
 
 
 def test_move_templates_and_folders(mocker):

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -131,17 +131,17 @@ def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(n
     "expected_cache_get_calls,cache_value,expected_api_calls,expected_cache_set_calls,expected_return_value",
     [
         (
-            [call(f"user-{user_id}")],
+            [call(f"user-{user_id}", skippable=True)],
             b'{"data": "from cache"}',
             [],
             [],
             "from cache",
         ),
         (
-            [call(f"user-{user_id}")],
+            [call(f"user-{user_id}", skippable=True)],
             None,
             [call(f"/user/{user_id}")],
-            [call(f"user-{user_id}", '{"data": "from api"}', ex=2_419_200)],
+            [call(f"user-{user_id}", '{"data": "from api"}', ex=2_419_200, skippable=True)],
             "from api",
         ),
     ],

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@119.0.0
+# This file was automatically copied from notifications-utils@120.1.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
It’s been removed in https://github.com/alphagov/notifications-utils/pull/1379 because the class in utils does not define `page_count`. Our base class here does.

***

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/1379