### PR TITLE
Bump utils to 131.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@128.0.0
+# This file was automatically copied from notifications-utils@131.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -883,7 +883,7 @@ class OnOffField(GovukRadiosField):
     def iter_choices(self):
         for value, label in self.choices:
             # This overrides WTForms default behaviour which is to check
-            # self.coerce(value) == self.data
+            # > self.coerce(value) == self.data
             # where self.coerce returns a string for a boolean input
             yield (value, label, (self.data in {value, self.coerce(value)}), {})
 

--- a/get_zendesk_tickets.py
+++ b/get_zendesk_tickets.py
@@ -9,11 +9,10 @@ import urllib.parse
 
 import requests
 
-# Group: 3rd Line--Notify Support
-NOTIFY_GROUP_ID = 360000036529
+NOTIFY_GROUP_ID = 360000036529  # Group: 3rd Line--Notify Support
 
-# Organization: GDS
-NOTIFY_ORG_ID = 21891972
+
+NOTIFY_ORG_ID = 21891972  # Organization: GDS
 
 # the account used to authenticate with. If no requester is provided, the ticket will come from this account.
 NOTIFY_ZENDESK_EMAIL = "zd-api-notify@digital.cabinet-office.gov.uk"

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ notifications-python-client~=10.0
 fido2~=1.1
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@128.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@131.0.0
 
 govuk-frontend-jinja==4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -706,7 +706,7 @@ mistune==0.8.4 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@389589cad26a55e77437cd078dd75a557cf5606e
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0293b8f06dc3ff7c7a62995a42609b2c673ba92c
     # via -r requirements.in
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1161,7 +1161,7 @@ mypy-extensions==1.1.0 \
 notifications-python-client==10.0.1 \
     --hash=sha256:00d88eacb6fd6eb0467d7396a7e23677194cfebe0ebd88de2efa031fb51eb23f
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@389589cad26a55e77437cd078dd75a557cf5606e
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0293b8f06dc3ff7c7a62995a42609b2c673ba92c
     # via -r requirements.txt
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@128.0.0
+# This file was automatically copied from notifications-utils@131.0.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@128.0.0
+# This file was automatically copied from notifications-utils@131.0.0
 
 extend-exclude = [
     "migrations/versions/",
@@ -30,5 +30,6 @@ select = [
     "PIE",  # flake8-pie
     "N804",  # First argument of a class method should be named `cls`
     "RUF100",  # Checks for noqa directives that are no longer applicable
+    "ERA001",  # Checks for commented-out code
 ]
 ignore = []

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@128.0.0
+# This file was automatically copied from notifications-utils@131.0.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
## 131.0.0

* Removes `RecipientCSV.rows`, `RecipientCSV._rows_as_list` (use, for example `for r in RecipientCSV(…)` instead)

 ## 130.2.0

* Bundles a reduced list of "protected" phone prefixes from OFCOM's `S7.csv` file and provides a new `PhoneNumber` method, `is_number_in_S7_protected_range()` to efficiently query it.

 ## 130.1.0

* Reverts change in 127.1.0. notifications-api is no longer using these methods.

 ## 130.0.0

* Removes `RecipientCSV.placeholders_as_column_keys` (use `RecipientCSV.placeholders` instead, now an instance of `InsensitiveSet`)
* Removes `RecipientCSV.recipient_column_headers_as_column_keys` (use `RecipientCSV.recipient_column_headers` instead, now an instance of `InsensitiveSet`)
* Renames `RecipientCSV.column_headers_as_column_keys` to `RecipientCSV.insensitive_column_headers`
* Removes `RecipientCSV.is_address_column(key)` (use `key in RecipientCSV.address_columns` instead)
* Removes `recipients.address_columns` (use `RecipientCSV.address_columns` instead)

 ## 129.0.0

* Running `make lint` will now flag commented-out code (per https://docs.astral.sh/ruff/rules/commented-out-code/)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/128.0.0...131.0.0