### PR TITLE
Update simple tables to use govuk-frontend table component

### DIFF
--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -84,6 +84,9 @@ td {
   color: govuk-functional-colour(secondary-text);
 }
 
+// this can be removed once the fullscreen table on
+// /services/<uuid:service_id>/send/<uuid:template_id>/csv 
+// is converted to a govuk-frontend table
 .spreadsheet {
 
   margin-bottom: -1 * govuk-spacing(6);

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -17,6 +17,7 @@
 @forward "govuk/components/tabs";
 @forward "govuk/components/textarea";
 @forward "govuk/components/summary-list";
+@forward "govuk/components/table";
 @forward "govuk/components/tag";
 @forward "govuk/components/task-list";
 @forward "govuk/components/service-navigation";

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -417,3 +417,41 @@ $govuk-touch-target-size: ($govuk-checkboxes-size + $govuk-touch-target-gutter);
   color: govuk-functional-colour(secondary-text);
   margin-bottom: 0;
 }
+
+// govuk-table extensions
+
+// most of our tables have body font size of 16px
+// but keep table headers at 19px
+// instead of adding govuk-!-font-size-16 to each cell
+// we can add a class modifier on the table
+// more apparent use with fullscreen tables
+.notify-table--body-small .govuk-table__body {
+  .govuk-table__cell, 
+  .govuk-table__header {
+    @include govuk-font-size(16);
+  }
+} 
+
+// spreadsheet styling on upload
+.notify-table--spreadsheet {
+  border: 1px solid govuk-functional-colour(border);
+
+  .govuk-table__head {
+    .govuk-table__header {
+      background: govuk-colour('black', $variant: "tint-95");
+      font-weight: bold;
+      text-align: center;
+    }
+  }
+  .govuk-table__body {
+    .govuk-table__header,
+    .govuk-table__cell {
+      padding-left: govuk-spacing(2);
+    }
+    .govuk-table__header:first-child {
+      border-right: 1px solid govuk-functional-colour(border);
+      padding-right: govuk-spacing(2);
+      width:15px;
+    }
+  }
+}

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -1,4 +1,5 @@
 {% extends "withoutnav_template.html" %}
+{% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 
 {% block per_page_title %}
   Cookies
@@ -18,29 +19,35 @@
     <p class="govuk-body">
       We do not need to ask permission to use essential cookies.
     </p>
-    <table>
-        <caption class="govuk-visually-hidden">Essential cookies</caption>
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Purpose</th>
-                <th>Expires</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>
-                  notify_admin_session
-                </td>
-                <td width="50%">
-                  Used to keep you signed in
-                </td>
-                <td>
-                  20 hours
-                </td>
-            </tr>
-        </tbody>
-    </table>
+    {{ govukTable({
+      "caption": "Essential cookies",
+      "captionClasses": "govuk-visually-hidden",
+      "head": [
+        {
+          "text": "Name"
+        },
+        {
+          "text": "Purpose",
+          "classes": "govuk-!-width-one-half"
+        },
+        {
+          "text": "Expires"
+        },
+      ],
+      "rows": [
+        [
+          {
+            "text": "notify_admin_session"
+          },
+          {
+            "text": " Used to keep you signed in"
+          },
+          {
+            "text": " 20 hours"
+          },
+        ]
+      ]
+    }) }}
   </div>
 </div>
 

--- a/app/templates/views/inbound-sms-admin.html
+++ b/app/templates/views/inbound-sms-admin.html
@@ -1,22 +1,9 @@
 {% extends "views/platform-admin/_base_template.html" %}
+{% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 
 {% block per_page_title %}
 Inbound SMS
 {% endblock %}
-
-{% set table_headings = {
-  'field_headings': [
-    'Number', 'Status', 'Service', 'Created on'
-  ],
-  'field_headings_visible': True,
-  'caption_visible': True
-} %}
-
-
-.inbound {
-  font-style:normal;
-  font-weight:normal;
-}
 
 {% block platform_admin_content %}
 
@@ -24,41 +11,39 @@ Inbound SMS
     Inbound SMS
   </h1>
 
-  <table class="inbound">
-          <col style="width:8%">
-          <col style="width:20%">
-          <col style="width:17%">
-          <col style="width:30%">
-          <thead>
-              <tr>
-                <th>{{table_headings.field_headings[0]}}</th>
-                <th>{{table_headings.field_headings[1]}}</th>
-                <th>{{table_headings.field_headings[2]}}</th>
-              </tr>
-          </thead>
-          <tbody>
+  {% set table_body = [] %}
+  {% for value in inbound_num_list.data: %}
+    {% do table_body.append(
+      [
+        {
+          "text": value.number
+        },
+        {
+          "text": "Active" if value.active else ("Not used" if not value.service.name else "Inactive")
+        },
+        {
+          "text": "",
+          "html": ('<a href="' ~ url_for('main.service_dashboard', service_id=value.service.id) ~ '" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-24 govuk-!-font-weight-bold">' ~ value.service.name ~ '</a>') if value.service else ""
+        }
+      ]
+    )%}
+  {% endfor %}
 
-          {% for value in inbound_num_list.data: %}
-          <tr>
-              <td>{{value.number}}</td>
-              <td>
-
-              {% if value.active %}
-                Active
-              {% elif not value.service.name  %}
-                  Not used
-              {% else %}
-                Inactive
-              {% endif %}
-              </td>
-              <td>
-                  {% if value.service %}
-                    <a href="{{ url_for('main.service_dashboard', service_id=value.service.id) }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-24 govuk-!-font-weight-bold">{{ value.service.name }}</a>
-                  {% endif %}
-              </td>
-          </tr>
-          {% endfor %}
-          </tbody>
-  </table>
+  {{ govukTable({
+    "caption": "Inbound sms",
+    "captionClasses": "govuk-visually-hidden",
+    "head": [
+      {
+        "text": "Number"
+      },
+      {
+        "text": "Status"
+      },
+      {
+        "text": "Service"
+      },
+    ],
+    "rows": table_body
+  }) }}
 
 {% endblock %}

--- a/app/templates/views/uploads/contact-list/upload.html
+++ b/app/templates/views/uploads/contact-list/upload.html
@@ -1,8 +1,8 @@
 {% extends "withnav_template.html" %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 
 {% block service_page_title %}
   Upload an emergency contact list
@@ -46,40 +46,48 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
-    <div class="spreadsheet">
-      {% call(item, row_number) list_table(
-        [
-          ['email address'],
-          ['test@example.gov.uk'],
+      {{ govukTable({
+        "caption": "Example list of staff email addresses",
+        "captionClasses": "govuk-visually-hidden",
+        "firstCellIsHeader": true,
+        "classes": "notify-table notify-table--body-small notify-table--spreadsheet",
+        "head": [
+          { "text": "" },
+          { "text": "A" }
         ],
-        caption="Example list of staff email addresses",
-        caption_visible=False,
-        field_headings=['', 'A']
-      ) %}
-        {{ index_field(row_number - 1) }}
-        {% for column in item %}
-          {{ text_field(column) }}
-        {% endfor %}
-      {% endcall %}
-    </div>
+        "rows": [
+          [
+            { "text": "1" },
+            { "text": "email address" }
+          ],
+          [
+            { "text": "2" },
+            { "text": " test@example.gov.uk" }
+          ]
+        ]
+      }) }}
   </div>
   <div class="govuk-grid-column-one-half">
-    <div class="spreadsheet">
-      {% call(item, row_number) list_table(
-        [
-          ['phone number'],
-          ['07700 900123'],
+      {{ govukTable({
+        "caption": "Example list of staff phone numbers",
+        "captionClasses": "govuk-visually-hidden",
+        "firstCellIsHeader": true,
+        "classes": "notify-table notify-table--body-small notify-table--spreadsheet",
+        "head": [
+          { "text": "" },
+          { "text": "A" }
         ],
-        caption="Example list of staff phone numbers",
-        caption_visible=False,
-        field_headings=['', 'A']
-      ) %}
-        {{ index_field(row_number - 1) }}
-        {% for column in item %}
-          {{ text_field(column) }}
-        {% endfor %}
-      {% endcall %}
-    </div>
+        "rows": [
+          [
+            { "text": "1" },
+            { "text": "phone number" }
+          ],
+          [
+            { "text": "2" },
+            { "text": "07700 900123" }
+          ]
+        ]
+      }) }}
   </div>
 </div>
 {% endblock %}

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -22,11 +22,11 @@ def test_upload_contact_list_page(client_request):
     assert page.select_one("form input")["accept"] == ".csv,.xlsx,.xls,.ods,.xlsm,.tsv"
 
     assert (
-        normalize_spaces(page.select(".spreadsheet")[0].text)
+        normalize_spaces(page.select(".notify-table--spreadsheet")[0].text)
         == "Example list of staff email addresses A 1 email address 2 test@example.gov.uk"
     )
     assert (
-        normalize_spaces(page.select(".spreadsheet")[1].text)
+        normalize_spaces(page.select(".notify-table--spreadsheet")[1].text)
         == "Example list of staff phone numbers A 1 phone number 2 07700 900123"
     )
 


### PR DESCRIPTION
Update simple tables to use govuk-frontend table component. Start of many


**Platform admin inbound sms table**
<img width="710" height="292" alt="Screenshot 2026-08-13 at 12 31 43" src="https://github.com/user-attachments/assets/72380637-c775-47d9-b4f0-b88579fb759a" />

**Cookies page table**
<img width="692" height="145" alt="Screenshot 2026-08-13 at 16 16 45" src="https://github.com/user-attachments/assets/67c9940b-ef55-4573-ae96-41185686a65e" />

**Upload contact list example table**
<img width="652" height="299" alt="Screenshot 2026-08-22 at 15 26 41" src="https://github.com/user-attachments/assets/c579238b-4c8c-49da-8134-2fc1f0c13661" />
