### PR TITLE
Fix list of contents on text message pricing page

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -37,11 +37,10 @@ Text message pricing
    </div>
    {% endif %}
 
-  <p class="govuk-body">A text message may cost more, or use more of your free allowance, if it:</p>
+  <p class="govuk-body">A text message may cost more, or use more of your free allowance, if it’s:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">is longer than 160 characters</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#language-other-than-english">is written in a language other than English</a></li>
-    <li> <a class="govuk-link govuk-link--no-visited-state" href="#symbols">uses certain signs and symbols</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">sent to an international phone number</a></li>
   </ul>
   <p class="govuk-body">We’ll tell you how many text messages your template may count as before you send it.</p>


### PR DESCRIPTION
The ‘symbols’ section doesn’t exist anymore 

Without that section we can remove the duplicated _is_ from the start of the other bullet points, and use the _it’s_ contraction per GOV.UK style

# Before

<img width="631" height="205" alt="image" src="https://github.com/user-attachments/assets/62bd54ff-c5c3-46e3-bdc5-46954dd82c9f" />

# After

<img width="633" height="205" alt="image" src="https://github.com/user-attachments/assets/164188c3-454c-42aa-b120-710e199aa2bf" />
