### PR TITLE
Add a new page for agreeing to the free allowance terms

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2103,6 +2103,13 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
     is_default = GovukCheckboxField("Make this text message sender ID the default")
 
 
+class ServiceConfirmFreeAllowanceTermsForm(StripWhitespaceForm):
+    confirm = GovukCheckboxField(
+        "I have read and understood the terms of the free allowance",
+        validators=[DataRequired(message="Select ‘I have read and understood the terms of the free allowance’")],
+    )
+
+
 class ServiceEditInboundNumberForm(StripWhitespaceForm):
     is_default = GovukCheckboxField("Make this text message sender ID the default")
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -46,6 +46,7 @@ from app.main.forms import (
     OnOffSettingForm,
     RenameServiceForm,
     SearchByNameForm,
+    ServiceConfirmFreeAllowanceTermsForm,
     ServiceContactDetailsForm,
     ServiceEditInboundNumberForm,
     ServiceEmailSenderForm,
@@ -990,6 +991,22 @@ def service_delete_letter_contact(service_id, letter_contact_id):
         letter_contact_id=letter_contact_id,
     )
     return redirect(url_for(".service_letter_contact_details", service_id=current_service.id))
+
+
+@main.route("/services/<uuid:service_id>/service-settings/free-allowance", methods=["GET", "POST"])
+@user_has_permissions("manage_service")
+def service_confirm_free_allowance_terms(service_id):
+    form = ServiceConfirmFreeAllowanceTermsForm()
+
+    if form.validate_on_submit():
+        current_service.update(confirmed_unique=True)
+        return redirect(url_for(".service_settings", service_id=service_id))
+
+    return render_template(
+        "views/service-settings/confirm-free-allowance-terms.html",
+        form=form,
+        error_summary_enabled=True,
+    )
 
 
 @main.route("/services/<uuid:service_id>/service-settings/sms-sender", methods=["GET"])

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -306,6 +306,7 @@ class MainNavigation(Navigation):
             "service_confirm_delete_email_reply_to",
             "service_confirm_delete_letter_contact",
             "service_confirm_delete_sms_sender",
+            "service_confirm_free_allowance_terms",
             "service_edit_email_reply_to",
             "service_edit_letter_contact",
             "service_edit_sms_sender",

--- a/app/templates/views/service-settings/confirm-free-allowance-terms.html
+++ b/app/templates/views/service-settings/confirm-free-allowance-terms.html
@@ -1,0 +1,83 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = "Free text message allowance" %}
+
+{% block service_page_title %}
+    {{ page_title }}
+{% endblock %}
+
+{% block backLink %}
+    {{ govukBackLink({ "href": url_for('main.service_settings', service_id=current_service.id) }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-five-sixths">
+        {{ page_header(page_title) }}
+
+        <p class="govuk-body">
+            If your service is eligible, it will get an annual allowance of free text messages.
+        </p>
+        <p class="govuk-body">
+            You can still use Notify if your service is not eligible for a free allowance.
+        </p>
+
+        <h2 class="heading-medium">Terms of the free allowance</h2>
+        <p class="govuk-body">
+            These terms apply to the way you use GOV.UK Notify.
+        </p>
+        <p class="govuk-body">
+            You accept our terms of use when you create an account.
+        </p>
+        <p class="govuk-body">
+            You must keep to the terms. If you do not, we will stop your free allowance.
+        </p>
+        <p class="govuk-body">
+            The free allowance is discretionary.
+        </p>
+        <p class="govuk-body">
+            The free allowance renews on 1 April. Unused free text messages expire on 31 March.
+        </p>
+        <p class="govuk-body">
+            GOV.UK Notify reviews the free allowance every year. As a result, we may need to change the size of the allowance.
+            This usually happens on 1 April.
+        </p>
+        <p class="govuk-body">
+            To qualify for the free allowance:
+        </p>
+        <ol class="govuk-list govuk-list--number">
+            <li>Your service must be the only one of its kind in your organisation.</li>
+            <li>Your service must not be for testing purposes.</li>
+            <li>Your service must not belong to a GP surgery.</li>
+        </ol>
+
+        <p class="govuk-body">
+            If your service sends a very high volume of text messages in a single financial year, we may not renew its free allowance on 1 April.
+        </p>
+
+        <p class="govuk-body">
+            GOV.UK Notify can remove your free allowance at any time if we find another live service with similar:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>text message templates</li>
+            <li>recipients</li>
+            <li>team members</li>
+        </ul>
+
+    {% if not current_service.confirmed_unique %}
+        {% call form_wrapper() %}
+            {{ form.confirm(
+            ) }}
+            {{ page_footer('Confirm') }}
+        {% endcall %}
+    {% endif %}
+    </div>
+</div>
+
+{% endblock %}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2967,6 +2967,46 @@ def test_inbound_sms_sender_is_not_editable(client_request, service_one, fake_uu
         )
 
 
+def test_service_confirm_free_allowance_terms(client_request):
+    page = client_request.get("main.service_confirm_free_allowance_terms", service_id=SERVICE_ONE_ID)
+
+    assert normalize_spaces(page.select_one("h1").text) == "Free text message allowance"
+    assert (
+        normalize_spaces(page.select_one("main .govuk-checkboxes").label.text)
+        == "I have read and understood the terms of the free allowance"
+    )
+
+
+def test_service_confirm_free_allowance_terms_hides_checkbox_if_terms_already_accepted(client_request, service_one):
+    service_one["confirmed_unique"] = True
+    page = client_request.get("main.service_confirm_free_allowance_terms", service_id=SERVICE_ONE_ID)
+
+    assert normalize_spaces(page.select_one("h1").text) == "Free text message allowance"
+    assert not page.select("main .govuk-checkboxes")
+
+
+def test_service_confirm_free_allowance_terms_redirects_when_checkbox_is_checked(client_request, mock_update_service):
+    client_request.post(
+        "main.service_confirm_free_allowance_terms",
+        service_id=SERVICE_ONE_ID,
+        _data={"confirm": True},
+        _expected_redirect=url_for("main.service_settings", service_id=SERVICE_ONE_ID),
+    )
+    mock_update_service.assert_called_once_with(SERVICE_ONE_ID, confirmed_unique=True)
+
+
+def test_service_confirm_free_allowance_terms_requires_checkbox_to_be_checked(client_request, mock_update_service):
+    page = client_request.post(
+        "main.service_confirm_free_allowance_terms", service_id=SERVICE_ONE_ID, _expected_status=200
+    )
+    assert normalize_spaces(page.select_one("h1").text) == "Free text message allowance"
+    assert (
+        normalize_spaces(page.select_one(".govuk-error-message").text)
+        == "Error: Select ‘I have read and understood the terms of the free allowance’"
+    )
+    assert not mock_update_service.called
+
+
 def test_service_set_letter_branding_platform_admin_only(
     client_request,
 ):

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -312,6 +312,7 @@ EXCLUDED_ENDPOINTS = set(
             "service_confirm_delete_letter_contact",
             "service_confirm_delete_sms_sender",
             "service_confirm_disable_email_auth",
+            "service_confirm_free_allowance_terms",
             "service_dashboard",
             "service_data_retention",
             "service_delete_email_reply_to",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -245,6 +245,7 @@
     "/services/<uuid:service_id>/service-settings/email-reply-to/add",
     "/services/<uuid:service_id>/service-settings/email-sender",
     "/services/<uuid:service_id>/service-settings/email-sender/preview-address",
+    "/services/<uuid:service_id>/service-settings/free-allowance",
     "/services/<uuid:service_id>/service-settings/letter-branding",
     "/services/<uuid:service_id>/service-settings/letter-branding/request",
     "/services/<uuid:service_id>/service-settings/letter-branding/set-name",


### PR DESCRIPTION
This adds a new page where users can tick that they agree to the terms of the text message free allowance. Ticking the box saves the data in the `is_unique` column. This page is not linked to from anywhere yet, however if people do come across this page it isn't an issue - there's nothing they shouldn't see, and clicking the box will save the data correctly.

If the terms have already been accepted, the content on the page is the same, but the form is hidden.

**Screenshots**
<img width="677" height="935" alt="Screenshot 2026-09-10 at 13 43 27" src="https://github.com/user-attachments/assets/a4ef87f3-8fe8-4913-9162-2899b96c0647" />

<img width="577" height="412" alt="Screenshot 2026-09-10 at 14 14 19" src="https://github.com/user-attachments/assets/e2963b2f-491c-4371-8483-f0e5e29a3815" />

<img width="693" height="371" alt="Screenshot 2026-09-10 at 13 52 36" src="https://github.com/user-attachments/assets/c4d6ddf9-104e-4f40-85fc-2741b244326c" />
