### PR TITLE
Add a new ‘Fonts and typefaces’ guidance page

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -238,10 +238,14 @@ def guidance_email_branding():
 
 
 @main.route("/using-notify/fonts-typefaces")
-def guidance_fonts_typefaces():
+@main.route("/using-notify/fonts-typefaces/<template_type:notification_type>")
+def guidance_fonts_typefaces(notification_type=None):
+    if not notification_type:
+        return redirect(url_for(".guidance_fonts_typefaces", notification_type="email"))
     return render_template(
         "views/guidance/using-notify/fonts-typefaces.html",
         navigation_links=using_notify_nav(),
+        notification_type=notification_type,
     )
 
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -237,6 +237,14 @@ def guidance_email_branding():
     )
 
 
+@main.route("/using-notify/fonts-typefaces")
+def guidance_formatting():
+    return render_template(
+        "views/guidance/using-notify/fonts-typefaces.html",
+        navigation_links=using_notify_nav(),
+    )
+
+
 @main.route("/using-notify/formatting")
 def guidance_formatting():
     return render_template(

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -238,7 +238,7 @@ def guidance_email_branding():
 
 
 @main.route("/using-notify/fonts-typefaces")
-def guidance_formatting():
+def guidance_fonts_typefaces():
     return render_template(
         "views/guidance/using-notify/fonts-typefaces.html",
         navigation_links=using_notify_nav(),

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -111,13 +111,13 @@ def using_notify_nav():
                     "link": "main.guidance_email_branding",
                 },
                 {
-                    "name": "Formatting emails and letters",
-                    "link": "main.guidance_formatting",
-                },
-                {
                     "name": "Fonts and typefaces",
                     "link": "main.guidance_fonts_typefaces",
                 },                
+                {
+                    "name": "Formatting emails and letters",
+                    "link": "main.guidance_formatting",
+                },
                 {
                     "name": "Letter branding",
                     "link": "main.guidance_letter_branding",

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -113,7 +113,7 @@ def using_notify_nav():
                 {
                     "name": "Fonts and typefaces",
                     "link": "main.guidance_fonts_typefaces",
-                },                
+                },
                 {
                     "name": "Formatting emails and letters",
                     "link": "main.guidance_formatting",

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -115,6 +115,10 @@ def using_notify_nav():
                     "link": "main.guidance_formatting",
                 },
                 {
+                    "name": "Fonts and typefaces",
+                    "link": "main.guidance_fonts_typefaces",
+                },                
+                {
                     "name": "Letter branding",
                     "link": "main.guidance_letter_branding",
                 },

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -65,6 +65,7 @@ class HeaderNavigation(Navigation):
             "guidance_data_retention_period",
             "guidance_delivery_times",
             "guidance_email_branding",
+            "guidance_fonts_typefaces",
             "guidance_formatting",
             "guidance_letter_branding",
             "guidance_links_and_URLs",

--- a/app/templates/views/guidance/using-notify/fonts-typefaces.html
+++ b/app/templates/views/guidance/using-notify/fonts-typefaces.html
@@ -1,7 +1,6 @@
 {% extends "content_template.html" %}
 
 {% from "components/pill.html" import pill %}
-{% from "components/service-link.html" import service_link %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Using Notify' %}

--- a/app/templates/views/guidance/using-notify/fonts-typefaces.html
+++ b/app/templates/views/guidance/using-notify/fonts-typefaces.html
@@ -1,0 +1,71 @@
+{% extends "content_template.html" %}
+
+{% from "components/pill.html" import pill %}
+{% from "components/service-link.html" import service_link %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
+{% set page_title = 'Fonts and typefaces' %}
+
+{% block per_page_title %}
+  {{ page_title }}
+{% endblock %}
+
+{% block content_column_content %}
+
+  <h1 class="heading-large">{{ page_title }}</h1>
+
+  <p class="govuk-body">This page describes the typefaces and font sizes used by GOV.UK Notify.</p>
+
+  <div class="govuk-!-margin-bottom-3">
+    {{ pill(
+      (
+        ("Emails", "email", url_for(".guidance_message_status"), 0),
+        ("Text messages", "sms", url_for(".guidance_message_status", notification_type="sms"), 0),
+        ("Letters", "letter", url_for(".guidance_message_status", notification_type="letter"), 0),
+      ),
+      current_value=notification_type,
+      show_count=False,
+    ) }}
+  </div>
+
+  {% if notification_type == "email" %}
+
+    <p class="govuk-body">Emails use the default sans-serif typeface installed on the recipient’s device.</p>
+
+    <p class="govuk-body">Our first choice is Helvetica, followed by Arial.</p>
+
+    <p class="govuk-body">The default font size for emails is 19 pixels.</p>
+
+    <p class="govuk-body">Recipients can change the font size in their device settings.</p>
+
+    <p class="govuk-body">Emails support any Unicode characters.</p>
+
+    <p class="govuk-body">You cannot change the typeface or font size.</p>
+
+    <p class="govuk-body">See: <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_formatting') }}">Formatting</a></p>
+
+
+  {% endif %}
+  {% if notification_type == "sms" %}
+
+    <p class="govuk-body">The typeface for text messages is set by the recipient’s mobile phone or device.</p>
+
+    <p class="govuk-body">Some characters can affect the cost of sending a text message.</p>
+
+    <p class="govuk-body">See: <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages') }}">Text message pricing</a></p>
+
+  {% endif %}
+  {% if notification_type == "letter" %}
+
+    <p class="govuk-body">Letters use the Nimbus Sans L typeface at 12.5pt size.</p>
+
+    <p class="govuk-body">You cannot change the typeface or font size.</p>
+
+    <p class="govuk-body">See: <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_formatting') }}">Formatting</a></p>
+
+    <p class="govuk-body">If you need to provide large format print letters, you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_upload_a_letter') }}">upload a PDF letter instead</a>.</p>
+
+  {% endif %}
+
+{% endblock %}

--- a/app/templates/views/guidance/using-notify/fonts-typefaces.html
+++ b/app/templates/views/guidance/using-notify/fonts-typefaces.html
@@ -19,9 +19,9 @@
   <div class="govuk-!-margin-bottom-3">
     {{ pill(
       (
-        ("Emails", "email", url_for(".guidance_message_status"), 0),
-        ("Text messages", "sms", url_for(".guidance_message_status", notification_type="sms"), 0),
-        ("Letters", "letter", url_for(".guidance_message_status", notification_type="letter"), 0),
+        ("Emails", "email", url_for(".guidance_fonts_typefaces"), 0),
+        ("Text messages", "sms", url_for(".guidance_fonts_typefaces", notification_type="sms"), 0),
+        ("Letters", "letter", url_for(".guidance_fonts_typefaces", notification_type="letter"), 0),
       ),
       current_value=notification_type,
       show_count=False,

--- a/app/templates/views/guidance/using-notify/formatting.html
+++ b/app/templates/views/guidance/using-notify/formatting.html
@@ -39,7 +39,7 @@
     <li><a class="govuk-link govuk-link--no-visited-state" href="#page-breaks">page breaks</a></li>
   </ul>
 
-<p class="govuk-body">You cannot use bold, italics, underlined text, different typefaces or fonts. This is because they can make it harder for people to read what you’ve written.</p>
+<p class="govuk-body">You cannot use bold, italics, underlined text, different <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_fonts_typefaces') }}">typefaces or fonts</a>. This is because they can make it harder for people to read what you’ve written.</p>
 
 <h2 class="heading-medium">Guidance</h2>
 

--- a/app/templates/views/guidance/using-notify/index.html
+++ b/app/templates/views/guidance/using-notify/index.html
@@ -30,6 +30,7 @@
 
    <ul class="govuk-list govuk-list--bullet">
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_formatting') }}">Formatting emails and letters</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_fonts_typefaces') }}">Fonts and typefaces</a></li>     
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_links_and_URLs') }}">Links and URLs</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_optional_content') }}">Optional content</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_personalisation') }}">Personalisation</a></li>

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -106,43 +106,48 @@ def test_hiding_pages_that_redirect_from_search_engines(client_request, endpoint
 
 
 @pytest.mark.parametrize(
-    "view",
+    "view, view_vars",
     [
-        "accessibility_statement",
-        "cookies",
-        "guidance_api_documentation",
-        "guidance_billing_details",
-        "guidance_delivery_times",
-        "guidance_email_branding",
-        "guidance_features",
-        "guidance_fonts_typefaces",
-        "guidance_formatting",
-        "guidance_how_to_pay",
-        "guidance_letter_branding",
-        "guidance_links_and_URLs",
-        "guidance_optional_content",
-        "guidance_personalisation",
-        "guidance_pricing_letters",
-        "guidance_pricing_text_messages",
-        "guidance_pricing",
-        "guidance_qr_codes",
-        "guidance_receive_text_messages",
-        "guidance_reply_to_email_address",
-        "guidance_returned_letters",
-        "guidance_roadmap",
-        "guidance_schedule_messages",
-        "guidance_security",
-        "guidance_send_files_by_email",
-        "guidance_sign_in_method",
-        "guidance_team_members_and_permissions",
-        "guidance_templates",
-        "guidance_text_message_sender",
-        "guidance_unsubscribe_links",
-        "guidance_upload_a_letter",
-        "guidance_using_notify",
-        "guidance_who_can_use_notify",
-        "privacy",
-        "terms_of_use",
+        ["accessibility_statement", {}],
+        ["cookies", {}],
+        ["guidance_api_documentation", {}],
+        ["guidance_billing_details", {}],
+        ["guidance_delivery_times", {}],
+        ["guidance_email_branding", {}],
+        ["guidance_features", {}],
+        ["guidance_fonts_typefaces", {"notification_type": "email"}],
+        ["guidance_fonts_typefaces", {"notification_type": "sms"}],
+        ["guidance_fonts_typefaces", {"notification_type": "letter"}],
+        ["guidance_formatting", {}],
+        ["guidance_how_to_pay", {}],
+        ["guidance_letter_branding", {}],
+        ["guidance_links_and_URLs", {}],
+        ["guidance_message_status", {"notification_type": "email"}],
+        ["guidance_message_status", {"notification_type": "sms"}],
+        ["guidance_message_status", {"notification_type": "letter"}],
+        ["guidance_optional_content", {}],
+        ["guidance_personalisation", {}],
+        ["guidance_pricing_letters", {}],
+        ["guidance_pricing_text_messages", {}],
+        ["guidance_pricing", {}],
+        ["guidance_qr_codes", {}],
+        ["guidance_receive_text_messages", {}],
+        ["guidance_reply_to_email_address", {}],
+        ["guidance_returned_letters", {}],
+        ["guidance_roadmap", {}],
+        ["guidance_schedule_messages", {}],
+        ["guidance_security", {}],
+        ["guidance_send_files_by_email", {}],
+        ["guidance_sign_in_method", {}],
+        ["guidance_team_members_and_permissions", {}],
+        ["guidance_templates", {}],
+        ["guidance_text_message_sender", {}],
+        ["guidance_unsubscribe_links", {}],
+        ["guidance_upload_a_letter", {}],
+        ["guidance_using_notify", {}],
+        ["guidance_who_can_use_notify", {}],
+        ["privacy", {}],
+        ["terms_of_use", {}],
     ],
 )
 def test_static_pages(
@@ -150,8 +155,9 @@ def test_static_pages(
     mock_get_letter_rates,
     mock_get_sms_rate,
     view,
+    view_vars,
 ):
-    request = partial(client_request.get, f"main.{view}")
+    request = partial(client_request.get, f"main.{view}", **view_vars)
 
     # Check the page loads when user is signed in
     page = request()
@@ -234,11 +240,18 @@ def test_redirect_blueprint_contains_valid_urls(_client):
     assert not invalid_redirects, "historical_redirects redirects to invalid endpoint name"
 
 
-def test_message_status_page_redirects_without_notification_type_specified(client_request):
+@pytest.mark.parametrize(
+    "view",
+    [
+        "guidance_message_status",
+        "guidance_fonts_typefaces",
+    ],
+)
+def test_guidance_pages_redirect_without_notification_type_specified(client_request, view):
     client_request.get(
-        "main.guidance_message_status",
+        f"main.{view}",
         _expected_redirect=url_for(
-            "main.guidance_message_status",
+            f"main.{view}",
             notification_type="email",
         ),
     )

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -115,6 +115,7 @@ def test_hiding_pages_that_redirect_from_search_engines(client_request, endpoint
         "guidance_delivery_times",
         "guidance_email_branding",
         "guidance_features",
+        "guidance_fonts_typefaces",
         "guidance_formatting",
         "guidance_how_to_pay",
         "guidance_letter_branding",

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -156,6 +156,7 @@ EXCLUDED_ENDPOINTS = set(
             "guidance_delivery_times",
             "guidance_email_branding",
             "guidance_features",
+            "guidance_fonts_typefaces",
             "guidance_formatting",
             "guidance_how_to_pay",
             "guidance_letter_branding",


### PR DESCRIPTION
Users sometimes ask:

* which fonts we use for emails, text messages and letters
* whether they can change the default fonts

The number of enquiries is not high, but this still feels like valuable information to include in the Using Notify pages.

This PR:

* adds a new guidance page
* adds that page to the left-hand navigation
* adds a link to the new page from the ‘Using Notify’ page
* adds a link to the new page from the ‘Formatting’ guidance page