### PR TITLE
add service_permission `block_ofcom_protected_block` to platform admin settings

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -77,6 +77,7 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = {
     "inbound_sms": {"title": "Receive inbound SMS", "requires": "sms", "endpoint": ".service_set_inbound_number"},
     "email_auth": {"title": "Email authentication"},
     "sms_to_uk_landlines": {"title": "Sending SMS to UK landlines"},
+    "block_ofcom_protected_block": {"title": "Block sending to ofcom protected range"},
 }
 
 THANKS_FOR_BRANDING_REQUEST_MESSAGE = (

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -76,6 +76,7 @@ class Service(JSONModel):
         "international_letters",
         "international_sms",
         "sms_to_uk_landlines",
+        "block_ofcom_protected_block",
     )
 
     @classmethod

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -79,6 +79,18 @@ def test_service_set_permission_requires_platform_admin(
             "False",
             [],
         ),
+        (
+            [],
+            "block_ofcom_protected_block",
+            "True",
+            ["block_ofcom_protected_block"],
+        ),
+        (
+            ["block_ofcom_protected_block"],
+            "block_ofcom_protected_block",
+            "False",
+            [],
+        ),
     ],
 )
 def test_service_set_permission(

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -150,6 +150,7 @@ FAKE_TEMPLATE_ID = uuid4()
                 "Receive inbound SMS Off Change your settings for Receive inbound SMS",
                 "Email authentication Off Change your settings for Email authentication",
                 "Sending SMS to UK landlines Off Change your settings for Sending SMS to UK landlines",
+                "Block sending to ofcom protected range Off Change your settings for Block sending to ofcom protected range",  # noqa: E501
             ],
         ),
         (
@@ -183,6 +184,7 @@ FAKE_TEMPLATE_ID = uuid4()
                 "Custom data retention Email – 7 days Change data retention",
                 "Email authentication Off Change your settings for Email authentication",
                 "Sending SMS to UK landlines Off Change your settings for Sending SMS to UK landlines",
+                "Block sending to ofcom protected range Off Change your settings for Block sending to ofcom protected range",  # noqa: E501
             ],
         ),
     ],


### PR DESCRIPTION
we have already updated the api to include the new service permission (https://github.com/alphagov/notifications-api/commit/b62ac01fbf27db49b80d7bca7c169258605b5a8b), this allows the permission to be set from the platform admin section in service settings.

This won't currently do anything, until we use this to introduce new checks on the frontend and the backend