### PR TITLE
Add file types guidance to the ‘Send files by email’ page

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -15,7 +15,7 @@ from notifications_utils.template import HTMLEmailTemplate
 from app import status_api_client
 from app.formatters import format_thousands
 from app.main import main
-from app.main.forms import FieldWithNoneOption
+from app.main.forms import FieldWithNoneOption, TemplateEmailFilesUploadForm
 from app.main.views.sub_navigation_dictionaries import features_nav, using_notify_nav
 from app.models.branding import EmailBranding
 from app.models.letter_rates import LetterRates
@@ -321,6 +321,7 @@ def guidance_schedule_messages():
 def guidance_send_files_by_email():
     return render_template(
         "views/guidance/using-notify/send-files-by-email.html",
+        allowed_file_formats=TemplateEmailFilesUploadForm.allowed_file_formats,
         navigation_links=using_notify_nav(),
     )
 

--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -34,14 +34,11 @@
 
   <p class="govuk-body">You can upload the following file types:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>CSV (.csv)</li>
-  <li>image (.jpeg, .jpg, .png)</li>
-  <li>Microsoft Excel Spreadsheet (.xlsx)</li>
-  <li>Microsoft Word Document (.doc, .docx)</li>
-  <li>PDF (.pdf)</li>
-  <li>text (.json, .odt, .rtf, .txt)</li>
-</ul>
+  <ul class="govuk-list govuk-list--bullet">
+    {% for label, extensions in allowed_file_formats.items() %}
+      <li>{{ label }} (.{{ extensions|join(", .") }})</li>
+    {% endfor %}
+  </ul>
 
   <p class="govuk-body">Your file must be smaller than 2MB. <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('main.support')}}">Contact the GOV.UK Notify team</a> if you need to send other file types.</p>
 

--- a/app/templates/views/guidance/using-notify/send-files-by-email.html
+++ b/app/templates/views/guidance/using-notify/send-files-by-email.html
@@ -21,16 +21,29 @@
   <li>they’re more secure</li>
   <li>email attachments are often marked as spam</li></ul>
 
+  <p class="govuk-body">For added security, you can choose how long the file is available for and ask recipients to confirm their email address before they can download it.</p>
 
-  <p class="govuk-body">To send a file by email:</p>
- <ol class="govuk-list govuk-list--number">
+  <h2 class="heading-medium">How to send a file by email</h2>
+
+<ol class="govuk-list govuk-list--number">
    <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
    <li>Add a new email template or choose an existing one.</li>
    <li>Select <b class="govuk-!-font-weight-bold">Attach files</b>.</li>
    <li>Upload your file.</li>
  </ol>
 
-  <p class="govuk-body">For security, choose how long the file is available for and ask recipients to confirm their email address before they can download it.</p>
+  <p class="govuk-body">You can upload the following file types:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>CSV (.csv)</li>
+  <li>image (.jpeg, .jpg, .png)</li>
+  <li>Microsoft Excel Spreadsheet (.xlsx)</li>
+  <li>Microsoft Word Document (.doc, .docx)</li>
+  <li>PDF (.pdf)</li>
+  <li>text (.json, .odt, .rtf, .txt)</li>
+</ul>
+
+  <p class="govuk-body">Your file must be smaller than 2MB. <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('main.support')}}">Contact the GOV.UK Notify team</a> if you need to send other file types.</p>
 
   <h2 class="heading-medium">If you use the Notify API</h2>
   <p class="govuk-body">


### PR DESCRIPTION
We’ve had a few users asking about this on support.

We already publish this information for API users in the documentation, so it makes sense to duplicate it here.