### PR TITLE
Remove header colour and Cloudfoundry-related config

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -279,7 +279,6 @@ def init_app(application):
     def inject_global_template_variables():
         return {
             "asset_path": application.config["ASSET_PATH"],
-            "header_colour": application.config["HEADER_COLOUR"],
             "asset_url": asset_fingerprinter.get_url,
             "font_paths": font_paths,
         }

--- a/app/config.py
+++ b/app/config.py
@@ -181,20 +181,7 @@ class Test(Development):
     ASSET_PATH = "https://static.example.com/"
 
 
-class CloudFoundryConfig(Config):
-    pass
-
-
-# CloudFoundry sandbox
-class Sandbox(CloudFoundryConfig):
-    HTTP_PROTOCOL = "https"
-    S3_BUCKET_CSV_UPLOAD = "cf-sandbox-notifications-csv-upload"
-    S3_BUCKET_LOGO_UPLOAD = "cf-sandbox-notifications-logo-upload"
-    NOTIFY_ENVIRONMENT = "sandbox"
-
-
 configs = {
     "development": Development,
     "test": Test,
-    "sandbox": Sandbox,
 }

--- a/app/config.py
+++ b/app/config.py
@@ -46,8 +46,6 @@ class Config:
     INVITATION_EXPIRY_SECONDS = 3600 * 24 * 2  # 2 days - also set on api
     EMAIL_2FA_EXPIRY_SECONDS = 1800  # 30 Minutes
 
-    # mix(govuk-colour("dark-grey"), govuk-colour("mid-grey"))
-    HEADER_COLOUR = os.environ.get("HEADER_COLOUR", "#81878b")
     HTTP_PROTOCOL = os.environ.get("HTTP_PROTOCOL", "http")
     NOTIFY_APP_NAME = "admin"
     NOTIFY_LOG_LEVEL = "DEBUG"
@@ -190,7 +188,6 @@ class CloudFoundryConfig(Config):
 # CloudFoundry sandbox
 class Sandbox(CloudFoundryConfig):
     HTTP_PROTOCOL = "https"
-    HEADER_COLOUR = "#F499BE"  # $baby-pink
     S3_BUCKET_CSV_UPLOAD = "cf-sandbox-notifications-csv-upload"
     S3_BUCKET_LOGO_UPLOAD = "cf-sandbox-notifications-logo-upload"
     NOTIFY_ENVIRONMENT = "sandbox"


### PR DESCRIPTION
In the old GOV.UK brand we used to [colour the bar under the header differently depending on the environment](https://github.com/alphagov/notifications-admin/pull/1036/files). This bar has gone in the rebrand so there’s nothing to re-colour, and no need to store or pass the colours we did use.

***

Removing the other Cloudfoundry config copies https://github.com/alphagov/notifications-api/pull/4474/changes/dd9d33b491e23180c899a825d01a35b10c46e19d