### PR TITLE
event handlers: reimplement using decorators instead of a metaclass

### DIFF
--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -1,54 +1,89 @@
+from collections.abc import Callable
+from functools import wraps
+from inspect import signature
+from typing import cast
+
 from flask import request
 
 from app.notify_client.events_api_client import events_api_client
 
 
-class Event:
-    def __init__(self, name, schema):
-        self.name = name
-        self.schema = schema
+def event_creator[T: Callable](fn: T) -> T:
+    sig = signature(fn)
 
-    def __call__(self, **kwargs):
-        actual_keys = set(kwargs.keys())
+    @wraps(fn)  # technically we don't actually wrap it, we just borrow its name and signature
+    def inner(*args, **kwargs):
+        bound_args = sig.bind(*args, **kwargs)
 
-        if self.schema != actual_keys:
-            raise ValueError(f"Expected {self.schema}, but got {actual_keys}")
+        event_data = {
+            "ip_address": _get_remote_addr(),
+            "browser_fingerprint": _get_browser_fingerprint(),
+            **bound_args.arguments,
+        }
+        events_api_client.create_event(fn.__name__, event_data)
 
-        events_api_client.create_event(self.name, self.event_data | kwargs)
-
-    @property
-    def event_data(self):
-        return {"ip_address": _get_remote_addr(), "browser_fingerprint": _get_browser_fingerprint()}
-
-
-class EventsMeta(type):
-    def __init__(cls, name, bases, dict_):
-        for key, value in dict_.items():
-            if not key.startswith("__"):
-                setattr(cls, key, Event(key, value))
-        super().__init__(name, bases, dict_)
+    return cast(T, inner)
 
 
-class Events(metaclass=EventsMeta):
-    sucessful_login = {"user_id"}
-    update_user_email = {"user_id", "updated_by_id", "original_email_address", "new_email_address"}
-    update_user_mobile_number = {"user_id", "updated_by_id", "original_mobile_number", "new_mobile_number"}
-    remove_user_from_service = {"user_id", "removed_by_id", "service_id"}
-    add_user_to_service = {"user_id", "invited_by_id", "service_id", "ui_permissions"}
-    set_user_permissions = {"user_id", "service_id", "original_ui_permissions", "new_ui_permissions", "set_by_id"}
-    set_organisation_user_permissions = {
-        "user_id",
-        "organisation_id",
-        "original_permissions",
-        "new_permissions",
-        "set_by_id",
-    }
-    archive_user = {"user_id", "user_email_address", "archived_by_id"}
-    archive_service = {"service_id", "archived_by_id"}
-    update_email_branding = {"email_branding_id", "updated_by_id", "old_email_branding"}
-    update_letter_branding = {"letter_branding_id", "updated_by_id", "old_letter_branding"}
-    set_inbound_sms_on = {"user_id", "service_id", "inbound_number_id"}
-    remove_platform_admin = {"user_id", "removed_by_id"}
+class Events:
+    @event_creator
+    def sucessful_login(*, user_id) -> None:
+        pass
+
+    @event_creator
+    def update_user_email(*, user_id, updated_by_id, original_email_address, new_email_address) -> None:
+        pass
+
+    @event_creator
+    def update_user_mobile_number(*, user_id, updated_by_id, original_mobile_number, new_mobile_number) -> None:
+        pass
+
+    @event_creator
+    def remove_user_from_service(*, user_id, removed_by_id, service_id) -> None:
+        pass
+
+    @event_creator
+    def add_user_to_service(*, user_id, invited_by_id, service_id, ui_permissions) -> None:
+        pass
+
+    @event_creator
+    def set_user_permissions(*, user_id, service_id, original_ui_permissions, new_ui_permissions, set_by_id) -> None:
+        pass
+
+    @event_creator
+    def set_organisation_user_permissions(
+        *,
+        user_id,
+        organisation_id,
+        original_permissions,
+        new_permissions,
+        set_by_id,
+    ) -> None:
+        pass
+
+    @event_creator
+    def archive_user(*, user_id, user_email_address, archived_by_id) -> None:
+        pass
+
+    @event_creator
+    def archive_service(*, service_id, archived_by_id) -> None:
+        pass
+
+    @event_creator
+    def update_email_branding(*, email_branding_id, updated_by_id, old_email_branding) -> None:
+        pass
+
+    @event_creator
+    def update_letter_branding(*, letter_branding_id, updated_by_id, old_letter_branding) -> None:
+        pass
+
+    @event_creator
+    def set_inbound_sms_on(*, user_id, service_id, inbound_number_id) -> None:
+        pass
+
+    @event_creator
+    def remove_platform_admin(*, user_id, removed_by_id) -> None:
+        pass
 
 
 # This might not be totally correct depending on proxy setup


### PR DESCRIPTION
This approach should work properly with static type hints, because we specify the accepted arguments via the call signature of the original method. The decorator sniffs its signature using the inspect module and assigns arguments to parameters in the same way a regular call would, but forwards this information to `events_api_client.create_event` instead. The original method is never actually called.

Should we choose to, this approach should also work with type constraints, and positional parameters - although for now I've used a leading `*` argument to retain the same keyword-only behaviour.

This reduces the number of `mypy` errors by 11.