### PR TITLE
Only make one request to the API to get service history

### DIFF
--- a/app/main/views/history.py
+++ b/app/main/views/history.py
@@ -6,6 +6,7 @@ from flask import render_template, request
 from app import current_service, format_date_numeric
 from app.main import main
 from app.models.event import APIKeyEvent, APIKeyEvents, ServiceEvents
+from app.notify_client.service_api_client import service_api_client
 from app.utils.user import user_has_permissions
 
 
@@ -23,11 +24,13 @@ def history(service_id):
 
 
 def _get_events(service_id, selected):
+    history = service_api_client.get_service_history(service_id)
+
     if selected == "api":
-        return APIKeyEvents(service_id)
+        return APIKeyEvents(history["api_key_history"])
     if selected == "service":
-        return ServiceEvents(service_id)
-    return APIKeyEvents(service_id) + ServiceEvents(service_id)
+        return ServiceEvents(history["service_history"])
+    return APIKeyEvents(history["api_key_history"]) + ServiceEvents(history["service_history"])
 
 
 def _chunk_events_by_day(events):

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -1,10 +1,9 @@
 from abc import ABC, abstractmethod
 
 from notifications_utils.formatters import formatted_list
+from notifications_utils.serialised_model import SerialisedModelCollection
 
 from app.formatters import format_thousands
-from app.models import ModelList
-from app.notify_client.service_api_client import service_api_client
 
 
 class Event(ABC):
@@ -130,22 +129,14 @@ class APIKeyEvent(Event):
             return f"Created an API key called ‘{self.item['name']}’"
 
 
-class APIKeyEvents(ModelList):
+class APIKeyEvents(SerialisedModelCollection):
     model = APIKeyEvent
 
-    @staticmethod
-    def _get_items(*args, **kwargs):
-        return service_api_client.get_service_api_key_history(*args, **kwargs)
 
-
-class ServiceEvents(ModelList):
+class ServiceEvents(SerialisedModelCollection):
     @property
     def model(self):
         return lambda x: x
-
-    @staticmethod
-    def _get_items(*args, **kwargs):
-        return service_api_client.get_service_service_history(*args, **kwargs)
 
     @staticmethod
     def splat(events):
@@ -162,5 +153,5 @@ class ServiceEvents(ModelList):
                         sorted_events[index][key],
                     )
 
-    def __init__(self, service_id):
-        self.items = [event for event in self.splat(self._get_items(service_id)) if event.relevant]
+    def __init__(self, items):
+        self.items = [event for event in self.splat(items) if event.relevant]

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -304,12 +304,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def get_service_history(self, service_id):
         return self.get(f"/service/{service_id}/history")["data"]
 
-    def get_service_service_history(self, service_id):
-        return self.get_service_history(service_id)["service_history"]
-
-    def get_service_api_key_history(self, service_id):
-        return self.get_service_history(service_id)["api_key_history"]
-
     def get_monthly_notification_stats(self, service_id, year):
         return self.get(f"/service/{service_id}/notifications/monthly?year={year}")
 


### PR DESCRIPTION
To view the history page we get events about a service and about API keys:
https://github.com/alphagov/notifications-admin/blob/c7fbd6ff2d4416a93ab2fb95ec9ead22448fdeac/app/main/views/history.py#L30

These each make calls to the service API client:
https://github.com/alphagov/notifications-admin/blob/c7fbd6ff2d4416a93ab2fb95ec9ead22448fdeac/app/models/event.py#L138

https://github.com/alphagov/notifications-admin/blob/c7fbd6ff2d4416a93ab2fb95ec9ead22448fdeac/app/models/event.py#L148

These API client methods call through to one underlying method (`get_service_history`): https://github.com/alphagov/notifications-admin/blob/c7fbd6ff2d4416a93ab2fb95ec9ead22448fdeac/app/notify_client/service_api_client.py#L303-L311

Therefore calling both of them calls the same underlying method twice. Because this query can be slow, calling it twice increases the chance of the request timing out.

Instead we can get the data once, then pass it into the `ServiceEvents` and `APIKeyEvents` models.