### PR TITLE
Linting: Fix ISC004 Unparenthesized implicit string concatenation in collection

### DIFF
--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2016,8 +2016,10 @@ def test_incorrect_letter_contact_block_input(
         ("abcdefghijkhgkg", "Error: Text message sender ID cannot be longer than 11 characters"),
         (
             r" ¯\_(ツ)_/¯ ",
-            "Error: Text message sender ID can only include letters, "
-            "numbers, spaces, and the following characters: & . - _",
+            (
+                "Error: Text message sender ID can only include letters, "
+                "numbers, spaces, and the following characters: & . - _"
+            ),
         ),
         ("blood.co.uk", None),
         ("00123", "Error: Text message sender ID cannot start with 00"),
@@ -4430,8 +4432,10 @@ def test_send_files_by_email_in_page_guidance(client_request):
         "To send a file by email, either:",
         "choose a template and select ‘Attach files’",
         "or follow the instructions in our API documentation",
-        "You need to include contact details for your service so your users can get in touch if "
-        "there’s a problem. For example, if the link to download the file you sent them has expired.",
+        (
+            "You need to include contact details for your service so your users can get in touch if "
+            "there’s a problem. For example, if the link to download the file you sent them has expired."
+        ),
     ]
 
 
@@ -5165,10 +5169,14 @@ def test_service_receive_text_messages_when_inbound_number_is_not_set(
                 "Your service will receive text messages sent to:",
                 "You can see the number of received messages on your dashboard.",
                 "You can also download the last 7 days’ worth of received text messages.",
-                "If you’re using the API, you can fetch received messages or set up a "
-                "callback to push the message to your service.",
-                "You can still send text messages from a sender ID if you need to, but people "
-                "will not be able to reply to those messages.",
+                (
+                    "If you’re using the API, you can fetch received messages or set up a "
+                    "callback to push the message to your service."
+                ),
+                (
+                    "You can still send text messages from a sender ID if you need to, but people "
+                    "will not be able to reply to those messages."
+                ),
                 "Stop receiving text messages",
             ],
         ),
@@ -5178,8 +5186,10 @@ def test_service_receive_text_messages_when_inbound_number_is_not_set(
                 "Your service will receive text messages sent to:",
                 "You can see the number of received messages on your dashboard.",
                 "You can also download the last 7 days’ worth of received text messages.",
-                "You can still send text messages from a sender ID if you need to, but people "
-                "will not be able to reply to those messages.",
+                (
+                    "You can still send text messages from a sender ID if you need to, but people "
+                    "will not be able to reply to those messages."
+                ),
                 "Stop receiving text messages",
             ],
         ),

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -818,13 +818,17 @@ def test_create_email_branding_government_identity_logo_form(client_request, pla
     assert list(zip(values, images, strict=True)) == [
         (
             "Department for Business & Trade",
-            "https://static.example.com/images/branding/insignia/"
-            "Department for Business & Trade.png?037794106095c182ff58655a47fe3bca",
+            (
+                "https://static.example.com/images/branding/insignia/"
+                "Department for Business & Trade.png?037794106095c182ff58655a47fe3bca"
+            ),
         ),
         (
             "Foreign, Commonwealth & Development Office",
-            "https://static.example.com/images/branding/insignia/"
-            "Foreign, Commonwealth & Development Office.png?890210781ce4936bb44462036e150b50",
+            (
+                "https://static.example.com/images/branding/insignia/"
+                "Foreign, Commonwealth & Development Office.png?890210781ce4936bb44462036e150b50"
+            ),
         ),
         (
             "HM Coastguard",
@@ -836,8 +840,10 @@ def test_create_email_branding_government_identity_logo_form(client_request, pla
         ),
         (
             "HM Revenue & Customs",
-            "https://static.example.com/images/branding/insignia/"
-            "HM Revenue & Customs.png?306230d3421662dacc0c2e185bc6a57b",
+            (
+                "https://static.example.com/images/branding/insignia/"
+                "HM Revenue & Customs.png?306230d3421662dacc0c2e185bc6a57b"
+            ),
         ),
         (
             "Home Office",
@@ -845,8 +851,10 @@ def test_create_email_branding_government_identity_logo_form(client_request, pla
         ),
         (
             "Ministry of Defence",
-            "https://static.example.com/images/branding/insignia/"
-            "Ministry of Defence.png?e58dccf7441c42356c5947a191a732ed",
+            (
+                "https://static.example.com/images/branding/insignia/"
+                "Ministry of Defence.png?e58dccf7441c42356c5947a191a732ed"
+            ),
         ),
         (
             "Scotland Office",

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -4891,8 +4891,10 @@ def test_choose_from_contact_list_with_personalised_template(
         template_id=fake_uuid,
     )
     assert [normalize_spaces(p.text) for p in page.select("main p")] == [
-        "You cannot use an emergency contact list with this template because "
-        "it is personalised with ((name)) and ((thing)).",
+        (
+            "You cannot use an emergency contact list with this template because "
+            "it is personalised with ((name)) and ((thing))."
+        ),
         "Emergency contact lists can only include email addresses or phone numbers.",
     ]
     assert not page.select("table")

--- a/tests/app/main/views/test_template_email_files.py
+++ b/tests/app/main/views/test_template_email_files.py
@@ -742,8 +742,10 @@ def test_setup_template_email_files_page(
     assert page.select_one("main form")
     assert [normalize_spaces(p.text) for p in page.select("main p.govuk-body")] == [
         "Upload a file, then send your recipients an email with a link to download it.",
-        "Add contact details for your service so your recipients can get in touch if there’s a problem. "
-        "For example, if the link to download the file you sent them has expired.",
+        (
+            "Add contact details for your service so your recipients can get in touch if there’s a problem. "
+            "For example, if the link to download the file you sent them has expired."
+        ),
     ]
 
 
@@ -766,8 +768,10 @@ def test_setup_template_email_files_page_without_manage_service_permission(
     assert not page.select_one("main form")
     assert [normalize_spaces(p.text) for p in page.select("main p.govuk-body")] == [
         "Upload a file, then send your recipients an email with a link to download it.",
-        "Add contact details for your service so your recipients can get in touch if there’s a problem. "
-        "For example, if the link to download the file you sent them has expired.",
+        (
+            "Add contact details for your service so your recipients can get in touch if there’s a problem. "
+            "For example, if the link to download the file you sent them has expired."
+        ),
         "Ask a team member with the ‘Manage settings, team and usage’ permission to set this up for you.",
     ]
 


### PR DESCRIPTION
Ruff is going to make this rule on by default in version 0.16.0

Let’s get ahead of that by fixing this now