### PR TITLE
Truncate SMS body to 1 line in notification list 

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -141,6 +141,12 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
   @include govuk-font-size(16);
 }
 
+.notify-summary-list__metadata--truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .notify-summary-list__key {
 
   @include govuk-media-query($from: tablet) {

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -53,9 +53,10 @@
       {% else %}
         {% set notifications_list = [] %}
         {% for item in notifications %}
+          {% set truncate_class = "notify-summary-list__metadata--truncate" if item.notification_type == 'sms' else "" %}
           {% set summary_key_html %}
             <a class="govuk-link govuk-link--no-visited-state notify-summary-list__filename" href="{{ url_for('main.view_notification', service_id=current_service.id, notification_id=item.id, from_job=job.id) }}">{{ item.to }}</a>
-            <p class="govuk-body notify-summary-list__metadata notify-summary-list__metadata--small">
+            <p class="govuk-body notify-summary-list__metadata notify-summary-list__metadata--small {{ truncate_class }}">
               {{ item.preview_of_content }}
             </p>
           {% endset %}

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -11,13 +11,14 @@
   {% else %}
     {% set notifications_list = [] %}
     {% for item in notifications %}
+      {% set truncate_class = "notify-summary-list__metadata--truncate" if item.notification_type == 'sms' else "" %}
       {% set summary_key_html %}
         {% if item.status in ('pending-virus-check', 'virus-scan-failed') %}
           <span class="notify-summary-list__filename loading-indicator">Checking</span>
         {% else %}
           <a class="govuk-link govuk-link--no-visited-state notify-summary-list__filename" href="{{ single_notification_url(notification_id=item.id) }}">{{ item.to.splitlines()|join(', ') if item.to else '' }}</a>
         {% endif %}
-        <p class="govuk-body notify-summary-list__metadata notify-summary-list__metadata--small">
+        <p class="govuk-body notify-summary-list__metadata notify-summary-list__metadata--small {{ truncate_class }}">
           {{ item.preview_of_content }}
         </p>
       {% endset %}


### PR DESCRIPTION
We can't easily split

```
SMSBodyPreviewTemplate(
    self.template,
    self.personalisation,
)
```
to show 1 line, so we'll use CSS to truncate it.

Fully message text is available when you view the notification.


**Before**
<img width="678" height="135" alt="Screenshot 2026-09-04 at 15 22 18" src="https://github.com/user-attachments/assets/8bc26be3-e54c-4d43-b8d3-00211a85239e" />


**After**
<img width="684" height="92" alt="Screenshot 2026-09-04 at 15 21 56" src="https://github.com/user-attachments/assets/f83fa217-966a-4d08-82ca-e1ff73e3c207" />
