### PR TITLE
Replace non-table uses of 'table-field-status-default' class

### DIFF
--- a/app/assets/stylesheets/components/browse-list.scss
+++ b/app/assets/stylesheets/components/browse-list.scss
@@ -26,4 +26,7 @@
 
     border-bottom: solid 1px govuk-functional-colour(border);
   }
+  &-item__status {
+    color: govuk-functional-colour(secondary-text);
+  }
 }

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -18,7 +18,7 @@
         <li class="browse-list-item">
           <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="govuk-link govuk-link--no-visited-state">{{ org.name }}</a>
           {% if not org.active %}
-            <span class="table-field-status-default heading-medium">– archived</span>
+            <span class="browse-list-item__status heading-medium">– archived</span>
           {% endif %}
           <p class="browse-list-hint">
             {{ org.count_of_live_services }}

--- a/app/templates/views/your-account.html
+++ b/app/templates/views/your-account.html
@@ -72,7 +72,7 @@
       },
       "value": {
         "text": current_user.mobile_number or "Not set",
-        "classes": "" if current_user.mobile_number else "table-field-status-default"
+        "classes": "" if current_user.mobile_number else "govuk-summary-list__value--default"
       },
       "actions": {
         "items": [
@@ -154,7 +154,7 @@
       },
       "value": {
         "text": ('{} registered'.format(current_user.webauthn_credentials|length)) if current_user.webauthn_credentials else "None registered",
-        "classes": "" if current_user.webauthn_credentials else "table-field-status-default"
+        "classes": "" if current_user.webauthn_credentials else "govuk-summary-list__value--default"
       },
       "actions": {
         "items": [

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -91,7 +91,7 @@ def test_organisation_page_shows_all_organisations(client_request, platform_admi
         ("Test 3", "0 live services", url_for("main.organisation_dashboard", org_id="A3")),
     ]
 
-    archived = page.select_one(".table-field-status-default.heading-medium")
+    archived = page.select_one(".browse-list-item__status.heading-medium")
     assert normalize_spaces(archived.text) == "– archived"
     assert normalize_spaces(archived.parent.text) == "Test 2 – archived 2 live services"
 


### PR DESCRIPTION
Replace now, so it doesn't get missed out when we come to replacing tables with a Design System component

<img width="725" height="106" alt="Screenshot 2026-08-19 at 13 52 46" src="https://github.com/user-attachments/assets/9ed7d4c8-e3fc-4969-bcc0-d3438ed53e99" />
<img width="427" height="238" alt="Screenshot 2026-08-19 at 14 05 37" src="https://github.com/user-attachments/assets/2a658e30-2ad7-4bef-a64e-f7879b66fc06" />
