### PR TITLE
Update link to free text message allowance

### DIFF
--- a/app/templates/views/guidance/pricing/index.html
+++ b/app/templates/views/guidance/pricing/index.html
@@ -4,7 +4,7 @@
 {% set navigation_label_prefix = 'Pricing information' %}
 
 {% block per_page_title %}
-  Pricing
+  Pricingt
 {% endblock %}
 
 {% block content_column_content %}
@@ -14,7 +14,7 @@
   <p class="govuk-body">It’s free to send emails through GOV.UK Notify. There’s also no monthly charge, no setup fee and no procurement cost.</p>
   <p class="govuk-body">You will only have to pay if you:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>exceed your <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_text_messages') }}">free text message allowance</a></li>
+    <li>exceed your <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_free_text_messages_allowance') }}">free text message allowance</a></li>
     <li>send <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_letters') }}">letters</a></li>
   </ul>
 

--- a/app/templates/views/guidance/pricing/index.html
+++ b/app/templates/views/guidance/pricing/index.html
@@ -14,7 +14,7 @@
   <p class="govuk-body">It’s free to send emails through GOV.UK Notify. There’s also no monthly charge, no setup fee and no procurement cost.</p>
   <p class="govuk-body">You will only have to pay if you:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>exceed your <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_free_text_messages_allowance') }}">free text message allowance</a></li>
+    <li>exceed your <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_free_text_message_allowance') }}">free text message allowance</a></li>
     <li>send <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_pricing_letters') }}">letters</a></li>
   </ul>
 

--- a/app/templates/views/guidance/pricing/index.html
+++ b/app/templates/views/guidance/pricing/index.html
@@ -4,7 +4,7 @@
 {% set navigation_label_prefix = 'Pricing information' %}
 
 {% block per_page_title %}
-  Pricingt
+  Pricing
 {% endblock %}
 
 {% block content_column_content %}


### PR DESCRIPTION
Link for free message allowance bullet point changed from text message pricing page to the new free text message allowance page as these have now separated since multilingual sms