### PR TITLE
Show cost of text message on the ‘preview sending’ page

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -14,6 +14,7 @@ from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
+from notifications_utils.recipient_validation.phone_number import PhoneNumber
 from notifications_utils.recipient_validation.postal_address import PostalAddress, address_lines_1_to_7_keys
 from notifications_utils.recipients import RecipientCSV, first_column_headings
 
@@ -947,9 +948,15 @@ def _check_notification(service_id, template_id, exception=None):
 
     template.values = get_recipient_and_placeholders_from_session(template.template_type)
 
+    rate_multiplier = None
+
+    if template.template_type == "sms":
+        rate_multiplier = PhoneNumber(template.values["phonenumber"]).get_international_phone_info().rate_multiplier
+
     return dict(
         template=template,
         back_link=back_link,
+        rate_multiplier=rate_multiplier,
         **(get_template_error_dict(exception) if exception else {}),
     )
 

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -70,6 +70,11 @@
   {{ template|string }}
 
   <div class="js-stick-at-bottom-when-scrolling">
+    {% if current_user.has_permissions("manage_service", "manage_templates") and rate_multiplier %}
+    <p class="govuk-body govuk-hint govuk-!-margin-bottom-4">
+      Will be charged as {{ (template.fragment_count * rate_multiplier) | message_count(template.template_type) }}
+    </p>
+    {% endif %}
     <form method="post" enctype="multipart/form-data" action="{{url_for(
         'main.send_notification',
         service_id=current_service.id,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -32,6 +32,7 @@ from tests.conftest import (
     create_multiple_email_reply_to_addresses,
     create_multiple_sms_senders,
     create_service_one_admin,
+    create_service_one_user,
     create_template,
     do_mock_get_page_counts_for_letter,
     mock_get_service_email_template,
@@ -4356,6 +4357,86 @@ def test_check_notification_shows_back_link(client_request, service_one, fake_uu
 
     previous_page = client_request.get_url(back_link)
     assert normalize_spaces(previous_page.select_one("label").text) == "thing"
+
+
+@pytest.mark.parametrize(
+    "template_content, personalisation, recipient, expected_cost_message",
+    (
+        (
+            "hello",
+            {},
+            "07900900123",
+            "Will be charged as 1 text message",
+        ),
+        (
+            "hello ((name))",
+            {"name": "a" * 161},
+            "07900900123",
+            "Will be charged as 2 text messages",
+        ),
+        (
+            "ŵ" * 80,
+            {},
+            "07900900123",
+            "Will be charged as 2 text messages",
+        ),
+        (
+            "Sending abroad",
+            {},
+            "+225 01 01 01 01 01",  # Côte d'Ivoire
+            "Will be charged as 10 text messages",
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "permissions",
+    [
+        ["send_texts", "send_emails", "send_letters", "manage_templates"],
+        ["send_texts", "send_emails", "send_letters", "manage_users", "manage_settings"],
+        pytest.param(
+            # All the permissions except manage templates/service
+            ["send_texts", "send_emails", "send_letters", "manage_api_keys", "view_activity"],
+            marks=pytest.mark.xfail(raises=AttributeError),  # Paragraph not found on page
+        ),
+    ],
+)
+def test_check_notification_shows_cost_of_text_message(
+    client_request,
+    template_content,
+    personalisation,
+    recipient,
+    expected_cost_message,
+    permissions,
+    fake_uuid,
+    mocker,
+):
+    user = create_service_one_user(
+        id=fake_uuid,
+        permissions={SERVICE_ONE_ID: permissions},
+    )
+    client_request.login(user)
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={
+            "data": template_json(
+                service_id=SERVICE_ONE_ID,
+                id_=fake_uuid,
+                type_="sms",
+                content=template_content,
+            )
+        },
+    )
+    with client_request.session_transaction() as session:
+        session["recipient"] = recipient
+        session["placeholders"] = personalisation
+
+    page = client_request.get(
+        "main.check_notification",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+    )
+
+    assert normalize_spaces(page.select_one("p.govuk-hint").text) == expected_cost_message
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_tour.py
+++ b/tests/app/main/views/test_tour.py
@@ -484,6 +484,9 @@ def test_should_200_for_check_tour_notification(
         "main.send_notification", service_id=SERVICE_ONE_ID, template_id=fake_uuid, help="3"
     )
 
+    # Don’t show cost data in the tour
+    assert "Will be charged" not in normalize_spaces(page.select_one("main").text)
+
 
 def test_back_link_from_check_tour_notification_points_to_last_tour_step(
     client_request,

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -427,6 +427,8 @@
     "/using-notify/delivery-status",
     "/using-notify/delivery-times",
     "/using-notify/email-branding",
+    "/using-notify/fonts-typefaces",
+    "/using-notify/fonts-typefaces/<template_type:notification_type>",
     "/using-notify/formatting",
     "/using-notify/get-started",
     "/using-notify/guidance",


### PR DESCRIPTION
We show an estimate of the cost of a text message when editing a template. However this will always be an estimate because:
- we don’t know how the message will be personalised
- we don’t know if the message will be sent to an international phone number

To better help users understand how text messages pricing works this commit adds the same cost information to the page the user sees before sending a message. This number will be exact because we know all the information that impacts the cost at this point.

We’re only going to show this information to people who have either the edit templates or manage service permission. This upholds a long-standing Notify principle that people who only have permission to send messages shouldn’t be using cost as a basis for whether or not to send the message – either it needs to be sent or it doesn’t.

We’re also not showing it in the tour because we don’t want to overload people with the cost information while they are trying to understand personalisation. Plus they will always be within the free allowance at this point.

# Before 

<img width="769" height="434" alt="image" src="https://github.com/user-attachments/assets/d4ea1525-bc49-4953-83c6-e00dc047a3e0" />

# After 

<img width="769" height="487" alt="image" src="https://github.com/user-attachments/assets/88b6ca62-1854-4f3e-944f-c4b4d7cd747d" />
