### PR TITLE
Upgrade Sentry from 1.45.1 to 2.63.0

### DIFF
--- a/app/performance.py
+++ b/app/performance.py
@@ -48,7 +48,7 @@ def init_performance_monitoring():
             environment=environment,
             sample_rate=error_sample_rate,
             send_default_pii=send_pii,
-            request_bodies=send_request_bodies,
+            max_request_body_size=send_request_bodies,
             traces_sampler=traces_sampler,
             release=release,
         )

--- a/requirements.in
+++ b/requirements.in
@@ -24,4 +24,4 @@ govuk-frontend-jinja==4.0.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 
-sentry-sdk[flask]~=1.45
+sentry-sdk[flask]~=2.63

--- a/requirements.txt
+++ b/requirements.txt
@@ -1017,9 +1017,9 @@ segno==1.6.6 \
     --hash=sha256:28c7d081ed0cf935e0411293a465efd4d500704072cdb039778a2ab8736190c7 \
     --hash=sha256:e60933afc4b52137d323a4434c8340e0ce1e58cec71439e46680d4db188f11b3
     # via notifications-utils
-sentry-sdk==1.45.1 \
-    --hash=sha256:608887855ccfe39032bfd03936e3a1c4f4fc99b3a4ac49ced54a4220de61c9c1 \
-    --hash=sha256:a16c997c0f4e3df63c0fc5e4207ccb1ab37900433e0f72fef88315d317829a26
+sentry-sdk==2.63.0 \
+    --hash=sha256:2a1502bf864769275dbc8c2c9fc7a0f7f5e18358180b615d262d13a31ffba216 \
+    --hash=sha256:3a9b5ddd403f79eb73bd670f75f04485819db53d28f76ced7bc09041cb0dfd6a
     # via -r requirements.in
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1293,9 +1293,9 @@ segno==1.6.6 \
     # via
     #   -r requirements.txt
     #   notifications-utils
-sentry-sdk==1.45.1 \
-    --hash=sha256:608887855ccfe39032bfd03936e3a1c4f4fc99b3a4ac49ced54a4220de61c9c1 \
-    --hash=sha256:a16c997c0f4e3df63c0fc5e4207ccb1ab37900433e0f72fef88315d317829a26
+sentry-sdk==2.63.0 \
+    --hash=sha256:2a1502bf864769275dbc8c2c9fc7a0f7f5e18358180b615d262d13a31ffba216 \
+    --hash=sha256:3a9b5ddd403f79eb73bd670f75f04485819db53d28f76ced7bc09041cb0dfd6a
     # via -r requirements.txt
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \


### PR DESCRIPTION
This requires changing the name of one argument to `sentry_sdk.init`.

The migration guide can be seen [here](https://github.com/getsentry/sentry-python/blob/master/MIGRATION_GUIDE.md)

Tested in a dev environment to confirm that we can still get data through as expected.