### PR TITLE
Update letter pricing side nav

### DIFF
--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -48,7 +48,7 @@ def pricing_nav():
                     "link": "main.guidance_pricing_text_messages",
                 },
                 {
-                    "name": "Letters",
+                    "name": "Letter pricing",
                     "link": "main.guidance_pricing_letters",
                 },
                 {


### PR DESCRIPTION
In prep for changes to side nav in https://github.com/alphagov/notifications-admin/pull/6011  Update side nav from 'Letters' to 'Letter pricing'

To publish once the PR https://github.com/alphagov/notifications-admin/pull/6011 is published. 

