### PR TITLE
fix rounding error with fractional pence to display pence to 1 decimal point

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -263,7 +263,7 @@ def nl2br(value):
 
 
 def format_pounds_as_currency(number: float):
-    return format_pennies_as_currency(round(number * 100), long=False)
+    return format_pennies_as_currency(round(number * 100, ndigits=0), long=False)
 
 
 def format_pennies_as_currency(pennies: int | float, long: bool) -> str:
@@ -272,7 +272,11 @@ def format_pennies_as_currency(pennies: int | float, long: bool) -> str:
     if pennies >= 100:
         pennies = round(pennies)
         return f"£{pennies // 100:,}.{pennies % 100:02}"
-    elif long:
+    # non-fractional pence should be reported to 2 sf 82 p not 82.0 p
+    if float(pennies) == float(int(pennies)):
+        pennies = round(pennies)
+
+    if long:
         return f"{pennies} pence"
 
     return f"{pennies}p"

--- a/app/models/letter_rates.py
+++ b/app/models/letter_rates.py
@@ -15,7 +15,7 @@ class LetterRate(JSONModel):
 
     @property
     def rate_in_pennies(self):
-        return int(round(self.rate * 100))
+        return round(self.rate * 100, ndigits=1)
 
 
 class LetterRates(ModelList):

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3914,7 +3914,7 @@ def test_unknown_channel_404s(
     [
         (
             "letter",
-            "It costs between 59 pence and £1.76 to send a letter using Notify.",
+            "It costs between 59.2 pence and £1.76 to send a letter using Notify.",
             "Send letters",
             ["email", "sms"],
             "False",
@@ -3923,7 +3923,7 @@ def test_unknown_channel_404s(
         ),
         (
             "letter",
-            "It costs between 59 pence and £1.76 to send a letter using Notify.",
+            "It costs between 59.2 pence and £1.76 to send a letter using Notify.",
             "Send letters",
             ["email", "sms", "letter"],
             "True",

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -36,7 +36,7 @@ def test_non_logged_in_user_can_see_homepage(
     )
     assert page.select_one("#whos-using-notify a")["href"] == url_for("main.performance")
 
-    assert "From 59 pence to print and post a one page letter" in normalize_spaces(page.text)
+    assert "From 59.2 pence to print and post a one page letter" in normalize_spaces(page.text)
 
 
 def test_logged_in_user_redirects_to_your_services(client_request):

--- a/tests/app/main/views/test_pricing.py
+++ b/tests/app/main/views/test_pricing.py
@@ -13,7 +13,7 @@ def test_guidance_pricing_letters(client_request, mock_get_letter_rates):
     first_row = pricing_rows[0]
     assert "1 sheet" in first_row.text
 
-    assert "59p" in first_row.text
+    assert "59.2p" in first_row.text
     assert "68p" in first_row.text
     assert "£1.49" in first_row.text
     assert "£1.56" in first_row.text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4557,7 +4557,7 @@ def mock_create_service_join_request(notify_admin, mocker):
 def mock_get_letter_rates(mocker):
     def _get_letter_rates():
         return [
-            {"post_class": "economy", "rate": "0.59", "sheet_count": 1, "start_date": "2024-06-30T23:00:00"},
+            {"post_class": "economy", "rate": "0.592", "sheet_count": 1, "start_date": "2024-06-30T23:00:00"},
             {"post_class": "second", "rate": "0.68", "sheet_count": 1, "start_date": "2024-06-30T23:00:00"},
             {"post_class": "first", "rate": "1.49", "sheet_count": 1, "start_date": "2024-06-30T23:00:00"},
             {"post_class": "europe", "rate": "1.56", "sheet_count": 1, "start_date": "2024-01-02T00:00:00"},


### PR DESCRIPTION
https://github.com/alphagov/notifications-api/commit/ad0b987c97fc0b0788bc16058ad17626cb9b1f14 updated letter pricing for economy mail to fractional pence. While billing etc. is expected to work fine with this, it doesn't display correctly on the pricing page in admin because we were rounding pence to 0 decimal points. THis now rounds to 1 decimal point to display the new economy pricing correctly.