### PR TITLE
Fix test environments base urls

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,8 @@ testpaths = tests
 log_level = 999
 env =
     NOTIFY_ENVIRONMENT=test
-
+    ADMIN_BASE_URL=http://localhost
+    DOCUMENT_DOWNLOAD_API_HOST=http://localhost:7000
 filterwarnings =
     error:Applying marks directly:pytest.RemovedInPytest4Warning
 addopts = -p no:warnings


### PR DESCRIPTION
The base URLs were expected to be localhost but this is not the case in docker containers.

This change fixes it by using the actual environment variable instead of hardcoded values.