### PR TITLE
Remove calls to `replace` on sender form data

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -920,7 +920,7 @@ def service_add_letter_contact(service_id):
     if form.validate_on_submit():
         new_letter_contact = service_api_client.add_letter_contact(
             current_service.id,
-            contact_block=form.letter_contact_block.data.replace("\r", "") or None,
+            contact_block=form.letter_contact_block.data,
             is_default=first_contact_block if first_contact_block else form.is_default.data,
         )
         if from_template:
@@ -963,7 +963,7 @@ def service_edit_letter_contact(service_id, letter_contact_id):
     if form.validate_on_submit():
         current_service.edit_letter_contact_block(
             id=letter_contact_id,
-            contact_block=form.letter_contact_block.data.replace("\r", "") or None,
+            contact_block=form.letter_contact_block.data,
             is_default=letter_contact_block["is_default"] or form.is_default.data,
         )
         return redirect(url_for(".service_letter_contact_details", service_id=service_id))
@@ -1014,7 +1014,7 @@ def service_add_sms_sender(service_id):
     if form.validate_on_submit():
         service_api_client.add_sms_sender(
             current_service.id,
-            sms_sender=form.sms_sender.data.replace("\r", "") or None,
+            sms_sender=form.sms_sender.data,
             is_default=first_sms_sender if first_sms_sender else form.is_default.data,
         )
         return redirect(url_for(".service_sms_senders", service_id=service_id))
@@ -1049,7 +1049,7 @@ def service_edit_sms_sender(service_id, sms_sender_id):
         service_api_client.update_sms_sender(
             current_service.id,
             sms_sender_id=sms_sender_id,
-            sms_sender=sms_sender["sms_sender"] if is_inbound_number else form.sms_sender.data.replace("\r", ""),
+            sms_sender=sms_sender["sms_sender"] if is_inbound_number else form.sms_sender.data,
             is_default=True if sms_sender["is_default"] else form.is_default.data,
         )
         return redirect(url_for(".service_sms_senders", service_id=service_id))


### PR DESCRIPTION
Our `Form` classes should be handling this kind of data santitisation.

I suspect this has mostly entered through copy/paste and before we had stuff like `StripWhitespaceForm` but need a bit more digging to:
- confirm the API will do the right thing here
- write tests for the expected behaviour (since this change doesn’t cause any tests to fail)