### PR TITLE
Upgrade utils and requests to the latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.0
+# This file was automatically copied from notifications-utils@124.2.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@124.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@124.2.1
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -998,9 +998,9 @@ redis==8.0.0 \
     --hash=sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49 \
     --hash=sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7
     # via flask-redis
-requests==2.33.1 \
-    --hash=sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517 \
-    --hash=sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
+requests==2.34.2 \
+    --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0 \
+    --hash=sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed
     # via
     #   govuk-bank-holidays
     #   notifications-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -756,7 +756,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ace9443c2800adc8107f3bb8ac32e483724612d6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@979201bc0943587311ddd70ebb3b404c2a550265
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1436,9 +1436,9 @@ redis==8.0.0 \
     # via
     #   -r requirements.txt
     #   flask-redis
-requests==2.33.1 \
-    --hash=sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517 \
-    --hash=sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
+requests==2.34.2 \
+    --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0 \
+    --hash=sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed
     # via
     #   -r requirements.txt
     #   govuk-bank-holidays

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1128,7 +1128,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ace9443c2800adc8107f3bb8ac32e483724612d6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@979201bc0943587311ddd70ebb3b404c2a550265
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.0
+# This file was automatically copied from notifications-utils@124.2.1
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.0
+# This file was automatically copied from notifications-utils@124.2.1
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.0
+# This file was automatically copied from notifications-utils@124.2.1
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
# Bump utils to 124.2.1

 ## 124.2.1

* Fix antivirus scan when the uploaded file is a Werkzeug `FileStorage` (requests 2.34)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/124.2.0...124.2.1

# Update requests to the latest version

This is safe to do now utils is bumped to a version which incorporates https://github.com/alphagov/notifications-utils/pull/1440