### PR TITLE
Remove inbound: raise, don’t append to `errors`

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2524,6 +2524,10 @@ class AdminServiceInboundNumberForm(StripWhitespaceForm):
 
 
 class AdminServiceInboundNumberArchive(StripWhitespaceForm):
+    def __init__(self, *args, service, **kwargs):
+        self.service = service
+        super().__init__(*args, **kwargs)
+
     removal_options = GovukRadiosField(
         "What do you want to do with the number?",
         choices=[("true", "Archive"), ("false", "Release")],
@@ -2535,6 +2539,10 @@ class AdminServiceInboundNumberArchive(StripWhitespaceForm):
             ]
         },
     )
+
+    def validate_removal_options(self, field):
+        if self.service.default_sms_sender == self.service.inbound_number:
+            raise ValidationError("You need to change your default text message sender ID before you can continue")
 
 
 class CallbackForm(StripWhitespaceForm):

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -699,37 +699,31 @@ def service_receive_text_messages_stop(service_id):
     if not current_service.has_permission("inbound_sms"):
         return redirect(url_for(".service_receive_text_messages", service_id=service_id))
 
-    form = AdminServiceInboundNumberArchive()
+    form = AdminServiceInboundNumberArchive(service=current_service)
     inbound_number = current_service.inbound_number
 
     if form.validate_on_submit():
-        if current_service.default_sms_sender == current_service.inbound_number:
-            form.removal_options.errors.append(
-                "You need to change your default text message sender ID before you can continue"
+        archive = form.removal_options.data == "true"
+
+        try:
+            service_api_client.remove_service_inbound_sms(service_id, archive)
+            return redirect(
+                url_for(
+                    ".service_receive_text_messages_stop_success",
+                    service_id=service_id,
+                    inbound_number=inbound_number,
+                )
             )
 
-        else:
-            archive = form.removal_options.data == "true"
-
-            try:
-                service_api_client.remove_service_inbound_sms(service_id, archive)
-                return redirect(
-                    url_for(
-                        ".service_receive_text_messages_stop_success",
-                        service_id=service_id,
-                        inbound_number=inbound_number,
-                    )
-                )
-
-            except Exception as e:
-                current_app.logger.error(
-                    "Error removing inbound number %s for service %s: %s",
-                    inbound_number,
-                    service_id,
-                    e,
-                    extra={"inbound_number": inbound_number, "service_id": service_id},
-                )
-                form.removal_options.errors.append("Failed to remove number from service")
+        except Exception as e:
+            current_app.logger.error(
+                "Error removing inbound number %s for service %s: %s",
+                inbound_number,
+                service_id,
+                e,
+                extra={"inbound_number": inbound_number, "service_id": service_id},
+            )
+            form.removal_options.errors.append("Failed to remove number from service")
 
     recent_use_date = None
 


### PR DESCRIPTION
Appending to the `errors` sequence is a bit icky and feels like it only just happens to work. It also isn’t type-safe because `errors` could theoretically be `None`, not a sequence.

The more idiomatic way to add errors in WTForms is by defining a validation method and raising a `ValidationError`. We do this on the field rather than the whole form, so the error message gets displayed in the same place as before.