### PR TITLE
Update platform admin warning message for ‘delete this service’

### DIFF
--- a/app/templates/partials/flash_messages/archive_service_confirmation_message.html
+++ b/app/templates/partials/flash_messages/archive_service_confirmation_message.html
@@ -1,14 +1,11 @@
 {% if platform_admin %}
       <h2 class="banner-title">Are you sure you want to delete ‘{{service_name}}’?</h2>
       <br>
-      <p class="govuk-body">Before you delete this service: </p>
-           <ul class="govuk-list govuk-list--bullet">
-             <li>confirm the exact name of the service the user wants to delete</li>
-             <li>check the user has the ‘Manage settings, team and usage’ permission for this service</li>
-             <li>confirm the request with another team member who has the ‘Manage settings, team and usage’ permission</li>
-             <li>check if we need to raise an invoice</li>
-           </ul>
-       <p class="govuk-body">If the service can receive text messages, tell the user that the phone number for this service will stop working.</p>
+      <p class="govuk-body">Before you delete this service:</p>
+           <ol class="govuk-list govuk-list--bullet">
+             <li>Open the GOV.UK Notify support manual.</li>
+             <li>Follow the ‘Delete a service’ guidance.</li>
+           </ol>
 {% else %}
       <h2 class="govuk-body govuk-!-font-weight-bold">
           Are you sure you want to delete ‘{{current_service.name}}’? There’s no way to undo this.


### PR DESCRIPTION
The ‘delete a service’ process has changed.
We may iterate it again in the near future.
This content points platform admins to the support manual so they can always follow the latest guidance.