### PR TITLE
Check agreeement_signed as well as agreeement_signed_by_id

### DIFF
--- a/app/templates/views/request-to-go-live.html
+++ b/app/templates/views/request-to-go-live.html
@@ -106,7 +106,7 @@
         {# the current user signed the org-level agreement #}
         {# this is because for other services in that org that want to go live #}
         {# we want to show a different text if org-level agreement already accepted #}
-        {% if current_service.able_to_accept_agreement and (current_service.organisation.agreement_signed_by_id == current_user.id or not current_service.organisation.agreement_signed_by_id) %}
+        {% if current_service.able_to_accept_agreement and (current_service.organisation.agreement_signed_by_id == current_user.id or not current_service.organisation.agreement_signed_by_id or not current_service.organisation.agreeement_signed)%}
           {{ govukTaskList({
             "idPrefix": "request-to-go-live-organisation",
             "items": [


### PR DESCRIPTION
If we don't do something like this we can get into a bad state.

This is where they have signed the agreement and then someone sets them not to have signed the agreement (due to a change of government or similar)

This sets agreement_signed to false but leaves agreement_signed_by_id, so it shows up in the UI as signed but still doesn't actually allow them to go live.