### PR TITLE
Remove custom padding from notify-summary list

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -114,8 +114,6 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 
   @include govuk-media-query($from: tablet) {
     font-weight: normal;
-    padding-top: govuk-spacing(3);
-    padding-bottom: govuk-spacing(2) + 1px;
     width: 33%;
   }
 


### PR DESCRIPTION
In https://github.com/alphagov/govuk-frontend/pull/6679 a change was made to align text in list and so our custom padding throws text into misalignment.

Removing custom padding and deferring to Design System styling resolves that.

**Before**

<img width="1496" height="584" alt="before" src="https://github.com/user-attachments/assets/dda040bc-03c2-4eaf-9871-e60202b292c1" />


**After**
<img width="1524" height="564" alt="after" src="https://github.com/user-attachments/assets/498b9e63-c50e-4dd0-b4b6-99f15d2cdf30" />
