### PR TITLE
Use `'recipient'` to get phone number from session

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -951,7 +951,7 @@ def _check_notification(service_id, template_id, exception=None):
     rate_multiplier = None
 
     if template.template_type == "sms":
-        rate_multiplier = PhoneNumber(template.values["phonenumber"]).get_international_phone_info().rate_multiplier
+        rate_multiplier = PhoneNumber(session["recipient"]).get_international_phone_info().rate_multiplier
 
     return dict(
         template=template,


### PR DESCRIPTION
I think the problem with using `'phonenumber'` on the template is that the case-and-whitespace-insensitivity doesn’t apply everywhere so this key could look like `phone_number` instead. And because we populate the session in the tests it’s hard to catch this.

There is a check on this line which ensures that `recipient` will always be present in the session:
https://github.com/alphagov/notifications-admin/blob/276cc1f12b53f2ba7ad4e168bf07ccfaa690049a/app/main/views/send.py#L944

So basically it’s more robust to use `'recipient'`

***

This is the error seen in the staging logs:
```
Traceback (most recent call last):
  File "/opt/venv/lib/python3.13/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/venv/lib/python3.13/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/vcap/app/app/utils/user.py", line 20, in wrap_func
    return func(*args, **kwargs)
  File "/home/vcap/app/app/main/views/send.py", line 918, in check_notification
    **_check_notification(service_id, template_id),
      ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vcap/app/app/main/views/send.py", line 954, in _check_notification
    rate_multiplier = PhoneNumber(template.values["phonenumber"]).get_international_phone_info().rate_multiplier
                                  ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'phonenumber'
```