### PR TITLE
Multilingual sms template guidance

### DIFF
--- a/app/templates/partials/templates/guidance-other-language-sms
+++ b/app/templates/partials/templates/guidance-other-language-sms
@@ -1,0 +1,5 @@
+<h2 class="heading-medium">Send a message in a language other than English</h2>
+
+<p class="govuk-body">Write the message in the language you want to send directly in the text message template.</p>
+
+<p class="govuk-body">If you cannot type in that language, write the message outside of Notify and copy and paste it into the template. </p>

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -53,6 +53,7 @@
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-optional-content.html" %}
           {% include "partials/templates/guidance-links-urls-sms.html" %}
+          {% include "partials/templates/guidance-other-language-sms" %}
           {% include "partials/templates/guidance-character-count.html" %}
         </div>
       </div>


### PR DESCRIPTION
Added some high level guidance on how to write a text message in a language other than English.

This was the most asked question once we'd released comms. 

<img width="2526" height="5864" alt="edit" src="https://github.com/user-attachments/assets/0c6c6c88-8b09-478a-89bb-69a9d38c1f9c" />
