### PR TITLE
notify client `RequestCache` instance: explicitly type-hint

### DIFF
--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -9,7 +9,7 @@ from notifications_utils.json import RelaxedContainerJSONEncoder, StrictJsonTopL
 from app import current_user
 from app.extensions import redis_client
 
-cache = RequestCache(redis_client)
+cache: RequestCache = RequestCache(redis_client)
 
 
 class _ExtraRelaxedContainerJSONEncoder(RelaxedContainerJSONEncoder):


### PR DESCRIPTION
This reduces the errors reported by `mypy` from 408 to 270.