### PR TITLE
Use `RelaxedContainerJSONEncoder` to encode json payloads and `FlaskRelaxedContainerJSONProvider` as `json_provider_class`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@121.0.0
+# This file was automatically copied from notifications-utils@124.2.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,6 +33,7 @@ from notifications_utils.formatters import (
     formatted_list,
     get_lines_with_normalised_whitespace,
 )
+from notifications_utils.json import FlaskRelaxedContainerJSONProvider
 from notifications_utils.logging import flask as utils_logging
 from notifications_utils.safe_string import make_string_safe_for_email_local_part, make_string_safe_for_id
 from notifications_utils.sanitise_text import SanitiseASCII
@@ -178,6 +179,8 @@ navigation = {
 
 
 def create_app(application):
+    application.json_provider_class = FlaskRelaxedContainerJSONProvider
+
     notify_environment = os.environ["NOTIFY_ENVIRONMENT"]
 
     if notify_environment in configs:

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from notifications_utils.letter_timings import (
     CANCELLABLE_JOB_LETTER_STATUSES,
-    get_letter_timings,
+    LetterTimings,
     letter_can_be_cancelled,
 )
 from werkzeug.utils import cached_property
@@ -175,7 +175,7 @@ class Job(JSONModel):
 
     @property
     def letter_timings(self):
-        return get_letter_timings(self.created_at, postage=self.postage)
+        return LetterTimings(self.created_at.replace(tzinfo=None), postage=self.postage)
 
     @property
     def failure_rate(self):

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from markupsafe import Markup
 from notifications_utils.interruptible_io import InterruptibleIterableMixin
-from notifications_utils.letter_timings import get_letter_timings, letter_can_be_cancelled
+from notifications_utils.letter_timings import LetterTimings, letter_can_be_cancelled
 from notifications_utils.template import (
     LetterPreviewTemplate,
     SMSBodyPreviewTemplate,
@@ -126,7 +126,7 @@ class Notification(JSONModel):
     @property
     def estimated_letter_delivery_date(self):
         if self.notification_type == "letter":
-            return get_letter_timings(self.created_at.replace(tzinfo=None), postage=self.postage).latest_delivery
+            return LetterTimings(self.created_at.replace(tzinfo=None), postage=self.postage).latest_delivery
 
     @property
     def letter_can_be_cancelled(self):

--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -1,12 +1,29 @@
+from typing import Any
+
 from flask import g, has_request_context, request
 from flask_login import current_user
 from notifications_python_client import __version__
 from notifications_python_client.base import BaseAPIClient
 from notifications_utils.clients.redis import RequestCache
+from notifications_utils.json import RelaxedContainerJSONEncoder, StrictJsonTopLevelType
 
 from app.extensions import redis_client
 
 cache = RequestCache(redis_client)
+
+
+class _ExtraRelaxedContainerJSONEncoder(RelaxedContainerJSONEncoder):
+    """
+    A RelaxedContainerJSONEncoder that even coerces `set`s into serializable types, mostly
+    because BaseAPIClient has committed to that.
+    """
+
+    def default(self, obj: Any) -> StrictJsonTopLevelType:
+        match obj:
+            case set():
+                return tuple(obj)
+
+        return super().default(obj)
 
 
 def _attach_current_user(data):
@@ -49,6 +66,9 @@ class NotifyAdminAPIClient(BaseAPIClient):
                 headers["X-Notify-User-Id"] = g.user_id
 
         return headers
+
+    def _serialize_data(self, data: Any) -> str:
+        return _ExtraRelaxedContainerJSONEncoder().encode(data)
 
 
 class InviteTokenError(Exception):

--- a/app/notify_client/document_download_api_client.py
+++ b/app/notify_client/document_download_api_client.py
@@ -3,6 +3,7 @@ from contextvars import ContextVar
 
 import requests
 from flask import current_app, has_request_context, request
+from notifications_utils.json import RelaxedContainerJSONEncoder as RCJSONEncoder
 from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
@@ -42,7 +43,10 @@ class DocumentDownloadAPIClient:
         This method runs file validation checks and an antivirus scan and also determines the file mimetype
         """
         file_check_url = f"{self.base_url}/services/{service_id}/antivirus-and-mimetype-check"
-        headers = {"Authorization": f"Bearer {self.auth_token}"}
+        headers = {
+            "Authorization": f"Bearer {self.auth_token}",
+            "Content-Type": "application/json",
+        }
         file_data = {"document": base64.b64encode(file_bytes).decode("utf-8"), "filename": file_name}
 
         if has_request_context() and hasattr(request, "get_onwards_request_headers"):
@@ -52,7 +56,7 @@ class DocumentDownloadAPIClient:
             response = self.request_session.post(
                 file_check_url,
                 headers=headers,
-                json=file_data,
+                data=RCJSONEncoder().encode(file_data),
             )
             response.raise_for_status()
         except requests.RequestException as e:

--- a/app/s3_client/s3_letter_upload_client.py
+++ b/app/s3_client/s3_letter_upload_client.py
@@ -1,4 +1,3 @@
-import json
 import urllib
 
 import botocore
@@ -6,6 +5,7 @@ from boto3 import resource
 from flask import current_app
 from notifications_utils.eventlet import EventletTimeout
 from notifications_utils.exception_handling import extract_reraise_chained_exception
+from notifications_utils.json import RelaxedContainerJSONEncoder as RCJSONEncoder
 from notifications_utils.s3 import s3upload as utils_s3upload
 
 
@@ -42,7 +42,7 @@ def upload_letter_to_s3(
     if message:
         metadata["message"] = message
     if invalid_pages:
-        metadata["invalid_pages"] = json.dumps(invalid_pages)
+        metadata["invalid_pages"] = RCJSONEncoder().encode(invalid_pages)
     if recipient:
         metadata["recipient"] = urllib.parse.quote(recipient)
 

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -5,6 +5,7 @@ from io import BytesIO
 import requests
 from flask import abort, current_app, json, request
 from flask.ctx import has_request_context
+from notifications_utils.json import RelaxedContainerJSONEncoder as RCJSONEncoder
 from notifications_utils.local_vars import LazyLocalGetter
 from notifications_utils.pdf import extract_page_from_pdf
 from werkzeug.local import LocalProxy
@@ -63,8 +64,11 @@ class TemplatePreviewClient:
                 filetype,
                 f"?page={page}" if page else "",
             ),
-            json=data,
-            headers=self._get_outbound_headers(),
+            data=RCJSONEncoder().encode(data),
+            headers={
+                "Content-type": "application/json",
+                **self._get_outbound_headers(),
+            },
         )
         headers = list(self.get_allowed_headers(response.headers))
         if filetype == "pdf":
@@ -104,8 +108,11 @@ class TemplatePreviewClient:
                 self.api_host,
                 f"?page={page}" if page else "",
             ),
-            json=data,
-            headers=self._get_outbound_headers(),
+            data=RCJSONEncoder().encode(data),
+            headers={
+                "Content-type": "application/json",
+                **self._get_outbound_headers(),
+            },
         )
         return response.content, response.status_code, self.get_allowed_headers(response.headers)
 
@@ -125,8 +132,11 @@ class TemplatePreviewClient:
         }
         response = self.requests_session.post(
             f"{self.api_host}/get-page-count",
-            json=data,
-            headers=self._get_outbound_headers(),
+            data=RCJSONEncoder().encode(data),
+            headers={
+                "Content-type": "application/json",
+                **self._get_outbound_headers(),
+            },
         )
 
         page_count = json.loads(response.content.decode("utf-8"))

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -7,6 +7,7 @@ from notifications_utils.countries import Postage
 from notifications_utils.field import Field
 from notifications_utils.formatters import escape_html, formatted_list, normalise_whitespace
 from notifications_utils.insensitive_dict import InsensitiveSet
+from notifications_utils.json import RelaxedContainerJSONEncoder as RCJSONEncoder
 from notifications_utils.take import Take
 from notifications_utils.template import (
     BaseEmailTemplate,
@@ -180,7 +181,7 @@ class TemplatedLetterImageTemplate(BaseLetterImageTemplate):
             service=current_service,
             values=self.values,
         )
-        redis_client.set(cache_key, json.dumps(self._all_page_counts), ex=cache.DEFAULT_TTL)
+        redis_client.set(cache_key, RCJSONEncoder().encode(self._all_page_counts), ex=cache.DEFAULT_TTL)
 
         return self._all_page_counts
 

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@121.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@124.2.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -756,7 +756,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c202643dda528216441a4cac3f7cf2797088d33f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ace9443c2800adc8107f3bb8ac32e483724612d6
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -932,7 +932,7 @@ moto==5.2.2 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c202643dda528216441a4cac3f7cf2797088d33f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ace9443c2800adc8107f3bb8ac32e483724612d6
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@121.0.0
+# This file was automatically copied from notifications-utils@124.2.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@121.0.0
+# This file was automatically copied from notifications-utils@124.2.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2218,39 +2218,38 @@ def test_dont_show_preview_letter_templates_for_bad_filetype(
 def test_letter_branding_preview_image(
     client_request,
     mock_onwards_request_headers,
-    mocker,
+    requests_mock,
 ):
-    class MockedResponse:
-        content = "foo"
-        status_code = 200
-        headers = {}
+    requests_mock.post(
+        "http://localhost:9999/preview.png",
+        request_headers={
+            "Authorization": "Token my-secret-key",
+            "some-onwards": "request-headers",
+        },
+        content=b"foo",
+        status_code=200,
+        headers={"content-type": "image/png"},
+    )
 
-    mocked_preview = mocker.patch("app.template_preview_client.requests_session.post", return_value=MockedResponse())
     response = client_request.get_response(
         "no_cookie.letter_branding_preview_image",
         filename="example",
     )
-
-    mocked_preview.assert_called_with(
-        "http://localhost:9999/preview.png",
-        json={
-            "letter_contact_block": "",
-            "template": {
-                "subject": "An example letter",
-                "content": ANY,
-                "template_type": "letter",
-                "is_precompiled_letter": False,
-            },
-            "values": None,
-            "filename": "example",
-            "date": None,
-        },
-        headers={
-            "Authorization": "Token my-secret-key",
-            "some-onwards": "request-headers",
-        },
-    )
     assert response.get_data(as_text=True) == "foo"
+
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].json() == {
+        "letter_contact_block": "",
+        "template": {
+            "subject": "An example letter",
+            "content": ANY,
+            "template_type": "letter",
+            "is_precompiled_letter": False,
+        },
+        "values": None,
+        "filename": "example",
+        "date": None,
+    }
 
 
 @pytest.mark.parametrize("filename", [None, FieldWithNoneOption.NONE_OPTION_VALUE])

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from unittest.mock import Mock
 
 import pytest
+from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.testing.comparisons import AnySupersetOf
 from werkzeug.exceptions import BadRequest, NotFound
 
@@ -305,6 +306,7 @@ def test_page_count_returns_none_for_non_letter_templates(notify_admin, template
     (
         None,
         {"foo": "bar"},
+        InsensitiveDict({"foo": "bar"}),
     ),
 )
 def test_page_count_makes_a_call_to_template_preview_and_gets_page_count(

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from unittest.mock import Mock
 
 import pytest
+from notifications_utils.testing.comparisons import AnySupersetOf
 from werkzeug.exceptions import BadRequest, NotFound
 
 from app import load_service_before_request, template_preview_client
@@ -42,7 +43,6 @@ from tests.conftest import create_notification
 )
 def test_get_preview_for_templated_letter_makes_request(
     client_request,
-    mocker,
     service_one,
     extra_kwargs,
     expected_url,
@@ -52,10 +52,19 @@ def test_get_preview_for_templated_letter_makes_request(
     expected_date_string_in_json,
     mock_get_service_letter_template,
     mock_onwards_request_headers,
+    requests_mock,
 ):
-    request_mock_returns = Mock(content="a", status_code="b", headers={"content-type": "image/png"})
-    request_mock = mocker.patch("app.template_preview_client.requests_session.post", return_value=request_mock_returns)
-    service = mocker.Mock(spec=Service, letter_branding=letter_branding)
+    requests_mock.post(
+        expected_url,
+        request_headers={
+            "Authorization": "Token my-secret-key",
+            "some-onwards": "request-headers",
+        },
+        content=b"a",
+        status_code=200,
+        headers={"content-type": "image/png"},
+    )
+    service = Mock(spec=Service, letter_branding=letter_branding)
     template = mock_get_service_letter_template("123", "456")["data"]
 
     response = template_preview_client.get_preview_for_templated_letter(
@@ -64,9 +73,7 @@ def test_get_preview_for_templated_letter_makes_request(
         **(extra_kwargs | date_kwargs),
     )
 
-    assert response[0] == "a"
-    assert response[1] == "b"
-    assert list(response[2]) == [("content-type", "image/png")]
+    assert response == (b"a", 200, [("content-type", "image/png")])
 
     data = {
         "letter_contact_block": None,
@@ -75,12 +82,9 @@ def test_get_preview_for_templated_letter_makes_request(
         "filename": expected_filename,
         "date": expected_date_string_in_json,
     }
-    headers = {
-        "Authorization": "Token my-secret-key",
-        "some-onwards": "request-headers",
-    }
 
-    request_mock.assert_called_once_with(expected_url, json=data, headers=headers)
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].json() == data
 
 
 @pytest.mark.parametrize(
@@ -92,15 +96,25 @@ def test_get_preview_for_templated_letter_makes_request(
 )
 def test_get_preview_for_templated_letter_allows_service_branding_to_be_overridden(
     client_request,
-    mocker,
     extra_args,
     expected_filename,
+    mock_onwards_request_headers,
     mock_get_service_letter_template,
+    requests_mock,
 ):
     load_service_before_request()
 
-    request_mock = mocker.patch("app.template_preview_client.requests_session.post")
-    service = mocker.Mock(spec=Service, letter_branding=LetterBranding({"filename": "hm-government"}))
+    requests_mock.post(
+        "http://localhost:9999/preview.png",
+        request_headers={
+            "Authorization": "Token my-secret-key",
+            "some-onwards": "request-headers",
+        },
+        content=b"a",
+        status_code=200,
+        headers={"content-type": "image/png"},
+    )
+    service = Mock(spec=Service, letter_branding=LetterBranding({"filename": "hm-government"}))
 
     template_preview_client.get_preview_for_templated_letter(
         db_template=create_notification(template_type="letter")["template"],
@@ -109,17 +123,30 @@ def test_get_preview_for_templated_letter_allows_service_branding_to_be_overridd
         **extra_args,
     )
 
-    assert request_mock.call_args[1]["json"]["filename"] == expected_filename
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].json() == AnySupersetOf(
+        {
+            "filename": expected_filename,
+        }
+    )
 
 
 def test_get_preview_for_templated_letter_from_notification_has_correct_args(
     client_request,
-    mocker,
     mock_onwards_request_headers,
+    requests_mock,
 ):
-    request_mock_returns = Mock(content="a", status_code="b", headers={"content-type": "image/png"})
-    request_mock = mocker.patch("app.template_preview_client.requests_session.post", return_value=request_mock_returns)
-    service = mocker.Mock(spec=Service, letter_branding=LetterBranding({"filename": "hm-government"}))
+    requests_mock.post(
+        "http://localhost:9999/preview.png",
+        request_headers={
+            "Authorization": "Token my-secret-key",
+            "some-onwards": "request-headers",
+        },
+        content=b"a",
+        status_code=200,
+        headers={"content-type": "image/png"},
+    )
+    service = Mock(spec=Service, letter_branding=LetterBranding({"filename": "hm-government"}))
 
     notification = create_notification(
         service_id="abcd",
@@ -134,26 +161,19 @@ def test_get_preview_for_templated_letter_from_notification_has_correct_args(
         service=service,
     )
 
-    assert response[0] == "a"
-    assert response[1] == "b"
-    assert list(response[2]) == [("content-type", "image/png")]
+    assert response == (b"a", 200, [("content-type", "image/png")])
 
-    data = {
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].json() == {
         "letter_contact_block": None,
         "template": notification["template"],
         "values": {"name": "Jo"},
         "filename": "hm-government",
         "date": None,
     }
-    headers = {
-        "Authorization": "Token my-secret-key",
-        "some-onwards": "request-headers",
-    }
-
-    request_mock.assert_called_once_with("http://localhost:9999/preview.png", json=data, headers=headers)
 
 
-def test_get_preview_for_templated_letter_from_notification_rejects_precompiled_templates(notify_admin, mocker):
+def test_get_preview_for_templated_letter_from_notification_rejects_precompiled_templates(notify_admin, requests_mock):
     notification = create_notification(
         service_id="abcd",
         template_type="letter",
@@ -166,14 +186,16 @@ def test_get_preview_for_templated_letter_from_notification_rejects_precompiled_
             notification["template"], "png", notification["personalisation"]
         )
 
+    assert not requests_mock.request_history
+
 
 @pytest.mark.parametrize("template_type", ("email", "sms"))
 @pytest.mark.parametrize("file_type", ("pdf", "png"))
 def test_get_preview_for_templated_letter_from_notification_404s_non_letter_templates(
     notify_admin,
-    mocker,
     template_type,
     file_type,
+    requests_mock,
 ):
     notification = create_notification(
         service_id="abcd",
@@ -186,8 +208,10 @@ def test_get_preview_for_templated_letter_from_notification_404s_non_letter_temp
             notification["template"], file_type, notification["personalisation"]
         )
 
+    assert not requests_mock.request_history
 
-def test_get_preview_for_templated_letter_from_notification_400s_for_page_of_pdf(notify_admin, mocker):
+
+def test_get_preview_for_templated_letter_from_notification_400s_for_page_of_pdf(notify_admin, requests_mock):
     notification = create_notification(
         service_id="abcd",
         template_type="letter",
@@ -200,6 +224,8 @@ def test_get_preview_for_templated_letter_from_notification_400s_for_page_of_pdf
             "pdf",
             page=1,
         )
+
+    assert not requests_mock.request_history
 
 
 @pytest.mark.parametrize(
@@ -215,84 +241,91 @@ def test_get_png_for_valid_pdf_page_makes_request(
     mock_onwards_request_headers,
     page_number,
     expected_url,
+    requests_mock,
 ):
     mocker.patch("app.template_previews.extract_page_from_pdf", return_value=b"pdf page")
-    request_mock = mocker.patch(
-        "app.template_preview_client.requests_session.post",
-        return_value=Mock(content="a", status_code="b", headers={"content-type": "image/png"}),
+    requests_mock.post(
+        expected_url,
+        request_headers={
+            "Authorization": "Token my-secret-key",
+            "some-onwards": "request-headers",
+        },
+        content=b"a",
+        status_code=200,
+        headers={"content-type": "image/png"},
     )
 
     response = template_preview_client.get_png_for_valid_pdf_page(b"pdf file", page_number)
 
-    assert response == ("a", "b", {"content-type": "image/png"}.items())
-    request_mock.assert_called_once_with(
-        expected_url,
-        data=base64.b64encode(b"pdf page").decode("utf-8"),
-        headers={
-            "Authorization": "Token my-secret-key",
-            "some-onwards": "request-headers",
-        },
-    )
+    assert response == (b"a", 200, {"content-type": "image/png"}.items())
+
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].body == base64.b64encode(b"pdf page").decode("utf-8")
 
 
 def test_get_png_for_invalid_pdf_page_makes_request(
     client_request,
     mocker,
     mock_onwards_request_headers,
+    requests_mock,
 ):
     mocker.patch("app.template_previews.extract_page_from_pdf", return_value=b"pdf page")
-    request_mock = mocker.patch(
-        "app.template_preview_client.requests_session.post",
-        return_value=Mock(content="a", status_code="b", headers={"content-type": "image/png"}),
+    requests_mock.post(
+        "http://localhost:9999/precompiled/overlay.png?page_number=1&is_an_attachment=False",
+        request_headers={
+            "Authorization": "Token my-secret-key",
+            "some-onwards": "request-headers",
+        },
+        content=b"a",
+        status_code=200,
+        headers={"content-type": "image/png"},
     )
 
     response = template_preview_client.get_png_for_invalid_pdf_page(b"pdf file", "1")
 
-    assert response == ("a", "b", {"content-type": "image/png"}.items())
-    request_mock.assert_called_once_with(
-        "http://localhost:9999/precompiled/overlay.png?page_number=1&is_an_attachment=False",
-        data=b"pdf page",
-        headers={
-            "Authorization": "Token my-secret-key",
-            "some-onwards": "request-headers",
-        },
-    )
+    assert response == (b"a", 200, {"content-type": "image/png"}.items())
+
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].body == b"pdf page"
 
 
 @pytest.mark.parametrize("template_type", ["email", "sms"])
-def test_page_count_returns_none_for_non_letter_templates(notify_admin, template_type, mocker):
+def test_page_count_returns_none_for_non_letter_templates(notify_admin, template_type):
     assert (
         template_preview_client.get_page_counts_for_letter(
             {"template_type": template_type},
-            service=mocker.Mock(),
+            service=Mock(),
         )
         is None
     )
 
 
 @pytest.mark.parametrize(
-    "values, expected_template_preview_args",
-    [
-        (None, ({"template_type": "letter"}, "json", None)),
-        (
-            {"foo": "bar"},
-            ({"template_type": "letter"}, "json", {"foo": "bar"}),
-        ),
-    ],
+    "values",
+    (
+        None,
+        {"foo": "bar"},
+    ),
 )
 def test_page_count_makes_a_call_to_template_preview_and_gets_page_count(
     client_request,
-    mocker,
     mock_get_service_letter_template,
     mock_onwards_request_headers,
     values,
-    expected_template_preview_args,
+    requests_mock,
 ):
-    request_mock_returns = Mock(
-        content=b'{"count": 9, "welsh_page_count": 4, "attachment_page_count": 1}', status_code=200
+    requests_mock.post(
+        "http://localhost:9999/get-page-count",
+        request_headers={
+            "Authorization": "Token my-secret-key",
+            "some-onwards": "request-headers",
+        },
+        content=b'{"count": 9, "welsh_page_count": 4, "attachment_page_count": 1}',
+        status_code=200,
+        headers={"content-type": "application/json"},
     )
-    request_mock = mocker.patch("app.template_preview_client.requests_session.post", return_value=request_mock_returns)
-    service = mocker.Mock(spec=Service, letter_branding=LetterBranding({"filename": "hm-government"}))
+
+    service = Mock(spec=Service, letter_branding=LetterBranding({"filename": "hm-government"}))
     template = mock_get_service_letter_template("123", "456")["data"]
 
     assert template_preview_client.get_page_counts_for_letter(
@@ -305,75 +338,68 @@ def test_page_count_makes_a_call_to_template_preview_and_gets_page_count(
         "attachment_page_count": 1,
     }
 
-    data = {
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].json() == {
         "letter_contact_block": None,
         "template": template,
         "values": values,
         "filename": "hm-government",
     }
-    headers = {
-        "Authorization": "Token my-secret-key",
-        "some-onwards": "request-headers",
-    }
-
-    request_mock.assert_called_once_with("http://localhost:9999/get-page-count", json=data, headers=headers)
 
 
 @pytest.mark.parametrize("allow_international_letters, query_param_value", [[False, "false"], [True, "true"]])
 def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file(
     client_request,
-    mocker,
     mock_onwards_request_headers,
     allow_international_letters,
     query_param_value,
     fake_uuid,
+    requests_mock,
 ):
-    request_mock = mocker.patch("app.template_preview_client.requests_session.post")
-
-    template_preview_client.sanitise_letter(
-        "pdf_data", upload_id=fake_uuid, allow_international_letters=allow_international_letters
-    )
-
     expected_url = (
         f"http://localhost:9999/precompiled/sanitise"
         f"?allow_international_letters={query_param_value}"
         f"&upload_id={fake_uuid}"
     )
-
-    request_mock.assert_called_once_with(
+    requests_mock.post(
         expected_url,
-        headers={
+        request_headers={
             "Authorization": "Token my-secret-key",
             "some-onwards": "request-headers",
         },
-        data="pdf_data",
     )
+
+    template_preview_client.sanitise_letter(
+        b"pdf_data", upload_id=fake_uuid, allow_international_letters=allow_international_letters
+    )
+
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].body == b"pdf_data"
 
 
 def test_sanitise_letter_calls_template_preview_sanitise_endpoint_with_file_for_an_attachment(
     client_request,
-    mocker,
     mock_onwards_request_headers,
     fake_uuid,
+    requests_mock,
 ):
-    request_mock = mocker.patch("app.template_preview_client.requests_session.post")
-
-    template_preview_client.sanitise_letter(
-        "pdf_data", upload_id=fake_uuid, allow_international_letters=False, is_an_attachment=True
-    )
-
     expected_url = (
         f"http://localhost:9999/precompiled/sanitise"
         f"?allow_international_letters=false"
         f"&upload_id={fake_uuid}"
         f"&is_an_attachment=true"
     )
-
-    request_mock.assert_called_once_with(
+    requests_mock.post(
         expected_url,
-        headers={
+        request_headers={
             "Authorization": "Token my-secret-key",
             "some-onwards": "request-headers",
         },
-        data="pdf_data",
     )
+
+    template_preview_client.sanitise_letter(
+        b"pdf_data", upload_id=fake_uuid, allow_international_letters=False, is_an_attachment=True
+    )
+
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].body == b"pdf_data"

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@121.0.0
+# This file was automatically copied from notifications-utils@124.2.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
The first thing this does is fix the `TemplatePreviewClient` tests to use `requests_mock` rather than simply mocking out the `requests.post` function, so that we're at least exercising the encoding and request-forming process.

Then this bumps notifications-utils to 124.2.0 and uses `RelaxedContainerJSONEncoder` to encode json payloads we're sending via `requests`. This should address any problems arising from `InsensitiveDict` no longer directly inheriting from `dict`.

It also sets `FlaskRelaxedContainerJSONProvider` our flask app's `json_provider_class` so we get the same robustness when returning json via e.g. `jsonify`.

There are also a couple of other random places we used `json.dumps` which I've replaced.