### PR TITLE
Remove `InvitedUser.has_permission_for_organisation`

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -583,11 +583,6 @@ class InvitedUser(BaseUser):
             return False
         return self.service == service_id and permission in self.permissions
 
-    def has_permission_for_organisation(self, organisation_id, permission):
-        if self.status == "cancelled":
-            return False
-        return self.organisation == organisation_id and permission in self.organisation_permissions
-
     def __eq__(self, other):
         if not isinstance(other, InvitedUser):
             return False


### PR DESCRIPTION
`InvitedUser`s (users invited to a service) do not have any relationship to organisations. They do not have an `organisation` attribute and it’s not a meaningful question to ask of an `InvitedUser`. There is a separate `InvitedOrgUser` class where this is relevant.

Long and short of it is: anything calling this code is going to encounter an error at some point. Better to remove the method and raise an error early, where a test is more likely to catch it.