### PR TITLE
Update Home Office brand colour hex

### DIFF
--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -268,7 +268,7 @@ GOVERNMENT_IDENTITY_SYSTEM_COLOURS = {
     "HM Government": "#0076c0",
     "HM Revenue & Customs": "#009390",
     "HM Treasury": "#af292e",
-    "Home Office": "#9325b2",
+    "Home Office": "#732282",
     "Ministry of Defence": "#4d2942",
     "Ministry of Justice": "#231f20",
     "Northern Ireland Office": "#002663",

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -913,7 +913,7 @@ def test_create_email_branding_government_identity_colour(client_request, platfo
         ("HM Government", "#0076c0"),
         ("HM Revenue & Customs", "#009390"),
         ("HM Treasury", "#af292e"),
-        ("Home Office", "#9325b2"),
+        ("Home Office", "#732282"),
         ("Ministry of Defence", "#4d2942"),
         ("Ministry of Justice", "#231f20"),
         ("Northern Ireland Office", "#002663"),


### PR DESCRIPTION
Based on https://github.com/alphagov/govuk-frontend/blob/a3b356a3db7358d828d020da84b8ae9158b6ab07/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss#L92 and https://www.gov.uk/government/organisations/home-office

This is for our branding identity creation tool. We won't update existing Home office brand hex