### PR TITLE
Remove `EXCLUDE_REQUIREMENTS_NEWER_THAN_DAYS` from `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2> /dev/null || echo "")
 
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 
-EXCLUDE_REQUIREMENTS_NEWER_THAN_DAYS ?= 7
-
 ## DEVELOPMENT
 
 .PHONY: bootstrap
@@ -71,7 +69,7 @@ fix-imports: ## Fix imports using ruff
 
 .PHONY: refreeze-requirements
 refreeze-requirements: ## Update unpinned requirements
-	EXTRA_UV_PIP_COMPILE_FLAGS="--upgrade --exclude-newer $(EXCLUDE_REQUIREMENTS_NEWER_THAN_DAYS)d" make freeze-requirements
+	EXTRA_UV_PIP_COMPILE_FLAGS="--upgrade" make freeze-requirements
 
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt


### PR DESCRIPTION
This is controlled by `uv.toml` now:
https://github.com/alphagov/notifications-admin/blob/128e956705c10fac805f70c5728f065180ab3a77/uv.toml#L3

Having it in here sometimes adds it to the flags the command is called with:
https://github.com/alphagov/notifications-admin/blob/361cae1084526ce3485ed9fc4b0ef120690d1c2f/requirements.txt#L2

And sometimes it is removed again:
https://github.com/alphagov/notifications-admin/blob/128e956705c10fac805f70c5728f065180ab3a77/requirements.txt#L2

When it is removed it causes confusion:
https://github.com/alphagov/notifications-template-preview/pull/994#pullrequestreview-4572574425

So lets not have it in the flags.