### PR TITLE
Update template statistics "dashboard" tables to summary lists

### DIFF
--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -208,3 +208,15 @@ details .arrow {
 .form--inline {
   display: inline-flex;
 }
+
+// paragraph style for no data text
+// used on template statistics
+.no-data {
+  @include govuk-font(16);
+  color: govuk-functional-colour(secondary-text);
+  margin-top: 10px;
+  margin-bottom: govuk-spacing(7);
+  border-top: 1px solid govuk-functional-colour(border);
+  border-bottom: 1px solid govuk-functional-colour(border);
+  padding: 0.75em 0 0.5625em 0;
+}

--- a/app/assets/stylesheets/components/spark-bar.scss
+++ b/app/assets/stylesheets/components/spark-bar.scss
@@ -1,0 +1,26 @@
+@use 'govuk/helpers' as *;
+@use 'govuk/settings' as *;
+
+.spark-bar {
+  @include govuk-font(16);
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  margin-bottom: govuk-spacing(3);
+  color: govuk-functional-colour(text);
+  text-align: left;
+}
+
+.spark-bar__bar {
+  @include govuk-font(27, $weight: bold, $tabular: true);
+  box-sizing: border-box;
+  display: inline-block;
+  overflow: visible;
+  background: mix(black, govuk-colour('black', $variant: "tint-95"), 7%);
+  color: govuk-functional-colour(text);
+  padding: 10px 6px 8px 0;
+  text-indent: 12px;
+  text-align: right;
+  margin: 2px 0 1px 0;
+  transition: width 0.6s ease-in-out;
+}

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -425,16 +425,6 @@ a.table-show-more-link {
   color: govuk-functional-colour(link);
 }
 
-.table-no-data {
-  @include govuk-font(16);
-  color: govuk-functional-colour(secondary-text);
-  margin-top: 10px;
-  margin-bottom: govuk-spacing(7);
-  border-top: 1px solid govuk-functional-colour(border);
-  border-bottom: 1px solid govuk-functional-colour(border);
-  padding: 0.75em 0 0.5625em 0;
-}
-
 .wide-left-hand-column {
   display: block;
   max-width: 560px;

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -110,6 +110,25 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 
 }
 
+// summary list with file name and metadata
+// there will be 2 variants
+// 24px filename and 19px metadata - template stats
+// 19px filename and 16px metadata - other lists
+
+.notify-summary-list__filename {
+  @include govuk-typography-weight-bold;
+}
+
+.notify-summary-list__filename--large {
+  @include govuk-font-size(24);
+}
+
+.notify-summary-list__metadata {
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: 0;
+  }
+}
+
 .notify-summary-list__key {
 
   @include govuk-media-query($from: tablet) {
@@ -125,6 +144,14 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 
   @include govuk-media-query($from: tablet) {
     width: 35%;
+  }
+
+}
+
+.notify-summary-list__key--50-100 {
+
+  @include govuk-media-query($from: tablet) {
+    width: 50%;
   }
 
 }

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -49,6 +49,7 @@
 @use 'components/simple-search-form';
 @use 'components/formatting-example';
 @use 'components/sender-email-preview';
+@use 'components/spark-bar';
 @use 'views/branding';
 @use 'views/dashboard';
 @use 'views/users';

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -18,33 +18,6 @@
   padding-top: govuk-spacing(3);
 }
 
-.spark-bar {
-
-  @include govuk-font(16);
-  box-sizing: border-box;
-  display: block;
-  width: 100%;
-  margin-bottom: govuk-spacing(3);
-  height: govuk-spacing(3);
-  color: govuk-functional-colour(text);
-  text-align: left;
-
-  &-bar {
-    @include govuk-font(27, $weight: bold, $tabular: true);
-    box-sizing: border-box;
-    display: inline-block;
-    overflow: visible;
-    background: mix(black, govuk-colour('black', $variant: "tint-95"), 7%);
-    color: govuk-functional-colour(text);
-    padding: 10px 6px 8px 0;
-    text-indent: 12px;
-    text-align: right;
-    margin: 2px 0 1px 0;
-    transition: width 0.6s ease-in-out;
-  }
-
-}
-
 .file-list {
 
   // for file-lists with section-like content and a single item

--- a/app/templates/components/spark-bar.html
+++ b/app/templates/components/spark-bar.html
@@ -1,0 +1,11 @@
+{% macro spark_bar(
+  count,
+  max_count,
+  id=None
+) %}
+<span {% if id %}id="{{ id }}"{% endif %} class="spark-bar">
+    <span class="spark-bar__bar" style="width: {{ count / max_count * 100 }}%">
+    {{ '{:,.0f}'.format(count) }}
+    </span>
+</span>
+{% endmacro %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -194,18 +194,3 @@
     {% endcall %}
   {% endif %}
 {% endmacro %}
-
-
-{% macro spark_bar_field(
-  count,
-  max_count,
-  id=None
-) %}
-  {% call field(align='right') %}
-    <span {% if id %}id="{{ id }}"{% endif %} class="spark-bar">
-      <span class="spark-bar-bar" style="width: {{ count / max_count * 100 }}%">
-        {{ '{:,.0f}'.format(count) }}
-      </span>
-    </span>
-  {% endcall %}
-{% endmacro %}

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -1,6 +1,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/pill.html" import pill %}
-{% from "components/table.html" import list_table, row_heading, spark_bar_field %}
+{% from "components/spark-bar.html" import spark_bar %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% extends "withnav_template.html" %}
 
@@ -24,31 +25,36 @@
     {% for month in months %}
       <h2>{{ month.name }}</h2>
       {% if not month.templates_used %}
-        <p class="table-no-data">
+        <p class="govuk-body no-data">
           No messages sent
         </p>
       {% else %}
-        <div class='template-statistics-table'>
-          {% call(item, row_number) list_table(
-            month.templates_used,
-            caption=month.name,
-            caption_visible=False,
-            empty_message='',
-            field_headings=[
-              'Template',
-              'Messages sent'
-            ],
-            field_headings_visible=False
-          ) %}
-            {% call row_heading() %}
-              <a class="govuk-link govuk-link--no-visited-state template-statistics-table-template-name" href="{{ url_for('main.view_template', service_id=current_service.id, template_id=item.id) }}">{{ item.name }}</a>
-              <span class="template-statistics-table-hint">
-                {{ 1|message_count_label(item.type, suffix='template')|capitalize }}
-              </span>
-            {% endcall %}
-            {{ spark_bar_field(item.requested_count, most_used_template_count) }}
-          {% endcall %}
-        </div>
+        {% set templates_used_month_data = [] %}
+        {% for item in month.templates_used %}
+            {% set summary_key_html %}
+              <a class="govuk-link govuk-link--no-visited-state notify-summary-list__filename notify-summary-list__filename--large"
+                href="{{ url_for('main.view_template', service_id=current_service.id, template_id=item.id) }}">
+                {{ item.name }}
+              </a>
+            <p class="govuk-body notify-summary-list__metadata">
+              {{ 1|message_count_label(item.type, suffix='template')|capitalize }}
+            </p>
+            {% endset %}
+            {% do templates_used_month_data.append({
+              "key": {
+                "classes": "notify-summary-list__key notify-summary-list__key--50-100",
+                "html": summary_key_html,
+              },
+              "value": {
+                "html": spark_bar(item.requested_count, most_used_template_count),
+              }
+            }) %}
+        {% endfor %}
+
+        {{ govukSummaryList({
+          "classes": "notify-summary-list",
+          "rows": templates_used_month_data
+        }) }}
       {% endif %}
     {% endfor %}
   </div>

--- a/app/templates/views/dashboard/template-statistics-lazy.html
+++ b/app/templates/views/dashboard/template-statistics-lazy.html
@@ -1,46 +1,39 @@
-{% from "components/table.html" import list_table, row_heading, field %}
 {% from "components/show-more.html" import show_more %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 <div class="ajax-block-container">
-    <div class='template-statistics-table'>
-      {% call(item, row_number) list_table(
-        [1],
-        caption="By template",
-        caption_visible=True,
-        empty_message='',
-        field_headings=[
-          'Template',
-          'Messages sent'
-        ],
-        field_headings_visible=False
-      ) %}
-
-        {% call row_heading() %}
-          <span class="template-statistics-table-template-name" aria-label="Loading data for templates">
-            <span class="spark-bar">
-              <span class="spark-bar-bar" style="width: 100%">
-                &nbsp;
-              </span>
-            </span>
-          </span>
-          <span class="template-statistics-table-hint">
-            &nbsp;
-          </span>
-        {% endcall %}
-
-        {% call field() %}
-          <span class="spark-bar" aria-label="Loading data for messages sent">
-            <span class="spark-bar-bar" style="width: 100%">
-              &nbsp;
-            </span>
-          </span>
-        {% endcall %}
-
-      {% endcall %}
-      {{ show_more(
-        url_for('main.template_usage', service_id=current_service.id),
-        'See templates used by month',
-        with_border=False
-      ) }}
-    </div>
+    <h2>By template</h2>
+    {% set summary_key_html %}
+      <span class="spark-bar" aria-label="Loading data for templates">
+        <span class="spark-bar__bar" style="width: 100%">
+          &nbsp;
+        </span>
+      </span>
+    {% endset %}
+    {% set summary_value_html %}
+      <span class="spark-bar" aria-label="Loading data for messages sent">
+        <span class="spark-bar__bar" style="width: 100%">
+          &nbsp;
+        </span>
+      </span>
+    {% endset %}
+    {{ govukSummaryList({
+      "classes": "notify-summary-list",
+      "rows": [
+        {
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--50-100",
+            "html": summary_key_html,
+          },
+          "value": {
+            "html": summary_value_html,
+          }
+        }
+      ]
+    }) }}
+    {{ show_more(
+      url_for('main.template_usage', service_id=current_service.id),
+      'See templates used by month',
+      with_border=False
+    ) }}
 </div>

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -1,44 +1,50 @@
-{% from "components/table.html" import list_table, row_heading, spark_bar_field %}
+{% from "components/spark-bar.html" import spark_bar %}
 {% from "components/show-more.html" import show_more %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 <div class="ajax-block-container">
   {% if template_statistics|length > 1 %}
-    <div class='template-statistics-table'>
-      {% call(item, row_number) list_table(
-        template_statistics,
-        caption="By template",
-        caption_visible=True,
-        empty_message='',
-        field_headings=[
-          'Template',
-          'Messages sent'
-        ],
-        field_headings_visible=False
-      ) %}
-
-        {% call row_heading() %}
+    <h2>By template</h2>
+    {% set template_stats = [] %}
+      {% for item in template_statistics %}
+        {% set summary_key_html %}
           {% if item.is_precompiled_letter %}
-          <span class="template-statistics-table-template-name">
-          Provided as PDF
-          </span>
-          <span class="template-statistics-table-hint">
-            Letter
-          </span>
+            <span class="notify-summary-list__key__filename">
+            Provided as PDF
+            </span>
+            <p class="govuk-body notify-summary-list__metadata">
+              Letter
+            </p>
           {% else %}
-          <a class="govuk-link govuk-link--no-visited-state template-statistics-table-template-name" href="{{ url_for('main.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
-          <span class="template-statistics-table-hint">
-            {{ 1|message_count_label(item.template_type, suffix='template')|capitalize }}
-          </span>
+            <a class="govuk-link govuk-link--no-visited-state notify-summary-list__filename notify-summary-list__filename--large"
+              href="{{ url_for('main.view_template', service_id=current_service.id, template_id=item.template_id) }}">
+              {{ item.template_name }}
+            </a>
+            <p class="govuk-body notify-summary-list__metadata">
+              {{ 1|message_count_label(item.template_type, suffix='template')|capitalize }}
+            </p>
           {% endif %}
-        {% endcall %}
+        {% endset %}
+        {% do template_stats.append({
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--50-100",
+            "html": summary_key_html,
+          },
+          "value": {
+            "html": spark_bar(item.count, most_used_template_count, id=item.template_id),
+          }
+        }) %}
+      {% endfor %}
 
-        {{ spark_bar_field(item.count, most_used_template_count, id=item.template_id) }}
-      {% endcall %}
+      {{ govukSummaryList({
+        "classes": "notify-summary-list",
+        "rows": template_stats
+      }) }}
+
       {{ show_more(
         url_for('main.template_usage', service_id=current_service.id),
         'See templates used by month',
         with_border=False
       ) }}
-    </div>
   {% endif %}
 </div>

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -689,25 +689,25 @@ def test_should_show_recent_templates_on_dashboard(
 
     mock_template_stats.assert_called_once_with(SERVICE_ONE_ID, limit_days=7)
 
-    table_rows = partial_page.select_one("tbody").select("tr")
+    list_rows = partial_page.select_one(".notify-summary-list").select(".govuk-summary-list__row")
 
-    assert len(table_rows) == 4
+    assert len(list_rows) == 4
 
-    assert "Provided as PDF" in table_rows[0].select("th")[0].text
-    assert "Letter" in table_rows[0].select("th")[0].text
-    assert "400" in table_rows[0].select("td")[0].text
+    assert "Provided as PDF" in list_rows[0].select("dt")[0].text
+    assert "Letter" in list_rows[0].select("dt")[0].text
+    assert "400" in list_rows[0].select("dd")[0].text
 
-    assert "three" in table_rows[1].select("th")[0].text
-    assert "Letter template" in table_rows[1].select("th")[0].text
-    assert "300" in table_rows[1].select("td")[0].text
+    assert "three" in list_rows[1].select("dt")[0].text
+    assert "Letter template" in list_rows[1].select("dt")[0].text
+    assert "300" in list_rows[1].select("dd")[0].text
 
-    assert "two" in table_rows[2].select("th")[0].text
-    assert "Email template" in table_rows[2].select("th")[0].text
-    assert "200" in table_rows[2].select("td")[0].text
+    assert "two" in list_rows[2].select("dt")[0].text
+    assert "Email template" in list_rows[2].select("dt")[0].text
+    assert "200" in list_rows[2].select("dd")[0].text
 
-    assert "one" in table_rows[3].select("th")[0].text
-    assert "Text message template" in table_rows[3].select("th")[0].text
-    assert "100" in table_rows[3].select("td")[0].text
+    assert "one" in list_rows[3].select("dt")[0].text
+    assert "Text message template" in list_rows[3].select("dt")[0].text
+    assert "100" in list_rows[3].select("dd")[0].text
 
 
 @pytest.mark.parametrize(
@@ -799,12 +799,12 @@ def test_should_show_monthly_breakdown_of_template_usage(
 
     mock_get_monthly_template_usage.assert_called_once_with(SERVICE_ONE_ID, 2016)
 
-    table_rows = page.select("tbody tr")
+    list_rows = page.select(".govuk-summary-list__row")
 
-    assert " ".join(table_rows[0].text.split()) == "My first template Text message template 2"
+    assert " ".join(list_rows[0].text.split()) == "My first template Text message template 2"
 
-    assert len(table_rows) == len(["April"])
-    assert len(page.select(".table-no-data")) == len(["May", "June", "July"])
+    assert len(list_rows) == len(["April"])
+    assert len(page.select(".no-data")) == len(["May", "June", "July"])
 
 
 def test_anyone_can_see_monthly_breakdown(
@@ -1986,6 +1986,7 @@ def test_service_dashboard_skeleton(
     assert [(heading.name, normalize_spaces(heading.text)) for heading in page.select("main h1, main h2, main h3")] == [
         ("h1", "Dashboard"),
         ("h2", "In the last 7 days"),
+        ("h2", "By template"),
         ("h2", "This year"),
     ]
 
@@ -2012,7 +2013,7 @@ def test_service_dashboard_skeleton(
         "letters sent failed – Unknown %",
     ]
 
-    assert normalize_spaces(template_statistics.select_one("table caption").text) == "By template"
+    assert normalize_spaces(template_statistics.select_one("h2").text) == "By template"
     assert template_statistics.select(".spark-bar")
 
     assert [


### PR DESCRIPTION
## What 

Replace template stats "dashboard" tables with a [summary list component](https://design-system.service.gov.uk/components/summary-list/). These stats are key:value pairs so from an accessibility standpoint, a summary list that's built on [description list](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl) element is more appropriate.

Key value pairs each take 50% of the available space and we no longer truncate the template name.

A new summary list modifier class introduced to contain needed styling.
Styles and jinja macro moved out of `table` as they're now n longer used in the table context.

## Review
- see individual commits for details.
- send some email with different templates to see stats.
- urls:
  - dashboard page: /services/<serviceId>
  - template usage: /services/<serviceId>/template-usage

## Visuals
**Dashboard page: lazy load and stats**
<img width="814" height="276" alt="dashboard-page" src="https://github.com/user-attachments/assets/2c93e0f3-371b-406b-ae0d-9590055daabb" />
<img width="804" height="206" alt="lazy-load" src="https://github.com/user-attachments/assets/44a6f5e0-f5d9-4729-a4b0-5783131b5ac0" />

**Template usage page**
<img width="811" height="644" alt="template-usage" src="https://github.com/user-attachments/assets/b28149ea-bdf8-4e49-b7ae-31ab790ead4d" />

