### PR TITLE
Don’t inspect API error messages to do template validation

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -25,9 +25,6 @@ REPORT_REQUEST_STORED = "stored"
 REPORT_REQUEST_FAILED = "failed"
 REPORT_REQUEST_DELETED = "deleted"
 
-# Error codes from the API
-QR_CODE_TOO_LONG = "qr-code-too-long"
-
 # Allow upto 800,000 notifications to be requested in a report for phase 1a
 REPORT_REQUEST_MAX_NOTIFICATIONS = 800_000
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -26,7 +26,7 @@ from notifications_utils.recipient_validation.phone_number import PhoneNumber as
 from notifications_utils.recipient_validation.postal_address import PostalAddress
 from notifications_utils.safe_string import make_string_safe_for_email_local_part
 from notifications_utils.sanitise_text import SanitiseASCII
-from notifications_utils.template import SMSMessageTemplate
+from notifications_utils.template import LetterPreviewTemplate, SMSMessageTemplate
 from notifications_utils.timezones import local_timezone, utc_string_to_aware_gmt_datetime
 from ordered_set import OrderedSet
 from werkzeug.utils import cached_property
@@ -1570,6 +1570,11 @@ class LetterTemplateForm(BaseTemplateForm, TemplateNameMixin):
         if kwargs.get("letter_languages") == LetterLanguageOptions.welsh_then_english:
             self.subject.label.text = f"{self.subject.label.text} (English)"
             self.template_content.label.text = f"{self.template_content.label.text} (English)"
+
+    def validate_template_content(self, field):
+        template = LetterPreviewTemplate({"subject": "", "content": field.data, "template_type": "letter"})
+        if template.has_qr_code_with_too_much_data():
+            raise ValidationError("Cannot create a usable QR code - the link you entered is too long")
 
 
 class WelshLetterTemplateForm(BaseTemplateForm, TemplateNameMixin):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -13,6 +13,7 @@ from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileAllowed, FileSize
 from flask_wtf.file import FileField as FileField_wtf
 from markupsafe import Markup
+from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.countries.data import Postage
 from notifications_utils.eventlet import SoftEventletTimeout
 from notifications_utils.field import Field as UtilsField
@@ -25,6 +26,7 @@ from notifications_utils.recipient_validation.phone_number import PhoneNumber as
 from notifications_utils.recipient_validation.postal_address import PostalAddress
 from notifications_utils.safe_string import make_string_safe_for_email_local_part
 from notifications_utils.sanitise_text import SanitiseASCII
+from notifications_utils.template import SMSMessageTemplate
 from notifications_utils.timezones import local_timezone, utc_string_to_aware_gmt_datetime
 from ordered_set import OrderedSet
 from werkzeug.utils import cached_property
@@ -1480,7 +1482,9 @@ class BaseTemplateForm(StripWhitespaceForm):
 
 
 class SMSTemplateForm(BaseTemplateForm, TemplateNameMixin):
-    pass
+    def validate_template_content(self, field):
+        if SMSMessageTemplate({"content": field.data, "template_type": "sms"}).is_message_too_long():
+            raise ValidationError(f"Content has a character count greater than the limit of {SMS_CHAR_COUNT_LIMIT}")
 
 
 class LetterAddressForm(StripWhitespaceForm):

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -666,14 +666,7 @@ def add_service_template(service_id, template_type, template_folder_id=None):
                 has_unsubscribe_link=form.has_unsubscribe_link.data if hasattr(form, "has_unsubscribe_link") else None,
             )
         except HTTPError as e:
-            if (
-                e.status_code == 400
-                and "content" in e.message
-                and any("character count greater than" in x for x in e.message["content"])
-            ):
-                form.template_content.errors.extend(e.message["content"])
-            else:
-                raise e
+            raise e
         else:
             return redirect(
                 url_for("main.view_template", service_id=service_id, template_id=new_template["data"]["id"])
@@ -739,7 +732,7 @@ def abort_for_unauthorised_bilingual_letters_or_invalid_options(language: str | 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/edit", methods=["GET", "POST"])
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/edit/<string:language>", methods=["GET", "POST"])
 @user_has_permissions("manage_templates")
-def edit_service_template(service_id, template_id, language=None):  # noqa
+def edit_service_template(service_id, template_id, language=None):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
     if template.template_type not in current_service.available_template_types:
@@ -786,9 +779,7 @@ def edit_service_template(service_id, template_id, language=None):  # noqa
             )
         except HTTPError as e:
             if e.status_code == 400:
-                if "content" in e.message and any("character count greater than" in x for x in e.message["content"]):
-                    form.template_content.errors.extend(e.message["content"])
-                elif "content" in e.message and any(x == QR_CODE_TOO_LONG for x in e.message["content"]):
+                if "content" in e.message and any(x == QR_CODE_TOO_LONG for x in e.message["content"]):
                     form.template_content.errors.append(
                         "Cannot create a usable QR code - the link you entered is too long"
                     )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -37,7 +37,7 @@ from app import (
     template_preview_client,
     template_statistics_client,
 )
-from app.constants import QR_CODE_TOO_LONG, LetterLanguageOptions
+from app.constants import LetterLanguageOptions
 from app.main import main, no_cookie
 from app.main.forms import (
     CopyTemplateForm,
@@ -778,15 +778,7 @@ def edit_service_template(service_id, template_id, language=None):
                 **update_data,
             )
         except HTTPError as e:
-            if e.status_code == 400:
-                if "content" in e.message and any(x == QR_CODE_TOO_LONG for x in e.message["content"]):
-                    form.template_content.errors.append(
-                        "Cannot create a usable QR code - the link you entered is too long"
-                    )
-                else:
-                    raise e
-            else:
-                raise e
+            raise e
         else:
             editing_english_content_in_bilingual_letter = (
                 template.template_type == "letter" and template.welsh_page_count and language != "welsh"

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -655,22 +655,16 @@ def add_service_template(service_id, template_type, template_folder_id=None):
 
     form = get_template_form(template_type)()
     if form.validate_on_submit():
-        try:
-            new_template = service_api_client.create_service_template(
-                name=form.name.data,
-                type_=template_type,
-                content=form.template_content.data,
-                service_id=service_id,
-                subject=form.subject.data if hasattr(form, "subject") else None,
-                parent_folder_id=template_folder_id,
-                has_unsubscribe_link=form.has_unsubscribe_link.data if hasattr(form, "has_unsubscribe_link") else None,
-            )
-        except HTTPError as e:
-            raise e
-        else:
-            return redirect(
-                url_for("main.view_template", service_id=service_id, template_id=new_template["data"]["id"])
-            )
+        new_template = service_api_client.create_service_template(
+            name=form.name.data,
+            type_=template_type,
+            content=form.template_content.data,
+            service_id=service_id,
+            subject=form.subject.data if hasattr(form, "subject") else None,
+            parent_folder_id=template_folder_id,
+            has_unsubscribe_link=form.has_unsubscribe_link.data if hasattr(form, "has_unsubscribe_link") else None,
+        )
+        return redirect(url_for("main.view_template", service_id=service_id, template_id=new_template["data"]["id"]))
 
     return render_template(
         f"views/edit-{template_type}-template.html",
@@ -771,37 +765,34 @@ def edit_service_template(service_id, template_id, language=None):
         update_data = form.new_template_data
         if template_change.email_files_removed:
             update_data["archive_email_file_ids"] = [file.id for file in template_change.email_files_removed]
-        try:
-            service_api_client.update_service_template(
+
+        service_api_client.update_service_template(
+            service_id=service_id,
+            template_id=template_id,
+            **update_data,
+        )
+        editing_english_content_in_bilingual_letter = (
+            template.template_type == "letter" and template.welsh_page_count and language != "welsh"
+        )
+        if template_change.email_files_removed:
+            multiple_files_removed = len(template_change.email_filenames_removed) > 1
+            flash(
+                f"{formatted_list(template_change.email_filenames_removed)} "
+                f"{'have' if multiple_files_removed else 'has'} been removed",
+                "default_with_tick",
+            )
+        return redirect(
+            url_for(
+                "main.view_template",
                 service_id=service_id,
                 template_id=template_id,
-                **update_data,
+                **(
+                    {"_anchor": "first-page-of-english-in-bilingual-letter"}
+                    if editing_english_content_in_bilingual_letter
+                    else {}
+                ),
             )
-        except HTTPError as e:
-            raise e
-        else:
-            editing_english_content_in_bilingual_letter = (
-                template.template_type == "letter" and template.welsh_page_count and language != "welsh"
-            )
-            if template_change.email_files_removed:
-                multiple_files_removed = len(template_change.email_filenames_removed) > 1
-                flash(
-                    f"{formatted_list(template_change.email_filenames_removed)} "
-                    f"{'have' if multiple_files_removed else 'has'} been removed",
-                    "default_with_tick",
-                )
-            return redirect(
-                url_for(
-                    "main.view_template",
-                    service_id=service_id,
-                    template_id=template_id,
-                    **(
-                        {"_anchor": "first-page-of-english-in-bilingual-letter"}
-                        if editing_english_content_in_bilingual_letter
-                        else {}
-                    ),
-                )
-            )
+        )
 
     return render_template(
         f"views/edit-{template.template_type}-template.html",

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -3936,8 +3936,8 @@ def test_should_not_update_too_big_template(
 
 def test_should_not_edit_letter_template_with_too_big_qr_code(
     client_request,
-    mock_get_service_template,
-    mock_update_service_template_400_qr_code_too_big,
+    mock_get_service_letter_template,
+    mock_update_service_template,
     mock_get_no_api_keys,
     fake_uuid,
     service_one,
@@ -3964,6 +3964,7 @@ def test_should_not_edit_letter_template_with_too_big_qr_code(
     assert normalize_spaces(page.select_one(".govuk-error-message").text) == (
         "Error: Cannot create a usable QR code - the link you entered is too long"
     )
+    assert mock_update_service_template.called is False
 
 
 def test_should_redirect_when_saving_a_template_email(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -3888,7 +3888,7 @@ def test_removing_placeholders_is_not_a_breaking_change(
 
 def test_should_not_create_too_big_template(
     client_request,
-    mock_create_service_template_content_too_big,
+    mock_create_service_template,
 ):
     page = client_request.post(
         ".add_service_template",
@@ -3896,19 +3896,22 @@ def test_should_not_create_too_big_template(
         template_type="sms",
         _data={
             "name": "new name",
-            "template_content": "template content",
+            "template_content": "a" * 919,
             "template_type": "sms",
             "service": SERVICE_ONE_ID,
         },
         _expected_status=200,
     )
-    assert "Content has a character count greater than the limit of 459" in page.text
+    assert normalize_spaces(page.select_one(".govuk-error-message")) == (
+        "Error: Content has a character count greater than the limit of 918"
+    )
+    assert mock_create_service_template.called is False
 
 
 def test_should_not_update_too_big_template(
     client_request,
     mock_get_service_template,
-    mock_update_service_template_400_content_too_big,
+    mock_update_service_template,
     mock_get_no_api_keys,
     fake_uuid,
 ):
@@ -3919,13 +3922,16 @@ def test_should_not_update_too_big_template(
         _data={
             "id": fake_uuid,
             "name": "new name",
-            "template_content": "template content",
+            "template_content": "a" * 919,
             "service": SERVICE_ONE_ID,
             "template_type": "sms",
         },
         _expected_status=200,
     )
-    assert "Content has a character count greater than the limit of 459" in page.text
+    assert normalize_spaces(page.select_one(".govuk-error-message")) == (
+        "Error: Content has a character count greater than the limit of 918"
+    )
+    assert mock_update_service_template.called is False
 
 
 def test_should_not_edit_letter_template_with_too_big_qr_code(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1090,22 +1090,6 @@ def mock_update_service_template(notify_admin, mocker):
     return mocker.patch("app.service_api_client.update_service_template", side_effect=_update)
 
 
-@pytest.fixture(scope="function")
-def mock_update_service_template_400_qr_code_too_big(notify_admin, mocker):
-    def _update(*, service_id, template_id, name=None, content=None, subject=None):
-        json_mock = Mock(
-            return_value={
-                "message": {"content": ["qr-code-too-long"]},
-                "result": "error",
-            }
-        )
-        resp_mock = Mock(status_code=400, json=json_mock)
-        http_error = HTTPError(response=resp_mock, message={"content": ["qr-code-too-long"]})
-        raise http_error
-
-    return mocker.patch("app.service_api_client.update_service_template", side_effect=_update)
-
-
 def create_service_templates(service_id, number_of_templates=6):
     template_types = ["sms", "sms", "email", "email", "letter", "letter"]
     service_templates = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1091,51 +1091,6 @@ def mock_update_service_template(notify_admin, mocker):
 
 
 @pytest.fixture(scope="function")
-def mock_create_service_template_content_too_big(notify_admin, mocker):
-    def _create(
-        *,
-        name,
-        type_,
-        content,
-        service_id,
-        subject=None,
-        parent_folder_id=None,
-        has_unsubscribe_link=None,
-    ):
-        json_mock = Mock(
-            return_value={
-                "message": {"content": ["Content has a character count greater than the limit of 459"]},
-                "result": "error",
-            }
-        )
-        resp_mock = Mock(status_code=400, json=json_mock)
-        http_error = HTTPError(
-            response=resp_mock, message={"content": ["Content has a character count greater than the limit of 459"]}
-        )
-        raise http_error
-
-    return mocker.patch("app.service_api_client.create_service_template", side_effect=_create)
-
-
-@pytest.fixture(scope="function")
-def mock_update_service_template_400_content_too_big(notify_admin, mocker):
-    def _update(*, service_id, template_id, name=None, content=None, subject=None):
-        json_mock = Mock(
-            return_value={
-                "message": {"content": ["Content has a character count greater than the limit of 459"]},
-                "result": "error",
-            }
-        )
-        resp_mock = Mock(status_code=400, json=json_mock)
-        http_error = HTTPError(
-            response=resp_mock, message={"content": ["Content has a character count greater than the limit of 459"]}
-        )
-        raise http_error
-
-    return mocker.patch("app.service_api_client.update_service_template", side_effect=_update)
-
-
-@pytest.fixture(scope="function")
 def mock_update_service_template_400_qr_code_too_big(notify_admin, mocker):
     def _update(*, service_id, template_id, name=None, content=None, subject=None):
         json_mock = Mock(


### PR DESCRIPTION
Catching an `HTTPError` then looking for a specific substring in something returned by the API is gross. Even more so when it’s plonked in the middle of a view method (and the cyclomatic complexity check agrees 😈).

The pattern we follow elsewhere, where possible, is:
- validate in the admin app
- pass to the API
- validate on the API as a backup

This is good because:
- we have 2 lines of defence against bad data
- the admin app code is simpler and easier to test
- the admin app code follows the same pattern as other validation (using WTForms objects and methods)
- the content of the error messages are codified in the admin app

If the admin app lets something through which the API rejects then we get an exception, and we know we have a mismatch to investigate. This is very unlikely since they are both using the same utils code to do the validation.