### PR TITLE
`Spreadsheet`: typing fixes

### DIFF
--- a/app/models/spreadsheet.py
+++ b/app/models/spreadsheet.py
@@ -1,10 +1,10 @@
 import csv
 import logging
-from io import RawIOBase, StringIO
+from io import BytesIO, StringIO
 from itertools import chain, compress, count, repeat
 from os import path
 from time import sleep
-from typing import Self, final
+from typing import IO, Self, final
 
 import openpyxl
 import openpyxl.reader.excel
@@ -15,7 +15,7 @@ from openpyxl.utils import get_column_letter as openpyxl_get_column_letter
 from openpyxl.worksheet.dimensions import DimensionHolder as openpyxl_DimensionHolder
 
 # monkeypatch the reference openpyxl will use for ZipFile
-openpyxl.reader.excel.ZipFile = InterruptibleIOZipFile
+openpyxl.reader.excel.ZipFile = InterruptibleIOZipFile  # type: ignore[attr-defined]
 
 
 logger = logging.getLogger(__name__)
@@ -90,14 +90,14 @@ class Spreadsheet:
         return cls(rows=rows, filename=filename, row_limit=row_limit)
 
     @staticmethod
-    def _openpyxl_dimension_visible(dimensions: openpyxl_DimensionHolder, index: [int, str]) -> bool:
+    def _openpyxl_dimension_visible(dimensions: openpyxl_DimensionHolder, index: int | str) -> bool:
         # test for containment before attempting access to avoid unnecessary defaultdict allocation
         return index not in dimensions or dimensions[index].hidden is False
 
     @classmethod
     def _from_xlsx(  # noqa C901 is bunk
         cls,
-        file_content: RawIOBase,
+        file_content: IO[bytes],
         filename: str,
         row_limit: int | None,
         column_limit_from_header: bool,
@@ -223,7 +223,7 @@ class Spreadsheet:
                 and cls._openpyxl_dimension_visible(sheet.row_dimensions, row_index)
                 and str("" if cell.value is None else cell.value).strip()
             ):
-                if row_index > row_limit:
+                if row_limit is not None and row_index > row_limit:
                     # fail earlier than we otherwise would to save pointless work, this calculation
                     # counting hidden rows also saves us from having to "skip" millions of them
                     raise cls.TooManyRowsError(f"Exceeded row limit of {row_limit}")
@@ -245,7 +245,7 @@ class Spreadsheet:
         # information into a big dict keyed by coordinates (akin to sheet._cells) with values being the value
         # each cell should instead have (taken from the top left cell of the range). note 1-based coordinates
         # to match sheet._cells keys.
-        max_range = openpyxl.worksheet.cell_range.CellRange(
+        max_range = openpyxl.worksheet.cell_range.CellRange(  # type: ignore[attr-defined]
             min_row=1, min_col=1, max_row=max_row_within_limit, max_col=max_col_within_limit
         )
         merged_cell_map = dict(
@@ -298,7 +298,7 @@ class Spreadsheet:
     @classmethod
     def from_file(  # noqa C901 is bunk
         cls,
-        file_content: RawIOBase,
+        file_content: IO[bytes],
         filename: str = "",
         row_limit: int | None | type[DEFAULT_ARG] = DEFAULT_ARG,
         column_limit_from_header: bool | type[DEFAULT_ARG] = DEFAULT_ARG,
@@ -322,7 +322,7 @@ class Spreadsheet:
             return cls(csv_data=Spreadsheet.normalise_newlines(file_content), filename=filename, row_limit=row_limit)
 
         if extension == "tsv":
-            file_content = StringIO(Spreadsheet.normalise_newlines(file_content))
+            file_content = BytesIO(Spreadsheet.normalise_newlines(file_content).encode("utf-8"))
 
         if extension in ("xlsx", "xlsm"):
             return cls._from_xlsx(


### PR DESCRIPTION
This makes some things type-check properly, ignores some places where we're using technically-non-public definitions and resolves the confusion over whether our `tsv` contents are handled as strings or bytes (all other file types are handled as bytes).

This reduces the number of `mypy` errors from 268 to 263.