### PR TITLE
Update govuk-frontend to v6.4.0

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -78,7 +78,7 @@
 
   @extend %banner;
   background: govuk-functional-colour(brand);
-  color: govuk-colour("white");
+  color: govuk-functional-colour(inverse-text);
   margin-top: 10px;
   margin-bottom: 0;
   padding: govuk-spacing(6);
@@ -107,7 +107,7 @@
 
     margin-top: 0;
     margin-bottom: govuk-spacing(6);
-    color: govuk-colour("white");
+    color: govuk-functional-colour(inverse-text);
 
     &:last-child {
       margin-bottom: 0;
@@ -121,7 +121,7 @@
 
   ul {
     @include govuk-font(24);
-    color: govuk-colour("white");
+    color: govuk-functional-colour(inverse-text);
     margin-bottom: govuk-spacing(5);
   }
 

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -2,18 +2,13 @@
 @use 'govuk/settings' as *;
 @use '../helpers' as *;
 
-$product-page-blue: #1D70B8;
-$product-page-underline-colour: rgb(govuk-colour("white"), 0.25);
-// See https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/button/_button.scss#L24
-$button-shadow-size: $govuk-border-width-form-element;
-
 .product-page {
 
   &-intro {
 
     margin: 0 0 govuk-spacing(6) * 1.5 0;
-    background: $product-page-blue;
-    color: govuk-colour("white");
+    background: govuk-functional-colour(brand);
+    color: govuk-functional-colour(inverse-text);
     padding-top: 2px;
 
     &-wrapper {
@@ -45,7 +40,7 @@ $button-shadow-size: $govuk-border-width-form-element;
 
     p {
       @include govuk-font(24);
-      color: govuk-colour("white");
+      color: govuk-functional-colour(inverse-text);
       margin: govuk-spacing(3) 0 govuk-spacing(6);
     }
 
@@ -89,10 +84,5 @@ $button-shadow-size: $govuk-border-width-form-element;
 }
 
 .product-page-button {
-
-  // based on the govuk-button styles:
-  // https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/button/_button.scss
   @include govuk-font($size: 24, $weight: bold);
-  box-shadow: 0 $button-shadow-size 0 mix(black, $product-page-blue, 15%);
-
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cbor2": "2.3.0",
-        "govuk-frontend": "6.3.0",
+        "govuk-frontend": "6.4.0",
         "morphdom": "2.6.1",
         "textarea-caret-ts": "4.1.1"
       },
@@ -5293,9 +5293,9 @@
       "license": "MIT"
     },
     "node_modules/govuk-frontend": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.3.0.tgz",
-      "integrity": "sha512-cXIQxm5PHCsbic47GXZrVBZhAeeshTLRL6ZBKilLsR6rMCjJuWb7Fruq0VUNMBJFlJk/srsRj/q8d5bM9cgKoA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.4.0.tgz",
+      "integrity": "sha512-jU3oaVFXqK1yDVIdZs1YZ6JD7YDB4PFUHF3rFMWJye9ArImp42F9wCsFzzB1+udjuzGCryJGcHHbBQ5HY+8rqQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor2": "2.3.0",
-    "govuk-frontend": "6.3.0",
+    "govuk-frontend": "6.4.0",
     "morphdom": "2.6.1",
     "textarea-caret-ts": "4.1.1"
   },

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -12,7 +12,7 @@ def test_govuk_frontend_jinja_overrides_on_design_system_v6():
     govuk_frontend_jinja_version = Version(metadata.version("govuk-frontend-jinja"))
 
     # Compatibility between these two libs is defined at https://github.com/LandRegistry/govuk-frontend-jinja/
-    correct_govuk_frontend_version = Version("6.3.0") == govuk_frontend_version
+    correct_govuk_frontend_version = Version("6.4.0") == govuk_frontend_version
     correct_govuk_frontend_jinja_version = Version("4.0.0") == govuk_frontend_jinja_version
 
     assert correct_govuk_frontend_version and correct_govuk_frontend_jinja_version, (


### PR DESCRIPTION
Ideally this would go after https://github.com/alphagov/notifications-admin/pull/6038 - less package-lock conflicts to address.

Release notes https://github.com/alphagov/govuk-frontend/releases/tag/v6.4.0

Changes we'll do will be in this section:

> Use inverse-text instead of govuk-colour("white") for text on dark backgrounds that use functional colours

Touches
- homepage
- tour

**See individual commits for details**

<img width="1038" height="493" alt="home-page" src="https://github.com/user-attachments/assets/66b64412-3cca-476c-b8e6-64dc458c5485" />
<img width="846" height="580" alt="tour-page" src="https://github.com/user-attachments/assets/3f25a2f5-82ce-42b4-96a3-85487898c878" />
