### PR TITLE
Fix missing API client mocks in unit tests 

### DIFF
--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3977,7 +3977,11 @@ def test_switch_service_channels_on_and_off(
     posted_value,
     expected_updated_permissions,
 ):
-    mocked_fn = mocker.patch("app.service_api_client.update_service", return_value=service_one)
+    mocked_update_service = mocker.patch("app.service_api_client.update_service", return_value=service_one)
+    mocked_get_reply_to_email_addresses = mocker.patch(
+        "app.service_api_client.get_reply_to_email_addresses", return_value=[]
+    )
+
     service_one["permissions"] = initial_permissions
 
     page = client_request.get(
@@ -4002,8 +4006,12 @@ def test_switch_service_channels_on_and_off(
             service_id=service_one["id"],
         ),
     )
-    assert set(mocked_fn.call_args[1]["permissions"]) == set(expected_updated_permissions)
-    assert mocked_fn.call_args[0][0] == service_one["id"]
+
+    assert set(mocked_update_service.call_args[1]["permissions"]) == set(expected_updated_permissions)
+    assert mocked_update_service.call_args[0][0] == service_one["id"]
+
+    # in cases where this *was* called we will have "failed" much earlier in the test
+    assert mocked_get_reply_to_email_addresses.mock_calls == []
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -98,7 +98,9 @@ def test_hiding_pages_from_search_engines(
         pytest.param("index", {}, marks=pytest.mark.xfail(raises=AssertionError)),
     ),
 )
-def test_hiding_pages_that_redirect_from_search_engines(client_request, endpoint, kwargs):
+def test_hiding_pages_that_redirect_from_search_engines(
+    client_request, mock_get_service_and_organisation_counts, mock_get_letter_rates, mock_get_sms_rate, endpoint, kwargs
+):
     client_request.logout()
     response = client_request.get_response(f"main.{endpoint}", _expected_status=301, **kwargs)
     assert "X-Robots-Tag" in response.headers

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -211,6 +211,7 @@ def test_process_webauthn_auth_sign_in_redirects_to_webauthn_with_next_redirect(
 def test_should_return_locked_out_true_when_user_is_locked(
     client_request,
     mock_get_user_by_email_locked,
+    mock_verify_password,
 ):
     client_request.logout()
     page = client_request.post(
@@ -222,6 +223,7 @@ def test_should_return_locked_out_true_when_user_is_locked(
         _expected_status=200,
     )
     assert "The email address or password you entered is incorrect" in page.text
+    assert not mock_verify_password.mock_calls
 
 
 def test_should_return_200_when_user_does_not_exist(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -3109,20 +3109,16 @@ def test_copy_letter_template_with_letter_attachment(
     [
         ("email", "New email template"),
         ("sms", "New text message template"),
-        ("letter", "Templates"),
     ],
 )
-def test_choose_template_for_each_template_type(
+def test_choose_template_for_email_sms(
     client_request,
-    mock_get_api_keys,
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
     template_type,
     expected_page_heading,
 ):
-    service_one["permissions"].append("letter")
-
     page = client_request.post(
         "main.choose_template",
         service_id=SERVICE_ONE_ID,
@@ -3134,6 +3130,35 @@ def test_choose_template_for_each_template_type(
     )
 
     assert normalize_spaces(page.select_one("h1").text) == expected_page_heading
+
+    assert mock_get_service_templates.called
+    assert mock_get_template_folders.called
+
+
+def test_choose_template_for_letter(
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    mock_create_service_template,
+    fake_uuid,
+):
+    service_one["permissions"].append("letter")
+
+    client_request.post(
+        "main.choose_template",
+        service_id=SERVICE_ONE_ID,
+        _data={
+            "operation": "add-new-template",
+            "add_template_by_template_type": "letter",
+        },
+        _follow_redirects=False,
+        _expected_redirect=f"/services/{SERVICE_ONE_ID}/templates/{fake_uuid}",
+    )
+
+    assert mock_create_service_template.called
+    assert mock_get_service_templates.called
+    assert mock_get_template_folders.called
 
 
 @pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1348,7 +1348,7 @@ def active_user_no_settings_permission():
 def api_user_locked(fake_uuid):
     return create_user(
         id=fake_uuid,
-        failed_login_count=5,
+        failed_login_count=11,
         password_changed_at=None,
     )
 
@@ -1357,7 +1357,7 @@ def api_user_locked(fake_uuid):
 def api_user_request_password_reset(fake_uuid):
     return create_user(
         id=fake_uuid,
-        failed_login_count=5,
+        failed_login_count=11,
     )
 
 
@@ -1365,7 +1365,7 @@ def api_user_request_password_reset(fake_uuid):
 def api_user_changed_password(fake_uuid):
     return create_user(
         id=fake_uuid,
-        failed_login_count=5,
+        failed_login_count=11,
         password_changed_at=str(datetime.now(UTC) + timedelta(minutes=1)),
     )
 


### PR DESCRIPTION
This is needed to get the unit tests passing on the new DSIT laptops, which send requests for `http://you-forgot-to-mock-an-api-call-to` to a cloudflare error page which the API client attempts to parse as json.

Quite a few tests here that really only passed by accident. A lot of admin's unit tests fail to create remotely realistic conditions under which to run the test.