### PR TITLE
Fix template-preview error cache

### DIFF
--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -138,6 +138,7 @@ class TemplatePreviewClient:
                 **self._get_outbound_headers(),
             },
         )
+        response.raise_for_status()
 
         page_count = json.loads(response.content.decode("utf-8"))
 

--- a/tests/app/utils/test_templates.py
+++ b/tests/app/utils/test_templates.py
@@ -1,4 +1,5 @@
 from datetime import date
+from functools import partial
 from unittest import mock
 from uuid import UUID
 
@@ -8,9 +9,11 @@ from freezegun import freeze_time
 from markupsafe import Markup
 from notifications_utils.template import Template
 from ordered_set import OrderedSet
+from requests.exceptions import HTTPError
 
 from app import load_service_before_request
 from app.models.template_email_file import TemplateEmailFile
+from app.template_previews import TemplatePreviewClient, template_preview_client
 from app.utils.templates import EmailPreviewTemplate, TemplateChange, TemplatedLetterImageTemplate, get_sample_template
 from tests import ConcreteTemplate, template_json
 from tests.conftest import SERVICE_ONE_ID, do_mock_get_page_counts_for_letter
@@ -66,6 +69,46 @@ def test_get_page_counts_for_letter_caches(
         ex=2_419_200,
     )
     assert len(mock_get_page_count.call_args_list) == 1
+
+
+def test_get_page_counts_for_letter_does_not_cache_on_error(
+    client_request,
+    service_one,
+    api_user_active,
+    mocker,
+    fake_uuid,
+    requests_mock,
+):
+    client_request.login(api_user_active, service_one)
+
+    mock_redis_get = mocker.patch(
+        "app.extensions.RedisClient.get",
+        return_value=None,
+    )
+    mock_redis_set = mocker.patch(
+        "app.extensions.RedisClient.set",
+    )
+
+    requests_mock.post("http://localhost:9999/get-page-count", status_code=500)
+    mocker.patch(
+        "app.template_preview_client.get_page_counts_for_letter",
+        wraps=partial(TemplatePreviewClient.get_page_counts_for_letter, template_preview_client),
+    )
+
+    template = TemplatedLetterImageTemplate(
+        template_json(
+            service_id=SERVICE_ONE_ID,
+            id_=fake_uuid,
+            type_="letter",
+        )
+    )
+
+    with pytest.raises(HTTPError):
+        _ = template.all_page_counts
+
+    mock_redis_get.assert_called_once_with(f"service-{SERVICE_ONE_ID}-template-{fake_uuid}-version-1-all-page-counts")
+
+    mock_redis_set.assert_not_called()
 
 
 def test_get_page_counts_for_letter_returns_cached_value(


### PR DESCRIPTION
When the admin requests a template-preview to get the page count for a letter, a connection error or another exception may occur. In this case, the template-preview returns an error, and the admin stores that error (for example, `{"message": "This is a test exception", "result": "error"}`) in Redis instead of the page count. Later, when the admin tries to use the cached page count, it fails because an error response was stored instead of a valid page count.
To fix this issue, we want to make sure the template-preview response always includes the required fields: `count`, `attachment_page_count`, and `welsh_page_count`. More details on this [card](https://trello.com/c/aOj7vNP2/1836-dont-cache-errors-from-template-preview).