### PR TITLE
Create NHS Notify service

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1350,6 +1350,18 @@ class CreateServiceForm(StripWhitespaceForm):
     organisation_type = OrganisationTypeField()
 
 
+class CreateNhsNotifyServiceForm(StripWhitespaceForm):
+    name = GovukTextInputField(
+        "Enter a service name",
+        validators=[
+            DataRequired(message="Enter a service name"),
+            MustContainAlphanumericCharacters(),
+            Length(max=255, thing="service name"),
+        ],
+    )
+    organisation_type = HiddenField("organisation_type", default="nhs_notify")
+
+
 class CreateNhsServiceForm(CreateServiceForm):
     organisation_type = OrganisationTypeField(
         include_only={"nhs_central", "nhs_local", "nhs_gp"},

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -3,7 +3,7 @@ from notifications_python_client.errors import HTTPError
 
 from app import current_user, service_api_client
 from app.main import main
-from app.main.forms import CreateNhsServiceForm, CreateServiceForm
+from app.main.forms import CreateNhsNotifyServiceForm, CreateNhsServiceForm, CreateServiceForm
 from app.models.organisation import Organisation
 from app.models.service import Service
 from app.utils.user import user_is_gov_user, user_is_logged_in
@@ -62,6 +62,9 @@ def name_service():
     if default_organisation_type == "nhs":
         form = CreateNhsServiceForm()
         default_organisation_type = None
+    elif default_organisation_type == "nhs_notify":
+        form = CreateNhsNotifyServiceForm(organisation_type=default_organisation_type)
+        form.organisation_type.data = "nhs_notify"
     else:
         form = CreateServiceForm(organisation_type=default_organisation_type)
 
@@ -78,14 +81,14 @@ def name_service():
 
         new_service = Service.from_id(service_id)
 
-        # GPs have a zero message limit (to prevent them sending messages while in trial mode)
-        if form.organisation_type.data == Organisation.TYPE_NHS_GP:
+        # GPs and NHS Notify services have a zero message limit (to prevent them sending messages while in trial mode)
+        if form.organisation_type.data in Organisation.TYPES_WITH_NO_FREE_ALLOWANCE:
             new_service.update(sms_message_limit=0)
 
-        # show the tour if the user doesn't have any other services. Never show for NHS GPs
+        # show the tour if the user doesn't have any other services. Never show for NHS GPs or NHS Notify services
         show_tour = (
             len(service_api_client.get_active_services({"user_id": session["user_id"]}).get("data", [])) <= 1
-            and form.organisation_type.data != Organisation.TYPE_NHS_GP
+            and form.organisation_type.data not in Organisation.TYPES_WITH_NO_FREE_ALLOWANCE
         )
 
         if show_tour:

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -33,6 +33,12 @@ class Organisation(JSONModel):
         TYPE_NHS_NOTIFY,
     )
 
+    TYPES_WITH_NO_FREE_ALLOWANCE = (
+        TYPE_NHS_GP,
+        TYPE_NHS_NOTIFY,
+    )
+
+    # NHS_NOTIFY is excluded - it should not appear as an option for people to pick
     TYPE_LABELS = {
         TYPE_CENTRAL: "Central government",
         TYPE_LOCAL: "Local government",
@@ -43,6 +49,9 @@ class Organisation(JSONModel):
         TYPE_SCHOOL_OR_COLLEGE: "School or college",
         TYPE_OTHER: "Other",
     }
+
+    NHS_NOTIFY_ID = "477f8870-af2b-4b81-9a2c-1fad12028919"
+    NHS_NOTIFY_TYPE_LABEL = "NHS Notify"
 
     id: Any
     name: str
@@ -126,6 +135,9 @@ class Organisation(JSONModel):
 
     @property
     def organisation_type_label(self):
+        if self.organisation_type == self.TYPE_NHS_NOTIFY:
+            return self.NHS_NOTIFY_TYPE_LABEL
+
         return self.TYPE_LABELS.get(self.organisation_type)
 
     @property

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -21,6 +21,7 @@ class Organisation(JSONModel):
     TYPE_NHS_CENTRAL = "nhs_central"
     TYPE_NHS_LOCAL = "nhs_local"
     TYPE_NHS_GP = "nhs_gp"
+    TYPE_NHS_NOTIFY = "nhs_notify"
     TYPE_EMERGENCY_SERVICE = "emergency_service"
     TYPE_SCHOOL_OR_COLLEGE = "school_or_college"
     TYPE_OTHER = "other"
@@ -29,6 +30,7 @@ class Organisation(JSONModel):
         TYPE_NHS_CENTRAL,
         TYPE_NHS_LOCAL,
         TYPE_NHS_GP,
+        TYPE_NHS_NOTIFY,
     )
 
     TYPE_LABELS = {

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -522,6 +522,9 @@ class Service(JSONModel):
 
     @property
     def organisation_type_label(self):
+        if self.organisation_type == Organisation.TYPE_NHS_NOTIFY:
+            return Organisation.NHS_NOTIFY_TYPE_LABEL
+
         return Organisation.TYPE_LABELS.get(self.organisation_type)
 
     @property

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -377,7 +377,13 @@ class User(BaseUser, UserMixin):
         return Organisation.from_domain(self.email_domain)
 
     @property
+    def is_nhs_notify_org_member(self):
+        return self.belongs_to_organisation(Organisation.NHS_NOTIFY_ID)
+
+    @property
     def default_organisation_type(self):
+        if self.is_nhs_notify_org_member:
+            return "nhs_notify"
         if self.default_organisation:
             return self.default_organisation.organisation_type
         if self.has_nhs_email_address:

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -340,17 +340,27 @@ def test_add_service_sets_nhs_gp_daily_sms_limit_to_zero_when_user_already_has_s
     assert mock_create_service_template.called is False
 
 
-def test_add_service_sets_nhs_gp_daily_sms_limit_to_zero_when_user_has_no_other_services(
+@pytest.mark.parametrize("org_type, mock_user_org_type", [("nhs_gp", "nhs"), ("nhs_notify", "nhs_notify")])
+def test_add_service_sets_daily_sms_limit_to_zero_for_nhs_services_with_no_allowance_when_user_has_no_other_services(
     mock_get_no_organisation_by_domain,
     client_request,
     mock_create_service,
     mock_create_service_template,
     mock_update_service,
     mock_get_services_with_no_services,
+    org_type,
+    mock_user_org_type,
+    mocker,
 ):
+    mocker.patch(
+        "app.models.user.User.default_organisation_type",
+        new_callable=mocker.PropertyMock,
+        return_value=mock_user_org_type,
+    )
+
     client_request.post(
         "main.name_service",
-        _data={"name": "testing the post", "organisation_type": "nhs_gp"},
+        _data={"name": "testing the post", "organisation_type": org_type},
         _expected_status=302,
         _expected_redirect=url_for(
             "main.service_dashboard",


### PR DESCRIPTION
Add NHS Notify Org type and new service created by a member of the NHS Notify organisation is assigned to the NHS Notify organisation and has its org type should be `nhs_notify` and 0 text message allowance by default. More details on this [card](https://trello.com/c/k4howfs3/1957-nhs-notify-3-4-assign-new-service-to-nhs-notify-org).
https://github.com/alphagov/notifications-api/pull/4928 PR will be deployed first.