### PR TITLE
Convert contact-list jobs table to a summary-list

### DIFF
--- a/app/templates/views/uploads/contact-list/contact-list.html
+++ b/app/templates/views/uploads/contact-list/contact-list.html
@@ -1,8 +1,8 @@
 {% extends "withnav_template.html" %}
 {% from "components/big-number.html" import big_number %}
-{% from "components/table.html" import list_table, field, row_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% block service_page_title %}
   {{ contact_list.original_file_name }}
@@ -26,39 +26,26 @@
       in the last {{ current_service.get_days_of_retention(contact_list.template_type) }}
       days.
     </p>
-    <div class='dashboard-table ajax-block-container'>
-      {% call(item, row_number) list_table(
-        jobs,
-        caption="Messages sent from this contact list",
-        caption_visible=False,
-        empty_message='',
-        field_headings=[
-          'Template',
-          'Status'
-        ],
-        field_headings_visible=False,
-        give_rows_ids=False,
-      ) %}
-        {% call row_heading() %}
-          <div class="file-list">
-            <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for('main.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.template_name }}</a>
-            {% if item.scheduled %}
-              <span class="file-list-hint-large">
-                Sending {{
-                  item.scheduled_for|format_datetime_relative
-                }}
-              </span>
-            {% else %}
-              <span class="file-list-hint-large">
-                Sent {{
-                  (item.scheduled_for or item.created_at)|format_datetime_relative
-                }}
-              </span>
-            {% endif %}
-
-          </div>
-        {% endcall %}
-        {% call field() %}
+    <div class="ajax-block-container">
+      {% set jobs_list = [] %}
+      {% for item in jobs %}
+        {% set summary_key_html %}
+          <a class="notify-summary-list__filename notify-summary-list__filename--large govuk-link govuk-link--no-visited-state" href="{{ url_for('main.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.template_name }}</a>
+          {% if item.scheduled %}
+            <span class="file-list-hint-large">
+              Sending {{
+                item.scheduled_for|format_datetime_relative
+              }}
+            </span>
+          {% else %}
+            <span class="file-list-hint-large">
+              Sent {{
+                (item.scheduled_for or item.created_at)|format_datetime_relative
+              }}
+            </span>
+          {% endif %}
+        {% endset %}
+        {% set summary_value_html %}
           {% if item.scheduled %}
             {{ big_number(
               item.notification_count,
@@ -85,8 +72,23 @@
               </div>
             </div>
           {% endif %}
-        {% endcall %}
-      {% endcall %}
+        {% endset %}
+        {% do jobs_list.append({
+          "key": {
+            "classes": "notify-summary-list__key notify-summary-list__key--50-100",
+            "html": summary_key_html,
+          },
+          "value": {
+            "classes": "",
+            "html":  summary_value_html,
+          }
+        }) %}
+      {% endfor %}
+
+      {{ govukSummaryList({
+        "classes": "notify-summary-list",
+        "rows": jobs_list
+      }) }}
     </div>
   {% else %}
     <p class="govuk-body">

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -510,8 +510,9 @@ def test_view_jobs_for_contact_list(
     assert normalize_spaces(page.select_one("h1").text) == "EmergencyContactList.xls"
     assert normalize_spaces(page.select("main p")[0].text) == "Uploaded by Test User today at 12:12pm."
     assert normalize_spaces(page.select("main p")[1].text) == "Used 6 times in the last 7 days."
-    assert [normalize_spaces(row.text) for row in page.select_one("table").select("tr")] == [
-        "Template Status",
+    assert [
+        normalize_spaces(row.text) for row in page.select_one(".govuk-summary-list").select(".govuk-summary-list__row")
+    ] == [
         "Template Y Sending tomorrow at 11:09pm 1 text message waiting to send",
         "Template Z Sending tomorrow at 11:09am 1 text message waiting to send",
         "Template A Sent today at 4:51pm 1 delivering 0 delivered 0 failed",
@@ -519,7 +520,7 @@ def test_view_jobs_for_contact_list(
         "Template C Sent today at 4:51pm 1 delivering 0 delivered 0 failed",
         "Template D Sent today at 4:51pm 1 delivering 0 delivered 0 failed",
     ]
-    assert page.select_one("table a")["href"] == url_for(
+    assert page.select_one(".notify-summary-list__filename")["href"] == url_for(
         "main.view_job",
         service_id=SERVICE_ONE_ID,
         job_id=fake_uuid,


### PR DESCRIPTION
If a contact list was used in a job, we show that alongside number of delivered, failed, delivering or scheduled numbers.

<img width="754" height="280" alt="Screenshot 2026-09-09 at 08 11 49" src="https://github.com/user-attachments/assets/43cbd7ce-dce5-4f87-9973-1ac0c94cb797" />

**Review**

- upload an emergency contact list
- use to send emails
- go back to Uploads and click to view it
- or view /services/serviceID/contact-list/contactlistID