### PR TITLE
Update `confirmed_service_name` data when service name is confirmed

### DIFF
--- a/app/main/views/make_your_service_live.py
+++ b/app/main/views/make_your_service_live.py
@@ -86,7 +86,7 @@ def confirm_service_is_unique(service_id):
 
     if form.validate_on_submit():
         try:
-            current_service.update(name=form.name.data, confirmed_unique=True)
+            current_service.update(name=form.name.data, confirmed_unique=True, confirmed_service_name=True)
         except HTTPError as http_error:
             if http_error.status_code == 400 and (
                 error_message := service_api_client.parse_edit_service_http_error(http_error)

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -99,7 +99,7 @@ def service_name_change(service_id):
 
     if form.validate_on_submit():
         try:
-            current_service.update(name=form.name.data, confirmed_unique=False)
+            current_service.update(name=form.name.data, confirmed_unique=False, confirmed_service_name=False)
         except HTTPError as http_error:
             if http_error.status_code == 400 and (
                 error_message := service_api_client.parse_edit_service_http_error(http_error)

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -39,6 +39,7 @@ class Service(JSONModel):
     billing_contact_names: str
     billing_reference: str
     confirmed_email_sender_name: Any
+    confirmed_service_name: bool
     confirmed_unique: bool
     contact_link: str
     count_as_live: bool

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -104,6 +104,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "billing_contact_names",
             "billing_reference",
             "confirmed_email_sender_name",
+            "confirmed_service_name",
             "confirmed_unique",
             "contact_link",
             "created_by",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -194,6 +194,7 @@ def service_json(
     has_active_go_live_request=False,
     go_live_user=None,
     confirmed_unique=False,
+    confirmed_service_name=False,
     confirmed_email_sender_name=None,
 ):
     if users is None:
@@ -241,6 +242,7 @@ def service_json(
         "has_active_go_live_request": has_active_go_live_request,
         "go_live_user": go_live_user,
         "confirmed_unique": confirmed_unique,
+        "confirmed_service_name": confirmed_service_name,
         "confirmed_email_sender_name": confirmed_email_sender_name,
     }
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -884,7 +884,12 @@ def test_should_redirect_after_service_name_change(
         ),
     )
 
-    mock_update_service.assert_called_once_with(SERVICE_ONE_ID, name="New Name", confirmed_unique=False)
+    mock_update_service.assert_called_once_with(
+        SERVICE_ONE_ID,
+        name="New Name",
+        confirmed_unique=False,
+        confirmed_service_name=False,
+    )
 
 
 class TestServiceDataRetention:

--- a/tests/app/main/views/test_make_your_service_live.py
+++ b/tests/app/main/views/test_make_your_service_live.py
@@ -1216,7 +1216,12 @@ def test_confirm_service_is_unique_sets_confirmed_unique_and_updates_name(
         _expected_redirect=url_for("main.request_to_go_live", service_id=SERVICE_ONE_ID),
     )
 
-    mock_update_service.assert_called_once_with(SERVICE_ONE_ID, name="Updated Service", confirmed_unique=True)
+    mock_update_service.assert_called_once_with(
+        SERVICE_ONE_ID,
+        name="Updated Service",
+        confirmed_unique=True,
+        confirmed_service_name=True,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
At the moment, the "Confirm your service name" page is used to populate the `is_unique` database column of the services table. We're splitting this page into two, so there will be two pages to confirm "something" each populating a different database column.

The `is_unique` data will be populated from a new page which talks about text message allowances. The `confirmed_service_name` data will be populated by a page which only talks about service name, or when the service name is changed.

For now, the existing page we have mentions both service name and the free allowance, so it should populate both columns.

<img width="915" height="754" alt="Screenshot 2026-09-03 at 17 35 06" src="https://github.com/user-attachments/assets/44a1d498-125d-4b6f-98d2-5125e4d316d5" />

---

**Deploy after**
- [x] https://github.com/alphagov/notifications-api/pull/4956