### PR TITLE
block sms sending to china

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@121.0.0
+# This file was automatically copied from notifications-utils@123.3.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from notifications_utils.letter_timings import (
     CANCELLABLE_JOB_LETTER_STATUSES,
-    get_letter_timings,
+    LetterTimings,
     letter_can_be_cancelled,
 )
 from werkzeug.utils import cached_property
@@ -175,7 +175,7 @@ class Job(JSONModel):
 
     @property
     def letter_timings(self):
-        return get_letter_timings(self.created_at, postage=self.postage)
+        return LetterTimings(self.created_at.replace(tzinfo=None), postage=self.postage)
 
     @property
     def failure_rate(self):

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from markupsafe import Markup
 from notifications_utils.interruptible_io import InterruptibleIterableMixin
-from notifications_utils.letter_timings import get_letter_timings, letter_can_be_cancelled
+from notifications_utils.letter_timings import LetterTimings, letter_can_be_cancelled
 from notifications_utils.template import (
     LetterPreviewTemplate,
     SMSBodyPreviewTemplate,
@@ -126,7 +126,7 @@ class Notification(JSONModel):
     @property
     def estimated_letter_delivery_date(self):
         if self.notification_type == "letter":
-            return get_letter_timings(self.created_at.replace(tzinfo=None), postage=self.postage).latest_delivery
+            return LetterTimings(self.created_at.replace(tzinfo=None), postage=self.postage).latest_delivery
 
     @property
     def letter_can_be_cancelled(self):

--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -3,6 +3,7 @@
 {% from "components/table.html" import mapping_table, row, text_field, field %}
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Pricing information' %}
@@ -12,6 +13,16 @@ Text message pricing
 {% endblock %}
 
 {% block content_column_content %}
+
+{% call govukNotificationBanner({
+    "titleText": "You can no longer send text messages to China",
+    "classes": "govuk-!-margin-top-9"
+  }) %}
+    <p class="govuk-body govuk-!-font-weight-bold">
+      Some mobile phone networks in China are rejecting text messages sent by GOV.UK Notify.
+      Until we can find a solution, you can no longer send text messages to the +86 country code.
+    </p>
+  {% endcall %}
 
   <h1 class="heading-large">Text message pricing</h1>
 
@@ -43,7 +54,7 @@ Text message pricing
   <p class="govuk-body">The size of the allowance depends on the organisation you work for.</p>
 
   <div class="bottom-gutter-3-2">
-    
+
     {% set central_government_organisations_text %}
     Central government departments and <br>national organisations
     {% endset %}

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@121.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@123.3.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -756,7 +756,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c202643dda528216441a4cac3f7cf2797088d33f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55644124cbb38ab581f5a687bfcf52f4c28db012
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -932,7 +932,7 @@ moto==5.2.2 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c202643dda528216441a4cac3f7cf2797088d33f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55644124cbb38ab581f5a687bfcf52f4c28db012
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@121.0.0
+# This file was automatically copied from notifications-utils@123.3.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@121.0.0
+# This file was automatically copied from notifications-utils@123.3.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/main/views/test_pricing.py
+++ b/tests/app/main/views/test_pricing.py
@@ -64,5 +64,5 @@ def test_guidance_pricing_sms(
     page = client_request.get(".guidance_pricing_text_messages")
 
     assert normalize_spaces(page.select_one(".content-metadata").text) == expected_last_updated
-    assert normalize_spaces(page.select("main .govuk-body")[0].text) == expected_first_paragraph
-    assert normalize_spaces(page.select("main .govuk-body")[1].text) == expected_second_paragraph
+    assert normalize_spaces(page.select("main .govuk-body")[1].text) == expected_first_paragraph
+    assert normalize_spaces(page.select("main .govuk-body")[2].text) == expected_second_paragraph

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@121.0.0
+# This file was automatically copied from notifications-utils@123.3.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
Removes China from our list of allowed countries after issues successfully sending to China were discovered:

<img width="656" height="405" alt="Screenshot 2026-07-17 at 12 37 01" src="https://github.com/user-attachments/assets/61ad9626-b108-4c21-bd43-442a1acb417d" />

Adds Banner to the top of the pricing page:
<img width="897" height="493" alt="Screenshot 2026-07-17 at 13 15 26" src="https://github.com/user-attachments/assets/0b16bc8b-8a26-4c26-aa01-698c2c34a460" />


