### PR TITLE
typing: hide complexity of `LocalProxy` globals by lying about type & correct `ContextVar`s generic types

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -168,11 +168,10 @@ login_manager = LoginManager()
 csrf = CSRFProtect()
 metrics = GDSMetrics()
 
-
-current_service = LocalProxy(lambda: g.current_service)
+current_service: Service = LocalProxy(lambda: g.current_service)  # type: ignore[assignment]
 
 # The current organisation attached to the request stack.
-current_organisation = LocalProxy(lambda: g.current_organisation)
+current_organisation: Organisation = LocalProxy(lambda: g.current_organisation)  # type: ignore[assignment]
 
 navigation = {
     "casework_navigation": CaseworkNavigation(),

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -9,7 +9,7 @@ from werkzeug.local import LocalProxy
 
 from app import memo_resetters
 
-_antivirus_client_context_var: ContextVar[AntivirusClient] = ContextVar("antivirus_client")
+_antivirus_client_context_var: ContextVar[AntivirusClient | None] = ContextVar("antivirus_client")
 get_antivirus_client: LazyLocalGetter[AntivirusClient] = LazyLocalGetter(
     _antivirus_client_context_var,
     lambda: AntivirusClient(
@@ -20,7 +20,7 @@ get_antivirus_client: LazyLocalGetter[AntivirusClient] = LazyLocalGetter(
 memo_resetters.append(lambda: get_antivirus_client.clear())
 antivirus_client: AntivirusClient = LocalProxy(get_antivirus_client)  # type: ignore[assignment]
 
-_zendesk_client_context_var: ContextVar[ZendeskClient] = ContextVar("zendesk_client")
+_zendesk_client_context_var: ContextVar[ZendeskClient | None] = ContextVar("zendesk_client")
 get_zendesk_client: LazyLocalGetter[ZendeskClient] = LazyLocalGetter(
     _zendesk_client_context_var,
     lambda: ZendeskClient(

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -18,7 +18,7 @@ get_antivirus_client: LazyLocalGetter[AntivirusClient] = LazyLocalGetter(
     ),
 )
 memo_resetters.append(lambda: get_antivirus_client.clear())
-antivirus_client = LocalProxy(get_antivirus_client)
+antivirus_client: AntivirusClient = LocalProxy(get_antivirus_client)  # type: ignore[assignment]
 
 _zendesk_client_context_var: ContextVar[ZendeskClient] = ContextVar("zendesk_client")
 get_zendesk_client: LazyLocalGetter[ZendeskClient] = LazyLocalGetter(
@@ -28,6 +28,6 @@ get_zendesk_client: LazyLocalGetter[ZendeskClient] = LazyLocalGetter(
     ),
 )
 memo_resetters.append(lambda: get_zendesk_client.clear())
-zendesk_client = LocalProxy(get_zendesk_client)
+zendesk_client: ZendeskClient = LocalProxy(get_zendesk_client)  # type: ignore[assignment]
 
 redis_client = RedisClient()

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -23,7 +23,7 @@ class ApiKeyApiClient(NotifyAdminAPIClient):
         return self.post(url=f"/service/{service_id}/api-key/revoke/{key_id}", data=data)
 
 
-_api_key_api_client_context_var: ContextVar[ApiKeyApiClient] = ContextVar("api_key_api_client")
+_api_key_api_client_context_var: ContextVar[ApiKeyApiClient | None] = ContextVar("api_key_api_client")
 get_api_key_api_client: LazyLocalGetter[ApiKeyApiClient] = LazyLocalGetter(
     _api_key_api_client_context_var,
     lambda: ApiKeyApiClient(current_app),

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -29,4 +29,4 @@ get_api_key_api_client: LazyLocalGetter[ApiKeyApiClient] = LazyLocalGetter(
     lambda: ApiKeyApiClient(current_app),
 )
 memo_resetters.append(lambda: get_api_key_api_client.clear())
-api_key_api_client = LocalProxy(get_api_key_api_client)
+api_key_api_client: ApiKeyApiClient = LocalProxy(get_api_key_api_client)  # type: ignore[assignment]

--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -75,7 +75,7 @@ class BillingAPIClient(NotifyAdminAPIClient):
         )
 
 
-_billing_api_client_context_var: ContextVar[BillingAPIClient] = ContextVar("billing_api_client")
+_billing_api_client_context_var: ContextVar[BillingAPIClient | None] = ContextVar("billing_api_client")
 get_billing_api_client: LazyLocalGetter[BillingAPIClient] = LazyLocalGetter(
     _billing_api_client_context_var,
     lambda: BillingAPIClient(current_app),

--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -81,4 +81,4 @@ get_billing_api_client: LazyLocalGetter[BillingAPIClient] = LazyLocalGetter(
     lambda: BillingAPIClient(current_app),
 )
 memo_resetters.append(lambda: get_billing_api_client.clear())
-billing_api_client = LocalProxy(get_billing_api_client)
+billing_api_client: BillingAPIClient = LocalProxy(get_billing_api_client)  # type: ignore[assignment]

--- a/app/notify_client/complaint_api_client.py
+++ b/app/notify_client/complaint_api_client.py
@@ -23,4 +23,4 @@ get_complaint_api_client: LazyLocalGetter[ComplaintApiClient] = LazyLocalGetter(
     lambda: ComplaintApiClient(current_app),
 )
 memo_resetters.append(lambda: get_complaint_api_client.clear())
-complaint_api_client = LocalProxy(get_complaint_api_client)
+complaint_api_client: ComplaintApiClient = LocalProxy(get_complaint_api_client)  # type: ignore[assignment]

--- a/app/notify_client/complaint_api_client.py
+++ b/app/notify_client/complaint_api_client.py
@@ -17,7 +17,7 @@ class ComplaintApiClient(NotifyAdminAPIClient):
         return self.get("/complaint/count-by-date-range", params=params_dict)
 
 
-_complaint_api_client_context_var: ContextVar[ComplaintApiClient] = ContextVar("complaint_api_client")
+_complaint_api_client_context_var: ContextVar[ComplaintApiClient | None] = ContextVar("complaint_api_client")
 get_complaint_api_client: LazyLocalGetter[ComplaintApiClient] = LazyLocalGetter(
     _complaint_api_client_context_var,
     lambda: ComplaintApiClient(current_app),

--- a/app/notify_client/contact_list_api_client.py
+++ b/app/notify_client/contact_list_api_client.py
@@ -46,4 +46,4 @@ get_contact_list_api_client: LazyLocalGetter[ContactListApiClient] = LazyLocalGe
     lambda: ContactListApiClient(current_app),
 )
 memo_resetters.append(lambda: get_contact_list_api_client.clear())
-contact_list_api_client = LocalProxy(get_contact_list_api_client)
+contact_list_api_client: ContactListApiClient = LocalProxy(get_contact_list_api_client)  # type: ignore[assignment]

--- a/app/notify_client/contact_list_api_client.py
+++ b/app/notify_client/contact_list_api_client.py
@@ -40,7 +40,7 @@ class ContactListApiClient(NotifyAdminAPIClient):
         return self.delete(f"/service/{service_id}/contact-list/{contact_list_id}")
 
 
-_contact_list_api_client_context_var: ContextVar[ContactListApiClient] = ContextVar("contact_list_api_client")
+_contact_list_api_client_context_var: ContextVar[ContactListApiClient | None] = ContextVar("contact_list_api_client")
 get_contact_list_api_client: LazyLocalGetter[ContactListApiClient] = LazyLocalGetter(
     _contact_list_api_client_context_var,
     lambda: ContactListApiClient(current_app),

--- a/app/notify_client/document_download_api_client.py
+++ b/app/notify_client/document_download_api_client.py
@@ -74,7 +74,7 @@ class DocumentDownloadAPIClient:
         return response.json()
 
 
-_document_download_api_client_context_var: ContextVar[DocumentDownloadAPIClient] = ContextVar(
+_document_download_api_client_context_var: ContextVar[DocumentDownloadAPIClient | None] = ContextVar(
     "document_download_api_client"
 )
 get_document_download_api_client: LazyLocalGetter[DocumentDownloadAPIClient] = LazyLocalGetter(

--- a/app/notify_client/document_download_api_client.py
+++ b/app/notify_client/document_download_api_client.py
@@ -82,4 +82,4 @@ get_document_download_api_client: LazyLocalGetter[DocumentDownloadAPIClient] = L
     lambda: DocumentDownloadAPIClient(current_app),
 )
 memo_resetters.append(lambda: get_document_download_api_client.clear())
-document_download_api_client = LocalProxy(get_document_download_api_client)
+document_download_api_client: DocumentDownloadAPIClient = LocalProxy(get_document_download_api_client)  # type: ignore[assignment]

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -67,4 +67,4 @@ get_email_branding_client: LazyLocalGetter[EmailBrandingClient] = LazyLocalGette
     lambda: EmailBrandingClient(current_app),
 )
 memo_resetters.append(lambda: get_email_branding_client.clear())
-email_branding_client = LocalProxy(get_email_branding_client)
+email_branding_client: EmailBrandingClient = LocalProxy(get_email_branding_client)  # type: ignore[assignment]

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -61,7 +61,7 @@ class EmailBrandingClient(NotifyAdminAPIClient):
         return self.get(url=f"/email-branding/{branding_id}/orgs_and_services")
 
 
-_email_branding_client_context_var: ContextVar[EmailBrandingClient] = ContextVar("email_branding_client")
+_email_branding_client_context_var: ContextVar[EmailBrandingClient | None] = ContextVar("email_branding_client")
 get_email_branding_client: LazyLocalGetter[EmailBrandingClient] = LazyLocalGetter(
     _email_branding_client_context_var,
     lambda: EmailBrandingClient(current_app),

--- a/app/notify_client/events_api_client.py
+++ b/app/notify_client/events_api_client.py
@@ -21,4 +21,4 @@ get_events_api_client: LazyLocalGetter[EventsApiClient] = LazyLocalGetter(
     lambda: EventsApiClient(current_app),
 )
 memo_resetters.append(lambda: get_events_api_client.clear())
-events_api_client = LocalProxy(get_events_api_client)
+events_api_client: EventsApiClient = LocalProxy(get_events_api_client)  # type: ignore[assignment]

--- a/app/notify_client/events_api_client.py
+++ b/app/notify_client/events_api_client.py
@@ -15,7 +15,7 @@ class EventsApiClient(NotifyAdminAPIClient):
         return resp["data"]
 
 
-_events_api_client_context_var: ContextVar[EventsApiClient] = ContextVar("events_api_client")
+_events_api_client_context_var: ContextVar[EventsApiClient | None] = ContextVar("events_api_client")
 get_events_api_client: LazyLocalGetter[EventsApiClient] = LazyLocalGetter(
     _events_api_client_context_var,
     lambda: EventsApiClient(current_app),

--- a/app/notify_client/inbound_number_client.py
+++ b/app/notify_client/inbound_number_client.py
@@ -35,4 +35,4 @@ get_inbound_number_client: LazyLocalGetter[InboundNumberClient] = LazyLocalGette
     lambda: InboundNumberClient(current_app),
 )
 memo_resetters.append(lambda: get_inbound_number_client.clear())
-inbound_number_client = LocalProxy(get_inbound_number_client)
+inbound_number_client: InboundNumberClient = LocalProxy(get_inbound_number_client)  # type: ignore[assignment]

--- a/app/notify_client/inbound_number_client.py
+++ b/app/notify_client/inbound_number_client.py
@@ -29,7 +29,7 @@ class InboundNumberClient(NotifyAdminAPIClient):
         return self.post(f"inbound-number/service/{service_id}", data=data)
 
 
-_inbound_number_client_context_var: ContextVar[InboundNumberClient] = ContextVar("inbound_number_client")
+_inbound_number_client_context_var: ContextVar[InboundNumberClient | None] = ContextVar("inbound_number_client")
 get_inbound_number_client: LazyLocalGetter[InboundNumberClient] = LazyLocalGetter(
     _inbound_number_client_context_var,
     lambda: InboundNumberClient(current_app),

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -74,7 +74,7 @@ class InviteApiClient(NotifyAdminAPIClient):
         self.post(url=f"/service/{service_id}/invite/{invited_user_id}", data=data)
 
 
-_invite_api_client_context_var: ContextVar[InviteApiClient] = ContextVar("invite_api_client")
+_invite_api_client_context_var: ContextVar[InviteApiClient | None] = ContextVar("invite_api_client")
 get_invite_api_client: LazyLocalGetter[InviteApiClient] = LazyLocalGetter(
     _invite_api_client_context_var,
     lambda: InviteApiClient(current_app),

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -80,4 +80,4 @@ get_invite_api_client: LazyLocalGetter[InviteApiClient] = LazyLocalGetter(
     lambda: InviteApiClient(current_app),
 )
 memo_resetters.append(lambda: get_invite_api_client.clear())
-invite_api_client = LocalProxy(get_invite_api_client)
+invite_api_client: InviteApiClient = LocalProxy(get_invite_api_client)  # type: ignore[assignment]

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -128,4 +128,4 @@ get_job_api_client: LazyLocalGetter[JobApiClient] = LazyLocalGetter(
     lambda: JobApiClient(current_app),
 )
 memo_resetters.append(lambda: get_job_api_client.clear())
-job_api_client = LocalProxy(get_job_api_client)
+job_api_client: JobApiClient = LocalProxy(get_job_api_client)  # type: ignore[assignment]

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -122,7 +122,7 @@ class JobApiClient(NotifyAdminAPIClient):
         return self.post(url=f"/service/{service_id}/job/{job_id}/cancel-letter-job", data={})
 
 
-_job_api_client_context_var: ContextVar[JobApiClient] = ContextVar("job_api_client")
+_job_api_client_context_var: ContextVar[JobApiClient | None] = ContextVar("job_api_client")
 get_job_api_client: LazyLocalGetter[JobApiClient] = LazyLocalGetter(
     _job_api_client_context_var,
     lambda: JobApiClient(current_app),

--- a/app/notify_client/letter_attachment_client.py
+++ b/app/notify_client/letter_attachment_client.py
@@ -33,7 +33,9 @@ class LetterAttachmentClient(NotifyAdminAPIClient):
         return self.post(url=f"/letter-attachment/{letter_attachment_id}/archive", data=data)
 
 
-_letter_attachment_client_context_var: ContextVar[LetterAttachmentClient] = ContextVar("letter_attachment_client")
+_letter_attachment_client_context_var: ContextVar[LetterAttachmentClient | None] = ContextVar(
+    "letter_attachment_client"
+)
 get_letter_attachment_client: LazyLocalGetter[LetterAttachmentClient] = LazyLocalGetter(
     _letter_attachment_client_context_var,
     lambda: LetterAttachmentClient(current_app),

--- a/app/notify_client/letter_attachment_client.py
+++ b/app/notify_client/letter_attachment_client.py
@@ -39,4 +39,4 @@ get_letter_attachment_client: LazyLocalGetter[LetterAttachmentClient] = LazyLoca
     lambda: LetterAttachmentClient(current_app),
 )
 memo_resetters.append(lambda: get_letter_attachment_client.clear())
-letter_attachment_client = LocalProxy(get_letter_attachment_client)
+letter_attachment_client: LetterAttachmentClient = LocalProxy(get_letter_attachment_client)  # type: ignore[assignment]

--- a/app/notify_client/letter_branding_client.py
+++ b/app/notify_client/letter_branding_client.py
@@ -44,7 +44,7 @@ class LetterBrandingClient(NotifyAdminAPIClient):
         return self.get(url=f"/letter-branding/{branding_id}/orgs_and_services")
 
 
-_letter_branding_client_context_var: ContextVar[LetterBrandingClient] = ContextVar("letter_branding_client")
+_letter_branding_client_context_var: ContextVar[LetterBrandingClient | None] = ContextVar("letter_branding_client")
 get_letter_branding_client: LazyLocalGetter[LetterBrandingClient] = LazyLocalGetter(
     _letter_branding_client_context_var,
     lambda: LetterBrandingClient(current_app),

--- a/app/notify_client/letter_branding_client.py
+++ b/app/notify_client/letter_branding_client.py
@@ -50,4 +50,4 @@ get_letter_branding_client: LazyLocalGetter[LetterBrandingClient] = LazyLocalGet
     lambda: LetterBrandingClient(current_app),
 )
 memo_resetters.append(lambda: get_letter_branding_client.clear())
-letter_branding_client = LocalProxy(get_letter_branding_client)
+letter_branding_client: LetterBrandingClient = LocalProxy(get_letter_branding_client)  # type: ignore[assignment]

--- a/app/notify_client/letter_jobs_client.py
+++ b/app/notify_client/letter_jobs_client.py
@@ -21,4 +21,4 @@ get_letter_jobs_client: LazyLocalGetter[LetterJobsClient] = LazyLocalGetter(
     lambda: LetterJobsClient(current_app),
 )
 memo_resetters.append(lambda: get_letter_jobs_client.clear())
-letter_jobs_client = LocalProxy(get_letter_jobs_client)
+letter_jobs_client: LetterJobsClient = LocalProxy(get_letter_jobs_client)  # type: ignore[assignment]

--- a/app/notify_client/letter_jobs_client.py
+++ b/app/notify_client/letter_jobs_client.py
@@ -15,7 +15,7 @@ class LetterJobsClient(NotifyAdminAPIClient):
         return self.post(url="/letters/returned", data={"references": references})
 
 
-_letter_jobs_client_context_var: ContextVar[LetterJobsClient] = ContextVar("letter_jobs_client")
+_letter_jobs_client_context_var: ContextVar[LetterJobsClient | None] = ContextVar("letter_jobs_client")
 get_letter_jobs_client: LazyLocalGetter[LetterJobsClient] = LazyLocalGetter(
     _letter_jobs_client_context_var,
     lambda: LetterJobsClient(current_app),

--- a/app/notify_client/letter_rate_api_client.py
+++ b/app/notify_client/letter_rate_api_client.py
@@ -20,4 +20,4 @@ get_letter_rate_api_client: LazyLocalGetter[LetterRateApiClient] = LazyLocalGett
     lambda: LetterRateApiClient(current_app),
 )
 memo_resetters.append(lambda: get_letter_rate_api_client.clear())
-letter_rate_api_client = LocalProxy(get_letter_rate_api_client)
+letter_rate_api_client: LetterRateApiClient = LocalProxy(get_letter_rate_api_client)  # type: ignore[assignment]

--- a/app/notify_client/letter_rate_api_client.py
+++ b/app/notify_client/letter_rate_api_client.py
@@ -14,7 +14,7 @@ class LetterRateApiClient(NotifyAdminAPIClient):
         return self.get(url="/letter-rates")
 
 
-_letter_rate_api_client_context_var: ContextVar[LetterRateApiClient] = ContextVar("letter_rate_api_client")
+_letter_rate_api_client_context_var: ContextVar[LetterRateApiClient | None] = ContextVar("letter_rate_api_client")
 get_letter_rate_api_client: LazyLocalGetter[LetterRateApiClient] = LazyLocalGetter(
     _letter_rate_api_client_context_var,
     lambda: LetterRateApiClient(current_app),

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -132,7 +132,7 @@ class NotificationApiClient(NotifyAdminAPIClient):
         return response.get("notifications_sent_count")
 
 
-_notification_api_client_context_var: ContextVar[NotificationApiClient] = ContextVar("notification_api_client")
+_notification_api_client_context_var: ContextVar[NotificationApiClient | None] = ContextVar("notification_api_client")
 get_notification_api_client: LazyLocalGetter[NotificationApiClient] = LazyLocalGetter(
     _notification_api_client_context_var,
     lambda: NotificationApiClient(current_app),

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -138,4 +138,4 @@ get_notification_api_client: LazyLocalGetter[NotificationApiClient] = LazyLocalG
     lambda: NotificationApiClient(current_app),
 )
 memo_resetters.append(lambda: get_notification_api_client.clear())
-notification_api_client = LocalProxy(get_notification_api_client)
+notification_api_client: NotificationApiClient = LocalProxy(get_notification_api_client)  # type: ignore[assignment]

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -50,7 +50,7 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
         self.post(url=f"/organisation/{org_id}/invite/{invited_user_id}", data=data)
 
 
-_org_invite_api_client_context_var: ContextVar[OrgInviteApiClient] = ContextVar("org_invite_api_client")
+_org_invite_api_client_context_var: ContextVar[OrgInviteApiClient | None] = ContextVar("org_invite_api_client")
 get_org_invite_api_client: LazyLocalGetter[OrgInviteApiClient] = LazyLocalGetter(
     _org_invite_api_client_context_var,
     lambda: OrgInviteApiClient(current_app),

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -56,4 +56,4 @@ get_org_invite_api_client: LazyLocalGetter[OrgInviteApiClient] = LazyLocalGetter
     lambda: OrgInviteApiClient(current_app),
 )
 memo_resetters.append(lambda: get_org_invite_api_client.clear())
-org_invite_api_client = LocalProxy(get_org_invite_api_client)
+org_invite_api_client: OrgInviteApiClient = LocalProxy(get_org_invite_api_client)  # type: ignore[assignment]

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -163,7 +163,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
         )
 
 
-_organisations_client_context_var: ContextVar[OrganisationsClient] = ContextVar("organisations_client")
+_organisations_client_context_var: ContextVar[OrganisationsClient | None] = ContextVar("organisations_client")
 get_organisations_client: LazyLocalGetter[OrganisationsClient] = LazyLocalGetter(
     _organisations_client_context_var,
     lambda: OrganisationsClient(current_app),

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -169,4 +169,4 @@ get_organisations_client: LazyLocalGetter[OrganisationsClient] = LazyLocalGetter
     lambda: OrganisationsClient(current_app),
 )
 memo_resetters.append(lambda: get_organisations_client.clear())
-organisations_client = LocalProxy(get_organisations_client)
+organisations_client: OrganisationsClient = LocalProxy(get_organisations_client)  # type: ignore[assignment]

--- a/app/notify_client/performance_dashboard_api_client.py
+++ b/app/notify_client/performance_dashboard_api_client.py
@@ -25,7 +25,7 @@ class PerformanceDashboardAPIClient(NotifyAdminAPIClient):
         )
 
 
-_performance_dashboard_api_client_context_var: ContextVar[PerformanceDashboardAPIClient] = ContextVar(
+_performance_dashboard_api_client_context_var: ContextVar[PerformanceDashboardAPIClient | None] = ContextVar(
     "performance_dashboard_api_client"
 )
 get_performance_dashboard_api_client: LazyLocalGetter[PerformanceDashboardAPIClient] = LazyLocalGetter(

--- a/app/notify_client/performance_dashboard_api_client.py
+++ b/app/notify_client/performance_dashboard_api_client.py
@@ -33,4 +33,4 @@ get_performance_dashboard_api_client: LazyLocalGetter[PerformanceDashboardAPICli
     lambda: PerformanceDashboardAPIClient(current_app),
 )
 memo_resetters.append(lambda: get_performance_dashboard_api_client.clear())
-performance_dashboard_api_client = LocalProxy(get_performance_dashboard_api_client)
+performance_dashboard_api_client: PerformanceDashboardAPIClient = LocalProxy(get_performance_dashboard_api_client)  # type: ignore[assignment]

--- a/app/notify_client/platform_admin_api_client.py
+++ b/app/notify_client/platform_admin_api_client.py
@@ -34,7 +34,7 @@ class AdminApiClient(NotifyAdminAPIClient):
         )
 
 
-_admin_api_client_context_var: ContextVar[AdminApiClient] = ContextVar("admin_api_client")
+_admin_api_client_context_var: ContextVar[AdminApiClient | None] = ContextVar("admin_api_client")
 get_admin_api_client: LazyLocalGetter[AdminApiClient] = LazyLocalGetter(
     _admin_api_client_context_var,
     lambda: AdminApiClient(current_app),

--- a/app/notify_client/platform_admin_api_client.py
+++ b/app/notify_client/platform_admin_api_client.py
@@ -40,4 +40,4 @@ get_admin_api_client: LazyLocalGetter[AdminApiClient] = LazyLocalGetter(
     lambda: AdminApiClient(current_app),
 )
 memo_resetters.append(lambda: get_admin_api_client.clear())
-admin_api_client = LocalProxy(get_admin_api_client)
+admin_api_client: AdminApiClient = LocalProxy(get_admin_api_client)  # type: ignore[assignment]

--- a/app/notify_client/protected_sender_id_api_client.py
+++ b/app/notify_client/protected_sender_id_api_client.py
@@ -13,7 +13,7 @@ class ProtectedSenderIDApiClient(NotifyAdminAPIClient):
         return self.get(url="/protected-sender-id/check", params={"sender_id": sender_id})
 
 
-_protected_sender_id_api_client_context_var: ContextVar[ProtectedSenderIDApiClient] = ContextVar(
+_protected_sender_id_api_client_context_var: ContextVar[ProtectedSenderIDApiClient | None] = ContextVar(
     "protected_sender_id_api_client"
 )
 get_protected_sender_id_api_client: LazyLocalGetter[ProtectedSenderIDApiClient] = LazyLocalGetter(

--- a/app/notify_client/protected_sender_id_api_client.py
+++ b/app/notify_client/protected_sender_id_api_client.py
@@ -21,4 +21,4 @@ get_protected_sender_id_api_client: LazyLocalGetter[ProtectedSenderIDApiClient] 
     lambda: ProtectedSenderIDApiClient(current_app),
 )
 memo_resetters.append(lambda: get_protected_sender_id_api_client.clear())
-protected_sender_id_api_client = LocalProxy(get_protected_sender_id_api_client)
+protected_sender_id_api_client: ProtectedSenderIDApiClient = LocalProxy(get_protected_sender_id_api_client)  # type: ignore[assignment]

--- a/app/notify_client/provider_client.py
+++ b/app/notify_client/provider_client.py
@@ -24,7 +24,7 @@ class ProviderClient(NotifyAdminAPIClient):
         return self.post(url=f"/provider-details/{provider_id}", data=data)
 
 
-_provider_client_context_var: ContextVar[ProviderClient] = ContextVar("provider_client")
+_provider_client_context_var: ContextVar[ProviderClient | None] = ContextVar("provider_client")
 get_provider_client: LazyLocalGetter[ProviderClient] = LazyLocalGetter(
     _provider_client_context_var,
     lambda: ProviderClient(current_app),

--- a/app/notify_client/provider_client.py
+++ b/app/notify_client/provider_client.py
@@ -30,4 +30,4 @@ get_provider_client: LazyLocalGetter[ProviderClient] = LazyLocalGetter(
     lambda: ProviderClient(current_app),
 )
 memo_resetters.append(lambda: get_provider_client.clear())
-provider_client = LocalProxy(get_provider_client)
+provider_client: ProviderClient = LocalProxy(get_provider_client)  # type: ignore[assignment]

--- a/app/notify_client/report_request_api_client.py
+++ b/app/notify_client/report_request_api_client.py
@@ -26,4 +26,4 @@ get_report_request_api_client: LazyLocalGetter[ReportRequestClient] = LazyLocalG
     lambda: ReportRequestClient(current_app),
 )
 memo_resetters.append(lambda: get_report_request_api_client.clear())
-report_request_api_client = LocalProxy(get_report_request_api_client)
+report_request_api_client: ReportRequestClient = LocalProxy(get_report_request_api_client)  # type: ignore[assignment]

--- a/app/notify_client/report_request_api_client.py
+++ b/app/notify_client/report_request_api_client.py
@@ -20,7 +20,7 @@ class ReportRequestClient(NotifyAdminAPIClient):
         return response["data"]["id"]
 
 
-_report_request_api_client_context_var: ContextVar[ReportRequestClient] = ContextVar("report_request_api_client")
+_report_request_api_client_context_var: ContextVar[ReportRequestClient | None] = ContextVar("report_request_api_client")
 get_report_request_api_client: LazyLocalGetter[ReportRequestClient] = LazyLocalGetter(
     _report_request_api_client_context_var,
     lambda: ReportRequestClient(current_app),

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -563,4 +563,4 @@ get_service_api_client: LazyLocalGetter[ServiceAPIClient] = LazyLocalGetter(
     lambda: ServiceAPIClient(current_app),
 )
 memo_resetters.append(lambda: get_service_api_client.clear())
-service_api_client = LocalProxy(get_service_api_client)
+service_api_client: ServiceAPIClient = LocalProxy(get_service_api_client)  # type: ignore[assignment]

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -557,7 +557,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(f"/service/{service_id}/service-join-request/{request_id}", data)
 
 
-_service_api_client_context_var: ContextVar[ServiceAPIClient] = ContextVar("service_api_client")
+_service_api_client_context_var: ContextVar[ServiceAPIClient | None] = ContextVar("service_api_client")
 get_service_api_client: LazyLocalGetter[ServiceAPIClient] = LazyLocalGetter(
     _service_api_client_context_var,
     lambda: ServiceAPIClient(current_app),

--- a/app/notify_client/sms_rate_client.py
+++ b/app/notify_client/sms_rate_client.py
@@ -14,7 +14,7 @@ class SMSRateApiClient(NotifyAdminAPIClient):
         return self.get(url="/sms-rate")
 
 
-_sms_rate_api_client_context_var: ContextVar[SMSRateApiClient] = ContextVar("sms_rate_api_client")
+_sms_rate_api_client_context_var: ContextVar[SMSRateApiClient | None] = ContextVar("sms_rate_api_client")
 get_sms_rate_api_client: LazyLocalGetter[SMSRateApiClient] = LazyLocalGetter(
     _sms_rate_api_client_context_var,
     lambda: SMSRateApiClient(current_app),

--- a/app/notify_client/sms_rate_client.py
+++ b/app/notify_client/sms_rate_client.py
@@ -20,4 +20,4 @@ get_sms_rate_api_client: LazyLocalGetter[SMSRateApiClient] = LazyLocalGetter(
     lambda: SMSRateApiClient(current_app),
 )
 memo_resetters.append(lambda: get_sms_rate_api_client.clear())
-sms_rate_api_client = LocalProxy(get_sms_rate_api_client)
+sms_rate_api_client: SMSRateApiClient = LocalProxy(get_sms_rate_api_client)  # type: ignore[assignment]

--- a/app/notify_client/status_api_client.py
+++ b/app/notify_client/status_api_client.py
@@ -23,4 +23,4 @@ get_status_api_client: LazyLocalGetter[StatusApiClient] = LazyLocalGetter(
     lambda: StatusApiClient(current_app),
 )
 memo_resetters.append(lambda: get_status_api_client.clear())
-status_api_client = LocalProxy(get_status_api_client)
+status_api_client: StatusApiClient = LocalProxy(get_status_api_client)  # type: ignore[assignment]

--- a/app/notify_client/status_api_client.py
+++ b/app/notify_client/status_api_client.py
@@ -17,7 +17,7 @@ class StatusApiClient(NotifyAdminAPIClient):
         return self.get("/_status/live-service-and-organisation-counts")
 
 
-_status_api_client_context_var: ContextVar[StatusApiClient] = ContextVar("status_api_client")
+_status_api_client_context_var: ContextVar[StatusApiClient | None] = ContextVar("status_api_client")
 get_status_api_client: LazyLocalGetter[StatusApiClient] = LazyLocalGetter(
     _status_api_client_context_var,
     lambda: StatusApiClient(current_app),

--- a/app/notify_client/template_email_file_client.py
+++ b/app/notify_client/template_email_file_client.py
@@ -45,7 +45,7 @@ class TemplateEmailFileClient(NotifyAdminAPIClient):
         return self.post(f"/service/{service_id}/templates/{template_id}/template_email_files/{file_id}", data=data)
 
 
-_template_email_file_api_client_context_var: ContextVar[TemplateEmailFileClient] = ContextVar(
+_template_email_file_api_client_context_var: ContextVar[TemplateEmailFileClient | None] = ContextVar(
     "template_email_file_api_client_context_var"
 )
 get_template_email_file_client: LazyLocalGetter[TemplateEmailFileClient] = LazyLocalGetter(

--- a/app/notify_client/template_email_file_client.py
+++ b/app/notify_client/template_email_file_client.py
@@ -53,4 +53,4 @@ get_template_email_file_client: LazyLocalGetter[TemplateEmailFileClient] = LazyL
     lambda: TemplateEmailFileClient(current_app),
 )
 memo_resetters.append(lambda: get_template_email_file_client.clear())
-template_email_file_client = LocalProxy(get_template_email_file_client)
+template_email_file_client: TemplateEmailFileClient = LocalProxy(get_template_email_file_client)  # type: ignore[assignment]

--- a/app/notify_client/template_folder_api_client.py
+++ b/app/notify_client/template_folder_api_client.py
@@ -66,4 +66,4 @@ get_template_folder_api_client: LazyLocalGetter[TemplateFolderAPIClient] = LazyL
     lambda: TemplateFolderAPIClient(current_app),
 )
 memo_resetters.append(lambda: get_template_folder_api_client.clear())
-template_folder_api_client = LocalProxy(get_template_folder_api_client)
+template_folder_api_client: TemplateFolderAPIClient = LocalProxy(get_template_folder_api_client)  # type: ignore[assignment]

--- a/app/notify_client/template_folder_api_client.py
+++ b/app/notify_client/template_folder_api_client.py
@@ -60,7 +60,9 @@ class TemplateFolderAPIClient(NotifyAdminAPIClient):
         self.delete(f"/service/{service_id}/template-folder/{template_folder_id}", {})
 
 
-_template_folder_api_client_context_var: ContextVar[TemplateFolderAPIClient] = ContextVar("template_folder_api_client")
+_template_folder_api_client_context_var: ContextVar[TemplateFolderAPIClient | None] = ContextVar(
+    "template_folder_api_client"
+)
 get_template_folder_api_client: LazyLocalGetter[TemplateFolderAPIClient] = LazyLocalGetter(
     _template_folder_api_client_context_var,
     lambda: TemplateFolderAPIClient(current_app),

--- a/app/notify_client/template_statistics_api_client.py
+++ b/app/notify_client/template_statistics_api_client.py
@@ -31,4 +31,4 @@ get_template_statistics_client: LazyLocalGetter[TemplateStatisticsApiClient] = L
     lambda: TemplateStatisticsApiClient(current_app),
 )
 memo_resetters.append(lambda: get_template_statistics_client.clear())
-template_statistics_client = LocalProxy(get_template_statistics_client)
+template_statistics_client: TemplateStatisticsApiClient = LocalProxy(get_template_statistics_client)  # type: ignore[assignment]

--- a/app/notify_client/template_statistics_api_client.py
+++ b/app/notify_client/template_statistics_api_client.py
@@ -23,7 +23,7 @@ class TemplateStatisticsApiClient(NotifyAdminAPIClient):
         return self.get(url=f"/service/{service_id}/template-statistics/last-used/{template_id}")["last_date_used"]
 
 
-_template_statistics_client_context_var: ContextVar[TemplateStatisticsApiClient] = ContextVar(
+_template_statistics_client_context_var: ContextVar[TemplateStatisticsApiClient | None] = ContextVar(
     "template_statistics_client"
 )
 get_template_statistics_client: LazyLocalGetter[TemplateStatisticsApiClient] = LazyLocalGetter(

--- a/app/notify_client/unsubscribe_api_client.py
+++ b/app/notify_client/unsubscribe_api_client.py
@@ -26,4 +26,4 @@ get_unsubscribe_api_client: LazyLocalGetter[UnsubscribeApiClient] = LazyLocalGet
     lambda: UnsubscribeApiClient(current_app),
 )
 memo_resetters.append(lambda: get_unsubscribe_api_client.clear())
-unsubscribe_api_client = LocalProxy(get_unsubscribe_api_client)
+unsubscribe_api_client: UnsubscribeApiClient = LocalProxy(get_unsubscribe_api_client)  # type: ignore[assignment]

--- a/app/notify_client/unsubscribe_api_client.py
+++ b/app/notify_client/unsubscribe_api_client.py
@@ -20,7 +20,7 @@ class UnsubscribeApiClient(NotifyAdminAPIClient):
         return True
 
 
-_unsubscribe_api_client_context_var: ContextVar[UnsubscribeApiClient] = ContextVar("unsubscribe_api_client")
+_unsubscribe_api_client_context_var: ContextVar[UnsubscribeApiClient | None] = ContextVar("unsubscribe_api_client")
 get_unsubscribe_api_client: LazyLocalGetter[UnsubscribeApiClient] = LazyLocalGetter(
     _unsubscribe_api_client_context_var,
     lambda: UnsubscribeApiClient(current_app),

--- a/app/notify_client/upload_api_client.py
+++ b/app/notify_client/upload_api_client.py
@@ -19,7 +19,7 @@ class UploadApiClient(NotifyAdminAPIClient):
         return self.get(url=f"/service/{service_id}/upload/uploaded-letters/{letter_print_day}?page={page}")
 
 
-_upload_api_client_context_var: ContextVar[UploadApiClient] = ContextVar("upload_api_client")
+_upload_api_client_context_var: ContextVar[UploadApiClient | None] = ContextVar("upload_api_client")
 get_upload_api_client: LazyLocalGetter[UploadApiClient] = LazyLocalGetter(
     _upload_api_client_context_var,
     lambda: UploadApiClient(current_app),

--- a/app/notify_client/upload_api_client.py
+++ b/app/notify_client/upload_api_client.py
@@ -25,4 +25,4 @@ get_upload_api_client: LazyLocalGetter[UploadApiClient] = LazyLocalGetter(
     lambda: UploadApiClient(current_app),
 )
 memo_resetters.append(lambda: get_upload_api_client.clear())
-upload_api_client = LocalProxy(get_upload_api_client)
+upload_api_client: UploadApiClient = LocalProxy(get_upload_api_client)  # type: ignore[assignment]

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -243,7 +243,7 @@ class UserApiClient(NotifyAdminAPIClient):
         return self.delete(endpoint)
 
 
-_user_api_client_context_var: ContextVar[UserApiClient] = ContextVar("user_api_client")
+_user_api_client_context_var: ContextVar[UserApiClient | None] = ContextVar("user_api_client")
 get_user_api_client: LazyLocalGetter[UserApiClient] = LazyLocalGetter(
     _user_api_client_context_var,
     lambda: UserApiClient(current_app),

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -249,4 +249,4 @@ get_user_api_client: LazyLocalGetter[UserApiClient] = LazyLocalGetter(
     lambda: UserApiClient(current_app),
 )
 memo_resetters.append(lambda: get_user_api_client.clear())
-user_api_client = LocalProxy(get_user_api_client)
+user_api_client: UserApiClient = LocalProxy(get_user_api_client)  # type: ignore[assignment]

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -165,4 +165,4 @@ get_template_preview_client: LazyLocalGetter[TemplatePreviewClient] = LazyLocalG
     lambda: TemplatePreviewClient(current_app),
 )
 memo_resetters.append(lambda: get_template_preview_client.clear())
-template_preview_client = LocalProxy(get_template_preview_client)
+template_preview_client: TemplatePreviewClient = LocalProxy(get_template_preview_client)

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -159,7 +159,7 @@ class TemplatePreviewClient:
         )
 
 
-_template_preview_client_context_var: ContextVar[TemplatePreviewClient] = ContextVar("template_preview_client")
+_template_preview_client_context_var: ContextVar[TemplatePreviewClient | None] = ContextVar("template_preview_client")
 get_template_preview_client: LazyLocalGetter[TemplatePreviewClient] = LazyLocalGetter(
     _template_preview_client_context_var,
     lambda: TemplatePreviewClient(current_app),


### PR DESCRIPTION
There isn't yet a way of handling proxy objects in type hints, so the best we can do for now is lying.

These changes bring the number of mypy errors from 1317 down to 410