### PR TITLE
Convert key:value tables to summary lists

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -115,10 +115,17 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 // 24px filename and 19px metadata - template stats
 // 19px filename and 16px metadata - other lists
 
+// by default this bold
 .notify-summary-list__filename {
   @include govuk-typography-weight-bold;
 }
 
+// used for unsubscribe requests
+.notify-summary-list__filename--regular {
+  @include govuk-typography-weight-regular;
+}
+
+// used for template usage list
 .notify-summary-list__filename--large {
   @include govuk-font-size(24);
 }
@@ -127,6 +134,11 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
   @include govuk-media-query($from: tablet) {
     margin-bottom: 0;
   }
+}
+
+// used for inbound sms, unsubscribe request lists and returned letters
+.notify-summary-list__metadata--small {
+  @include govuk-font-size(16);
 }
 
 .notify-summary-list__key {
@@ -148,6 +160,7 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 
 }
 
+// used for template stats list
 .notify-summary-list__key--50-100 {
 
   @include govuk-media-query($from: tablet) {
@@ -156,8 +169,28 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 
 }
 
+// unsubscribe reports, inbound sms list and returned letters
+// value does not need 50% of the width
+.notify-summary-list__key--60-100 {
+
+  @include govuk-media-query($from: tablet) {
+    width: 60%;
+  }
+
+}
+
 .govuk-summary-list__value--default {
   color: govuk-functional-colour(secondary-text);
+}
+
+.govuk-summary-list__value--align-right {
+  @include govuk-media-query($from: tablet) {
+    text-align: right;
+  }
+}
+
+.govuk-summary-list__value--small {
+  @include govuk-font-size(16);
 }
 
 .govuk-summary-list__value--truncate {

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -1,5 +1,5 @@
-{% from "components/table.html" import list_table, field %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 <div class="ajax-block-container">
   {% if messages %}
@@ -7,38 +7,41 @@
       <a href="{{ url_for('main.inbox_download', service_id=current_service.id) }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download all messages</a>
     </p>
   {% endif %}
-  {% call(item, row_number) list_table(
-    messages,
-    caption="Inbox",
-    caption_visible=False,
-    empty_message='When users text your service’s phone number ({}) you’ll see the messages here'.format(inbound_number),
-    field_headings=[
-      {
-        'text':'From',
-        'classes': 'govuk-!-width-two-thirds--static'
-      },
-      {
-        'text':'First two lines of message',
-        'classes': 'govuk-!-width-one-third--static'
-      }
-    ],
-    field_headings_visible=False
-  ) %}
-    {% call field() %}
-      <a
-        class="govuk-link govuk-link--no-visited-state file-list-filename"
-        href="{{ url_for('main.conversation', service_id=current_service.id, notification_id=item.id) }}"
-      >
-        {{ item.user_number | format_phone_number_human_readable }}
-      </a>
-      <span class="file-list-hint file-list-hint--flow-text">{{ item.content }}</span>
-    {% endcall %}
-    {% call field(align='right') %}
-      <span class="align-with-message-body">
-        {{ item.created_at | format_delta }}
-      </span>
-    {% endcall %}
-  {% endcall %}
+
+  {% if not messages %}
+    <p class="govuk-body no-data">
+      When users text your service’s phone number ({{ inbound_number | format }}) you’ll see the messages here
+    </p>
+  {% else %}
+    {% set message_list = [] %}
+    {% for item in messages %}
+        {% set summary_key_html %}
+          <a class="govuk-link govuk-link--no-visited-state notify-summary-list__filename"
+            href="{{ url_for('main.conversation', service_id=current_service.id, notification_id=item.id) }}">
+            {{ item.user_number | format_phone_number_human_readable }}
+          </a>
+        <p class="govuk-body notify-summary-list__metadata notify-summary-list__metadata--small">
+          {{ item.content }}
+        </p>
+        {% endset %}
+        {% do message_list.append({
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--60-100",
+            "html": summary_key_html,
+          },
+          "value": {
+            "classes": "govuk-summary-list__value--align-right govuk-summary-list__value--small",
+            "text": item.created_at | format_delta,
+          }
+        }) %}
+    {% endfor %}
+
+    {{ govukSummaryList({
+        "classes": "notify-summary-list",
+        "rows": message_list
+      }) }}
+
+  {% endif %}
 
   {{ previous_next_navigation(prev_page, next_page) }}
 </div>

--- a/app/templates/views/returned-letters.html
+++ b/app/templates/views/returned-letters.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% block service_page_title %}
   Returned letters for {{ reported_at|format_date_normal }}
@@ -26,18 +26,18 @@
   <a href="{{ url_for('main.returned_letters_report', service_id=current_service.id, reported_at=reported_at) }}" class="govuk-link govuk-link--no-visited-state heading-small">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
 </p>
 
-<div class="dashboard-table">
-  {% call(item, row_number) list_table(
-      returned_letters,
-      caption="Returned letters for {}".format(reported_at|format_date_normal),
-      caption_visible=False,
-      empty_message='If you have returned letter reports they will be listed here',
-      field_headings=['Template name', 'Originally sent'],
-      field_headings_visible=False
-  ) %}
-    {% call field() %}
-      <span class="file-list-filename file-list-filename-unlinked">{{ item.template_name or item.uploaded_letter_file_name or 'Provided as PDF' }}</span>
-      <span class="file-list-hint">
+{% if not returned_letters %}
+  <p class="govuk-body no-data">
+    If you have returned letter reports they will be listed here
+  </p>
+{% else %}
+  {% set returned_letters_list = [] %}
+  {% for item in returned_letters %}
+    {% set summary_key_html %}
+        <span class="notify-summary-list__filename notify-summary-list__filename--regular">
+         {{ item.template_name or item.uploaded_letter_file_name or 'Provided as PDF' }}
+        </span>
+      <p class="govuk-body notify-summary-list__metadata notify-summary-list__metadata--small">
         {% if item.client_reference %}
           Reference {{ item.client_reference }}
         {% elif item.original_file_name %}
@@ -45,21 +45,31 @@
         {% else %}
           No reference provided
         {% endif %}
-      </span>
-    {% endcall %}
-    {% call field(align='right') %}
-      <span class="align-with-message-body">
-        <span class="status-hint">
-          Sent {{ item.created_at|format_date_normal }}
-        </span>
-      </span>
-    {% endcall %}
-  {% endcall %}
+      </p>
+      {% endset %}
+      {% do returned_letters_list.append({
+        "key": {
+          "classes": "notify-summary-list__key notify-summary-list__key--60-100",
+          "html": summary_key_html,
+        },
+        "value": {
+          "classes": "govuk-summary-list__value--align-right govuk-summary-list__value--small",
+          "text":  "Sent " + item.created_at|format_date_normal,
+        }
+      }) %}
+  {% endfor %}
+
+  {{ govukSummaryList({
+    "classes": "notify-summary-list",
+    "rows": returned_letters_list
+  }) }}
+
   {% if more_than_one_page %}
-    <p class="table-show-more-link">
+    <p class="govuk-body more-items-available-text">
       Only showing the first {{ page_size }} of {{ count_of_returned_letters|format_thousands }} rows
     </p>
   {% endif %}
-</div>
+
+{% endif %}
 
 {% endblock %}

--- a/app/templates/views/unsubscribe-request-reports-summary.html
+++ b/app/templates/views/unsubscribe-request-reports-summary.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import field, list_table, row_heading%}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% block service_page_title %}
   Email unsubscribe requests
@@ -15,33 +15,40 @@
 
     {{ page_header('Email unsubscribe requests') }}
 
-<div class="dashboard-table">
-    {% call(item, row_number) list_table(
-        current_service.unsubscribe_request_reports_summary,
-        caption="Unsubscribe Request Reports",
-        caption_visible=False,
-        empty_message='If you have any email unsubscribe requests they will be listed here',
-        field_headings=['Report', 'Status'],
-        field_headings_visible=False
-    ) %}
-    {% call row_heading() %}
+  {% if not current_service.unsubscribe_request_reports_summary %}
+    <p class="govuk-body no-data">
+      If you have any email unsubscribe requests they will be listed here
+    </p>
+  {% else %}
+    {% set report_list = [] %}
+    {% for item in current_service.unsubscribe_request_reports_summary %}
+      {% set summary_key_html %}
+          <a class="govuk-link govuk-link--no-visited-state notify-summary-list__filename"
+            href="{{url_for('main.unsubscribe_request_report', service_id=current_service.id, batch_id=item.batch_id)}}">
+              {{ item.title|sentence_case }}
+          </a>
+        <p class="govuk-body notify-summary-list__metadata notify-summary-list__metadata--small">
+          {{ item.count|format_thousands}} {{ item.count | message_count_label('unsubscribe request', suffix='') }}
+        </p>
+        {% endset %}
+        {% do report_list.append({
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--60-100",
+            "html": summary_key_html,
+          },
+          "value": {
+           "classes": "govuk-summary-list__value--align-right govuk-summary-list__value--small" ~ (" govuk-summary-list__value--default" if not item.is_a_batched_report else ""),
+            "text":  item.status,
+          }
+        }) %}
+    {% endfor %}
 
-      <a class="govuk-link govuk-link--no-visited-state file-list-filename"
-         href="{{url_for('main.unsubscribe_request_report', service_id=current_service.id, batch_id=item.batch_id)}}" >
-          {{ item.title|sentence_case }}
-        </a>
-       <p class="file-list-hint">
+    {{ govukSummaryList({
+      "classes": "notify-summary-list",
+      "rows": report_list
+    }) }}
 
-         {{ item.count|format_thousands}} {{ item.count | message_count_label('unsubscribe request', suffix='') }}
-         </p>
-    {% endcall %}
-    {% call field(align='right', status='' if item.is_a_batched_report else 'default') %}
-      <span class="align-with-message-body">
-        {{ item.status}}
-      </span>
-    {% endcall %}
-  {% endcall %}
-</div>
+  {% endif %}
 
 {% endblock %}
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -293,15 +293,13 @@ def test_inbox_showing_inbound_messages(
         service_id=SERVICE_ONE_ID,
     )
 
-    rows = page.select("tbody tr")
+    rows = page.select(".govuk-summary-list__row")
     assert len(rows) == 8
     assert normalize_spaces(rows[index].text) == expected_row
     assert page.select_one("[data-key=messages] a.govuk-\\!-font-weight-bold")["href"] == url_for(
         "main.inbox_download",
         service_id=SERVICE_ONE_ID,
     )
-    assert len(page.select("thead th:first-child.govuk-\\!-width-two-thirds--static")) == 1
-    assert len(page.select("thead th:last-child.govuk-\\!-width-one-third--static")) == 1
 
 
 def test_get_inbound_sms_shows_page_links(
@@ -345,7 +343,7 @@ def test_empty_inbox(
         service_id=SERVICE_ONE_ID,
     )
 
-    assert normalize_spaces(page.select("tbody tr")) == (
+    assert normalize_spaces(page.select("p.no-data")) == (
         "When users text your service’s phone number (07812398712) you’ll see the messages here"
     )
     assert not page.select("a[download]")

--- a/tests/app/main/views/test_returned_letters.py
+++ b/tests/app/main/views/test_returned_letters.py
@@ -108,14 +108,13 @@ def test_returned_letters_page(client_request, mocker):
     )
 
     assert [
-        "Template name Originally sent",
         "Example template Reference ABC123 Sent 24 December 2019",
         "Example template Sent from Example spreadsheet.xlsx Sent 24 December 2019",
         "Example template No reference provided Sent 24 December 2019",
         "Example precompiled.pdf Reference DEF456 Sent 24 December 2019",
         "Example one-off.pdf No reference provided Sent 24 December 2019",
         "Provided as PDF Reference XYZ999 Sent 24 December 2019",
-    ] == [normalize_spaces(row.text) for row in page.select("tr")]
+    ] == [normalize_spaces(list_item.text) for list_item in page.select(".govuk-summary-list__row")]
 
 
 @pytest.mark.parametrize(
@@ -169,7 +168,7 @@ def test_returned_letters_page_with_many_letters(
         reported_at="2019-12-24",
     )
 
-    assert len(page.select("tbody tr")) == 50
+    assert len(page.select(".govuk-summary-list__row")) == 50
 
     download_link = page.select_one("main a")
     assert normalize_spaces(download_link.text) == "Download this report (CSV)"
@@ -185,7 +184,7 @@ def test_returned_letters_page_with_many_letters(
     else:
         assert [normalize_spaces(e.text) for e in orphaned_paras] == [orphaned_expected_message]
 
-    show_more_links = [e for e in page.select(".table-show-more-link") if "Only showing" in e.text]
+    show_more_links = [e for e in page.select(".more-items-available-text") if "Only showing" in e.text]
     if more_expected_message is None:
         assert show_more_links == []
     else:

--- a/tests/app/main/views/test_unsubscribe_requests.py
+++ b/tests/app/main/views/test_unsubscribe_requests.py
@@ -46,7 +46,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                 ),
             ],
             [
-                "Report Status",
                 "Today at 4:00pm 1 unsubscribe request Not downloaded",
                 "Today from midday to 2:17pm 1 unsubscribe request Downloaded",
                 "Today until midday 34 unsubscribe requests Downloaded",
@@ -68,7 +67,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                 ),
             ],
             [
-                "Report Status",
                 "1 January 2020 to 1 June 1 unsubscribe request Downloaded",
             ],
             [],
@@ -88,7 +86,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                 ),
             ],
             [
-                "Report Status",
                 "1 January at 1:18pm 1 unsubscribe request Downloaded",
                 "1 January at 12:17pm 1 unsubscribe request Downloaded",
             ],
@@ -112,7 +109,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                 ),
             ],
             [
-                "Report Status",
                 "1 May from midday to 2:17pm 1 unsubscribe request Completed",
                 "30 April to 1 May at 10:00am 12,345,678 unsubscribe requests Completed",
             ],
@@ -141,7 +137,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                 ),
             ],
             [
-                "Report Status",
                 "Today 1,234 unsubscribe requests Downloaded",
                 "Yesterday 4,567 unsubscribe requests Downloaded",
                 "20 June 7,890 unsubscribe requests Downloaded",
@@ -171,7 +166,6 @@ from tests.conftest import SERVICE_ONE_ID, create_unsubscribe_request_report, no
                 ),
             ],
             [
-                "Report Status",
                 "1 June from 11:22pm to midnight 1,234 unsubscribe requests Downloaded",
                 "1 June from 2:17pm to 2:18pm 4,567 unsubscribe requests Downloaded",
                 "1 June until midday 7,890 unsubscribe requests Downloaded",
@@ -192,10 +186,9 @@ def test_unsubscribe_request_reports_summary(
 
     page = client_request.get("main.unsubscribe_request_reports_summary", service_id=SERVICE_ONE_ID)
 
-    assert [normalize_spaces(row.text) for row in page.select("tr")] == expected_rows
+    assert [normalize_spaces(list_item.text) for list_item in page.select(".govuk-summary-list__row")] == expected_rows
     assert [
-        normalize_spaces(field.text)
-        for field in page.select("td.table-field-right-aligned .table-field-status-default .align-with-message-body")
+        normalize_spaces(list_value.text) for list_value in page.select(".govuk-summary-list__value--default")
     ] == expected_grey_text_statuses
 
 
@@ -204,9 +197,10 @@ def test_no_unsubscribe_request_reports_summary_to_display(client_request, mocke
 
     page = client_request.get("main.unsubscribe_request_reports_summary", service_id=SERVICE_ONE_ID)
 
-    assert ["Report Status", "If you have any email unsubscribe requests they will be listed here"] == [
-        normalize_spaces(row.text) for row in page.select("tr")
-    ]
+    assert (
+        normalize_spaces(page.select("p.no-data"))
+        == "If you have any email unsubscribe requests they will be listed here"
+    )
 
 
 @freeze_time("2024-06-22 12:00")


### PR DESCRIPTION


Accompanying FTs https://github.com/alphagov/notifications-functional-tests/pull/665.

## What

Convert tables on 
- returned letters summary page
- unsubscribe requests summary page
- received text message list page

to summary lists.  These lists are key:value pairs so from an accessibility standpoint, a summary list that's built on [description list](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl) element is more appropriate.

## Review
See individual commits for details

Changes on following pages
- services/serviceID/inbox
- services/serviceID/returned-letters
- services/serviceID/unsubscribe-requests/summary

To generate returned letters, best way to generate a letter, update its status is db to 'returned-letter'.
To generate unsubscribe requests, send yourself an email with the unsubscribe link and then unsubscribe.
To generate received text messages, you need a valid inbound number. You can then send text to it, or fake with below.

```
INSERT INTO inbound_sms (
    id,
    service_id,
    content,
    notify_number,
    user_number,
    created_at,
    provider_date,
    provider_reference,
    provider
) VALUES (
    gen_random_uuid(),                   
    '<yourServiceId>',
    'IkhpLCBJIHdvdWxkIGxpa2UgdG8gc3RhcnQgdXNpbmcgdGhpcyBzZXJ2aWNlIG9uIDAxLzAzLzIwMjUuIg.uWFcCtvoSZs8ZI1Hs7qZZ_3HMzY', 
    '<yourInboundNumber>',                       
    '<senderNumber>',                       
    NOW(),                               
    NOW(),                               
    'SOME-REF',                       
    'mmg'                             
);
```

## Visuals

Received SMS list
<img width="787" height="229" alt="inbound-sms" src="https://github.com/user-attachments/assets/09889460-f164-48b0-9b89-f527fb528f5e" />

Returned letters list
<img width="776" height="244" alt="returned_letters" src="https://github.com/user-attachments/assets/453c1317-5dd8-43c0-b692-f6976ddb1ef6" />

Unsubscribe requests list
<img width="780" height="315" alt="unsubscribe requests" src="https://github.com/user-attachments/assets/10eea8f5-0ed5-432a-9dcc-f3a2000a9e21" />

