### PR TITLE
Update API keys page

### DIFF
--- a/app/assets/stylesheets/components/api-key-list.scss
+++ b/app/assets/stylesheets/components/api-key-list.scss
@@ -1,0 +1,55 @@
+@use "govuk/helpers" as * ;
+@use "govuk/settings" as * ;
+
+.api-key-list {
+  border-top: 1px solid govuk-functional-colour(border);
+}
+
+.api-key-list__item {
+  border-bottom: 1px solid govuk-functional-colour(border);
+  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(4);
+}
+
+.api-key__header {
+  display: flex;
+  flex-direction: column;
+  gap: govuk-spacing(1);
+  margin-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: govuk-spacing(3);
+  }
+}
+
+.api-key__name {
+  margin-bottom: 0;
+  @include govuk-media-query($from: tablet) {
+    max-width: 50%;
+  }
+}
+
+.api-key__action-link {
+  font-weight: $govuk-font-weight-bold;
+  max-width: fit-content;
+}
+
+.api-key__revoked {
+  color: govuk-functional-colour(secondary-text);
+  @include govuk-media-query($from: tablet) {
+    text-align: right;
+  }
+}
+
+.api-key__type {
+  max-width: fit-content;
+  margin-bottom: govuk-spacing(2);
+}
+
+.api-key__metadata {
+  color: govuk-functional-colour(secondary-text);
+  margin-bottom: govuk-spacing(2);
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -18,6 +18,7 @@
 // Specific to this application
 @use 'local/typography';
 @use 'grids';
+@use 'components/api-key-list';
 @use 'components/placeholder';
 @use 'components/sms-message';
 @use 'components/page-footer';

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -62,7 +62,7 @@ def guest_list(service_id):
 @main.route("/services/<uuid:service_id>/api/keys")
 @user_has_permissions("manage_api_keys")
 def api_keys(service_id):
-    return render_template("views/api/keys.html")
+    return render_template("views/api/keys.html", user_getter=current_service.active_users.get_name_from_id)
 
 
 @main.route("/services/<uuid:service_id>/api/keys/create", methods=["GET", "POST"])
@@ -117,9 +117,7 @@ def revoke_api_key(service_id, key_id):
             ],
             "revoke this API key",
         )
-        return render_template(
-            "views/api/keys.html",
-        )
+        return render_template("views/api/keys.html", user_getter=current_service.active_users.get_name_from_id)
     elif request.method == "POST":
         key.revoke(service_id=service_id)
         flash(f"‘{key.name}’ was revoked", "default_with_tick")

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -1,8 +1,8 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
 {% block service_page_title %}
   API keys
@@ -16,46 +16,49 @@
 
   {{ page_header('API keys') }}
 
-  <div class="body-copy-table">
-    {% call(item, row_number) list_table(
-      current_service.api_keys|sort,
-      empty_message="You have not created any API keys yet",
-      caption="API keys",
-      caption_visible=false,
-      field_headings=[
-        'API keys',
-        'Action'
-      ],
-      field_headings_visible=False
-    ) %}
-      {% call field() %}
-        <div class="file-list">
-          {{ item.name }}
-          <div class="hint">
-            {% if item.key_type == 'normal' %}
-              Live – sends to anyone
-            {% elif item.key_type == 'team' %}
-              Team and guest list – limits who you can send to
-            {% elif item.key_type == 'test' %}
-              Test – pretends to send messages
+  {% if current_service.api_keys %}
+    <ul class="govuk-list api-key-list" aria-label="API keys">
+      {% for item in current_service.api_keys|sort %}
+        <li class="api-key-list__item api-key">
+          
+          <div class="api-key__header">
+            <h3 class="govuk-heading-s api-key__name">{{ item.name }}</h3>
+            {% if item.expiry_date %}
+              <span class="api-key__revoked">Revoked {{ item.expiry_date|format_datetime_human(date_prefix='on') }}</span>
+            {% else %}
+              <a class="govuk-link govuk-link--destructive api-key__action-link" href="{{ url_for('main.revoke_api_key', service_id=current_service.id, key_id=item.id) }}">
+                Revoke <span class="govuk-visually-hidden"> {{ item.name }} API key</span>
+              </a>
             {% endif %}
           </div>
-          <p>Created by {{ user_getter(item.created_by) }} {{item.created_at | format_datetime_human}}</p>
-        </div>
-      {% endcall %}
-      {% if item.expiry_date %}
-        {% call field(align='right') %}
-          <span class='hint'>Revoked {{ item.expiry_date|format_datetime_short }}</span>
-        {% endcall %}
-      {% else %}
-        {% call field(align='right', status='error') %}
-          <a class="govuk-link govuk-link--destructive" href='{{ url_for('main.revoke_api_key', service_id=current_service.id, key_id=item.id) }}'>
-            Revoke<span class="govuk-visually-hidden"> {{ item.name }}</span>
-          </a>
-        {% endcall %}
-      {% endif %}
-    {% endcall %}
-  </div>
+
+          {% if item.key_type == 'normal' %}
+            {{ govukTag({
+              "text": "Live – sends to anyone",
+              "classes": "govuk-tag--turquoise api-key__type",
+            }) }}
+          {% elif item.key_type == 'team' %}
+            {{ govukTag({
+              "text": "Team and guest list – limits who you can send to",
+              "classes": "govuk-tag--grey  api-key__type",
+            }) }}
+          {% elif item.key_type == 'test' %}
+            {{ govukTag({
+              "text": "Test – pretends to send messages",
+              "classes": "govuk-tag--purple api-key__type",
+            }) }}
+          {% endif %}
+
+          <p class="api-key__metadata">
+            Created by {{ user_getter(item.created_by) }}
+            <time datetime="{{ item.created_at }}">{{ item.created_at|format_datetime_human(date_prefix='on') }}</time>
+          </p>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p class="govuk-body">You have not created any API keys yet</p>
+  {% endif %}
 
   <div class="js-stick-at-bottom-when-scrolling">
     {{ govukButton({

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -40,6 +40,7 @@
               Test – pretends to send messages
             {% endif %}
           </div>
+          <p>Created by {{ user_getter(item.created_by) }} {{item.created_at | format_datetime_human}}</p>
         </div>
       {% endcall %}
       {% if item.expiry_date %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -384,8 +384,15 @@ def template_version_json(service_id, id_, created_by, version=1, created_at=Non
     return template
 
 
-def api_key_json(id_, name, expiry_date=None, key_type="normal"):
-    return {"id": id_, "name": name, "expiry_date": expiry_date, "key_type": key_type}
+def api_key_json(id_, name, expiry_date=None, key_type="normal", created_by=None, created_at=None):
+    return {
+        "id": id_,
+        "name": name,
+        "expiry_date": expiry_date,
+        "key_type": key_type,
+        "created_by": created_by or sample_uuid(),
+        "created_at": created_at,
+    }
 
 
 def invite_json(

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -300,6 +300,7 @@ def test_should_show_empty_api_keys_page(
     mock_login,
     mock_get_no_api_keys,
     mock_has_permissions,
+    mock_get_users_by_service,
 ):
     client_request.login(api_user_active)
     page = client_request.get("main.api_keys", service_id=SERVICE_ONE_ID)
@@ -313,17 +314,26 @@ def test_should_show_api_keys_page(
     client_request,
     mock_get_api_keys,
     fake_uuid,
+    mock_get_users_by_service,
 ):
     page = client_request.get("main.api_keys", service_id=SERVICE_ONE_ID)
-    rows = [normalize_spaces(row.text) for row in page.select("main tr")]
-    revoke_link = page.select_one("main tr a.govuk-link.govuk-link--destructive")
+    items = [normalize_spaces(item.text) for item in page.select("ul.api-key-list li")]
+    revoke_link = page.select_one("ul li a.govuk-link.govuk-link--destructive")
 
-    assert rows[0] == "API keys Action"
-    assert rows[1] == "another key name Test – pretends to send messages Revoked 1 January at 1:00am"
-    assert rows[2] == "some key name Live – sends to anyone Revoke some key name"
-    assert rows[3] == "third key Team and guest list – limits who you can send to Revoke third key"
+    assert items[0] == (
+        "another key name Revoked on 1 January 1970 at 1:00am Test – "
+        "pretends to send messages Created by Test User on 2 September at 1:00pm"
+    )
+    assert items[1] == (
+        "some key name Revoke some key name API key Live – "
+        "sends to anyone Created by Test User on 1 September at 11:00am"
+    )
+    assert items[2] == (
+        "third key Revoke third key API key Team and guest list – "
+        "limits who you can send to Created by Test User on 3 September at 8:00pm"
+    )
 
-    assert normalize_spaces(revoke_link.text) == "Revoke some key name"
+    assert normalize_spaces(revoke_link.text) == "Revoke some key name API key"
     assert revoke_link["href"] == url_for(
         "main.revoke_api_key",
         service_id=SERVICE_ONE_ID,
@@ -442,6 +452,7 @@ def test_should_show_confirm_revoke_api_key(
     client_request,
     mock_get_api_keys,
     fake_uuid,
+    mock_get_users_by_service,
 ):
     page = client_request.get(
         "main.revoke_api_key",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1458,17 +1458,27 @@ def mock_get_api_keys(notify_admin, mocker, fake_uuid):
     def _get_keys(service_id, key_id=None):
         keys = {
             "apiKeys": [
-                api_key_json(id_=fake_uuid, name="some key name", key_type="normal"),
+                api_key_json(
+                    id_=fake_uuid,
+                    name="some key name",
+                    key_type="normal",
+                    created_by=fake_uuid,
+                    created_at="2026-09-01 10:00:00.000000",
+                ),
                 api_key_json(
                     id_="1234567",
                     name="another key name",
                     expiry_date=str(date.fromtimestamp(0)),
                     key_type="test",
+                    created_by=fake_uuid,
+                    created_at="2026-09-02 12:00:00.000000",
                 ),
                 api_key_json(
                     id_=str(uuid4()),
                     name="third key",
                     key_type="team",
+                    created_by=fake_uuid,
+                    created_at="2026-09-03 19:00:00.000000",
                 ),
             ]
         }


### PR DESCRIPTION
Update api key page:

- add created_at and created_by data to each key
- convert the keys list from a table to an unordered list
- update design based on https://github.com/alphagov/notify-design-archive/issues/18 

See individual commits for details

**Before**
<img width="763" height="345" alt="Screenshot 2026-09-10 at 12 28 18" src="https://github.com/user-attachments/assets/d9b40f7d-fe04-4f59-a45a-44823104cab4" />

**After**
<img width="750" height="576" alt="Screenshot 2026-09-10 at 11 42 13" src="https://github.com/user-attachments/assets/62e8fe55-a470-4ddb-8ad4-b827651ff041" />
