### PR TITLE
Navigate to user info from org team member list 

### DIFF
--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -25,7 +25,13 @@
           <div class="govuk-grid-column-three-quarters">
             <h2 class="user-list-item-heading">
               {%- if user.name -%}
-                <span class="heading-small">{{ user.name }}</span>&ensp;
+                {% if current_user.platform_admin and not user.is_invited_user%}
+                  <span class="heading-small">
+                    <a class="govuk-link govuk-link--text-colour" href="{{ url_for('main.user_information', user_id=user.id) }}">
+                  </span>&ensp;
+                {% else %}
+                  <span class="heading-small">{{ user.name }}</span>&ensp;
+                {% endif %}
               {%- endif -%}
               <span class="hint">
                 {%- if user.is_invited_user and user.status == 'pending' -%}


### PR DESCRIPTION
Platform admin only feature:

- Allows platform admins to click on a users name  in an org team member list to support with queries for user contact info etc.
- Exact same pattern that's already used on the service team member view.