### PR TITLE
Bump utils to 127.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@125.0.1
+# This file was automatically copied from notifications-utils@127.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -205,7 +205,7 @@ class OnlySMSCharacters:
         super().__init__(*args, **kwargs)
 
     def __call__(self, form, field):
-        non_sms_characters = sorted(SanitiseSMS.get_non_compatible_characters(field.data))
+        non_sms_characters = sorted(SanitiseSMS.get_non_gsm_characters(field.data))
         if non_sms_characters:
             list_of_characters = formatted_list(
                 non_sms_characters,

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@125.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@127.0.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -706,7 +706,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a4e315988da7cefbd56f53f51da900c95ded471f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a9af02ae77c034bb6b20e7a01909e2c789ae3ddf
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1161,7 +1161,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a4e315988da7cefbd56f53f51da900c95ded471f
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a9af02ae77c034bb6b20e7a01909e2c789ae3ddf
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@125.0.1
+# This file was automatically copied from notifications-utils@127.0.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@125.0.1
+# This file was automatically copied from notifications-utils@127.0.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@125.0.1
+# This file was automatically copied from notifications-utils@127.0.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
 ## 127.0.0

* Removes `SanitiseText.get_non_compatible_characters()` (for text message content use `SanitiseText.get_non_gsm_characters()` instead)

 ## 126.0.1

* Runs `remove_whitespace_before_punctuation` before GSM-7-encoding in subclasses of `BaseSMSTemplate`

 ## 126.0.0

* Removes `formatters.sms_encode` (use `sanitise_text.SantiseSMS.encode` directly instead)

 ## 125.1.1

* Ran `make refreeze-requirements` during dependency day

 ## 125.1.0

* `NotifyTask`: measure thread time used by celery task execution, annotate this on to completion log messages and emit a metric.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/125.0.1...127.0.0