### PR TITLE
Copy config from current utils before compiling requirements files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ refreeze-requirements: ## Update unpinned requirements
 freeze-requirements: ## create static requirements.txt
 	uv pip install "`cat requirements.in | grep 'notifications-utils @'`"
 	python -c "from notifications_utils.version_tools import copy_config; copy_config()"
-	uv pip compile requirements.in -o requirements.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
-	uv pip compile requirements_for_test.in -o requirements_for_test.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
+	uv pip compile --quiet requirements.in -o requirements.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
+	uv pip compile --quiet requirements_for_test.in -o requirements_for_test.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
 	uv pip sync requirements_for_test.txt
 
 .PHONY: show-outdated-requirements

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,9 @@ refreeze-requirements: ## Update unpinned requirements
 
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt
-	uv pip compile requirements.in -o requirements.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
-	uv pip sync requirements.txt
+	uv pip install "`cat requirements.in | grep 'notifications-utils @'`"
 	python -c "from notifications_utils.version_tools import copy_config; copy_config()"
+	uv pip compile requirements.in -o requirements.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
 	uv pip compile requirements_for_test.in -o requirements_for_test.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
 	uv pip sync requirements_for_test.txt
 


### PR DESCRIPTION
Copies https://github.com/alphagov/notifications-api/pull/4923

***

We compile 2 different requirements files:
- `requirements.txt`
- `requirements_for_test.txt`

In order to know how to resolve dependencies when compiling these files we need to look at `uv.toml`, which is copied from utils.

In order to get utils we:
1. compiled `requirements.in` into `requirements.txt`
2. installed the dependencies (including utils) from `requirements.txt`

This means that at step 1 we were using whatever version of `uv.toml` was in the working dir. We then go on to compile
`requirements_for_test.txt` with (potentially) a different version of `uv.toml`.

This commit makes it so that installing the specified version of utils is the first step, before doing any compiling.

***

## Add `--quiet` flag to `uv pip compile`

It produces a lot of output which fills the terminal.

Often I want to do `make bump-utils freeze-requirements` but have to do a lot of scrolling back to see the useful output of `bump-utils`.

Running `uv pip sync` also produces some output about which packages have changed, so I don’t think we need similar output from the `compile` command.

Changing it in this PR while I’m going through each `Makefile`.