### PR TITLE
Add white-space: no-wrap to spark-bar to correctly display text and % value bar

### DIFF
--- a/app/assets/stylesheets/components/spark-bar.scss
+++ b/app/assets/stylesheets/components/spark-bar.scss
@@ -23,4 +23,5 @@
   text-align: right;
   margin: 2px 0 1px 0;
   transition: width 0.6s ease-in-out;
+  white-space: nowrap;
 }


### PR DESCRIPTION
Fix spark-bar display

When a service has a large spread of template-usage,  the calculated percentage width is too small to contain the value.

Because govuk-summary list uses table-cell display we need to cell the spark-bar_bar to no wrap.

This is caused by the summary-list__value container having `display: table-cell;`

<img width="299" height="363" alt="Screenshot 2026-08-03 at 13 47 35" src="https://github.com/user-attachments/assets/7ed0a126-b0e7-4be1-b521-f0999a66e255" />

