### PR TITLE
Tweak banner markup on text message pricing page

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -20,6 +20,8 @@ Text message pricing
   }) %}
     <p class="govuk-body govuk-!-font-weight-bold">
       Some mobile phone networks in China are rejecting text messages sent by GOV.UK Notify.
+    </p>
+    <p class="govuk-body govuk-!-font-weight-bold">
       Until we can find a solution, you can no longer send text messages to the +86 country code.
     </p>
   {% endcall %}

--- a/tests/app/main/views/test_pricing.py
+++ b/tests/app/main/views/test_pricing.py
@@ -64,5 +64,5 @@ def test_guidance_pricing_sms(
     page = client_request.get(".guidance_pricing_text_messages")
 
     assert normalize_spaces(page.select_one(".content-metadata").text) == expected_last_updated
-    assert normalize_spaces(page.select("main .govuk-body")[1].text) == expected_first_paragraph
-    assert normalize_spaces(page.select("main .govuk-body")[2].text) == expected_second_paragraph
+    assert normalize_spaces(page.select("main > .govuk-body")[0].text) == expected_first_paragraph
+    assert normalize_spaces(page.select("main > .govuk-body")[1].text) == expected_second_paragraph


### PR DESCRIPTION
Split into paragraphs and update test_pricing
<img width="889" height="491" alt="Screenshot 2026-07-17 at 15 20 17" src="https://github.com/user-attachments/assets/ac66a54b-b291-48c3-95b4-738316bddfd3" />
