### PR TITLE
Fix typo on SMS pricing page

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -37,10 +37,10 @@ Text message pricing
    </div>
    {% endif %}
 
-  <p class="govuk-body">A text message may cost more, or use more of your free allowance, if it’s:</p>
+  <p class="govuk-body">A text message may cost more, or use more of your free allowance, if it is:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">is longer than 160 characters</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#language-other-than-english">is written in a language other than English</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">longer than 160 characters</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#language-other-than-english">written in a language other than English</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">sent to an international phone number</a></li>
   </ul>
   <p class="govuk-body">We’ll tell you how many text messages your template may count as before you send it.</p>


### PR DESCRIPTION
Lead-in line contraction repeats the ‘is’ from 2 of the bullet points