### PR TITLE
Bump utils to 125.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.1
+# This file was automatically copied from notifications-utils@125.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@124.2.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@125.0.1
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -756,7 +756,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@979201bc0943587311ddd70ebb3b404c2a550265
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a4e315988da7cefbd56f53f51da900c95ded471f
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1128,7 +1128,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@979201bc0943587311ddd70ebb3b404c2a550265
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a4e315988da7cefbd56f53f51da900c95ded471f
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.1
+# This file was automatically copied from notifications-utils@125.0.1
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.1
+# This file was automatically copied from notifications-utils@125.0.1
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@124.2.1
+# This file was automatically copied from notifications-utils@125.0.1
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
 ## 125.0.1

* Fixes a number of bugs with counting characters in text message templates

 ## 125.0.0

* Removes `RecipientCSV.rows_as_list` and `RecipientCSV.get_rows()`. Use `for row in recipient_csv_instance:`, `len(recipient_csv_instance)`, etc. instead

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/124.2.1...125.0.1