### PR TITLE
refactor: extend tests to include revoker_id for expiring api keys

### DIFF
--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -473,10 +473,13 @@ def test_should_404_for_api_key_that_doesnt_exist(
 
 def test_should_redirect_after_revoking_api_key(
     client_request,
-    mock_revoke_api_key,
+    api_user_active,
     mock_get_api_keys,
     fake_uuid,
+    mocker,
 ):
+    post = mocker.patch("app.models.api_key.api_key_api_client.post")
+
     client_request.post(
         "main.revoke_api_key",
         service_id=SERVICE_ONE_ID,
@@ -487,7 +490,11 @@ def test_should_redirect_after_revoking_api_key(
             service_id=SERVICE_ONE_ID,
         ),
     )
-    mock_revoke_api_key.assert_called_once_with(service_id=SERVICE_ONE_ID, key_id=fake_uuid)
+
+    post.assert_called_once_with(
+        url=f"/service/{SERVICE_ONE_ID}/api-key/revoke/{fake_uuid}",
+        data={"created_by": api_user_active["id"]},
+    )
     mock_get_api_keys.assert_called_once_with(
         SERVICE_ONE_ID,
     )

--- a/tests/app/main/views/test_history.py
+++ b/tests/app/main/views/test_history.py
@@ -1,7 +1,7 @@
 import pytest
 from freezegun import freeze_time
 
-from tests.conftest import SERVICE_ONE_ID, normalize_spaces
+from tests.conftest import API_KEY_REVOKER_ID, SERVICE_ONE_ID, create_service_one_admin, normalize_spaces, sample_uuid
 
 
 @pytest.mark.parametrize(
@@ -23,7 +23,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                 ),
                 (
                     "11 November",
-                    "Test User 12:12pm Revoked the ‘Bad key’ API key",
+                    "Key Revoker 12:12pm Revoked the ‘Bad key’ API key",
                 ),
                 (
                     "11 November 2011",
@@ -47,7 +47,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
             [
                 (
                     "11 November",
-                    "Test User 12:12pm Revoked the ‘Bad key’ API key",
+                    "Key Revoker 12:12pm Revoked the ‘Bad key’ API key",
                 ),
                 (
                     "11 November 2011",
@@ -94,6 +94,11 @@ def test_history(
     extra_args,
     expected_headings_and_events,
 ):
+    mock_get_users_by_service.side_effect = lambda service_id: [
+        create_service_one_admin(id=sample_uuid(), name="Test User"),
+        create_service_one_admin(id=API_KEY_REVOKER_ID, name="Key Revoker"),
+    ]
+
     page = client_request.get("main.history", service_id=SERVICE_ONE_ID, **extra_args)
 
     assert page.select_one("h1").text == "Audit events"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -713,6 +713,7 @@ ORGANISATION_ID = "c011fa40-4cbe-4524-b415-dde2f421bd9c"
 ORGANISATION_TWO_ID = "d9b5be73-0b36-4210-9d89-8f1a5c2fef26"
 TEMPLATE_ONE_ID = "b22d7d94-2197-4a7d-a8e7-fd5f9770bf48"
 USER_ONE_ID = "7b395b52-c6c1-469c-9d61-54166461c1ab"
+API_KEY_REVOKER_ID = "df4beeef-8ee7-4fa2-b3d8-0d9d7f739dcc"
 
 
 @pytest.fixture(scope="function")
@@ -3969,7 +3970,7 @@ def mock_get_service_history(notify_admin, mocker):
                     "name": "Bad key",
                     "updated_at": "2012-11-11T12:12:12.000000Z",
                     "created_at": "2011-11-11T11:11:11.000000Z",
-                    "created_by_id": sample_uuid(),
+                    "created_by_id": API_KEY_REVOKER_ID,
                 },
                 {
                     "name": "Bad key",


### PR DESCRIPTION
### Summary
Updated API Key history audit tests to include revoker id, separate from creation ID to better reflect the behaviour


Ticket: https://trello.com/c/BwLKBEc4/645-api-key-history-shows-incorrect-data