### PR TITLE
Convert tables with single fields to unordered lists

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -332,3 +332,18 @@ $govuk-touch-target-size: ($govuk-checkboxes-size + $govuk-touch-target-gutter);
 .govuk-error-summary__list a {
   word-break: break-word;
 }
+
+// extending the list component
+// border between items
+.govuk-list--bordered > li {
+  border-top: 1px solid govuk-functional-colour(border);
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  // with borders we're using padding to control spacing,
+  // so this removes the additional margin added by the Design System styles
+  margin-bottom: 0; 
+}
+.govuk-list--bordered > li:last-of-type {
+  border-bottom: 1px solid govuk-functional-colour(border);
+  padding-bottom: govuk-spacing(2);
+}

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -343,7 +343,19 @@ $govuk-touch-target-size: ($govuk-checkboxes-size + $govuk-touch-target-gutter);
   // so this removes the additional margin added by the Design System styles
   margin-bottom: 0; 
 }
+
 .govuk-list--bordered > li:last-of-type {
   border-bottom: 1px solid govuk-functional-colour(border);
   padding-bottom: govuk-spacing(2);
+}
+
+// list with link and metadata
+.govuk-list__with-link-and-metadata a {
+  @include govuk-typography-weight-bold;
+}
+
+.govuk-list__with-link-and-metadata p {
+  @include govuk-font-size(16);
+  color: govuk-functional-colour(secondary-text);
+  margin-bottom: 0;
 }

--- a/app/templates/views/returned-letter-summary.html
+++ b/app/templates/views/returned-letter-summary.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, row_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
@@ -29,23 +28,23 @@
     {% endif %}
   </div>
 </div>
-<div class="dashboard-table">
-    {% call(item, row_number) list_table(
-        data,
-        caption="Returned letters report",
-        caption_visible=False,
-        empty_message='If you have returned letter reports they will be listed here',
-        field_headings=['Report'],
-        field_headings_visible=False
-    ) %}
-    {% call row_heading() %}
-      <a class="govuk-link govuk-link--no-visited-state file-list-filename"
-         href="{{url_for('main.returned_letters', service_id=current_service.id, reported_at=item.reported_at)}}">{{ item.reported_at | format_date_normal }}</a>
-       <p class="file-list-hint">
-         {{ item.returned_letter_count|format_thousands }} {{ item.returned_letter_count|message_count_label('letter', suffix='')}}
-       </p>
-    {% endcall %}
-  {% endcall %}
-</div>
+
+{% if data %}
+  <ul class="returned-letters-list govuk-list govuk-list--bordered govuk-list__with-link-and-metadata">
+    {% for item in data %}
+    <li>
+      <a class="govuk-link govuk-link--no-visited-state"
+         href="{{url_for('main.returned_letters', service_id=current_service.id, reported_at=item.reported_at)}}">
+         {{ item.reported_at | format_date_normal }}
+      </a>
+      <p class="govuk-body">
+        {{ item.returned_letter_count|format_thousands }} {{ item.returned_letter_count|message_count_label('letter', suffix='')}}
+      </p>
+    </li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <p class="govuk-body">If you have returned letter reports they will be listed here</p>
+{% endif %}
 
 {% endblock %}

--- a/app/templates/views/uploads/contact-list/contact-list.html
+++ b/app/templates/views/uploads/contact-list/contact-list.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/big-number.html" import big_number %}
-{% from "components/table.html" import list_table, field, text_field, row_heading %}
+{% from "components/table.html" import list_table, field, row_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
@@ -104,25 +104,20 @@
 
   {% set recipient_column = contact_list.recipients.column_headers[0] %}
 
-  <div class="body-copy-table">
-    {% call(item, row_number) list_table(
-      contact_list.recipients.displayed_rows,
-      caption=contact_list.recipients|length|recipient_count_label(contact_list.template_type)|capitalize,
-      caption_visible=False,
-      field_headings=[recipient_column],
-      field_headings_visible=False,
-    ) %}
-      {{ text_field(item[recipient_column].data) }}
-    {% endcall %}
+  <ul class="contact-list govuk-list govuk-list--bordered">
+    {% for item in contact_list.recipients.displayed_rows %}
+    <li>
+      {{ item[recipient_column].data }}
+    </li>
+    {% endfor %}
+  </ul>
 
-    {% if contact_list.recipients.displayed_rows|list|length < contact_list.recipients|length %}
-      <p class="table-show-more-link">
-        Only showing the first {{ contact_list.recipients.displayed_rows|list|length }} rows
-      </p>
-    {% endif %}
-  </div>
-
-
+  {% if contact_list.recipients.displayed_rows|list|length < contact_list.recipients|length %}
+    <p class="govuk-body more-items-available-text">
+      Only showing the first {{ contact_list.recipients.displayed_rows|list|length }} rows
+    </p>
+  {% endif %}
+ 
   <div class="js-stick-at-bottom-when-scrolling">
     <div class="page-footer">
       {% if not confirm_delete_banner %}

--- a/tests/app/main/views/test_returned_letters.py
+++ b/tests/app/main/views/test_returned_letters.py
@@ -49,9 +49,11 @@ def test_returned_letter_summary(
     mock.assert_called_once_with(SERVICE_ONE_ID)
 
     assert page.select_one("h1").string.strip() == "Returned letters"
-    assert [normalize_spaces(p.text) for p in page.select("main p.govuk-body")] == expected_paragraphs
-    assert normalize_spaces(page.select_one(".table-field").text) == "24 December 2019 1,234 letters"
-    assert page.select_one(".table-field a")["href"] == url_for(
+    assert [
+        normalize_spaces(p.text) for p in page.select("main p.govuk-body:not(ul p.govuk-body)")
+    ] == expected_paragraphs
+    assert normalize_spaces(page.select_one(".returned-letters-list li").text) == "24 December 2019 1,234 letters"
+    assert page.select_one(".returned-letters-list li a")["href"] == url_for(
         ".returned_letters",
         service_id=SERVICE_ONE_ID,
         reported_at="2019-12-24",
@@ -67,7 +69,7 @@ def test_returned_letter_summary_with_one_letter(client_request, mock_get_api_ke
     mock.assert_called_once_with(SERVICE_ONE_ID)
 
     assert page.select_one("h1").string.strip() == "Returned letters"
-    assert normalize_spaces(page.select_one(".table-field").text) == "24 December 2019 1 letter"
+    assert normalize_spaces(page.select_one(".returned-letters-list li").text) == "24 December 2019 1 letter"
 
 
 def test_returned_letters_page(client_request, mocker):

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -461,20 +461,20 @@ def test_view_contact_list(
         service_id=SERVICE_ONE_ID,
         contact_list_id=fake_uuid,
     )
-    assert len(page.select("tbody tr")) == 50
+    assert len(page.select(".contact-list li")) == 50
     assert [
-        normalize_spaces(page.select("tbody tr")[0].text),
-        normalize_spaces(page.select("tbody tr")[1].text),
-        normalize_spaces(page.select("tbody tr")[48].text),
-        normalize_spaces(page.select("tbody tr")[49].text),
+        normalize_spaces(page.select(".contact-list li")[0].text),
+        normalize_spaces(page.select(".contact-list li")[1].text),
+        normalize_spaces(page.select(".contact-list li")[48].text),
+        normalize_spaces(page.select(".contact-list li")[49].text),
     ] == [
         "test-0@example.com",
         "test-1@example.com",
         "test-48@example.com",
         "test-49@example.com",
     ]
-    assert "test-50@example.com" not in page.select_one("tbody").text
-    assert normalize_spaces(page.select_one(".table-show-more-link").text) == "Only showing the first 50 rows"
+    assert "test-50@example.com" not in page.select_one(".contact-list").text
+    assert normalize_spaces(page.select_one(".more-items-available-text").text) == "Only showing the first 50 rows"
 
 
 @freeze_time("2015-12-31 16:51:56")


### PR DESCRIPTION
## What 

Convert tables with single fields to use an unordered list.
- app/templates/views/uploads/contact-list/contact-list.html
- app/templates/views/returned-letter-summary.html

utilising the Design system's `govuk-list` and extending it to create a border list and list with metadata


## Review

To test the contact-list, upload a CSV or phone number or email addresses.

To test the list of returned letters you can use the below script to insert some dummy data in your local DB
```
INSERT INTO returned_letters (
    id, 
    reported_at, 
    service_id, 
    notification_id, 
    created_at, 
    updated_at
) VALUES 
(
    '8517c43e-63fa-4921-bdd0-eef86683f23d', 
    '2026-07-01', 
    'yourserviceid', 
    'cd44b76e-bdf3-44e2-94ad-88e86c75fd59', 
    '2026-07-01 12:51:28.011264', 
    NULL
),
(
    '06f55df0-5d51-4fce-a7c2-c50331027dd2', 
    '2026-07-01', 
    'yourserviceid', 
    '39b579c0-ec0e-4365-86e3-8ad9e34ee02f', 
    '2026-07-01 08:02:42.989609', 
    NULL
);
``` 

and then view the list on `services/<serviceID>/returned-letters` 

## Visuals

**Before**
<img width="755" height="267" alt="list-before" src="https://github.com/user-attachments/assets/9f10e694-9a20-4b53-afbe-561142fbc54d" />

**After**
<img width="767" height="271" alt="list-after" src="https://github.com/user-attachments/assets/5922ae41-0f76-41c6-ad91-e06505550f78" />

**Before**
<img width="543" height="379" alt="metadatalist-before" src="https://github.com/user-attachments/assets/edccc085-4a37-4284-ba3d-45d82f5aa32b" />

**After**
<img width="551" height="369" alt="metadatalist-after" src="https://github.com/user-attachments/assets/e841c87e-8f4e-442e-8581-4eb8b9c086ee" />
