### PR TITLE
Migrate table  to summary list on api/callbacks page

### DIFF
--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, optional_text_field with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% block service_page_title %}
   Callbacks
@@ -13,35 +13,83 @@
 
 {% block maincolumn_content %}
   {{ page_header('Callbacks') }}
-  <div class="bottom-gutter-3-2 dashboard-table body-copy-table">
-    {% call mapping_table(
-      caption='General',
-      field_headings=['Label', 'Value', 'Action'],
-      field_headings_visible=False,
-      caption_visible=False
+
+  {% set callback_configuration = [
+    {
+      "key": {
+        "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+        "text": "Delivery receipts"
+      },
+      "value": {
+        "text": current_service.delivery_status_callback_details.url or "Not set",
+        "classes": "govuk-summary-list__value--truncate" if current_service.delivery_status_callback_details.url else "govuk-summary-list__value--default"
+      },
+      "actions": {
+        "items": [
+          {
+            "href": url_for('main.delivery_status_callback', service_id=current_service.id),
+            "text": "Change",
+            "visuallyHiddenText": "delivery receipts callback settings",
+            "classes": "govuk-link--no-visited-state"
+          }
+        ]
+      }
+    }
+  ]%}
+
+  {% if current_service.has_permission("inbound_sms") %}
+    {% do callback_configuration.append(
+      {
+        "key": {
+          "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+          "text": "Received text messages"
+        },
+        "value": {
+          "text": current_service.inbound_sms_callback_details.url or "Not set",
+          "classes": "govuk-summary-list__value--truncate" if current_service.inbound_sms_callback_details.url else "govuk-summary-list__value--default"
+        },
+        "actions": {
+          "items": [
+            {
+              "href": url_for('main.received_text_messages_callback', service_id=current_service.id),
+              "text": "Change",
+              "visuallyHiddenText": "received text messages callback settings",
+              "classes": "govuk-link--no-visited-state"
+            }
+          ]
+        }
+      }
     ) %}
-      {% call row() %}
-        {{ text_field('Delivery receipts') }}
-        {{ optional_text_field(current_service.delivery_status_callback_details.url, truncate=true) }}
-        {{ edit_field('Change', url_for('main.delivery_status_callback', service_id=current_service.id)) }}
-      {% endcall %}
+  {% endif %}
 
-      {% if current_service.has_permission("inbound_sms") %}
-        {% call row() %}
-          {{ text_field('Received text messages') }}
-          {{ optional_text_field(current_service.inbound_sms_callback_details.url, truncate=true) }}
-          {{ edit_field('Change', url_for('main.received_text_messages_callback', service_id=current_service.id)) }}
-        {% endcall %}
-      {% endif %}
+  {% if current_service.has_permission("letter") %}
+    {% do callback_configuration.append(
+      {
+        "key": {
+          "classes": "notify-summary-list__key notify-summary-list__key--35-100",
+          "text": "Returned letters"
+        },
+        "value": {
+          "text": current_service.returned_letters_callback_details.url or "Not set",
+          "classes": "govuk-summary-list__value--truncate" if current_service.returned_letters_callback_details.url else "govuk-summary-list__value--default"
+        },
+        "actions": {
+          "items": [
+            {
+              "href": url_for('main.returned_letters_callback', service_id=current_service.id),
+              "text": "Change",
+              "visuallyHiddenText": "returned letters callback settings",
+              "classes": "govuk-link--no-visited-state"
+            }
+          ]
+        }
+      }
+    ) %}
+  {% endif %}
 
-      {% if current_service.has_permission("letter") %}
-        {% call row() %}
-          {{ text_field('Returned letters') }}
-          {{ optional_text_field(current_service.returned_letters_callback_details.url, truncate=true) }}
-          {{ edit_field('Change', url_for('main.returned_letters_callback', service_id=current_service.id)) }}
-        {% endcall %}
-      {% endif %}
+  {{ govukSummaryList({
+    "classes": "notify-summary-list govuk-!-margin-bottom-7",
+    "rows": callback_configuration
+  }) }}
 
-    {% endcall %}
-  </div>
 {% endblock %}

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -780,29 +780,29 @@ def test_callbacks_button_links_straight_to_delivery_status_if_service_has_no_in
     [
         pytest.param(
             [],
-            ["Delivery receipts Not set Change"],
+            ["Delivery receipts Not set Change delivery receipts callback settings"],
             marks=pytest.mark.xfail(reason="Endpoint will redirect to delivery receipts page"),
         ),
         (
             ["inbound_sms"],
             [
-                "Delivery receipts Not set Change",
-                "Received text messages Not set Change",
+                "Delivery receipts Not set Change delivery receipts callback settings",
+                "Received text messages Not set Change received text messages callback settings",
             ],
         ),
         (
             ["letter"],
             [
-                "Delivery receipts Not set Change",
-                "Returned letters Not set Change",
+                "Delivery receipts Not set Change delivery receipts callback settings",
+                "Returned letters Not set Change returned letters callback settings",
             ],
         ),
         (
             ["inbound_sms", "letter"],
             [
-                "Delivery receipts Not set Change",
-                "Received text messages Not set Change",
-                "Returned letters Not set Change",
+                "Delivery receipts Not set Change delivery receipts callback settings",
+                "Received text messages Not set Change received text messages callback settings",
+                "Returned letters Not set Change returned letters callback settings",
             ],
         ),
     ],
@@ -817,7 +817,7 @@ def test_callbacks_page_lists_correct_rows_depending_on_service_permissions(
         service_id=service_one["id"],
     )
 
-    assert [normalize_spaces(row.text) for row in page.select("main tbody tr")] == expected_rows
+    assert [normalize_spaces(row.text) for row in page.select("main .govuk-summary-list__row")] == expected_rows
 
 
 def test_callbacks_page_redirects_to_delivery_status_if_service_has_no_inbound_sms_or_letter_permissions(
@@ -988,9 +988,9 @@ def test_update_service_callback_without_changes_does_not_update(
         (
             None,
             {},
-            "Delivery receipts Not set Change",
-            "Received text messages Not set Change",
-            "Returned letters Not set Change",
+            "Delivery receipts Not set Change delivery receipts callback settings",
+            "Received text messages Not set Change received text messages callback settings",
+            "Returned letters Not set Change returned letters callback settings",
         ),
         (
             [
@@ -999,36 +999,36 @@ def test_update_service_callback_without_changes_does_not_update(
                 {"callback_id": uuid.uuid4(), "callback_type": "inbound_sms"},
             ],
             {"url": "https://generic.urls"},
-            "Delivery receipts https://generic.urls Change",
-            "Received text messages https://generic.urls Change",
-            "Returned letters https://generic.urls Change",
+            "Delivery receipts https://generic.urls Change delivery receipts callback settings",
+            "Received text messages https://generic.urls Change received text messages callback settings",
+            "Returned letters https://generic.urls Change returned letters callback settings",
         ),
         (
             [
                 {"callback_id": uuid.uuid4(), "callback_type": "delivery_status"},
             ],
             {"url": "https://delivery.receipts"},
-            "Delivery receipts https://delivery.receipts Change",
-            "Received text messages Not set Change",
-            "Returned letters Not set Change",
+            "Delivery receipts https://delivery.receipts Change delivery receipts callback settings",
+            "Received text messages Not set Change received text messages callback settings",
+            "Returned letters Not set Change returned letters callback settings",
         ),
         (
             [
                 {"callback_id": uuid.uuid4(), "callback_type": "returned_letter"},
             ],
             {"url": "https://returned.letter"},
-            "Delivery receipts Not set Change",
-            "Received text messages Not set Change",
-            "Returned letters https://returned.letter Change",
+            "Delivery receipts Not set Change delivery receipts callback settings",
+            "Received text messages Not set Change received text messages callback settings",
+            "Returned letters https://returned.letter Change returned letters callback settings",
         ),
         (
             [
                 {"callback_id": uuid.uuid4(), "callback_type": "inbound_sms"},
             ],
             {"url": "https://inbound.sms"},
-            "Delivery receipts Not set Change",
-            "Received text messages https://inbound.sms Change",
-            "Returned letters Not set Change",
+            "Delivery receipts Not set Change delivery receipts callback settings",
+            "Received text messages https://inbound.sms Change received text messages callback settings",
+            "Returned letters Not set Change returned letters callback settings",
         ),
     ],
 )
@@ -1055,7 +1055,7 @@ def test_callbacks_page_works_when_no_apis_set(
         expected_2nd_row,
         expected_3rd_row,
     ]
-    rows = page.select("tbody tr")
+    rows = page.select("main .govuk-summary-list__row")
     assert len(rows) == 3
     for index, row in enumerate(expected_rows):
         assert row == normalize_spaces(rows[index].text)


### PR DESCRIPTION
Summary list is a more appropriate way to represent key:value pairs

- replace "bottom-gutter-3-2 wrapper with responsive margin on the summary list
(govuk-!-margin-bottom-7)
- apply size to key item and truncated and default (Not set) styles as we do on the
service settings page
- update "Change" links to be more descriptive for SR users

**Before**
<img width="790" height="231" alt="before" src="https://github.com/user-attachments/assets/1d902416-d33b-43c0-ad03-6bb92cfe7817" />


**After**
<img width="771" height="234" alt="after" src="https://github.com/user-attachments/assets/e220add1-6302-43e1-880a-b76784b36e78" />
