### PR TITLE
typing: fix imports of `current_user`

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,7 +18,8 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import LoginManager, current_user
+from flask_login import LoginManager
+from flask_login import current_user as _current_user
 from flask_wtf import CSRFProtect
 from flask_wtf.csrf import CSRFError
 from gds_metrics import GDSMetrics
@@ -41,11 +42,14 @@ from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
 from werkzeug.exceptions import abort
 from werkzeug.local import LocalProxy
 
-from app.formatters import format_phone_number_human_readable
-
-# must be declared before rest of app is imported to satisfy circular import
+# things up here must be declared before rest of app is imported to satisfy circular import
 # ruff: noqa: E402
 memo_resetters: list[Callable] = []
+
+# importing this rather than current_user directly from flask_login will give you
+# a variable with the apparently-correct type (though it *is* technically a lie)
+current_user: "User" = _current_user  # type: ignore[assignment]
+
 
 from app import webauthn_server
 from app.commands import setup_commands
@@ -80,6 +84,7 @@ from app.formatters import (
     format_notification_status_as_url,
     format_notification_type,
     format_pennies_as_currency,
+    format_phone_number_human_readable,
     format_pluralise,
     format_pounds_as_currency,
     format_provider,

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -9,7 +9,6 @@ from numbers import Number
 from zipfile import BadZipFile
 
 from flask import request
-from flask_login import current_user
 from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileAllowed, FileSize
 from flask_wtf.file import FileField as FileField_wtf
@@ -58,7 +57,7 @@ from wtforms.validators import (
 from xlrd.biffh import XLRDError
 from xlrd.xldate import XLDateError
 
-from app import asset_fingerprinter, current_organisation, document_download_api_client
+from app import asset_fingerprinter, current_organisation, current_user, document_download_api_client
 from app.constants import (
     SERVICE_JOIN_REQUEST_APPROVED,
     SERVICE_JOIN_REQUEST_REJECTED,

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -1,8 +1,7 @@
 from flask import current_app, redirect, render_template, session, url_for
-from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
-from app import service_api_client
+from app import current_user, service_api_client
 from app.main import main
 from app.main.forms import CreateNhsServiceForm, CreateServiceForm
 from app.models.organisation import Organisation

--- a/app/main/views/agreement.py
+++ b/app/main/views/agreement.py
@@ -1,9 +1,8 @@
 from datetime import UTC, datetime
 
 from flask import abort, redirect, render_template, request, send_file, url_for
-from flask_login import current_user
 
-from app import current_service
+from app import current_service, current_user
 from app.main import main
 from app.main.forms import AcceptAgreementForm
 from app.models.organisation import Organisation

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -1,10 +1,10 @@
 from flask import abort, flash, redirect, render_template, request, url_for
-from flask_login import current_user
 from markupsafe import Markup
 from notifications_utils.safe_string import make_string_safe
 
 from app import (
     current_service,
+    current_user,
     service_api_client,
 )
 from app.constants import ServiceCallbackTypes

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -4,12 +4,12 @@ from functools import partial
 from itertools import groupby
 
 from flask import Response, abort, jsonify, render_template, request, session, url_for
-from flask_login import current_user
 from werkzeug.utils import redirect
 
 from app import (
     billing_api_client,
     current_service,
+    current_user,
     notification_api_client,
     report_request_api_client,
     service_api_client,

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -1,11 +1,10 @@
 from io import BytesIO
 
 from flask import abort, current_app, flash, redirect, render_template, request, url_for
-from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from werkzeug.datastructures import FileStorage
 
-from app import email_branding_client
+from app import current_user, email_branding_client
 from app.event_handlers import Events
 from app.main import main
 from app.main.forms import (

--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -1,7 +1,6 @@
 from datetime import UTC, datetime
 
 from flask import current_app, redirect, render_template, request, session, url_for
-from flask_login import current_user
 from notifications_utils.bank_holidays import BankHolidays
 from notifications_utils.clients.zendesk.zendesk_client import (
     NotifySupportTicket,
@@ -10,7 +9,7 @@ from notifications_utils.clients.zendesk.zendesk_client import (
 )
 from notifications_utils.timezones import local_timezone
 
-from app import convert_to_boolean, current_service
+from app import convert_to_boolean, current_service, current_user
 from app.constants import ZendeskTopicId
 from app.extensions import zendesk_client
 from app.main import main

--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -1,9 +1,8 @@
 from flask import abort, flash, redirect, render_template, request, url_for
-from flask_login import current_user
 from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 
-from app import user_api_client
+from app import current_user, user_api_client
 from app.event_handlers import Events
 from app.main import main
 from app.main.forms import AuthTypeForm

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -8,11 +8,10 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import current_user
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.template import HTMLEmailTemplate
 
-from app import status_api_client
+from app import current_user, status_api_client
 from app.formatters import format_thousands
 from app.main import main
 from app.main.forms import FieldWithNoneOption, TemplateEmailFilesUploadForm

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -1,7 +1,7 @@
 from flask import abort, flash, redirect, render_template, session, url_for
-from flask_login import current_user
 from markupsafe import Markup
 
+from app import current_user
 from app.main import main
 from app.models.organisation import Organisation
 from app.models.service import Service

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -1,9 +1,8 @@
 from botocore.exceptions import ClientError as BotoClientError
 from flask import current_app, redirect, render_template, request, url_for
-from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
-from app import letter_branding_client, logo_client
+from app import current_user, letter_branding_client, logo_client
 from app.event_handlers import Events
 from app.main import main
 from app.main.forms import (

--- a/app/main/views/make_your_service_live.py
+++ b/app/main/views/make_your_service_live.py
@@ -1,10 +1,9 @@
 from flask import flash, redirect, render_template, url_for
-from flask_login import current_user
 from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket, NotifyTicketType
 
-from app import current_service, service_api_client
+from app import current_service, current_user, service_api_client
 from app.extensions import zendesk_client
 from app.main import main
 from app.main.forms import RenameServiceForm

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -1,11 +1,10 @@
 from datetime import UTC, datetime
 
 from flask import abort, flash, redirect, render_template, request, session, url_for
-from flask_login import current_user
 from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 
-from app import current_service, service_api_client
+from app import current_service, current_user, service_api_client
 from app.constants import SERVICE_JOIN_REQUEST_APPROVED, SERVICE_JOIN_REQUEST_REJECTED
 from app.event_handlers import Events
 from app.formatters import (

--- a/app/main/views/org_member_make_service_live.py
+++ b/app/main/views/org_member_make_service_live.py
@@ -1,7 +1,6 @@
 from flask import abort, flash, redirect, render_template, request, url_for
-from flask_login import current_user
 
-from app import current_service, organisations_client
+from app import current_service, current_user, organisations_client
 from app.main import main
 from app.main.forms import OnOffSettingForm, ServiceGoLiveDecisionForm, UniqueServiceForm
 from app.utils.user import user_has_permissions

--- a/app/main/views/organisations/index.py
+++ b/app/main/views/organisations/index.py
@@ -2,13 +2,13 @@ from datetime import datetime
 from functools import partial
 
 from flask import flash, redirect, render_template, request, send_file, url_for
-from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from werkzeug.exceptions import abort
 
 from app import (
     current_organisation,
     current_service,
+    current_user,
     org_invite_api_client,
     organisations_client,
 )

--- a/app/main/views/pricing.py
+++ b/app/main/views/pricing.py
@@ -1,9 +1,9 @@
 from datetime import UTC, datetime
 
 from flask import current_app, render_template
-from flask_login import current_user
 from notifications_utils.international_billing_rates import INTERNATIONAL_BILLING_RATES
 
+from app import current_user
 from app.main import main
 from app.main.forms import SearchByNameForm
 from app.main.views.sub_navigation_dictionaries import pricing_nav

--- a/app/main/views/report_requests.py
+++ b/app/main/views/report_requests.py
@@ -1,9 +1,8 @@
 from flask import abort, jsonify, render_template, send_file, url_for
-from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from werkzeug.utils import redirect
 
-from app import current_service
+from app import current_service, current_user
 from app.constants import REPORT_REQUEST_FAILED, REPORT_REQUEST_MAX_NOTIFICATIONS, REPORT_REQUEST_STORED
 from app.main import main
 from app.models.report_request import ReportRequest

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -10,7 +10,6 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
@@ -20,6 +19,7 @@ from notifications_utils.recipients import RecipientCSV, first_column_headings
 
 from app import (
     current_service,
+    current_user,
     job_api_client,
     nl2br,
     notification_api_client,

--- a/app/main/views/service_settings/branding.py
+++ b/app/main/views/service_settings/branding.py
@@ -1,9 +1,9 @@
 from flask import abort, flash, redirect, render_template, request, url_for
-from flask_login import current_user
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket, NotifyTicketType
 
 from app import (
     current_service,
+    current_user,
     letter_branding_client,
     logo_client,
     organisations_client,

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -10,7 +10,6 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import current_user
 from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
@@ -18,6 +17,7 @@ from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 from app import (
     billing_api_client,
     current_service,
+    current_user,
     inbound_number_client,
     notification_api_client,
     organisations_client,

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -10,10 +10,9 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user
 from markupsafe import Markup
 
-from app import login_manager
+from app import current_user, login_manager
 from app.constants import JSON_UPDATES_BLUEPRINT_NAME
 from app.main import main
 from app.main.forms import LoginForm

--- a/app/main/views/sign_out.py
+++ b/app/main/views/sign_out.py
@@ -1,6 +1,6 @@
 from flask import redirect, url_for
-from flask_login import current_user
 
+from app import current_user
 from app.main import main
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -16,7 +16,6 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import current_user
 from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils.formatters import formatted_list
@@ -28,6 +27,7 @@ from requests import RequestException
 
 from app import (
     current_service,
+    current_user,
     format_delta,
     letter_attachment_client,
     letter_branding_client,

--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -1,8 +1,8 @@
 from fido2 import cbor
 from fido2.webauthn import AuthenticatorData, CollectedClientData
 from flask import abort, current_app, flash, redirect, request, session, url_for
-from flask_login import current_user
 
+from app import current_user
 from app.main import main
 from app.models.user import User
 from app.models.webauthn_credential import RegistrationError, WebAuthnCredential

--- a/app/main/views/your_account.py
+++ b/app/main/views/your_account.py
@@ -8,11 +8,10 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils.url_safe_token import check_token
 
-from app import user_api_client
+from app import current_user, user_api_client
 from app.main import main
 from app.main.forms import (
     ChangeEmailForm,

--- a/app/main/views/your_services.py
+++ b/app/main/views/your_services.py
@@ -1,7 +1,6 @@
 from flask import redirect, render_template, session, url_for
-from flask_login import current_user
 
-from app import status_api_client
+from app import current_user, status_api_client
 from app.main import main
 from app.models.organisation import AllOrganisations
 from app.utils import PermanentRedirect

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -4,10 +4,9 @@ from pathlib import Path
 from typing import Any, TypedDict
 
 from flask import current_app
-from flask_login import current_user
 from notifications_utils.safe_string import make_string_safe
 
-from app import asset_fingerprinter
+from app import asset_fingerprinter, current_user
 from app.models import JSONModel, ModelList
 from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.letter_branding_client import letter_branding_client

--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -1,12 +1,12 @@
 from typing import Any
 
 from flask import g, has_request_context, request
-from flask_login import current_user
 from notifications_python_client import __version__
 from notifications_python_client.base import BaseAPIClient
 from notifications_utils.clients.redis import RequestCache
 from notifications_utils.json import RelaxedContainerJSONEncoder, StrictJsonTopLevelType
 
+from app import current_user
 from app.extensions import redis_client
 
 cache = RequestCache(redis_client)

--- a/app/notify_client/letter_attachment_client.py
+++ b/app/notify_client/letter_attachment_client.py
@@ -1,11 +1,10 @@
 from contextvars import ContextVar
 
 from flask import current_app
-from flask_login import current_user
 from notifications_utils.local_vars import LazyLocalGetter
 from werkzeug.local import LocalProxy
 
-from app import memo_resetters
+from app import current_user, memo_resetters
 from app.notify_client import NotifyAdminAPIClient, cache
 
 

--- a/app/notify_session.py
+++ b/app/notify_session.py
@@ -2,8 +2,8 @@ from datetime import UTC, datetime, timedelta
 
 from flask import Flask, Request, Response, request
 from flask.sessions import SecureCookieSession, SecureCookieSessionInterface
-from flask_login import current_user
 
+from app import current_user
 from app.constants import JSON_UPDATES_BLUEPRINT_NAME, NO_COOKIE_BLUEPRINT_NAME
 
 

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -4,11 +4,12 @@ from functools import wraps
 from itertools import chain
 
 from flask import abort, g, make_response, request
-from flask_login import current_user
 from notifications_utils.field import Field
 from ordered_set import OrderedSet
 from werkzeug.datastructures import MultiDict
 from werkzeug.routing import RequestRedirect
+
+from app import current_user
 
 # if changing these, note there may be database indexes corresponding to some of
 # these status sets in -api which may also need updating to prevent a

--- a/app/utils/user.py
+++ b/app/utils/user.py
@@ -1,9 +1,10 @@
 from functools import wraps
 
 from flask import abort, current_app
-from flask_login import current_user, login_required
+from flask_login import login_required
 from notifications_utils.user import GOVERNMENT_EMAIL_DOMAIN_NAMES, email_address_ends_with
 
+from app import current_user
 from app.notify_client.organisations_api_client import organisations_client
 
 user_is_logged_in = login_required


### PR DESCRIPTION
No stubs for the flask-login package + complexity of `LocalProxy` use + complexity of custom `User` class means the most straightforward thing is to cheat and lie about the type, which also means we have to do a weird reassignment thing. ~Avoid unnecessarily introducing new potential cyclical imports through use of `TYPE_CHECKING`.~

This reduces the number of mypy errors from 1522 to 1317.