### PR TITLE
Convert security keys table to list

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -110,6 +110,15 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 
 }
 
+.notify-summary-list--no-action-full-span {
+  .govuk-summary-list__value {
+    @include govuk-media-query($from: tablet) {
+      text-align: right;
+      width: 20%;
+    }
+  }
+}
+
 // summary list with file name and metadata
 // there will be 2 variants
 // 24px filename and 19px metadata - template stats

--- a/app/templates/views/your-account/security-keys.html
+++ b/app/templates/views/your-account/security-keys.html
@@ -2,9 +2,9 @@
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/table.html" import edit_field, mapping_table, row, field %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
 {% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% set page_title = 'Security keys' %}
 {% set credentials = current_user.webauthn_credentials %}
@@ -70,30 +70,40 @@
       <div class="govuk-grid-column-five-sixths">
         {{ errorSummaries }}
         {{ page_header(page_title) }}
-        <div class="body-copy-table">
-          {% call mapping_table(
-            caption=page_title,
-            field_headings=['Security key details', 'Action'],
-            field_headings_visible=False,
-            caption_visible=False,
-          ) %}
-            {% for credential in credentials %}
-              {% call row() %}
-                {% call field() %}
-                  <div class="govuk-body govuk-!-margin-bottom-2">{{ credential.name }}</div>
-                  <div class="govuk-hint govuk-!-margin-bottom-2">
-                    {% if credential.logged_in_at %}
-                      Last used {{ credential.logged_in_at|format_delta }}
-                    {% else %}
-                      Never used (registered {{ credential.created_at|format_delta }})
-                    {% endif %}
-                  </div>
-                {% endcall %}
-                {{ edit_field('Manage', url_for('main.your_account_manage_security_key', key_id=credential.id)) }}
-              {% endcall %}
-            {% endfor %}
-          {% endcall %}
-        </div>
+
+        {% set credentials_list = [] %}
+        {% for credential in credentials %}
+          {% set summary_key_html %}
+            <div class="govuk-body govuk-!-margin-bottom-2">{{ credential.name }}</div>
+            <div class="govuk-hint govuk-!-margin-bottom-2">
+              {% if credential.logged_in_at %}
+                Last used {{ credential.logged_in_at|format_delta }}
+              {% else %}
+                Never used (registered {{ credential.created_at|format_delta }})
+              {% endif %}
+            </div>
+          {% endset %}
+          {% set summary_key_value %}
+              <a class="govuk-link govuk-link--no-visited-state"
+                href="{{ url_for('main.your_account_manage_security_key', key_id=credential.id) }}">
+                Manage<span class="govuk-visually-hidden"> {{ credential.name }}</span>
+              </a>
+          {% endset %}
+          {% do credentials_list.append({
+            "key": {
+              "html": summary_key_html
+            },
+            "value": {
+              "html": summary_key_value
+            }
+          }) %}
+        {% endfor %}
+
+        {{ govukSummaryList({
+          "classes": "notify-summary-list notify-summary-list--no-action-full-span",
+          "rows": credentials_list
+          }) }}
+
         {{ webauthn_button }}
       </div>
     {% else %}

--- a/tests/app/main/views/test_your_account.py
+++ b/tests/app/main/views/test_your_account.py
@@ -562,15 +562,15 @@ def test_should_show_security_keys_page(
     page = client_request.get(".your_account_security_keys")
     assert page.select_one("h1").text.strip() == "Security keys"
 
-    cred_1 = page.select("tr")[1]
-    cred_2 = page.select("tr")[2]
-    cred_1_lhs = cred_1.select_one("td.table-field-left-aligned")
-    cred_2_lhs = cred_2.select_one("td.table-field-left-aligned")
+    cred_1 = page.select(".govuk-summary-list__row")[0]
+    cred_2 = page.select(".govuk-summary-list__row")[1]
+    cred_1_lhs = cred_1.select_one(".govuk-summary-list__key")
+    cred_2_lhs = cred_2.select_one(".govuk-summary-list__key")
 
     assert normalize_spaces(cred_1_lhs.text) == "Test credential Last used 4 years ago"
     assert normalize_spaces(cred_2_lhs.text) == "Another test credential Never used (registered 1 year, 5 months ago)"
-    manage_link = cred_1.select_one("td.table-field-right-aligned a")
-    assert normalize_spaces(manage_link.text) == "Manage"
+    manage_link = cred_1.select_one(".govuk-summary-list__value a")
+    assert normalize_spaces(manage_link.text) == "Manage Test credential"
     assert manage_link["href"] == url_for(".your_account_manage_security_key", key_id=webauthn_credential["id"])
 
     register_button = page.select_one("[data-notify-module='register-security-key']")


### PR DESCRIPTION
Utilising the Summary List with a tweak as we use "manage" link  as the list value.

Variant of the notify-list style class sets the width of the value as well as align the text to the right.

<img width="927" height="301" alt="Screenshot 2026-09-11 at 11 42 05" src="https://github.com/user-attachments/assets/b456f93c-82ca-4b49-9b37-15f1fe55acce" />
