### PR TITLE
Bump utils to 121.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@120.1.0
+# This file was automatically copied from notifications-utils@121.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -135,7 +135,7 @@ def send_messages(service_id, template_id):
             )
         )
 
-    column_headings = get_spreadsheet_column_headings_from_template(template)
+    column_headings = fields_to_fill_in(template)
 
     return render_template(
         "views/send.html",
@@ -152,9 +152,7 @@ def send_messages(service_id, template_id):
 def get_example_csv(service_id, template_id):
     template = current_service.get_template(template_id)
     return (
-        Spreadsheet.from_rows(
-            [get_spreadsheet_column_headings_from_template(template), get_example_csv_rows(template)]
-        ).as_csv_data,
+        Spreadsheet.from_rows([fields_to_fill_in(template), get_example_csv_rows(template)]).as_csv_data,
         200,
         {
             "Content-Type": "text/csv; charset=utf-8",
@@ -1047,22 +1045,6 @@ def get_email_reply_to_address_from_session():
 def get_sms_sender_from_session():
     if session.get("sender_id"):
         return current_service.get_sms_sender(session["sender_id"])["sms_sender"]
-
-
-def get_spreadsheet_column_headings_from_template(template):
-    column_headings = []
-
-    if template.template_type == "letter":
-        # We want to avoid showing `address line 7` for now
-        recipient_columns = letter_address_columns
-    else:
-        recipient_columns = first_column_headings[template.template_type]
-
-    for column_heading in recipient_columns + list(template.placeholders):
-        if column_heading not in InsensitiveDict.from_keys(column_headings):
-            column_headings.append(column_heading)
-
-    return column_headings
 
 
 def get_recipient():

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -45,7 +45,7 @@ from app.utils import PermanentRedirect, should_skip_template_page
 from app.utils.csv import Spreadsheet, get_errors_for_csv
 from app.utils.user import user_has_permissions
 
-letter_address_columns = [column.replace("_", " ") for column in address_lines_1_to_7_keys]
+letter_address_columns = InsensitiveSet(column.replace("_", " ") for column in address_lines_1_to_7_keys)
 
 
 def get_example_csv_fields(column_headers, use_example_as_example, submitted_fields):
@@ -66,11 +66,7 @@ def get_example_csv_rows(template, use_example_as_example=True, submitted_fields
             for key in letter_address_columns
         ],
     }[template.template_type] + get_example_csv_fields(
-        (
-            placeholder
-            for placeholder in template.placeholders
-            if placeholder not in InsensitiveSet(first_column_headings[template.template_type])
-        ),
+        template.placeholders - first_column_headings[template.template_type],
         use_example_as_example,
         submitted_fields,
     )
@@ -778,10 +774,10 @@ def start_job(service_id, upload_id):
 
 def fields_to_fill_in(template, prefill_current_user=False):
     if "letter" == template.template_type:
-        return InsensitiveSet(letter_address_columns + list(template.placeholders))
+        return letter_address_columns | template.placeholders
 
     if not prefill_current_user:
-        return InsensitiveSet(first_column_headings[template.template_type] + list(template.placeholders))
+        return first_column_headings[template.template_type] | template.placeholders
 
     if template.template_type == "sms":
         session["recipient"] = current_user.mobile_number

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -69,7 +69,7 @@ def get_example_csv_rows(template, use_example_as_example=True, submitted_fields
         (
             placeholder
             for placeholder in template.placeholders
-            if placeholder not in InsensitiveDict.from_keys(first_column_headings[template.template_type])
+            if placeholder not in InsensitiveSet(first_column_headings[template.template_type])
         ),
         use_example_as_example,
         submitted_fields,

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@120.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@121.0.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -756,7 +756,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@6c3744d9b7eb1c7554833737cceb2d25f2944824
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c202643dda528216441a4cac3f7cf2797088d33f
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -932,7 +932,7 @@ moto==5.2.2 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@6c3744d9b7eb1c7554833737cceb2d25f2944824
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c202643dda528216441a4cac3f7cf2797088d33f
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@120.1.0
+# This file was automatically copied from notifications-utils@121.0.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@120.1.0
+# This file was automatically copied from notifications-utils@121.0.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@120.1.0
+# This file was automatically copied from notifications-utils@121.0.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
Breaking change is replacing the use of `InsensitiveDict.from_keys()` with `InsensitiveSet`, which enables some nice refactors.

***

## 121.0.0

* Removes `InsensitiveDict.from_keys`
* Removes the `override_duplicates` argument to `InsensitiveDict`

## 120.2.0

* Adds the ability to specify per-project config for uv by creating an optional `uv-overrides.toml` file

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/120.1.0...121.0.0